### PR TITLE
Active producer/consumer checking has been remove due to unnecessary …

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/api/container/task/TaskProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/api/container/task/TaskProcessor.java
@@ -69,20 +69,6 @@ public interface TaskProcessor {
     boolean isFinalized();
 
     /**
-     * Indicates of task has active consumers for writing;
-     *
-     * @return - true if corresponding task has active consumers; false - otherwise;
-     */
-    boolean hasActiveConsumers();
-
-    /**
-     * Indicates of task has active consumers for reading;
-     *
-     * @return - true if corresponding task has active producers; false - otherwise;
-     */
-    boolean hasActiveProducers();
-
-    /**
      * Resets producer to the initial state;
      */
     void reset();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/DefaultContainerTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/DefaultContainerTask.java
@@ -213,6 +213,7 @@ public class DefaultContainerTask extends AbstractTask
         this.receiversClosed = false;
         this.sendersFlushed = false;
         this.producersClosed = false;
+
         this.activeProducersCounter.set(this.producers.size());
         this.activeReceiversCounter.set(this.shufflingReceivers.values().size());
         this.finalizedReceiversCounter.set(this.shufflingReceivers.values().size());
@@ -349,8 +350,6 @@ public class DefaultContainerTask extends AbstractTask
         payload.set(activity);
 
         if (((!activity) && (success))) {
-            checkActiveProducers(processor);
-
             if (checkProducersClosed()) {
                 processor.onProducersWriteFinished();
                 return true;
@@ -419,14 +418,6 @@ public class DefaultContainerTask extends AbstractTask
         }
 
         return false;
-    }
-
-    private void checkActiveProducers(TaskProcessor processor) {
-        if ((!processor.hasActiveProducers())) {
-            this.activeProducersCounter.set(0);
-            this.finalizedReceiversCounter.set(0);
-            this.activeReceiversCounter.set(0);
-        }
     }
 
     private void notifyFinalizationStarted() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ActorTaskProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ActorTaskProcessor.java
@@ -71,11 +71,6 @@ public class ActorTaskProcessor extends ProducerTaskProcessor {
     }
 
     @Override
-    public boolean hasActiveConsumers() {
-        return this.consumerProcessor.hasActiveConsumers();
-    }
-
-    @Override
     public void reset() {
         super.reset();
         this.consumerProcessor.reset();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ConsumerTaskProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ConsumerTaskProcessor.java
@@ -201,14 +201,4 @@ public class ConsumerTaskProcessor implements TaskProcessor {
     public boolean produced() {
         return false;
     }
-
-    @Override
-    public boolean hasActiveConsumers() {
-        return true;
-    }
-
-    @Override
-    public boolean hasActiveProducers() {
-        return false;
-    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ProducerTaskProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/ProducerTaskProcessor.java
@@ -198,11 +198,6 @@ public class ProducerTaskProcessor implements TaskProcessor {
     }
 
     @Override
-    public boolean hasActiveProducers() {
-        return this.producers.length > 0;
-    }
-
-    @Override
     public void reset() {
         resetProducers();
 
@@ -253,11 +248,6 @@ public class ProducerTaskProcessor implements TaskProcessor {
 
     @Override
     public boolean consumed() {
-        return false;
-    }
-
-    @Override
-    public boolean hasActiveConsumers() {
         return false;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/SimpleTaskProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/container/task/processors/SimpleTaskProcessor.java
@@ -77,16 +77,6 @@ public class SimpleTaskProcessor implements TaskProcessor {
     }
 
     @Override
-    public boolean hasActiveConsumers() {
-        return false;
-    }
-
-    @Override
-    public boolean hasActiveProducers() {
-        return false;
-    }
-
-    @Override
     public void reset() {
         this.finalized = false;
         this.tupleInputStream.reset();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ShufflingLogicalTests.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ShufflingLogicalTests.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.jet;
+
+import com.hazelcast.core.IList;
+import com.hazelcast.jet.api.application.Application;
+import com.hazelcast.jet.base.JetBaseTest;
+import com.hazelcast.jet.impl.dag.EdgeImpl;
+import com.hazelcast.jet.impl.strategy.IListBasedShufflingStrategy;
+import com.hazelcast.jet.processors.CombinerProcessor;
+import com.hazelcast.jet.processors.CountProcessor;
+import com.hazelcast.jet.spi.dag.DAG;
+import com.hazelcast.jet.spi.dag.Edge;
+import com.hazelcast.jet.spi.dag.Vertex;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.Repeat;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+public class ShufflingLogicalTests extends JetBaseTest {
+    @BeforeClass
+    public static void initCluster() throws Exception {
+        JetBaseTest.initCluster(2);
+    }
+
+    @Test
+    @Repeat(100)
+    public void counterCombinerListTest() throws Exception {
+        Application application = createApplication("counterCombinerListTest");
+
+        IList<Integer> sourceList = SERVER.getList(randomName());
+        IList targetList = SERVER.getList(randomName());
+
+        try {
+            DAG dag = createDAG();
+
+            int CNT = 10_000;
+
+            for (int i = 0; i < CNT; i++) {
+                sourceList.add(i);
+            }
+
+            Vertex counter = createVertex("counter", CountProcessor.Factory.class, 1);
+            Vertex combiner = createVertex("combiner", CombinerProcessor.Factory.class, 1);
+            addVertices(dag, counter, combiner);
+
+            Edge edge = new EdgeImpl.EdgeBuilder("edge", counter, combiner)
+                    .shuffling(true)
+                    .shufflingStrategy(new IListBasedShufflingStrategy(targetList.getName()))
+                    .build();
+
+            addEdges(dag, edge);
+
+            counter.addSourceList(sourceList.getName());
+            combiner.addSinkList(targetList.getName());
+            executeApplication(dag, application).get(TIME_TO_AWAIT, TimeUnit.SECONDS);
+            assertEquals(1, targetList.size());
+            System.out.println("targetList.get(0)=" + targetList.get(0));
+            assertEquals(CNT, targetList.get(0));
+        } finally {
+
+            application.finalizeApplication().get(TIME_TO_AWAIT, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/CombinerProcessor.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/CombinerProcessor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.processors;
+
+import com.hazelcast.jet.api.container.ProcessorContext;
+import com.hazelcast.jet.api.data.io.ConsumerOutputStream;
+import com.hazelcast.jet.api.data.io.ProducerInputStream;
+import com.hazelcast.jet.impl.data.tuple.Tuple2;
+import com.hazelcast.jet.spi.dag.Vertex;
+import com.hazelcast.jet.spi.data.tuple.Tuple;
+import com.hazelcast.jet.spi.processor.tuple.TupleContainerProcessor;
+import com.hazelcast.jet.spi.processor.tuple.TupleContainerProcessorFactory;
+
+public class CombinerProcessor implements TupleContainerProcessor<Long, Integer, Long, Integer> {
+
+    Integer result = null;
+
+    @Override
+    public void beforeProcessing(ProcessorContext processorContext) {
+        result = null;
+    }
+
+    @Override
+    public boolean process(ProducerInputStream<Tuple<Long, Integer>> inputStream,
+                           ConsumerOutputStream<Tuple<Long, Integer>> outputStream,
+                           String sourceName, ProcessorContext processorContext) throws Exception {
+        for (Tuple<Long, Integer> tuple : inputStream) {
+            if (result == null) {
+                result = tuple.getValue(0);
+            } else {
+                result += tuple.getValue(0);
+            }
+
+            System.out.println("YatutBil result=" + result + " " + tuple.getValue(0));
+        }
+        return true;
+    }
+
+    @Override
+    public boolean finalizeProcessor(ConsumerOutputStream<Tuple<Long, Integer>> outputStream, ProcessorContext processorContext) throws Exception {
+        if (result != null) {
+            outputStream.consume(new Tuple2<>(0L, result));
+        }
+        return true;
+    }
+
+    @Override
+    public void afterProcessing(ProcessorContext processorContext) {
+
+    }
+
+    public static class Factory implements TupleContainerProcessorFactory {
+        public TupleContainerProcessor getProcessor(Vertex vertex) {
+            return new CombinerProcessor();
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/CountProcessor.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/CountProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.processors;
+
+import com.hazelcast.jet.api.container.ProcessorContext;
+import com.hazelcast.jet.api.data.io.ConsumerOutputStream;
+import com.hazelcast.jet.api.data.io.ProducerInputStream;
+import com.hazelcast.jet.impl.data.tuple.Tuple2;
+import com.hazelcast.jet.spi.dag.Vertex;
+import com.hazelcast.jet.spi.data.tuple.Tuple;
+import com.hazelcast.jet.spi.processor.tuple.TupleContainerProcessor;
+import com.hazelcast.jet.spi.processor.tuple.TupleContainerProcessorFactory;
+
+public class CountProcessor implements TupleContainerProcessor<Long, Integer, Long, Integer> {
+    private int result = 0;
+
+    @Override
+    public void beforeProcessing(ProcessorContext processorContext) {
+        result = 0;
+    }
+
+    @Override
+    public boolean process(ProducerInputStream<Tuple<Long, Integer>> inputStream,
+                           ConsumerOutputStream<Tuple<Long, Integer>> outputStream,
+                           String sourceName, ProcessorContext processorContext) throws Exception {
+        for (Tuple<Long, Integer> ignored : inputStream) {
+            result++;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean finalizeProcessor(ConsumerOutputStream<Tuple<Long, Integer>> outputStream,
+                                     ProcessorContext processorContext) throws Exception {
+        System.out.println("result=" + result + " " + processorContext.getNodeEngine().getLocalMember());
+        outputStream.consume(new Tuple2<>(0L, result));
+        return true;
+    }
+
+    @Override
+    public void afterProcessing(ProcessorContext processorContext) {
+
+    }
+
+    public static class Factory implements TupleContainerProcessorFactory {
+        public TupleContainerProcessor getProcessor(Vertex vertex) {
+            return new CountProcessor();
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/DummyProcessorForShufflingList.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/DummyProcessorForShufflingList.java
@@ -42,7 +42,7 @@ public class DummyProcessorForShufflingList implements TupleContainerProcessor<I
 
     public static class Factory implements TupleContainerProcessorFactory {
         public TupleContainerProcessor getProcessor(Vertex vertex) {
-            return new DummyProcessor();
+            return new DummyProcessorForShufflingList();
         }
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/ListProcessor.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/processors/ListProcessor.java
@@ -49,6 +49,8 @@ public class ListProcessor implements TupleContainerProcessor<Integer, String, I
         activeNode = processorContext.getNodeEngine().getHazelcastInstance().getName();
         DEBUG_COUNTER.addAndGet(inputStream.size());
 
+        System.out.println("Received node= " + activeNode);
+
         for (Tuple<Integer, String> tuple : inputStream) {
             list.put(tuple.getKey(0), tuple);
         }


### PR DESCRIPTION
Before I had an idea to skip task before some close packet would be sent from another node.

During complication of JET and cases of producer/consumer combination

hasActiveProducer definition appeared too necessary and overcomplicated.

Removed due to low value and huge potential bugs.
