### PR TITLE
ConsumerTaskProcessor should close non-shuffled consumers - bugFix

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ConsumerTaskProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ConsumerTaskProcessor.java
@@ -171,7 +171,7 @@ public class ConsumerTaskProcessor implements TaskProcessor {
         reset();
 
         for (ObjectConsumer consumer : consumers) {
-            if (consumer.isShuffled()) {
+            if (!consumer.isShuffled()) {
                 consumer.close();
             }
         }


### PR DESCRIPTION
ConsumerTaskProcessor should close non-shuffled consumers - bugFix
