### PR TITLE
Fix null value in types array

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/data/io/Types.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/data/io/Types.java
@@ -88,20 +88,18 @@ public enum Types implements DataType {
     private static final Map<Integer, DataType> TYPES = new Int2ObjectHashMap<DataType>();
 
     static {
-        CLASSES = new Class[Types.values().length - 1];
+        CLASSES = new Class[Types.values().length - 2];
         int i = 0;
 
         for (Types type : Types.values()) {
-            if (type.getClazz() == null) {
+            if (type.getClazz() == null || (type.getClazz().equals(Object.class))) {
                 continue;
             }
 
-            if (!(type.getClazz().equals(Object.class))) {
-                TYPES.put((int) type.getTypeID(), type);
-                CLASSES2_TYPES.put(type.getClazz(), type);
-                CLASSES[i] = type.getClazz();
-                i++;
-            }
+            TYPES.put((int) type.getTypeID(), type);
+            CLASSES2_TYPES.put(type.getClazz(), type);
+            CLASSES[i] = type.getClazz();
+            i++;
         }
     }
 
@@ -131,6 +129,10 @@ public enum Types implements DataType {
     }
 
     public static DataType getDataType(Object object) {
+        if (object == null) {
+            return Types.NULL;
+        }
+
         for (Class<?> clazz : CLASSES) {
             if (clazz.isAssignableFrom(object.getClass())) {
                 return CLASSES2_TYPES.get(clazz);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/data/io/TypesTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/data/io/TypesTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.jet.impl.data.io;
+
+import com.hazelcast.jet.impl.data.tuple.Tuple2;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Category(QuickTest.class)
+public class TypesTest {
+
+    private Object object;
+    private Types type;
+
+    public TypesTest(Object object, Types type) {
+        this.object = object;
+        this.type = type;
+    }
+
+    @Parameterized.Parameters(name="object={0}, type={1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { true , Types.BOOLEAN },
+                { (byte) 0 , Types.BYTE },
+                { 'c' , Types.CHAR },
+                { 0.0d , Types.DOUBLE },
+                { 0.0f , Types.FLOAT },
+                { 0 , Types.INT },
+                { 0L , Types.LONG },
+                { (short) 0 , Types.SHORT },
+                { "string" , Types.STRING },
+                { null , Types.NULL },
+                { new Tuple2<>(0, 0) , Types.TUPLE },
+                { new Object() , Types.OBJECT }
+        });
+    }
+
+    @Test
+    public void testGetDataType() {
+        assertEquals(type, Types.getDataType(object));
+    }
+}


### PR DESCRIPTION
CLASSES array contained an extra null value causing nullPointerException in Types.getDataType() method.
