### PR TITLE
Improve Partitioner API

### DIFF
--- a/hazelcast-jet-cascading/src/main/java/com/hazelcast/jet/cascading/planner/JetFlowStep.java
+++ b/hazelcast-jet-cascading/src/main/java/com/hazelcast/jet/cascading/planner/JetFlowStep.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Edge.from;
+import static com.hazelcast.jet.KeyExtractors.wholeItem;
 import static java.util.stream.Collectors.toList;
 
 public class JetFlowStep extends BaseFlowStep<JetConfig> {
@@ -190,7 +191,8 @@ public class JetFlowStep extends BaseFlowStep<JetConfig> {
                             dag.vertex(v.vertex);
                             return v;
                         });
-                        Edge edge = from(tapVertex.vertex, tapVertex.currOutput++).to(vertex, annotatedVertex.currInput);
+                        Edge edge = from(tapVertex.vertex, tapVertex.currOutput++)
+                                    .to(vertex, annotatedVertex.currInput);
                         if (isAccumulated) {
                             edge = edge.broadcast().distributed().priority(-1);
                         }
@@ -235,7 +237,7 @@ public class JetFlowStep extends BaseFlowStep<JetConfig> {
 
             Edge edge = Edge.from(sourceVertex.vertex, sourceVertex.currOutput)
                             .to(targetVertex.vertex, targetVertex.currInput)
-                            .partitionedByCustom(getPartitioner(processEdge, targetNode, element))
+                            .partitioned(wholeItem(), getPartitioner(processEdge, targetNode, element))
                             .distributed();
             if (isAccumulated) {
                 edge = edge.broadcast().priority(-1);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/KeyExtractors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/KeyExtractors.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet;
+
+import com.hazelcast.jet.Distributed.Function;
+
+import java.util.Map;
+
+/**
+ * Factory methods for several common key extractor functions, to be used
+ * in {@link Edge#partitioned(Function) Edge.partitioned(...)} calls.
+ */
+public final class KeyExtractors {
+
+    private KeyExtractors() {
+    }
+
+    /**
+     * Transparent key extractor: returns its argument.
+     */
+    public static <T> Distributed.Function<T, T> wholeItem() {
+        return Distributed.Function.identity();
+    }
+
+    /**
+     * Extractor that returns the key of a {@link Map.Entry}.
+     *
+     * @param <K> type of entry's key
+     */
+    public static <K> Distributed.Function<Map.Entry<K, ?>, K> entryKey() {
+        return Map.Entry::getKey;
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/EdgeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/EdgeTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import static com.hazelcast.jet.KeyExtractors.wholeItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -110,7 +111,7 @@ public class EdgeTest {
         final Edge e = Edge.from(a);
 
         // When
-        e.partitioned();
+        e.partitioned(wholeItem());
         final Partitioner partitioner = e.getPartitioner();
         assertNotNull(partitioner);
         partitioner.init(Integer.class::cast);
@@ -127,7 +128,7 @@ public class EdgeTest {
         final int partitioningKey = 42;
 
         // When
-        e.partitionedByKey(o -> partitioningKey);
+        e.partitioned(o -> partitioningKey);
         final Partitioner partitioner = e.getPartitioner();
         assertNotNull(partitioner);
         partitioner.init(Integer.class::cast);
@@ -144,7 +145,7 @@ public class EdgeTest {
         final int partitionId = 42;
 
         // When
-        e.partitionedByCustom((o, x) -> partitionId);
+        e.partitioned(wholeItem(), (o, x) -> partitionId);
         final Partitioner partitioner = e.getPartitioner();
         assertNotNull(partitioner);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ForwardingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ForwardingTest.java
@@ -32,6 +32,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Edge.between;
+import static com.hazelcast.jet.KeyExtractors.wholeItem;
 import static com.hazelcast.jet.TestUtil.executeAndPeel;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
@@ -111,9 +112,8 @@ public class ForwardingTest extends JetTestSupport {
 
         dag.vertex(producer)
            .vertex(consumer)
-           .edge(between(producer, consumer).partitionedByCustom(
-                   (item, numPartitions) -> (int) item % numPartitions
-           ));
+           .edge(between(producer, consumer)
+                   .partitioned(wholeItem(), (Integer item, int numPartitions) -> item % numPartitions));
 
         execute(dag);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/PartitionAlignmentTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/PartitionAlignmentTest.java
@@ -35,6 +35,7 @@ import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.Edge.from;
+import static com.hazelcast.jet.KeyExtractors.wholeItem;
 import static com.hazelcast.jet.Processors.listWriter;
 import static com.hazelcast.jet.TestUtil.executeAndPeel;
 import static java.util.stream.Collectors.toList;
@@ -79,8 +80,8 @@ public class PartitionAlignmentTest {
         final Vertex processor = dag.newVertex("processor", Counter::new).localParallelism(localProcessorCount);
         final Vertex consumer = dag.newVertex("consumer", listWriter("numbers")).localParallelism(1);
 
-        dag.edge(between(distributedProducer, processor).partitionedByCustom(partitioner).distributed())
-           .edge(from(localProducer).to(processor, 1).partitionedByCustom(partitioner))
+        dag.edge(between(distributedProducer, processor).partitioned(wholeItem(), partitioner).distributed())
+           .edge(from(localProducer).to(processor, 1).partitioned(wholeItem(), partitioner))
            .edge(between(processor, consumer));
 
         executeAndPeel(instance.newJob(dag));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.hazelcast.jet.Edge.between;
+import static com.hazelcast.jet.KeyExtractors.wholeItem;
 import static com.hazelcast.jet.impl.util.Util.uncheckedGet;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -101,8 +102,7 @@ public class BackpressureTest extends JetTestSupport {
         Vertex consumer = dag.newVertex("consumer", IMapWriter.supplier("counts"));
 
         dag.edge(between(generator, hiccuper)
-                .distributed()
-                .partitionedByCustom((x, y) -> ptionOwnedByMember2))
+                .distributed().partitioned(wholeItem(), (x, y) -> ptionOwnedByMember2))
            .edge(between(hiccuper, consumer));
 
         uncheckedGet(jet1.newJob(dag).execute());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamTest.java
@@ -49,7 +49,7 @@ public class LongStreamTest extends AbstractStreamTest {
         stream = map.stream().mapToLong(Map.Entry::getValue);
     }
 
-    private long fillMapLongs(IStreamMap<String, Long> map) {
+    private static long fillMapLongs(IStreamMap<String, Long> map) {
         for (int i = 0; i < COUNT; i++) {
             map.put("key-" + i, (long) i);
         }


### PR DESCRIPTION
- `Partitioner` is now parameterized
- `Edge.partitioned()` always requires a key extractor
- remove `Edge.partitionedByKey()` as redundant
- remove `Edge.partitionedByCustom(partitioner)`, replaced with `partitioned(keyExtractor, partitioner)`
- add `Partitioner.DEFAULT` and `Partitioner.HASH_CODE` as out-of-the-box partitioners
- add `class KeyExtractors` with simple key extractor functions
