### PR TITLE
Prevent a failing finally from swallowing exception

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/ServerJobClusterService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/job/ServerJobClusterService.java
@@ -83,6 +83,7 @@ public class ServerJobClusterService extends JobClusterService<JetOperation> {
         return new FinishDeploymentOperation(name);
     }
 
+    @Override
     public JetOperation createEventInvoker(JobEvent jobEvent) {
         return new JobEventOperation(name, jobEvent);
     }
@@ -107,6 +108,7 @@ public class ServerJobClusterService extends JobClusterService<JetOperation> {
         return nodeEngine.toObject(data);
     }
 
+    @Override
     @SuppressWarnings("unchecked")
     public Map<String, Accumulator> readAccumulatorsResponse(Future future) throws Exception {
         return (Map<String, Accumulator>) future.get();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/statemachine/job/JobStateMachineRequestProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/statemachine/job/JobStateMachineRequestProcessor.java
@@ -59,10 +59,9 @@ public class JobStateMachineRequestProcessor implements StateMachineRequestProce
                 || (event == JobEvent.INTERRUPTION_SUCCESS)
                 ) {
             try {
-                List<Throwable> listeners = invokeListeners();
-
-                if (listeners.size() > 0) {
-                    throw new CombinedJetException(listeners);
+                List<Throwable> exceptions = invokeListeners();
+                if (!exceptions.isEmpty()) {
+                    throw new CombinedJetException(exceptions);
                 }
             } finally {
                 jobContext.getExecutorContext().getNetworkTasks().forEach(Task::destroy);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestSupport.java
@@ -32,6 +32,8 @@ import org.apache.log4j.Level;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import static com.hazelcast.jet.impl.util.JetUtil.unchecked;
+
 public class JetTestSupport extends HazelcastTestSupport {
 
     protected static TestHazelcastFactory hazelcastInstanceFactory;
@@ -88,10 +90,20 @@ public class JetTestSupport extends HazelcastTestSupport {
     }
 
     public static void execute(Job job) throws ExecutionException, InterruptedException {
+        Throwable failure = null;
         try {
             job.execute().get();
+        } catch (Throwable t) {
+            failure = t;
+            throw t;
         } finally {
-            job.destroy();
+            try {
+                job.destroy();
+            } catch (Throwable t) {
+                if (failure == null) {
+                    throw t;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
`JetTestSupport.execute` had `finally { job.destroy(); }`, which could throw
an exception and overwrite the actual exception thrown from `job.execute()`

+some code style
