### PR TITLE
Add an optional done callback to ExecutionService to track actual done

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ExecuteOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ExecuteOperation.java
@@ -47,8 +47,9 @@ class ExecuteOperation extends AsyncOperation {
     protected void doRun() throws Exception {
         JetService service = getService();
         EngineContext engineContext = service.getEngineContext(engineName);
-        executionFuture = engineContext.getExecutionContext(planId).execute();
-        executionFuture.whenComplete((r, error) -> doSendResponse(error != null ? error : null));
+        executionFuture = engineContext.getExecutionContext(planId)
+                                       .execute(f -> f.handle((r, error) -> error != null ? error : null)
+                                                      .thenAccept(this::doSendResponse));
     }
 
     @Override

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TimeoutTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TimeoutTest.java
@@ -37,7 +37,7 @@ import static com.hazelcast.jet.TestUtil.executeAndPeel;
 @RunWith(HazelcastParallelClassRunner.class)
 public class TimeoutTest extends HazelcastTestSupport {
 
-    private static final int TIMEOUT_MILLIS = 1000;
+    private static final int TIMEOUT_MILLIS = 8000;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -85,7 +85,7 @@ public class TimeoutTest extends HazelcastTestSupport {
 
         @Override
         public boolean complete() {
-            sleepMillis(5 * TIMEOUT_MILLIS);
+            sleepMillis(2 * TIMEOUT_MILLIS);
             return true;
         }
     }


### PR DESCRIPTION
Previously ExecuteOperation would send a response before all resources
are released. A new done callback ensures that the response is only sent
after all the tasklets have finished running.

Also tightened timeouts on the tests related to cancellation to shorten
their run time.