### PR TITLE
Cleaned up Job interface

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/JobClusterService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/JobClusterService.java
@@ -24,7 +24,7 @@ import com.hazelcast.jet.counters.Accumulator;
 import com.hazelcast.jet.dag.DAG;
 import com.hazelcast.jet.impl.job.deployment.Chunk;
 import com.hazelcast.jet.impl.job.deployment.ChunkIterator;
-import com.hazelcast.jet.impl.job.deployment.DeploymentResource;
+import com.hazelcast.jet.config.DeploymentConfig;
 import com.hazelcast.jet.impl.statemachine.job.JobEvent;
 import com.hazelcast.jet.impl.statemachine.job.JobStateMachine;
 import com.hazelcast.jet.impl.util.JetUtil;
@@ -79,7 +79,7 @@ public abstract class JobClusterService<Payload> {
      * @param resources classpath resources
      * @param jobStateMachine    manager to work with job state-machine
      */
-    public void deploy(Set<DeploymentResource> resources, JobStateMachine jobStateMachine) {
+    public void deploy(Set<DeploymentConfig> resources, JobStateMachine jobStateMachine) {
         new OperationExecutor(
                 JobEvent.DEPLOYMENT_START,
                 JobEvent.DEPLOYMENT_SUCCESS,
@@ -294,7 +294,7 @@ public abstract class JobClusterService<Payload> {
         await(futures);
     }
 
-    private void executeDeployment(final Set<DeploymentResource> resources) {
+    private void executeDeployment(final Set<DeploymentConfig> resources) {
         Iterator<Chunk> iterator = new ChunkIterator(resources, getDeploymentChunkSize());
         List<Future> futures = new ArrayList<>();
         while (iterator.hasNext()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/client/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/client/ClientJobProxy.java
@@ -18,36 +18,28 @@ package com.hazelcast.jet.impl.job.client;
 
 import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.config.DeploymentConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.counters.Accumulator;
 import com.hazelcast.jet.dag.DAG;
 import com.hazelcast.jet.impl.job.JobClusterService;
-import com.hazelcast.jet.impl.job.deployment.DeploymentResource;
-import com.hazelcast.jet.impl.job.deployment.ResourceType;
 import com.hazelcast.jet.impl.statemachine.job.JobState;
 import com.hazelcast.jet.impl.statemachine.job.JobStateMachine;
 import com.hazelcast.jet.impl.util.JetThreadFactory;
 import com.hazelcast.jet.impl.util.JetUtil;
 import com.hazelcast.jet.job.Job;
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.util.Preconditions.checkNotNull;
-
 public class ClientJobProxy extends ClientProxy implements Job {
-    private final Set<DeploymentResource> resources;
     private final JobStateMachine jobStateMachine;
     private JobClusterService jobClusterService;
 
     public ClientJobProxy(String serviceName, String name) {
         super(serviceName, name);
-        resources = new HashSet<>();
         jobStateMachine = new JobStateMachine(name);
     }
 
@@ -68,72 +60,18 @@ public class ClientJobProxy extends ClientProxy implements Job {
         jobClusterService.init(config, jobStateMachine);
     }
 
-    private void deploy() {
-        jobClusterService.deploy(resources, jobStateMachine);
+    public void submit(DAG dag, Set<DeploymentConfig> deploymentConfigs) {
+        deploy(deploymentConfigs);
+        submit0(dag);
     }
 
-    @Override
-    public void submit(DAG dag) {
-        deploy();
-        submit0(dag);
+    private void deploy(Set<DeploymentConfig> deploymentConfigs) {
+        jobClusterService.deploy(deploymentConfigs, jobStateMachine);
     }
 
     private void submit0(final DAG dag) {
         jobClusterService.submitDag(dag, jobStateMachine);
     }
-
-    @Override
-    public void addClass(Class... classes) {
-        checkNotNull(classes, "Classes can not be null");
-
-        for (Class clazz : classes) {
-            try {
-                resources.add(new DeploymentResource(clazz));
-            } catch (IOException e) {
-                JetUtil.reThrow(e);
-            }
-        }
-    }
-
-    @Override
-    public void addClass(URL url, String name) {
-        checkNotNull(name, "Class name cannot be null");
-        add(url, name, ResourceType.CLASS);
-    }
-
-    @Override
-    public void addJar(URL url) {
-        addJar(url, getFileName(url));
-    }
-
-    @Override
-    public void addJar(URL url, String name) {
-        add(url, name, ResourceType.JAR);
-    }
-
-    @Override
-    public void addResource(URL url) {
-        addResource(url, getFileName(url));
-    }
-
-    @Override
-    public void addResource(URL url, String name) {
-        add(url, name, ResourceType.DATA);
-    }
-
-    private void add(URL url, String name, ResourceType type) {
-        try {
-            resources.add(new DeploymentResource(url, name, type));
-        } catch (IOException e) {
-            throw JetUtil.reThrow(e);
-        }
-    }
-
-    private String getFileName(URL url) {
-        String urlFile = url.getFile();
-        return urlFile.substring(urlFile.lastIndexOf('/') + 1, urlFile.length());
-    }
-
 
     @Override
     public JobState getJobState() {
@@ -153,7 +91,6 @@ public class ClientJobProxy extends ClientProxy implements Job {
     @Override
     protected boolean preDestroy() {
         try {
-            resources.clear();
             jobClusterService.destroy(jobStateMachine).get();
             return true;
         } catch (Exception e) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/AbstractDeploymentStorage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/AbstractDeploymentStorage.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class AbstractDeploymentStorage<S> implements DeploymentStorage {
-    protected final Map<ResourceDescriptor, S> resources = new ConcurrentHashMap<>();
+    protected final Map<DeploymentDescriptor, S> resources = new ConcurrentHashMap<>();
 
     protected final JobConfig config;
 
@@ -47,12 +47,12 @@ public abstract class AbstractDeploymentStorage<S> implements DeploymentStorage 
 
     protected abstract void setChunk(S resource, Chunk chunk);
 
-    protected abstract S createResource(ResourceDescriptor descriptor);
+    protected abstract S createResource(DeploymentDescriptor descriptor);
 
-    public Map<ResourceDescriptor, ResourceStream> getResources() throws IOException {
-        Map<ResourceDescriptor, ResourceStream> resourceStreams = new LinkedHashMap<>(resources.size());
+    public Map<DeploymentDescriptor, ResourceStream> getResources() throws IOException {
+        Map<DeploymentDescriptor, ResourceStream> resourceStreams = new LinkedHashMap<>(resources.size());
 
-        for (Map.Entry<ResourceDescriptor, S> entry : this.resources.entrySet()) {
+        for (Map.Entry<DeploymentDescriptor, S> entry : this.resources.entrySet()) {
             resourceStreams.put(entry.getKey(), asResourceStream(entry.getValue()));
         }
 
@@ -60,7 +60,7 @@ public abstract class AbstractDeploymentStorage<S> implements DeploymentStorage 
     }
 
     public synchronized void receiveChunk(Chunk chunk) {
-        ResourceDescriptor descriptor = chunk.getDescriptor();
+        DeploymentDescriptor descriptor = chunk.getDescriptor();
         if (!resources.containsKey(descriptor)) {
             createResource(descriptor);
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/Chunk.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/Chunk.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 public class Chunk implements DataSerializable {
     private byte[] bytes;
-    private ResourceDescriptor descriptor;
+    private DeploymentDescriptor descriptor;
     private int chunkSize;
     private int length;
     private int sequence;
@@ -34,7 +34,7 @@ public class Chunk implements DataSerializable {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP")
-    public Chunk(byte[] bytes, ResourceDescriptor descriptor, int chunkSize, int length, int sequence) {
+    public Chunk(byte[] bytes, DeploymentDescriptor descriptor, int chunkSize, int length, int sequence) {
         this.bytes = bytes;
         this.chunkSize = chunkSize;
         this.length = length;
@@ -47,7 +47,7 @@ public class Chunk implements DataSerializable {
         return bytes;
     }
 
-    public ResourceDescriptor getDescriptor() {
+    public DeploymentDescriptor getDescriptor() {
         return descriptor;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DeploymentDescriptor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DeploymentDescriptor.java
@@ -18,17 +18,17 @@ package com.hazelcast.jet.impl.job.deployment;
 
 import java.io.Serializable;
 
-public class ResourceDescriptor implements Serializable {
+public class DeploymentDescriptor implements Serializable {
     private final String name;
-    private final ResourceType resourceType;
+    private final DeploymentType deploymentType;
 
-    public ResourceDescriptor(String name, ResourceType resourceType) {
+    public DeploymentDescriptor(String name, DeploymentType deploymentType) {
         this.name = name;
-        this.resourceType = resourceType;
+        this.deploymentType = deploymentType;
     }
 
-    public ResourceType getResourceType() {
-        return this.resourceType;
+    public DeploymentType getDeploymentType() {
+        return this.deploymentType;
     }
 
     public String getName() {
@@ -45,28 +45,28 @@ public class ResourceDescriptor implements Serializable {
             return false;
         }
 
-        ResourceDescriptor that = (ResourceDescriptor) o;
+        DeploymentDescriptor that = (DeploymentDescriptor) o;
 
         if (!this.name.equals(that.name)) {
             return false;
         }
 
-        return resourceType == that.resourceType;
+        return deploymentType == that.deploymentType;
 
     }
 
     @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + resourceType.hashCode();
+        result = 31 * result + deploymentType.hashCode();
         return result;
     }
 
     @Override
     public String toString() {
-        return "ResourceDescriptor{"
+        return "DeploymentDescriptor{"
                 + "name='" + name + '\''
-                + ", resourceType=" + resourceType
+                + ", deploymentType=" + deploymentType
                 + '}';
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DeploymentStorage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DeploymentStorage.java
@@ -48,7 +48,7 @@ public interface DeploymentStorage {
      * @return all resources stored in storage
      * @throws IOException if IOException
      */
-    Map<ResourceDescriptor, ResourceStream> getResources() throws IOException;
+    Map<DeploymentDescriptor, ResourceStream> getResources() throws IOException;
 
     /**
      * Clean-up all data in storage

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DeploymentType.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DeploymentType.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.impl.job.deployment;
 
 import java.io.Serializable;
 
-public enum ResourceType implements Serializable {
+public enum DeploymentType implements Serializable {
     JAR,
     CLASS,
     DATA

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DiskDeploymentStorage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/DiskDeploymentStorage.java
@@ -97,7 +97,7 @@ public class DiskDeploymentStorage extends AbstractDeploymentStorage<File> {
     }
 
     @Override
-    protected File createResource(ResourceDescriptor descriptor) {
+    protected File createResource(DeploymentDescriptor descriptor) {
         String path = getPath();
         File file = new File(path);
         if (!file.exists()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/classloader/JobClassLoader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/deployment/classloader/JobClassLoader.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.impl.job.deployment.classloader;
 
 import com.hazelcast.jet.impl.job.deployment.DeploymentStorage;
 import com.hazelcast.jet.impl.job.deployment.JetClassLoaderException;
-import com.hazelcast.jet.impl.job.deployment.ResourceDescriptor;
+import com.hazelcast.jet.impl.job.deployment.DeploymentDescriptor;
 import com.hazelcast.jet.impl.util.JetUtil;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
@@ -236,10 +236,10 @@ public class JobClassLoader extends ClassLoader {
         private final Map<String, ClassLoaderEntry> dataEntries = new HashMap<>();
         private final Map<String, ClassLoaderEntry> classEntries = new HashMap<>();
 
-        JobUserClassLoader(Map<ResourceDescriptor, ResourceStream> resourceMap) {
-            for (Map.Entry<ResourceDescriptor, ResourceStream> entry : resourceMap.entrySet()) {
-                ResourceDescriptor descriptor = entry.getKey();
-                switch (descriptor.getResourceType()) {
+        JobUserClassLoader(Map<DeploymentDescriptor, ResourceStream> resourceMap) {
+            for (Map.Entry<DeploymentDescriptor, ResourceStream> entry : resourceMap.entrySet()) {
+                DeploymentDescriptor descriptor = entry.getKey();
+                switch (descriptor.getDeploymentType()) {
                     case JAR:
                         loadJarStream(entry.getValue());
                         break;
@@ -315,12 +315,12 @@ public class JobClassLoader extends ClassLoader {
             return url;
         }
 
-        private void loadClassStream(ResourceDescriptor descriptor, ResourceStream resourceStream) {
+        private void loadClassStream(DeploymentDescriptor descriptor, ResourceStream resourceStream) {
             byte[] classBytes = JetUtil.readFully(resourceStream.getInputStream());
             classEntries.put(descriptor.getName(), new ClassLoaderEntry(classBytes, resourceStream.getBaseUrl()));
         }
 
-        private void loadDataStream(ResourceDescriptor descriptor, ResourceStream resourceStream) {
+        private void loadDataStream(DeploymentDescriptor descriptor, ResourceStream resourceStream) {
             byte[] bytes = JetUtil.readFully(resourceStream.getInputStream());
             dataEntries.put(descriptor.getName(), new ClassLoaderEntry(bytes, resourceStream.getBaseUrl()));
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/job/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/job/Job.java
@@ -19,9 +19,7 @@ package com.hazelcast.jet.job;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.counters.Accumulator;
-import com.hazelcast.jet.dag.DAG;
 import com.hazelcast.jet.impl.statemachine.job.JobState;
-import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.Future;
 
@@ -29,58 +27,6 @@ import java.util.concurrent.Future;
  * Represents abstract job
  */
 public interface Job extends DistributedObject {
-    /**
-     * Submit dag to the cluster
-     *
-     * @param dag Direct acyclic graph, which describes calculation flow
-     */
-    void submit(DAG dag);
-
-
-    /**
-     * Add class to the job classLoader
-     *
-     * @param classes classes, which will be used during calculation
-     */
-    void addClass(Class... classes);
-
-    /**
-     * Add class to the job classLoader
-     *
-     * @param url       location of the class file
-     * @param className fully qualified name of the class
-     */
-    void addClass(URL url, String className);
-
-    /**
-     * Add JAR to the job classLoader
-     *
-     * @param url location of the JAR file
-     */
-    void addJar(URL url);
-
-    /**
-     * Add JAR to the job classLoader
-     *
-     * @param url  location of the JAR file
-     * @param name name of the JAR file
-     */
-    void addJar(URL url, String name);
-
-    /**
-     * Add resource to the job classLoader
-     *
-     * @param url source url with classes
-     */
-    void addResource(URL url);
-
-    /**
-     * Add resource to the job classLoader
-     *
-     * @param url  source url with classes
-     * @param name name of the resource
-     */
-    void addResource(URL url, String name) ;
 
     /**
      * @return state for the job's state-machine

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/AccumulatorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/AccumulatorTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.container.ProcessorContext;
 import com.hazelcast.jet.counters.Accumulator;
 import com.hazelcast.jet.dag.DAG;
@@ -27,16 +26,16 @@ import com.hazelcast.jet.dag.source.MapSource;
 import com.hazelcast.jet.data.io.ConsumerOutputStream;
 import com.hazelcast.jet.data.io.ProducerInputStream;
 import com.hazelcast.jet.impl.counters.LongCounter;
+import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.processor.ContainerProcessor;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
 
@@ -59,13 +58,12 @@ public class AccumulatorTest extends JetTestSupport {
         IMap<Integer, Integer> map = getMap(instance);
         fillMapWithInts(map, COUNT);
 
-        final Job job = JetEngine.getJob(instance, "emptyProducerNoConsumer");
         DAG dag = new DAG();
         Vertex vertex = createVertex("accumulator", AccumulatorProcessor.class);
         vertex.addSource(new MapSource(map));
         dag.addVertex(vertex);
 
-        job.submit(dag);
+        final Job job = JetEngine.getJob(instance, "emptyProducerNoConsumer", dag);
         try {
             job.execute().get();
             Accumulator accumulator = job.getAccumulators().get(AccumulatorProcessor.ACCUMULATOR_KEY);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ConsumerProducerTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ConsumerProducerTest.java
@@ -18,16 +18,16 @@ package com.hazelcast.jet;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.container.ProcessorContext;
 import com.hazelcast.jet.dag.DAG;
 import com.hazelcast.jet.dag.Edge;
 import com.hazelcast.jet.dag.Vertex;
 import com.hazelcast.jet.dag.sink.ListSink;
 import com.hazelcast.jet.dag.source.ListSource;
-import com.hazelcast.jet.data.io.ConsumerOutputStream;
 import com.hazelcast.jet.data.JetPair;
+import com.hazelcast.jet.data.io.ConsumerOutputStream;
 import com.hazelcast.jet.io.Pair;
+import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.processor.ContainerProcessor;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -52,7 +52,6 @@ public class ConsumerProducerTest extends JetTestSupport {
 
     @Test
     public void testFinalization_whenEmptyProducerWithNoConsumer() throws Exception {
-        final Job job = JetEngine.getJob(instance, "emptyProducerNoConsumer");
         DAG dag = new DAG();
 
         IList<String> sourceList = getList(instance);
@@ -61,13 +60,12 @@ public class ConsumerProducerTest extends JetTestSupport {
 
         dag.addVertex(producer);
 
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, "emptyProducerNoConsumer", dag);
         execute(job);
     }
 
     @Test
     public void testFinalization_whenEmptyProducerWithConsumer() throws Exception {
-        final Job job = JetEngine.getJob(instance, "emptyProducerWithConsumer");
         DAG dag = new DAG();
 
         IList<String> sourceList = getList(instance);
@@ -82,7 +80,7 @@ public class ConsumerProducerTest extends JetTestSupport {
         dag.addVertex(consumer);
         dag.addEdge(new Edge("", producer, consumer));
 
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, "emptyProducerWithConsumer", dag);
         execute(job);
 
         assertEquals(TASK_COUNT * NODE_COUNT, sinkList.size());
@@ -90,19 +88,18 @@ public class ConsumerProducerTest extends JetTestSupport {
 
     @Test
     public void testArrayProducer() throws Exception {
-        Job job = JetEngine.getJob(instance, "arrayProducer");
         IList<Integer[]> sourceList = getList(instance);
         IList<Integer[]> sinkList = getList(instance);
         DAG dag = new DAG();
         int count = 10;
         for (int i = 0; i < count; i++) {
-            sourceList.add(new Integer[] {i});
+            sourceList.add(new Integer[]{i});
         }
         Vertex vertex = createVertex("vertex", TestProcessors.Noop.class, 1);
         vertex.addSource(new ListSource(sourceList));
         vertex.addSink(new ListSink(sinkList));
         dag.addVertex(vertex);
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, "arrayProducer", dag);
         execute(job);
         for (int i = 0; i < count; i++) {
             assertEquals(i, (int) sinkList.get(i)[0]);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ProcessingStrategyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ProcessingStrategyTest.java
@@ -2,12 +2,12 @@ package com.hazelcast.jet;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
-import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.dag.DAG;
 import com.hazelcast.jet.dag.Edge;
 import com.hazelcast.jet.dag.Vertex;
 import com.hazelcast.jet.dag.sink.ListSink;
 import com.hazelcast.jet.dag.source.ListSource;
+import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.strategy.ProcessingStrategy;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -44,8 +44,6 @@ public class ProcessingStrategyTest extends JetTestSupport {
     }
 
     private int getCountWithStrategy(ProcessingStrategy processingStrategy) throws Exception {
-        Job job = JetEngine.getJob(instance, processingStrategy.toString());
-
         IList<Integer> source = getList(instance);
         IList<Integer> sink = getList(instance);
         fillListWithInts(source, COUNT);
@@ -64,7 +62,7 @@ public class ProcessingStrategyTest extends JetTestSupport {
                 processingStrategy(processingStrategy)
                 .build());
 
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, processingStrategy.toString(), dag);
         execute(job);
 
         return sink.size();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SourceSinkTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SourceSinkTest.java
@@ -29,11 +29,11 @@ import com.hazelcast.jet.dag.sink.MapSink;
 import com.hazelcast.jet.dag.source.FileSource;
 import com.hazelcast.jet.dag.source.ListSource;
 import com.hazelcast.jet.dag.source.MapSource;
+import com.hazelcast.jet.data.JetPair;
 import com.hazelcast.jet.data.io.ConsumerOutputStream;
 import com.hazelcast.jet.data.io.ProducerInputStream;
-import com.hazelcast.jet.data.JetPair;
-import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.io.Pair;
+import com.hazelcast.jet.job.Job;
 import com.hazelcast.jet.processor.ContainerProcessor;
 import com.hazelcast.jet.strategy.SingleNodeShufflingStrategy;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -66,7 +66,6 @@ public class SourceSinkTest extends JetTestSupport {
 
     @Test
     public void testMapToList() throws Exception {
-        Job job = JetEngine.getJob(instance, "mapToList");
         IMap<Integer, Integer> sourceMap = getMap(instance);
         IList<Integer> sinkList = getList(instance);
         fillMapWithInts(sourceMap, COUNT);
@@ -76,7 +75,7 @@ public class SourceSinkTest extends JetTestSupport {
         vertex.addSource(new MapSource(sourceMap));
         vertex.addSink(new ListSink(sinkList));
         dag.addVertex(vertex);
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, "mapToList", dag);
 
         execute(job);
 
@@ -85,7 +84,6 @@ public class SourceSinkTest extends JetTestSupport {
 
     @Test
     public void testListToList() throws Exception {
-        Job job = JetEngine.getJob(instance, "listToList");
 
         IList<Integer> sourceList = getList(instance);
         fillListWithInts(sourceList, COUNT);
@@ -98,7 +96,7 @@ public class SourceSinkTest extends JetTestSupport {
         vertex.addSink(new ListSink(targetList));
         dag.addVertex(vertex);
 
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, "listToList", dag);
 
         execute(job);
         assertEquals(COUNT, targetList.size());
@@ -106,7 +104,6 @@ public class SourceSinkTest extends JetTestSupport {
 
     @Test
     public void testMapToMultipleSinks() throws Exception {
-        Job job = JetEngine.getJob(instance, "multipleSinks");
 
         IMap<Integer, Integer> sourceMap = instance.getMap("sourceMap");
 
@@ -126,7 +123,7 @@ public class SourceSinkTest extends JetTestSupport {
         dag.addVertex(vertex1);
         dag.addVertex(vertex2);
         dag.addEdge(new Edge("edge", vertex1, vertex2));
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, "multipleSinks", dag);
 
         execute(job);
 
@@ -136,7 +133,6 @@ public class SourceSinkTest extends JetTestSupport {
 
     @Test
     public void testFileToFile() throws Exception {
-        Job job = JetEngine.getJob(instance, "fileToFile");
 
         File input = createInputFile();
         File output = File.createTempFile("output", null);
@@ -159,7 +155,7 @@ public class SourceSinkTest extends JetTestSupport {
                 .build();
         dag.addEdge(edge);
 
-        job.submit(dag);
+        Job job = JetEngine.getJob(instance, "fileToFile", dag);
         execute(job);
 
         List<String> files = Files.readAllLines(output.toPath());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/job/deployment/AbstractDeploymentTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/job/deployment/AbstractDeploymentTest.java
@@ -1,0 +1,189 @@
+package com.hazelcast.jet.impl.job.deployment;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.JetEngine;
+import com.hazelcast.jet.JetTestSupport;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.dag.DAG;
+import com.hazelcast.jet.impl.job.deployment.processors.ApacheV1;
+import com.hazelcast.jet.impl.job.deployment.processors.ApacheV2;
+import com.hazelcast.jet.impl.job.deployment.processors.PrintCarVertex;
+import com.hazelcast.jet.impl.job.deployment.processors.PrintPersonVertex;
+import com.hazelcast.jet.job.Job;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.Future;
+import java.util.zip.GZIPInputStream;
+import org.junit.Test;
+
+public abstract class AbstractDeploymentTest extends JetTestSupport {
+
+    abstract TestHazelcastInstanceFactory getFactory();
+
+    abstract HazelcastInstance getHazelcastInstance();
+
+    @Test
+    public void test_Jar_Distribution() throws Exception {
+        getFactory().newInstances(new Config(), 3);
+
+        DAG dag = new DAG();
+        dag.addVertex(createVertex("create and print person", PrintPersonVertex.class));
+
+        String name = generateRandomString(10);
+        JobConfig jobConfig = new JobConfig(name);
+        jobConfig.addJar(this.getClass().getResource("/sample-pojo-1.0-person.jar"));
+        Job job = JetEngine.getJob(getHazelcastInstance(), name, dag, jobConfig);
+
+        execute(job);
+    }
+
+    @Test
+    public void test_Class_Distribution() throws Exception {
+        getFactory().newInstances(new Config(), 3);
+
+        DAG dag = new DAG();
+        dag.addVertex(createVertex("create and print person", PrintPersonVertex.class));
+
+        String name = generateRandomString(10);
+        JobConfig jobConfig = new JobConfig(name);
+        URL gzipResource = this.getClass().getResource("/Person$Appereance.class.gz");
+        File classFile = createClassFileFromGzip(gzipResource, "Person$Appereance.class");
+        jobConfig.addClass(classFile.toURI().toURL(), "com.sample.pojo.person.Person$Appereance");
+        Job job = JetEngine.getJob(getHazelcastInstance(), name, dag, jobConfig);
+
+        execute(job);
+
+    }
+
+    @Test
+    public void test_Resource_Distribution() throws Exception {
+        getFactory().newInstances(new Config(), 3);
+
+        DAG dag = new DAG();
+        dag.addVertex(createVertex("apachev1", ApacheV1.class));
+
+        String name = generateRandomString(10);
+        JobConfig jobConfig = new JobConfig(name);
+        jobConfig.addResource(new URL("http://www.apache.org/licenses/LICENSE-1.1.txt"), "apachev1");
+        Job job = JetEngine.getJob(getHazelcastInstance(), name, dag, jobConfig);
+
+        execute(job);
+    }
+
+    @Test
+    public void test_Jar_Isolation() throws Exception {
+        getFactory().newInstances(new Config(), 3);
+
+        DAG dag1 = new DAG();
+        dag1.addVertex(createVertex("create and print person", PrintPersonVertex.class));
+        String name1 = generateRandomString(10);
+        JobConfig jobConfig1 = new JobConfig(name1);
+        jobConfig1.addJar(this.getClass().getResource("/sample-pojo-1.0-person.jar"));
+
+        Job job1 = JetEngine.getJob(getHazelcastInstance(), name1, dag1, jobConfig1);
+
+        DAG dag2 = new DAG();
+        dag2.addVertex(createVertex("create and print car", PrintCarVertex.class));
+        String name2 = generateRandomString(10);
+        JobConfig jobConfig2 = new JobConfig(name2);
+        jobConfig2.addJar(this.getClass().getResource("/sample-pojo-1.0-car.jar"));
+
+        Job job2 = JetEngine.getJob(getHazelcastInstance(), name2, dag2, jobConfig2);
+
+        Future f1 = job1.execute();
+        Future f2 = job2.execute();
+
+        assertCompletesEventually(f1);
+        assertCompletesEventually(f2);
+
+        f1.get();
+        f2.get();
+    }
+
+    @Test
+    public void test_Class_Isolation() throws Exception {
+        getFactory().newInstances(new Config(), 3);
+
+        DAG dag1 = new DAG();
+        dag1.addVertex(createVertex("create and print person", PrintPersonVertex.class));
+        URL gzipResource1 = this.getClass().getResource("/Person$Appereance.class.gz");
+        File classFile1 = createClassFileFromGzip(gzipResource1, "Person$Appereance.class");
+        String name1 = generateRandomString(10);
+        JobConfig jobConfig1 = new JobConfig(name1);
+        jobConfig1.addClass(classFile1.toURI().toURL(), "com.sample.pojo.person.Person$Appereance");
+
+        Job job1 = JetEngine.getJob(getHazelcastInstance(), name1, dag1, jobConfig1);
+
+
+        DAG dag2 = new DAG();
+        dag2.addVertex(createVertex("create and print car", PrintCarVertex.class));
+        URL gzipResource2 = this.getClass().getResource("/Car.class.gz");
+        File classFile2 = createClassFileFromGzip(gzipResource2, "Car.class");
+        String name2 = generateRandomString(10);
+        JobConfig jobConfig2 = new JobConfig(name2);
+        jobConfig2.addClass(classFile2.toURI().toURL(), "com.sample.pojo.car.Car");
+
+        Job job2 = JetEngine.getJob(getHazelcastInstance(), name2, dag2, jobConfig2);
+
+        Future f1 = job1.execute();
+        Future f2 = job2.execute();
+
+        assertCompletesEventually(f1);
+        assertCompletesEventually(f2);
+        f1.get();
+        f2.get();
+    }
+
+    @Test
+    public void test_Resource_Isolation() throws Exception {
+        getFactory().newInstances(new Config(), 3);
+
+        DAG dag1 = new DAG();
+        dag1.addVertex(createVertex("apachev1", ApacheV1.class));
+        String name1 = generateRandomString(10);
+        JobConfig jobConfig1 = new JobConfig(name1);
+        jobConfig1.addResource(new URL("http://www.apache.org/licenses/LICENSE-1.1.txt"), "apachev1");
+
+        Job job1 = JetEngine.getJob(getHazelcastInstance(), name1, dag1, jobConfig1);
+
+
+        DAG dag2 = new DAG();
+        dag2.addVertex(createVertex("apachev2", ApacheV2.class));
+        String name2 = generateRandomString(10);
+        JobConfig jobConfig2 = new JobConfig(name2);
+        jobConfig2.addResource(new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"), "apachev2");
+
+        Job job2 = JetEngine.getJob(getHazelcastInstance(), name2, dag2, jobConfig2);
+
+        Future f1 = job1.execute();
+        Future f2 = job2.execute();
+
+        assertCompletesEventually(f1);
+        assertCompletesEventually(f2);
+
+        f1.get();
+        f2.get();
+
+    }
+
+    private File createClassFileFromGzip(URL gzipResource, String className) throws IOException {
+        GZIPInputStream inputStream = new GZIPInputStream(gzipResource.openStream());
+        String tempDir = System.getProperty("java.io.tmpdir");
+        File classFile = new File(tempDir, className);
+        classFile.deleteOnExit();
+        FileOutputStream outputStream = new FileOutputStream(classFile);
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = inputStream.read(buffer)) != -1) {
+            outputStream.write(buffer, 0, len);
+        }
+        outputStream.flush();
+        outputStream.close();
+        inputStream.close();
+        return classFile;
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/job/deployment/ClientDeploymentTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/job/deployment/ClientDeploymentTest.java
@@ -1,33 +1,17 @@
 package com.hazelcast.jet.impl.job.deployment;
 
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.jet.JetEngine;
-import com.hazelcast.jet.JetTestSupport;
-import com.hazelcast.jet.dag.DAG;
-import com.hazelcast.jet.impl.job.deployment.processors.ApacheV1;
-import com.hazelcast.jet.impl.job.deployment.processors.ApacheV2;
-import com.hazelcast.jet.impl.job.deployment.processors.PrintCarVertex;
-import com.hazelcast.jet.impl.job.deployment.processors.PrintPersonVertex;
-import com.hazelcast.jet.job.Job;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.Future;
-import java.util.zip.GZIPInputStream;
 import org.junit.After;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
-public class ClientDeploymentTest extends JetTestSupport {
+public class ClientDeploymentTest extends AbstractDeploymentTest {
 
     private TestHazelcastFactory factory = new TestHazelcastFactory();
 
@@ -36,156 +20,14 @@ public class ClientDeploymentTest extends JetTestSupport {
         factory.terminateAll();
     }
 
-    @Test
-    public void test_Jar_Distribution() throws Exception {
-        factory.newInstances(new Config(), 3);
-        final Job job = JetEngine.getJob(factory.newHazelcastClient(), generateRandomString(10));
 
-        DAG dag = new DAG();
-        dag.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        job.addJar(this.getClass().getResource("/sample-pojo-1.0-person.jar"));
-
-        job.submit(dag);
-        execute(job);
+    @Override
+    TestHazelcastInstanceFactory getFactory() {
+        return factory;
     }
 
-
-    @Test
-    public void test_Class_Distribution() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job = JetEngine.getJob(instances[0], generateRandomString(10));
-
-        DAG dag = new DAG();
-        dag.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        URL gzipResource = this.getClass().getResource("/Person$Appereance.class.gz");
-        File classFile = createClassFileFromGzip(gzipResource, "Person$Appereance.class");
-
-        job.addClass(classFile.toURI().toURL(), "com.sample.pojo.person.Person$Appereance");
-
-        job.submit(dag);
-        execute(job);
-
+    @Override
+    HazelcastInstance getHazelcastInstance() {
+        return factory.newHazelcastClient();
     }
-
-
-    @Test
-    public void test_Resource_Distribution() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job = JetEngine.getJob(instances[0], generateRandomString(10));
-        DAG dag = new DAG();
-        dag.addVertex(createVertex("apachev1", ApacheV1.class));
-        job.addResource(new URL("http://www.apache.org/licenses/LICENSE-1.1.txt"), "apachev1");
-        job.submit(dag);
-        execute(job);
-    }
-
-
-    @Test
-    public void test_Jar_Isolation() throws Exception {
-        factory.newInstances(new Config(), 3);
-        HazelcastInstance client = factory.newHazelcastClient();
-        final Job job1 = JetEngine.getJob(client, generateRandomString(10));
-        final Job job2 = JetEngine.getJob(client, generateRandomString(10));
-
-        DAG dag1 = new DAG();
-        dag1.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        job1.addJar(this.getClass().getResource("/sample-pojo-1.0-person.jar"));
-        job1.submit(dag1);
-
-        DAG dag2 = new DAG();
-        dag2.addVertex(createVertex("create and print car", PrintCarVertex.class));
-        job2.addJar(this.getClass().getResource("/sample-pojo-1.0-car.jar"));
-        job2.submit(dag2);
-
-        Future f1 = job1.execute();
-        Future f2 = job2.execute();
-
-        assertCompletesEventually(f1);
-        assertCompletesEventually(f2);
-
-        f1.get();
-        f2.get();
-    }
-
-    @Test
-    public void test_Class_Isolation() throws Exception {
-        factory.newInstances(new Config(), 3);
-        HazelcastInstance client = factory.newHazelcastClient();
-        final Job job1 = JetEngine.getJob(client, generateRandomString(10));
-        final Job job2 = JetEngine.getJob(client, generateRandomString(10));
-
-        DAG dag1 = new DAG();
-        dag1.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        URL gzipResource1 = this.getClass().getResource("/Person$Appereance.class.gz");
-        File classFile1 = createClassFileFromGzip(gzipResource1, "Person$Appereance.class");
-        job1.addClass(classFile1.toURI().toURL(), "com.sample.pojo.person.Person$Appereance");
-        job1.submit(dag1);
-
-
-        DAG dag2 = new DAG();
-        dag2.addVertex(createVertex("create and print car", PrintCarVertex.class));
-        URL gzipResource2 = this.getClass().getResource("/Car.class.gz");
-        File classFile2 = createClassFileFromGzip(gzipResource2, "Car.class");
-        job2.addClass(classFile2.toURI().toURL(), "com.sample.pojo.car.Car");
-
-        job2.submit(dag2);
-
-        Future f1 = job1.execute();
-        Future f2 = job2.execute();
-
-        assertCompletesEventually(f1);
-        assertCompletesEventually(f2);
-        f1.get();
-        f2.get();
-    }
-
-    @Test
-    public void test_Resource_Isolation() throws Exception {
-        factory.newInstances(new Config(), 3);
-        HazelcastInstance client = factory.newHazelcastClient();
-        final Job job1 = JetEngine.getJob(client, generateRandomString(10));
-        final Job job2 = JetEngine.getJob(client, generateRandomString(10));
-
-        DAG dag1 = new DAG();
-        dag1.addVertex(createVertex("apachev1", ApacheV1.class));
-        job1.addResource(new URL("http://www.apache.org/licenses/LICENSE-1.1.txt"), "apachev1");
-        job1.submit(dag1);
-
-
-        DAG dag2 = new DAG();
-        dag2.addVertex(createVertex("apachev2", ApacheV2.class));
-        job2.addResource(new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"), "apachev2");
-        job2.submit(dag2);
-
-        Future f1 = job1.execute();
-        Future f2 = job2.execute();
-
-        assertCompletesEventually(f1);
-        assertCompletesEventually(f2);
-
-        f1.get();
-        f2.get();
-
-    }
-
-    private File createClassFileFromGzip(URL gzipResource, String className) throws IOException {
-        GZIPInputStream inputStream = new GZIPInputStream(gzipResource.openStream());
-        String tempDir = System.getProperty("java.io.tmpdir");
-        File classFile = new File(tempDir, className);
-        classFile.deleteOnExit();
-        FileOutputStream outputStream = new FileOutputStream(classFile);
-        byte[] buffer = new byte[1024];
-        int len;
-        while ((len = inputStream.read(buffer)) != -1) {
-            outputStream.write(buffer, 0, len);
-        }
-        outputStream.flush();
-        outputStream.close();
-        inputStream.close();
-        return classFile;
-    }
-
-
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/job/deployment/DeploymentTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/job/deployment/DeploymentTest.java
@@ -1,181 +1,32 @@
 package com.hazelcast.jet.impl.job.deployment;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.jet.JetEngine;
-import com.hazelcast.jet.JetTestSupport;
-import com.hazelcast.jet.dag.DAG;
-import com.hazelcast.jet.impl.job.deployment.processors.ApacheV1;
-import com.hazelcast.jet.impl.job.deployment.processors.ApacheV2;
-import com.hazelcast.jet.impl.job.deployment.processors.PrintCarVertex;
-import com.hazelcast.jet.impl.job.deployment.processors.PrintPersonVertex;
-import com.hazelcast.jet.job.Job;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.URL;
-import java.util.concurrent.Future;
-import java.util.zip.GZIPInputStream;
-import org.junit.Test;
+import org.junit.After;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
-public class DeploymentTest extends JetTestSupport {
+public class DeploymentTest extends AbstractDeploymentTest {
 
-    @Test
-    public void test_Jar_Distribution() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job = JetEngine.getJob(instances[0], generateRandomString(10));
+    private TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
 
-        DAG dag = new DAG();
-        dag.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        job.addJar(this.getClass().getResource("/sample-pojo-1.0-person.jar"));
-        job.submit(dag);
-        execute(job);
+    @After
+    public void tearDown() {
+        factory.terminateAll();
     }
 
-
-    @Test
-    public void test_Class_Distribution() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job = JetEngine.getJob(instances[0], generateRandomString(10));
-
-        DAG dag = new DAG();
-        dag.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        URL gzipResource = this.getClass().getResource("/Person$Appereance.class.gz");
-        File classFile = createClassFileFromGzip(gzipResource, "Person$Appereance.class");
-
-        job.addClass(classFile.toURI().toURL(), "com.sample.pojo.person.Person$Appereance");
-
-        job.submit(dag);
-        execute(job);
-
+    @Override
+    TestHazelcastInstanceFactory getFactory() {
+        return factory;
     }
 
-    @Test
-    public void test_Resource_Distribution() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job = JetEngine.getJob(instances[0], generateRandomString(10));
-        DAG dag = new DAG();
-        dag.addVertex(createVertex("apachev1", ApacheV1.class));
-        job.addResource(new URL("http://www.apache.org/licenses/LICENSE-1.1.txt"), "apachev1");
-        job.submit(dag);
-        execute(job);
+    @Override
+    HazelcastInstance getHazelcastInstance() {
+        return factory.getAllHazelcastInstances().iterator().next();
     }
-
-
-    @Test
-    public void test_Jar_Isolation() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job1 = JetEngine.getJob(instances[0], generateRandomString(10));
-        final Job job2 = JetEngine.getJob(instances[0], generateRandomString(10));
-
-        DAG dag1 = new DAG();
-        dag1.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        job1.addJar(this.getClass().getResource("/sample-pojo-1.0-person.jar"));
-        job1.submit(dag1);
-
-        DAG dag2 = new DAG();
-        dag2.addVertex(createVertex("create and print car", PrintCarVertex.class));
-        job2.addJar(this.getClass().getResource("/sample-pojo-1.0-car.jar"));
-        job2.submit(dag2);
-
-        Future f1 = job1.execute();
-        Future f2 = job2.execute();
-
-        assertCompletesEventually(f1);
-        assertCompletesEventually(f2);
-        f1.get();
-        f2.get();
-    }
-
-
-    @Test
-    public void test_Class_Isolation() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job1 = JetEngine.getJob(instances[0], generateRandomString(10));
-        final Job job2 = JetEngine.getJob(instances[0], generateRandomString(10));
-
-        DAG dag1 = new DAG();
-
-        dag1.addVertex(createVertex("create and print person", PrintPersonVertex.class));
-        URL gzipResource1 = this.getClass().getResource("/Person$Appereance.class.gz");
-        File classFile1 = createClassFileFromGzip(gzipResource1, "Person$Appereance.class");
-        job1.addClass(classFile1.toURI().toURL(), "com.sample.pojo.person.Person$Appereance");
-        job1.submit(dag1);
-
-
-        DAG dag2 = new DAG();
-        dag2.addVertex(createVertex("create and print car", PrintCarVertex.class));
-        URL gzipResource2 = this.getClass().getResource("/Car.class.gz");
-        File classFile2 = createClassFileFromGzip(gzipResource2, "Car.class");
-        job2.addClass(classFile2.toURI().toURL(), "com.sample.pojo.car.Car");
-
-        job2.submit(dag2);
-
-        Future f1 = job1.execute();
-        Future f2 = job2.execute();
-
-        assertCompletesEventually(f1);
-        assertCompletesEventually(f2);
-        f1.get();
-        f2.get();
-    }
-
-    @Test
-    public void test_Resource_Isolation() throws Exception {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
-        HazelcastInstance[] instances = factory.newInstances();
-        final Job job1 = JetEngine.getJob(instances[0], generateRandomString(10));
-        final Job job2 = JetEngine.getJob(instances[0], generateRandomString(10));
-
-        DAG dag1 = new DAG();
-        dag1.addVertex(createVertex("apachev1", ApacheV1.class));
-        job1.addResource(new URL("http://www.apache.org/licenses/LICENSE-1.1.txt"), "apachev1");
-        job1.submit(dag1);
-
-
-        DAG dag2 = new DAG();
-        dag2.addVertex(createVertex("apachev2", ApacheV2.class));
-        job2.addResource(new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"), "apachev2");
-        job2.submit(dag2);
-
-        Future f1 = job1.execute();
-        Future f2 = job2.execute();
-
-        assertCompletesEventually(f1);
-        assertCompletesEventually(f2);
-
-        f1.get();
-        f2.get();
-    }
-
-
-    private File createClassFileFromGzip(URL gzipResource, String className) throws IOException {
-        GZIPInputStream inputStream = new GZIPInputStream(gzipResource.openStream());
-        String tempDir = System.getProperty("java.io.tmpdir");
-        File classFile = new File(tempDir, className);
-        classFile.deleteOnExit();
-        FileOutputStream outputStream = new FileOutputStream(classFile);
-        byte[] buffer = new byte[1024];
-        int len;
-        while ((len = inputStream.read(buffer)) != -1) {
-            outputStream.write(buffer, 0, len);
-        }
-        outputStream.flush();
-        outputStream.close();
-        inputStream.close();
-        return classFile;
-    }
-
 
 }

--- a/hazelcast-jet-java.util.stream/src/main/java/com/hazelcast/jet/stream/impl/StreamUtil.java
+++ b/hazelcast-jet-java.util.stream/src/main/java/com/hazelcast/jet/stream/impl/StreamUtil.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.JetEngine;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.dag.DAG;
 import com.hazelcast.jet.dag.Edge;
 import com.hazelcast.jet.dag.Vertex;
@@ -33,7 +34,6 @@ import com.hazelcast.jet.stream.Distributed;
 import com.hazelcast.jet.stream.impl.pipeline.StreamContext;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.util.UuidUtil;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -83,10 +83,10 @@ public final class StreamUtil {
     }
 
     public static void executeJob(StreamContext context, DAG dag) {
-        Job job = JetEngine.getJob(context.getHazelcastInstance(), randomName());
         Set<Class> classes = context.getClasses();
-        job.addClass(classes.toArray(new Class[classes.size()]));
-        job.submit(dag);
+        JobConfig config = new JobConfig();
+        config.addClass(classes.toArray(new Class[classes.size()]));
+        Job job = JetEngine.getJob(context.getHazelcastInstance(), randomName(), dag, config);
         try {
             result(job.execute());
             context.getStreamListeners().forEach(Runnable::run);


### PR DESCRIPTION
- Moved `addClass()`,`addJar()` and `addResource()` from `Job` interface to `JobConfig` 
- `DeploymentResource` renamed to `DeploymentConfig` and became part of `JobConfig`
- `AbstractDeploymentTest` is introduced, `DeploymentTest` and  `ClientDeploymentTest` extends it.
