### PR TITLE
Added remote cluster support to the reader/writers

### DIFF
--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-client</artifactId>
-            <scope>provided</scope>
+            <version>${hazelcast.version}</version>
         </dependency>
 
         <!--TEST DEPENDENCIES-->

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.jet.impl.IListReader;
 import com.hazelcast.jet.impl.IListWriter;
 import com.hazelcast.jet.impl.IMapReader;
@@ -37,10 +38,24 @@ public final class Processors {
     }
 
     /**
+     * @return processors for partitioned reading from a remote Hazelcast IMap
+     */
+    public static ProcessorMetaSupplier mapReader(String mapName, ClientConfig clientConfig) {
+        return IMapReader.supplier(mapName, clientConfig);
+    }
+
+    /**
      * @return processors for  writing to a Hazelcast IMap
      */
     public static ProcessorMetaSupplier mapWriter(String mapName) {
         return IMapWriter.supplier(mapName);
+    }
+
+    /**
+     * @return processors for  writing to a remote Hazelcast IMap
+     */
+    public static ProcessorMetaSupplier mapWriter(String mapName, ClientConfig clientConfig) {
+        return IMapWriter.supplier(mapName, clientConfig);
     }
 
     /**
@@ -51,9 +66,23 @@ public final class Processors {
     }
 
     /**
+     * @return processors for reading from a remote Hazelcast IList
+     */
+    public static ProcessorMetaSupplier listReader(String listName, ClientConfig clientConfig) {
+        return IListReader.supplier(listName, clientConfig);
+    }
+
+    /**
      * @return a processor for writing to a Hazelcast IList
      */
     public static ProcessorSupplier listWriter(String listName) {
         return IListWriter.supplier(listName);
+    }
+
+    /**
+     * @return a processor for writing to a remote Hazelcast IList
+     */
+    public static ProcessorSupplier listWriter(String listName, ClientConfig clientConfig) {
+        return IListWriter.supplier(listName, clientConfig);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/IListReader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/IListReader.java
@@ -16,37 +16,51 @@
 
 package com.hazelcast.jet.impl;
 
-import com.hazelcast.collection.impl.list.ListProxyImpl;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IList;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.ProcessorMetaSupplier;
 import com.hazelcast.jet.ProcessorSupplier;
 import com.hazelcast.nio.Address;
-
-import javax.annotation.Nonnull;
 import java.util.Iterator;
 import java.util.List;
+import javax.annotation.Nonnull;
 
+import static com.hazelcast.client.HazelcastClient.newHazelcastClient;
 import static java.util.Collections.singletonList;
 
 public final class IListReader extends AbstractProducer {
 
-    private final ListProxyImpl list;
-    private Iterator iterator;
+    private static final int DEFAULT_FETCH_SIZE = 16384;
 
-    private IListReader(ListProxyImpl list) {
+    private final IList list;
+    private final int fetchSize;
+    private Iterator iterator;
+    private int currentIndex;
+    private int size;
+
+    private IListReader(IList list, int fetchSize) {
         this.list = list;
+        this.fetchSize = fetchSize;
     }
 
     @Override
     public void init(@Nonnull Outbox outbox) {
         super.init(outbox);
-        this.iterator = list.iterator();
+        size = list.size();
+        if (fetchSize < size) {
+            this.iterator = list.subList(0, fetchSize).iterator();
+        } else {
+            this.iterator = list.iterator();
+        }
     }
 
     @Override
     public boolean complete() {
-        while (iterator.hasNext()) {
+        while (hasNext()) {
+            currentIndex++;
             emit(iterator.next());
             if (getOutbox().isHighWater()) {
                 return false;
@@ -55,24 +69,58 @@ public final class IListReader extends AbstractProducer {
         return true;
     }
 
+    private boolean hasNext() {
+        return iterator.hasNext() || currentIndex < size && advance();
+    }
+
+    private int getNextIndex() {
+        int jump = currentIndex + fetchSize;
+        return jump >= size ? size : jump;
+    }
+
+    private boolean advance() {
+        iterator = list.subList(currentIndex, getNextIndex()).iterator();
+        return iterator.hasNext();
+    }
+
     @Override
     public boolean isBlocking() {
         return true;
     }
 
     public static ProcessorMetaSupplier supplier(String listName) {
-        return new MetaSupplier(listName);
+        return new MetaSupplier(listName, DEFAULT_FETCH_SIZE);
+    }
+
+    public static ProcessorMetaSupplier supplier(String listName, int fetchSize) {
+        return new MetaSupplier(listName, fetchSize);
+    }
+
+    public static ProcessorMetaSupplier supplier(String listName, ClientConfig clientConfig) {
+        return new MetaSupplier(listName, clientConfig, DEFAULT_FETCH_SIZE);
+    }
+
+    public static ProcessorMetaSupplier supplier(String listName, ClientConfig clientConfig, int fetchSize) {
+        return new MetaSupplier(listName, clientConfig, fetchSize);
     }
 
     private static class MetaSupplier implements ProcessorMetaSupplier {
 
         static final long serialVersionUID = 1L;
         private final String name;
+        private final SerializableClientConfig clientConfig;
+        private final int fetchSize;
 
         private transient Address ownerAddress;
 
-        MetaSupplier(String name) {
+        MetaSupplier(String name, int fetchSize) {
+            this(name, null, fetchSize);
+        }
+
+        MetaSupplier(String name, ClientConfig clientConfig, int fetchSize) {
             this.name = name;
+            this.clientConfig = clientConfig != null ? new SerializableClientConfig(clientConfig) : null;
+            this.fetchSize = fetchSize;
         }
 
         @Override
@@ -84,7 +132,7 @@ public final class IListReader extends AbstractProducer {
         @Override
         public ProcessorSupplier get(Address address) {
             if (address.equals(ownerAddress)) {
-                return new Supplier(name);
+                return new Supplier(name, clientConfig, fetchSize);
             } else {
                 // nothing to read on other nodes
                 return (c) -> {
@@ -101,21 +149,43 @@ public final class IListReader extends AbstractProducer {
         static final long serialVersionUID = 1L;
 
         private final String name;
-        private transient ListProxyImpl list;
+        private final SerializableClientConfig clientConfig;
+        private final int fetchSize;
+        private transient IList list;
+        private transient HazelcastInstance client;
 
-        Supplier(String name) {
+        Supplier(String name, SerializableClientConfig clientConfig, int fetchSize) {
             this.name = name;
+            this.clientConfig = clientConfig;
+            this.fetchSize = fetchSize;
         }
 
         @Override
         public void init(Context context) {
-            list = (ListProxyImpl) context.getHazelcastInstance().getList(name);
+            HazelcastInstance instance;
+            if (isRemote()) {
+                instance = client = newHazelcastClient(clientConfig.asClientConfig());
+            } else {
+                instance = context.getHazelcastInstance();
+            }
+            list = instance.getList(name);
+        }
+
+        private boolean isRemote() {
+            return clientConfig != null;
+        }
+
+        @Override
+        public void complete(Throwable error) {
+            if (client != null) {
+                client.shutdown();
+            }
         }
 
         @Override
         public List<Processor> get(int count) {
             assertCountIsOne(count);
-            return singletonList(new IListReader(list));
+            return singletonList(new IListReader(list, fetchSize));
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/IMapReader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/IMapReader.java
@@ -16,6 +16,12 @@
 
 package com.hazelcast.jet.impl;
 
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.client.proxy.ClientMapProxy;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.ProcessorMetaSupplier;
@@ -23,42 +29,41 @@ import com.hazelcast.jet.ProcessorSupplier;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.partition.IPartitionService;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 
+import static java.util.AbstractMap.SimpleImmutableEntry;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
 
 public final class IMapReader extends AbstractProducer {
 
     private static final int DEFAULT_FETCH_SIZE = 16384;
 
-    private final MapProxyImpl map;
+    private final Function<Integer, Iterator<Map.Entry>> supplier;
     private final List<Integer> partitions;
-    private final int fetchSize;
 
     private List<Iterator> iterators;
-
     private CircularCursor<Iterator> iteratorCursor;
 
-    private IMapReader(MapProxyImpl map, List<Integer> partitions, int fetchSize) {
-        this.map = map;
+    private IMapReader(Function<Integer, Iterator<Map.Entry>> supplier, List<Integer> partitions) {
+        this.supplier = supplier;
         this.partitions = partitions;
-        this.fetchSize = fetchSize;
         this.iterators = new ArrayList<>();
     }
 
     @Override
     public void init(@Nonnull Outbox outbox) {
         super.init(outbox);
-        iterators = partitions.stream().map(p -> map.iterator(fetchSize, p, true)).collect(toList());
+        iterators = partitions.stream().map(supplier::apply).collect(toList());
         this.iteratorCursor = new CircularCursor<>(iterators);
     }
 
@@ -89,6 +94,90 @@ public final class IMapReader extends AbstractProducer {
 
     public static ProcessorMetaSupplier supplier(String mapName, int fetchSize) {
         return new MetaSupplier(mapName, fetchSize);
+    }
+
+    public static ProcessorMetaSupplier supplier(String mapName, int fetchSize, ClientConfig clientConfig) {
+        return new RemoteClusterMetaSupplier(mapName, fetchSize, clientConfig);
+    }
+
+    public static ProcessorMetaSupplier supplier(String mapName, ClientConfig clientConfig) {
+        return new RemoteClusterMetaSupplier(mapName, DEFAULT_FETCH_SIZE, clientConfig);
+    }
+
+    private static class RemoteClusterMetaSupplier implements ProcessorMetaSupplier {
+
+        static final long serialVersionUID = 1L;
+
+        private final String name;
+        private final int fetchSize;
+        private final SerializableClientConfig serializableClientConfig;
+        private transient Map<Address, List<Integer>> memberToPartitions;
+
+
+        RemoteClusterMetaSupplier(String name, int fetchSize, ClientConfig clientConfig) {
+            this.name = name;
+            this.fetchSize = fetchSize;
+            this.serializableClientConfig = new SerializableClientConfig(clientConfig);
+        }
+
+        @Override
+        public void init(Context context) {
+            List<Member> members = new ArrayList<>(context.getHazelcastInstance().getCluster().getMembers());
+            int memberSize = members.size();
+            HazelcastInstance client = HazelcastClient.newHazelcastClient(serializableClientConfig.asClientConfig());
+            try {
+                HazelcastClientProxy clientProxy = (HazelcastClientProxy) client;
+                int partitionCount = clientProxy.client.getClientPartitionService().getPartitionCount();
+                memberToPartitions = IntStream.range(0, partitionCount).boxed().collect(
+                        groupingBy(partition -> members.get(partition % memberSize).getAddress())
+                );
+            } finally {
+                client.shutdown();
+            }
+        }
+
+        @Override
+        public ProcessorSupplier get(Address address) {
+            List<Integer> ownedPartitions = memberToPartitions.get(address);
+            return new RemoteClusterProcessorSupplier(name, fetchSize, ownedPartitions, serializableClientConfig);
+        }
+    }
+
+    private static class RemoteClusterProcessorSupplier implements ProcessorSupplier {
+
+        static final long serialVersionUID = 1L;
+
+        private final String mapName;
+        private final int fetchSize;
+        private List<Integer> ownedPartitions;
+        private SerializableClientConfig serializableClientConfig;
+
+        private transient HazelcastInstance client;
+        private transient ClientMapProxy map;
+
+        RemoteClusterProcessorSupplier(String mapName, int fetchSize, List<Integer> ownedPartitions,
+                                       SerializableClientConfig serializableClientConfig) {
+            this.mapName = mapName;
+            this.fetchSize = fetchSize;
+            this.ownedPartitions = ownedPartitions;
+            this.serializableClientConfig = serializableClientConfig;
+        }
+
+        @Override
+        public void init(Context context) {
+            client = HazelcastClient.newHazelcastClient(serializableClientConfig.asClientConfig());
+            map = (ClientMapProxy) client.getMap(mapName);
+        }
+
+        @Override
+        public void complete(Throwable error) {
+            client.shutdown();
+        }
+
+        @Override
+        public List<Processor> get(int count) {
+            return getProcessors(count, ownedPartitions, partitionId -> map.iterator(fetchSize, partitionId, true));
+        }
     }
 
     private static class MetaSupplier implements ProcessorMetaSupplier {
@@ -140,19 +229,24 @@ public final class IMapReader extends AbstractProducer {
 
         @Override
         public List<Processor> get(int count) {
-            Map<Integer, List<Integer>> processorToPartitions = IntStream.range(0, ownedPartitions.size()).boxed()
-                    .map(i -> new AbstractMap.SimpleImmutableEntry<>(i, ownedPartitions.get(i)))
-                    .collect(groupingBy(e -> e.getKey() % count,
-                            mapping(e -> e.getValue(), toList())));
-            IntStream.range(0, count)
-                    .forEach(processor -> processorToPartitions.computeIfAbsent(processor, x -> emptyList()));
-            return processorToPartitions
-                    .values().stream()
-                    .map(partitions -> !partitions.isEmpty()
-                            ? new IMapReader(map, partitions, fetchSize)
-                            : new AbstractProducer() { }
-                    )
-                    .collect(toList());
+            return getProcessors(count, ownedPartitions, partitionId -> map.iterator(fetchSize, partitionId, true));
         }
+
+    }
+
+    static List<Processor> getProcessors(int count, List<Integer> ownedPartitions,
+                                         Function<Integer, Iterator<Map.Entry>> supplier) {
+        Map<Integer, List<Integer>> processorToPartitions = range(0, ownedPartitions.size()).boxed()
+                .map(i -> new SimpleImmutableEntry<>(i, ownedPartitions.get(i)))
+                .collect(groupingBy(e -> e.getKey() % count, mapping(Map.Entry::getValue, toList())));
+        range(0, count).forEach(processor -> processorToPartitions.computeIfAbsent(processor, x -> emptyList()));
+        return processorToPartitions
+                .values().stream()
+                .map(partitions -> !partitions.isEmpty()
+                                ? new IMapReader(supplier, partitions)
+                                : new AbstractProducer() {
+                        }
+                )
+                .collect(toList());
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SerializableClientConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SerializableClientConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.GroupConfig;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Serializable subset of the {@link com.hazelcast.client.config.ClientConfig} which contains address and authentication
+ * information to be used to create a Hazelcast Client when the data needs to be fetched from remote cluster.
+ */
+class SerializableClientConfig implements Serializable {
+
+    private String groupName;
+    private String groupPass;
+    private List<String> addresses;
+
+    SerializableClientConfig(ClientConfig clientConfig) {
+        GroupConfig groupConfig = clientConfig.getGroupConfig();
+        List<String> addresses = clientConfig.getNetworkConfig().getAddresses();
+        this.groupName = groupConfig.getName();
+        this.groupPass = groupConfig.getPassword();
+        this.addresses = addresses;
+    }
+
+    ClientConfig asClientConfig() {
+        ClientConfig config = new ClientConfig();
+        config.getGroupConfig().setName(groupName);
+        config.getGroupConfig().setPassword(groupPass);
+        config.getNetworkConfig().setAddresses(addresses);
+        return config;
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IListReaderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IListReaderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.com.hazelcast.jet.connector;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.DAG;
+import com.hazelcast.jet.Edge;
+import com.hazelcast.jet.JetEngine;
+import com.hazelcast.jet.Vertex;
+import com.hazelcast.jet.impl.IListReader;
+import com.hazelcast.jet.impl.IListWriter;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+import static org.junit.Assert.assertEquals;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class IListReaderTest extends HazelcastTestSupport {
+
+    @After
+    public void tearDown() throws Exception {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void when_readerConfiguredWithClientConfig_then_readFromRemoteCluster() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance c1 = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+        HazelcastInstance c2 = Hazelcast.newHazelcastInstance();
+        Hazelcast.newHazelcastInstance();
+
+        int messageCount = 20;
+        c2.getList("producer").addAll(range(0, messageCount).boxed().collect(toList()));
+
+
+        JetEngine jetEngine = JetEngine.get(c1, randomName());
+        DAG dag = new DAG();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName("dev");
+        clientConfig.getGroupConfig().setPassword("dev-pass");
+        Address address = c2.getCluster().getLocalMember().getAddress();
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+
+        Vertex producer = new Vertex("producer", IListReader.supplier("producer", clientConfig)).parallelism(1);
+        Vertex consumer = new Vertex("consumer", IListWriter.supplier("consumer")).parallelism(1);
+
+        dag.addVertex(producer)
+                .addVertex(consumer)
+                .addEdge(new Edge(producer, consumer));
+
+        Future<Void> execute = jetEngine.newJob(dag).execute();
+        assertCompletesEventually(execute);
+        assertEquals(messageCount, c1.getList("consumer").size());
+    }
+
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IListWriterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IListWriterTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.com.hazelcast.jet.connector;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.DAG;
+import com.hazelcast.jet.Edge;
+import com.hazelcast.jet.JetEngine;
+import com.hazelcast.jet.Vertex;
+import com.hazelcast.jet.impl.IListReader;
+import com.hazelcast.jet.impl.IListWriter;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
+import static org.junit.Assert.assertEquals;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class IListWriterTest extends HazelcastTestSupport {
+
+    @After
+    public void tearDown() throws Exception {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void when_writerConfiguredWithClientConfig_then_writeToRemoteCluster() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance c1 = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+        HazelcastInstance c2 = Hazelcast.newHazelcastInstance();
+        Hazelcast.newHazelcastInstance();
+
+        int messageCount = 20;
+        c1.getList("producer").addAll(range(0, messageCount).boxed().collect(toList()));
+
+
+        JetEngine jetEngine = JetEngine.get(c1, randomName());
+        DAG dag = new DAG();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName("dev");
+        clientConfig.getGroupConfig().setPassword("dev-pass");
+        Address address = c2.getCluster().getLocalMember().getAddress();
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+
+        Vertex producer = new Vertex("producer", IListReader.supplier("producer")).parallelism(1);
+        Vertex consumer = new Vertex("consumer", IListWriter.supplier("consumer", clientConfig)).parallelism(4);
+
+        dag.addVertex(producer)
+                .addVertex(consumer)
+                .addEdge(new Edge(producer, consumer));
+
+        Future<Void> execute = jetEngine.newJob(dag).execute();
+        assertCompletesEventually(execute);
+        assertEquals(messageCount, c2.getList("consumer").size());
+    }
+
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IMapReaderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IMapReaderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.com.hazelcast.jet.connector;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.DAG;
+import com.hazelcast.jet.Edge;
+import com.hazelcast.jet.JetEngine;
+import com.hazelcast.jet.Vertex;
+import com.hazelcast.jet.impl.IListWriter;
+import com.hazelcast.jet.impl.IMapReader;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class IMapReaderTest extends HazelcastTestSupport {
+
+    @After
+    public void tearDown() throws Exception {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void when_readerConfiguredWithClientConfig_then_readFromRemoteCluster() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance c1 = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+        HazelcastInstance c2 = Hazelcast.newHazelcastInstance();
+        Hazelcast.newHazelcastInstance();
+
+        int messageCount = 20;
+        Map<Integer, Integer> map = IntStream.range(0, messageCount).boxed().collect(Collectors.toMap(m -> m, m -> m));
+        c2.getMap("producer").putAll(map);
+
+
+        JetEngine jetEngine = JetEngine.get(c1, randomName());
+        DAG dag = new DAG();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName("dev");
+        clientConfig.getGroupConfig().setPassword("dev-pass");
+        Address address = c2.getCluster().getLocalMember().getAddress();
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+
+        Vertex producer = new Vertex("producer", IMapReader.supplier("producer", clientConfig)).parallelism(4);
+        Vertex consumer = new Vertex("consumer", IListWriter.supplier("consumer")).parallelism(1);
+
+        dag.addVertex(producer)
+                .addVertex(consumer)
+                .addEdge(new Edge(producer, consumer));
+
+        Future<Void> execute = jetEngine.newJob(dag).execute();
+        assertCompletesEventually(execute);
+        assertEquals(messageCount, c1.getList("consumer").size());
+    }
+
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IMapWriterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/com/hazelcast/jet/connector/IMapWriterTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.com.hazelcast.jet.connector;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.DAG;
+import com.hazelcast.jet.Edge;
+import com.hazelcast.jet.JetEngine;
+import com.hazelcast.jet.Vertex;
+import com.hazelcast.jet.impl.IMapReader;
+import com.hazelcast.jet.impl.IMapWriter;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class IMapWriterTest extends HazelcastTestSupport {
+
+    @After
+    public void tearDown() throws Exception {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void when_writerConfiguredWithClientConfig_then_writeToRemoteCluster() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance c1 = factory.newHazelcastInstance();
+        factory.newHazelcastInstance();
+        HazelcastInstance c2 = Hazelcast.newHazelcastInstance();
+        Hazelcast.newHazelcastInstance();
+
+        int messageCount = 20;
+        Map<Integer, Integer> map = IntStream.range(0, messageCount).boxed().collect(Collectors.toMap(m -> m, m -> m));
+        c1.getMap("producer").putAll(map);
+
+
+        JetEngine jetEngine = JetEngine.get(c1, randomName());
+        DAG dag = new DAG();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName("dev");
+        clientConfig.getGroupConfig().setPassword("dev-pass");
+        Address address = c2.getCluster().getLocalMember().getAddress();
+        clientConfig.getNetworkConfig().addAddress(address.getHost() + ":" + address.getPort());
+
+        Vertex producer = new Vertex("producer", IMapReader.supplier("producer")).parallelism(4);
+        Vertex consumer = new Vertex("consumer", IMapWriter.supplier("consumer", clientConfig)).parallelism(4);
+
+        dag.addVertex(producer)
+                .addVertex(consumer)
+                .addEdge(new Edge(producer, consumer));
+
+        Future<Void> execute = jetEngine.newJob(dag).execute();
+        assertCompletesEventually(execute);
+        assertEquals(messageCount, c2.getMap("consumer").size());
+    }
+
+
+}


### PR DESCRIPTION
Map and List reader can fetch data from remote clusters via Hazelcast client.

Added extra supplier methods which accepts client configuration.