### PR TITLE
Fix spurious crashes in ResourceStore.createStorageDirectory

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/ResourceStore.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/ResourceStore.java
@@ -101,8 +101,8 @@ public class ResourceStore {
     private Path createStorageDirectory(String storagePath) {
         try {
             Path path = Paths.get(storagePath, "resources");
-            if (!path.toFile().exists() && !path.toFile().mkdirs()) {
-                throw new IOException("Could not create requested storage path " + storagePath);
+            if (!path.toFile().mkdirs() && !path.toFile().exists()) {
+                throw new IOException("Could not create requested storage path " + path);
             }
             return path;
         } catch (IOException e) {


### PR DESCRIPTION
This method might happen to be called concurrently. Thread A checked, that the
dir does not exist, Thread B also, Thread A created it and Thread B failed to
create, because it already existed.

Fix is to just create, and if it returned false, then check, if it exists.