### PR TITLE
IPartition migration

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/shuffling/ShuffledConsumerTaskProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/shuffling/ShuffledConsumerTaskProcessor.java
@@ -36,7 +36,7 @@ import com.hazelcast.jet.spi.strategy.CalculationStrategy;
 import com.hazelcast.jet.spi.strategy.CalculationStrategyAware;
 import com.hazelcast.jet.spi.strategy.ShufflingStrategy;
 import com.hazelcast.nio.Address;
-import com.hazelcast.partition.IPartition;
+import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.NodeEngine;
 
 import java.util.ArrayList;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/dag/tap/sink/HazelcastSinkTap.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/dag/tap/sink/HazelcastSinkTap.java
@@ -24,7 +24,7 @@ import com.hazelcast.jet.spi.dag.tap.SinkTap;
 import com.hazelcast.jet.spi.dag.tap.SinkTapWriteStrategy;
 import com.hazelcast.jet.spi.dag.tap.TapType;
 import com.hazelcast.jet.spi.data.DataWriter;
-import com.hazelcast.partition.IPartition;
+import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.NodeEngine;
 
 import java.util.ArrayList;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/dag/tap/source/HazelcastListPartitionReader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/dag/tap/source/HazelcastListPartitionReader.java
@@ -31,7 +31,7 @@ import com.hazelcast.jet.spi.data.tuple.TupleConvertor;
 import com.hazelcast.jet.spi.data.tuple.TupleFactory;
 import com.hazelcast.jet.spi.strategy.CalculationStrategy;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.partition.IPartitionService;
+import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.partition.strategy.StringAndPartitionAwarePartitioningStrategy;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.NodeEngine;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/dag/tap/source/HazelcastSourceTap.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/dag/tap/source/HazelcastSourceTap.java
@@ -23,7 +23,7 @@ import com.hazelcast.jet.spi.dag.tap.SourceTap;
 import com.hazelcast.jet.spi.dag.tap.TapType;
 import com.hazelcast.jet.spi.data.DataReader;
 import com.hazelcast.jet.spi.data.tuple.TupleFactory;
-import com.hazelcast.partition.IPartition;
+import com.hazelcast.spi.partition.IPartition;
 
 import java.io.File;
 import java.util.ArrayList;


### PR DESCRIPTION
com.hazelcast.partition.IPartition occurences have been renamed to com.hazelcast.spi.partition.IPartition occurences
