### PR TITLE
Shuffling bugs fixes

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/factory/ShuffledTaskProcessorFactory.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/factory/ShuffledTaskProcessorFactory.java
@@ -57,6 +57,7 @@ public class ShuffledTaskProcessorFactory extends DefaultTaskProcessorFactory {
                                             int taskID) {
         return new ShuffledActorTaskProcessor(
                 producers,
+                consumers,
                 processor,
                 containerContext,
                 processorContext,


### PR DESCRIPTION
1) Detection of active input producers has been modified.
   The case when there is just one vertex and one output consumer without input producers
   (List -> Vertex-> List) hasn't bee taken into account in the previous architecture.

2) Fixed bug with setting produced flag for the receivers reading - so application hunged.
