### PR TITLE
Do not require our Distributed version of functional interfaces

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Distributed.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Distributed.java
@@ -28,6 +28,8 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+
 /**
  * Utility class with serializable versions of {@code java.util.function} interfaces.
  */
@@ -1343,7 +1345,7 @@ public final class Distributed {
          * @see Comparable
          */
         @SuppressWarnings("unchecked")
-        static <T extends Comparable<? super T>> Comparator<T> naturalOrder() {
+        static <T extends Comparable<? super T>> Distributed.Comparator<T> naturalOrder() {
             return (Comparator<T>) DistributedComparators.NATURAL_ORDER_COMPARATOR;
         }
 
@@ -1360,8 +1362,228 @@ public final class Distributed {
          * @see Comparable
          */
         @SuppressWarnings("unchecked")
-        static <T extends Comparable<? super T>> Comparator<T> reverseOrder() {
+        static <T extends Comparable<? super T>> Distributed.Comparator<T> reverseOrder() {
             return (Comparator<T>) DistributedComparators.REVERSE_ORDER_COMPARATOR;
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparing(java.util.Comparator)
+         */
+        default Distributed.Comparator<T> thenComparing(java.util.Comparator<? super T> other) {
+            Objects.requireNonNull(other);
+            checkSerializable(other, "other");
+            return (c1, c2) -> {
+                int res = compare(c1, c2);
+                return (res != 0) ? res : other.compare(c1, c2);
+            };
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparing(java.util.Comparator)
+         */
+        default Distributed.Comparator<T> thenComparing(Distributed.Comparator<? super T> other) {
+            return thenComparing((java.util.Comparator<? super T>) other);
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparing(java.util.function.Function, java.util.Comparator)
+         */
+        default <U> Distributed.Comparator<T> thenComparing(
+                java.util.function.Function<? super T, ? extends U> keyExtractor,
+                java.util.Comparator<? super U> keyComparator) {
+            checkSerializable(keyExtractor, "keyExtractor");
+            checkSerializable(keyComparator, "keyComparator");
+            return thenComparing(comparing(keyExtractor, keyComparator));
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparing(java.util.function.Function, java.util.Comparator)
+         */
+        default <U> Distributed.Comparator<T> thenComparing(
+                Distributed.Function<? super T, ? extends U> keyExtractor,
+                Distributed.Comparator<? super U> keyComparator) {
+            return thenComparing((java.util.function.Function<? super T, ? extends U>) keyExtractor, keyComparator);
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparing(java.util.function.Function)
+         */
+        default <U extends Comparable<? super U>> Distributed.Comparator<T> thenComparing(
+                java.util.function.Function<? super T, ? extends U> keyExtractor) {
+            checkSerializable(keyExtractor, "keyExtractor");
+            return thenComparing(comparing(keyExtractor));
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparing(java.util.function.Function)
+         */
+        default <U extends Comparable<? super U>> Distributed.Comparator<T> thenComparing(
+                Distributed.Function<? super T, ? extends U> keyExtractor) {
+            return thenComparing((java.util.function.Function<? super T, ? extends U>) keyExtractor);
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparingInt(java.util.function.ToIntFunction)
+         */
+        default Distributed.Comparator<T> thenComparingInt(java.util.function.ToIntFunction<? super T> keyExtractor) {
+            checkSerializable(keyExtractor, "keyExtractor");
+            return thenComparing(comparingInt(keyExtractor));
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparingInt(java.util.function.ToIntFunction)
+         */
+        default Distributed.Comparator<T> thenComparingInt(Distributed.ToIntFunction<? super T> keyExtractor) {
+            return thenComparingInt((java.util.function.ToIntFunction<? super T>) keyExtractor);
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparingLong(java.util.function.ToLongFunction)
+         */
+        default Distributed.Comparator<T> thenComparingLong(java.util.function.ToLongFunction<? super T> keyExtractor) {
+            checkSerializable(keyExtractor, "keyExtractor");
+            return thenComparing(comparingLong(keyExtractor));
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparingLong(java.util.function.ToLongFunction)
+         */
+        default Distributed.Comparator<T> thenComparingLong(Distributed.ToLongFunction<? super T> keyExtractor) {
+            return thenComparingLong((java.util.function.ToLongFunction<? super T>) keyExtractor);
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparingDouble(java.util.function.ToDoubleFunction)
+         */
+        default Distributed.Comparator<T> thenComparingDouble(java.util.function.ToDoubleFunction<? super T> keyExtractor) {
+            checkSerializable(keyExtractor, "keyExtractor");
+            return thenComparing(comparingDouble(keyExtractor));
+        }
+
+        /**
+         * @see java.util.Comparator#thenComparingDouble(java.util.function.ToDoubleFunction)
+         */
+        default Distributed.Comparator<T> thenComparingDouble(Distributed.ToDoubleFunction<? super T> keyExtractor) {
+            return thenComparingDouble((java.util.function.ToDoubleFunction<? super T>) keyExtractor);
+        }
+
+        /**
+         * @see java.util.Comparator#nullsFirst(java.util.Comparator)
+         */
+        static <T> Distributed.Comparator<T> nullsFirst(java.util.Comparator<? super T> comparator) {
+            checkSerializable(comparator, "comparator");
+            return new DistributedComparators.NullComparator<>(true, comparator);
+        }
+
+        /**
+         * @see java.util.Comparator#nullsFirst(java.util.Comparator)
+         */
+        static <T> Distributed.Comparator<T> nullsFirst(Distributed.Comparator<? super T> comparator) {
+            return nullsFirst((java.util.Comparator<? super T>) comparator);
+        }
+
+        /**
+         * @see java.util.Comparator#nullsLast(java.util.Comparator)
+         */
+        static <T> Distributed.Comparator<T> nullsLast(java.util.Comparator<? super T> comparator) {
+            checkSerializable(comparator, "comparator");
+            return new DistributedComparators.NullComparator<>(false, comparator);
+        }
+
+        /**
+         * @see java.util.Comparator#nullsLast(java.util.Comparator)
+         */
+        static <T> Distributed.Comparator<T> nullsLast(Distributed.Comparator<? super T> comparator) {
+            return nullsLast((java.util.Comparator<? super T>) comparator);
+        }
+
+        /**
+         * @see java.util.Comparator#comparing(java.util.function.Function, java.util.Comparator)
+         */
+        static <T, U> Distributed.Comparator<T> comparing(
+                java.util.function.Function<? super T, ? extends U> keyExtractor,
+                java.util.Comparator<? super U> keyComparator) {
+            Objects.requireNonNull(keyExtractor);
+            Objects.requireNonNull(keyComparator);
+            checkSerializable(keyExtractor, "keyExtractor");
+            checkSerializable(keyComparator, "keyComparator");
+            return (c1, c2) -> keyComparator.compare(keyExtractor.apply(c1),
+                            keyExtractor.apply(c2));
+        }
+
+        /**
+         * @see java.util.Comparator#comparing(java.util.function.Function, java.util.Comparator)
+         */
+        static <T, U> Distributed.Comparator<T> comparing(
+                Distributed.Function<? super T, ? extends U> keyExtractor,
+                Distributed.Comparator<? super U> keyComparator) {
+            return comparing((java.util.function.Function<? super T, ? extends U>) keyExtractor, keyComparator);
+        }
+
+        /**
+         * @see java.util.Comparator#comparing(java.util.function.Function)
+         */
+        static <T, U extends Comparable<? super U>> Distributed.Comparator<T> comparing(
+                java.util.function.Function<? super T, ? extends U> keyExtractor) {
+            Objects.requireNonNull(keyExtractor);
+            checkSerializable(keyExtractor, "keyExtractor");
+            return (c1, c2) -> keyExtractor.apply(c1).compareTo(keyExtractor.apply(c2));
+        }
+
+        /**
+         * @see java.util.Comparator#comparing(java.util.function.Function)
+         */
+        static <T, U extends Comparable<? super U>> Distributed.Comparator<T> comparing(
+                Distributed.Function<? super T, ? extends U> keyExtractor) {
+            return comparing((java.util.function.Function<? super T, ? extends U>) keyExtractor);
+        }
+
+        /**
+         * @see java.util.Comparator#comparingInt(java.util.function.ToIntFunction)
+         */
+        static <T> Distributed.Comparator<T> comparingInt(java.util.function.ToIntFunction<? super T> keyExtractor) {
+            Objects.requireNonNull(keyExtractor);
+            checkSerializable(keyExtractor, "keyExtractor");
+            return (c1, c2) -> Integer.compare(keyExtractor.applyAsInt(c1), keyExtractor.applyAsInt(c2));
+        }
+
+        /**
+         * @see java.util.Comparator#comparingInt(java.util.function.ToIntFunction)
+         */
+        static <T> Distributed.Comparator<T> comparingInt(Distributed.ToIntFunction<? super T> keyExtractor) {
+            return comparingInt((java.util.function.ToIntFunction<? super T>) keyExtractor);
+        }
+
+        /**
+         * @see java.util.Comparator#comparingInt(java.util.function.ToIntFunction)
+         */
+        static <T> Distributed.Comparator<T> comparingLong(java.util.function.ToLongFunction<? super T> keyExtractor) {
+            Objects.requireNonNull(keyExtractor);
+            checkSerializable(keyExtractor, "keyExtractor");
+            return (c1, c2) -> Long.compare(keyExtractor.applyAsLong(c1), keyExtractor.applyAsLong(c2));
+        }
+
+        /**
+         * @see java.util.Comparator#comparingLong(java.util.function.ToLongFunction)
+         */
+        static <T> Distributed.Comparator<T> comparingLong(Distributed.ToLongFunction<? super T> keyExtractor) {
+            return comparingLong((java.util.function.ToLongFunction<? super T>) keyExtractor);
+        }
+
+        /**
+         * @see java.util.Comparator#comparingDouble(java.util.function.ToDoubleFunction)
+         */
+        static <T> Distributed.Comparator<T> comparingDouble(java.util.function.ToDoubleFunction<? super T> keyExtractor) {
+            Objects.requireNonNull(keyExtractor);
+            checkSerializable(keyExtractor, "keyExtractor");
+            return (c1, c2) -> Double.compare(keyExtractor.applyAsDouble(c1), keyExtractor.applyAsDouble(c2));
+        }
+
+        /**
+         * @see java.util.Comparator#comparingDouble(java.util.function.ToDoubleFunction)
+         */
+        static <T> Distributed.Comparator<T> comparingDouble(Distributed.ToDoubleFunction<? super T> keyExtractor) {
+            return comparingDouble((java.util.function.ToDoubleFunction<? super T>) keyExtractor);
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedDoubleStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedDoubleStream.java
@@ -30,8 +30,6 @@ import java.util.function.DoubleUnaryOperator;
 import java.util.function.ObjDoubleConsumer;
 import java.util.function.Supplier;
 import java.util.stream.DoubleStream;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 /**
@@ -54,7 +52,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      *                  should be included
      * @return the new stream
      */
-    DistributedDoubleStream filter(Distributed.DoublePredicate predicate);
+    default DistributedDoubleStream filter(Distributed.DoublePredicate predicate) {
+        return filter((DoublePredicate) predicate);
+    }
 
     /**
      * Returns a stream consisting of the results of applying the given
@@ -68,7 +68,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedDoubleStream map(Distributed.DoubleUnaryOperator mapper);
+    default DistributedDoubleStream map(Distributed.DoubleUnaryOperator mapper) {
+        return map((DoubleUnaryOperator) mapper);
+    }
 
     /**
      * Returns an object-valued {@code Stream} consisting of the results of
@@ -83,7 +85,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      *               function to apply to each element
      * @return the new stream
      */
-    <U> DistributedStream<U> mapToObj(Distributed.DoubleFunction<? extends U> mapper);
+    default <U> DistributedStream<U> mapToObj(Distributed.DoubleFunction<? extends U> mapper) {
+        return mapToObj((DoubleFunction<? extends U>) mapper);
+    }
 
     /**
      * Returns a {@code LongStream} consisting of the results of applying the
@@ -97,7 +101,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedLongStream mapToLong(Distributed.DoubleToLongFunction mapper);
+    default DistributedLongStream mapToLong(Distributed.DoubleToLongFunction mapper) {
+        return mapToLong((DoubleToLongFunction) mapper);
+    }
 
     /**
      * Returns an {@code IntStream} consisting of the results of applying the
@@ -111,7 +117,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedIntStream mapToInt(Distributed.DoubleToIntFunction mapper);
+    default DistributedIntStream mapToInt(Distributed.DoubleToIntFunction mapper) {
+        return mapToInt((DoubleToIntFunction) mapper);
+    }
 
     /**
      * Returns a stream consisting of the results of replacing each element of
@@ -131,7 +139,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @return the new stream
      * @see DistributedStream#flatMap(Distributed.Function)
      */
-    DistributedDoubleStream flatMap(Distributed.DoubleFunction<? extends DoubleStream> mapper);
+    default DistributedDoubleStream flatMap(Distributed.DoubleFunction<? extends DoubleStream> mapper) {
+        return flatMap((DoubleFunction<? extends DoubleStream>) mapper);
+    }
 
     /**
      * Returns a stream consisting of the distinct elements of this stream. The
@@ -175,7 +185,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      *               they are consumed from the stream
      * @return the new stream
      */
-    DistributedDoubleStream peek(Distributed.DoubleConsumer action);
+    default DistributedDoubleStream peek(Distributed.DoubleConsumer action) {
+        return peek((DoubleConsumer) action);
+    }
 
     /**
      * Returns a stream consisting of the elements of this stream, truncated
@@ -214,7 +226,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @param action a
      *               non-interfering action to perform on the elements
      */
-    void forEach(Distributed.DoubleConsumer action);
+    default void forEach(Distributed.DoubleConsumer action) {
+        forEach((DoubleConsumer) action);
+    }
 
     /**
      * Performs an action for each element of this stream, guaranteeing that
@@ -228,7 +242,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      *               non-interfering action to perform on the elements
      * @see #forEach(DoubleConsumer)
      */
-    void forEachOrdered(Distributed.DoubleConsumer action);
+    default void forEachOrdered(Distributed.DoubleConsumer action) {
+        forEachOrdered((DoubleConsumer) action);
+    }
 
     /**
      * Performs a reduction on the
@@ -265,7 +281,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @see #max()
      * @see #average()
      */
-    double reduce(double identity, Distributed.DoubleBinaryOperator op);
+    default double reduce(double identity, Distributed.DoubleBinaryOperator op) {
+        return reduce(identity, (DoubleBinaryOperator) op);
+    }
 
     /**
      * Performs a reduction on the
@@ -302,7 +320,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @return the result of the reduction
      * @see #reduce(double, DoubleBinaryOperator)
      */
-    OptionalDouble reduce(Distributed.DoubleBinaryOperator op);
+    default OptionalDouble reduce(Distributed.DoubleBinaryOperator op) {
+        return reduce((DoubleBinaryOperator) op);
+    }
 
     /**
      * Performs a mutable
@@ -341,8 +361,10 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @return the result of the reduction
      * @see Stream#collect(Supplier, BiConsumer, BiConsumer)
      */
-    <R> R collect(Distributed.Supplier<R> supplier, Distributed.ObjDoubleConsumer<R> accumulator,
-                  Distributed.BiConsumer<R, R> combiner);
+    default <R> R collect(Distributed.Supplier<R> supplier, Distributed.ObjDoubleConsumer<R> accumulator,
+                          Distributed.BiConsumer<R, R> combiner) {
+        return collect((Supplier<R>) supplier, accumulator, combiner);
+    }
 
     /**
      * Returns whether any elements of this stream match the provided
@@ -359,7 +381,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @return {@code true} if any elements of the stream match the provided
      * predicate, otherwise {@code false}
      */
-    boolean anyMatch(Distributed.DoublePredicate predicate);
+    default boolean anyMatch(Distributed.DoublePredicate predicate) {
+        return anyMatch((DoublePredicate) predicate);
+    }
 
     /**
      * Returns whether all elements of this stream match the provided predicate.
@@ -376,7 +400,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @return {@code true} if either all elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean allMatch(Distributed.DoublePredicate predicate);
+    default boolean allMatch(Distributed.DoublePredicate predicate) {
+        return allMatch((DoublePredicate) predicate);
+    }
 
     /**
      * Returns whether no elements of this stream match the provided predicate.
@@ -393,7 +419,9 @@ public interface DistributedDoubleStream extends DoubleStream {
      * @return {@code true} if either no elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean noneMatch(Distributed.DoublePredicate predicate);
+    default boolean noneMatch(Distributed.DoublePredicate predicate) {
+        return noneMatch((DoublePredicate) predicate);
+    }
 
     /**
      * Returns a {@code DistributedStream} consisting of the elements of this stream,
@@ -434,79 +462,47 @@ public interface DistributedDoubleStream extends DoubleStream {
     DistributedDoubleStream parallel();
 
     @Override
-    default DoubleStream filter(DoublePredicate predicate) {
-        return filter((Distributed.DoublePredicate) predicate);
-    }
+    DistributedDoubleStream filter(DoublePredicate predicate);
 
     @Override
-    default DoubleStream map(DoubleUnaryOperator mapper) {
-        return map((Distributed.DoubleUnaryOperator) mapper);
-    }
+    DistributedDoubleStream map(DoubleUnaryOperator mapper);
 
     @Override
-    default <U> Stream<U> mapToObj(DoubleFunction<? extends U> mapper) {
-        return mapToObj((Distributed.DoubleFunction) mapper);
-    }
+    <U> DistributedStream<U> mapToObj(DoubleFunction<? extends U> mapper);
 
     @Override
-    default LongStream mapToLong(DoubleToLongFunction mapper) {
-        return mapToLong((Distributed.DoubleToLongFunction) mapper);
-    }
+    DistributedLongStream mapToLong(DoubleToLongFunction mapper);
 
     @Override
-    default IntStream mapToInt(DoubleToIntFunction mapper) {
-        return mapToInt((Distributed.DoubleToIntFunction) mapper);
-    }
+    DistributedIntStream mapToInt(DoubleToIntFunction mapper);
 
     @Override
-    default DoubleStream flatMap(DoubleFunction<? extends DoubleStream> mapper) {
-        return flatMap((Distributed.DoubleFunction) mapper);
-    }
+    DistributedDoubleStream flatMap(DoubleFunction<? extends DoubleStream> mapper);
 
     @Override
-    default DoubleStream peek(DoubleConsumer action) {
-        return peek((Distributed.DoubleConsumer) action);
-    }
+    DistributedDoubleStream peek(DoubleConsumer action);
 
     @Override
-    default void forEach(DoubleConsumer action) {
-        forEach((Distributed.DoubleConsumer) action);
-    }
+    void forEach(DoubleConsumer action);
 
     @Override
-    default void forEachOrdered(DoubleConsumer action) {
-        forEachOrdered((Distributed.DoubleConsumer) action);
-    }
+    void forEachOrdered(DoubleConsumer action);
 
     @Override
-    default double reduce(double identity, DoubleBinaryOperator op) {
-        return reduce(identity, (Distributed.DoubleBinaryOperator) op);
-    }
+    double reduce(double identity, DoubleBinaryOperator op);
 
     @Override
-    default OptionalDouble reduce(DoubleBinaryOperator op) {
-        return reduce((Distributed.DoubleBinaryOperator) op);
-    }
+    OptionalDouble reduce(DoubleBinaryOperator op);
 
     @Override
-    default <R> R collect(Supplier<R> supplier, ObjDoubleConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-        return collect((Distributed.Supplier<R>) supplier,
-                (Distributed.ObjDoubleConsumer<R>) accumulator,
-                (Distributed.BiConsumer<R, R>) combiner);
-    }
+    <R> R collect(Supplier<R> supplier, ObjDoubleConsumer<R> accumulator, BiConsumer<R, R> combiner);
 
     @Override
-    default boolean anyMatch(DoublePredicate predicate) {
-        return anyMatch((Distributed.DoublePredicate) predicate);
-    }
+    boolean anyMatch(DoublePredicate predicate);
 
     @Override
-    default boolean allMatch(DoublePredicate predicate) {
-        return allMatch((Distributed.DoublePredicate) predicate);
-    }
+    boolean allMatch(DoublePredicate predicate);
 
     @Override
-    default boolean noneMatch(DoublePredicate predicate) {
-        return noneMatch((Distributed.DoublePredicate) predicate);
-    }
+    boolean noneMatch(DoublePredicate predicate);
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedIntStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedIntStream.java
@@ -29,10 +29,7 @@ import java.util.function.IntToLongFunction;
 import java.util.function.IntUnaryOperator;
 import java.util.function.ObjIntConsumer;
 import java.util.function.Supplier;
-import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 
 /**
  * An extension of {@link java.util.stream.IntStream} to support distributed stream operations by replacing
@@ -54,7 +51,9 @@ public interface DistributedIntStream extends IntStream {
      *                  should be included
      * @return the new stream
      */
-    DistributedIntStream filter(Distributed.IntPredicate predicate);
+    default DistributedIntStream filter(Distributed.IntPredicate predicate) {
+        return filter((IntPredicate) predicate);
+    }
 
     /**
      * Returns a stream consisting of the results of applying the given
@@ -68,7 +67,9 @@ public interface DistributedIntStream extends IntStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedIntStream map(Distributed.IntUnaryOperator mapper);
+    default DistributedIntStream map(Distributed.IntUnaryOperator mapper) {
+        return map((IntUnaryOperator) mapper);
+    }
 
     /**
      * Returns an object-valued {@code DistributedStream} consisting of the results of
@@ -83,7 +84,9 @@ public interface DistributedIntStream extends IntStream {
      *               function to apply to each element
      * @return the new stream
      */
-    <U> DistributedStream<U> mapToObj(Distributed.IntFunction<? extends U> mapper);
+    default <U> DistributedStream<U> mapToObj(Distributed.IntFunction<? extends U> mapper) {
+        return mapToObj((IntFunction<? extends U>) mapper);
+    }
 
     /**
      * Returns a {@code DistributedLongStream} consisting of the results of applying the
@@ -97,7 +100,9 @@ public interface DistributedIntStream extends IntStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedLongStream mapToLong(Distributed.IntToLongFunction mapper);
+    default DistributedLongStream mapToLong(Distributed.IntToLongFunction mapper) {
+        return mapToLong((IntToLongFunction) mapper);
+    }
 
     /**
      * Returns a {@code DistributedDoubleStream} consisting of the results of applying the
@@ -111,7 +116,9 @@ public interface DistributedIntStream extends IntStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedDoubleStream mapToDouble(Distributed.IntToDoubleFunction mapper);
+    default DistributedDoubleStream mapToDouble(Distributed.IntToDoubleFunction mapper) {
+        return mapToDouble((IntToDoubleFunction) mapper);
+    }
 
     /**
      * Returns a stream consisting of the results of replacing each element of
@@ -131,7 +138,9 @@ public interface DistributedIntStream extends IntStream {
      * @return the new stream
      * @see DistributedStream#flatMap(Distributed.Function)
      */
-    DistributedIntStream flatMap(Distributed.IntFunction<? extends IntStream> mapper);
+    default DistributedIntStream flatMap(Distributed.IntFunction<? extends IntStream> mapper) {
+        return flatMap((IntFunction<? extends IntStream>) mapper);
+    }
 
     /**
      * Returns a stream consisting of the distinct elements of this stream.
@@ -172,7 +181,9 @@ public interface DistributedIntStream extends IntStream {
      *               they are consumed from the stream
      * @return the new stream
      */
-    DistributedIntStream peek(Distributed.IntConsumer action);
+    default DistributedIntStream peek(Distributed.IntConsumer action) {
+        return peek((IntConsumer) action);
+    }
 
     /**
      * Returns a stream consisting of the elements of this stream, truncated
@@ -218,7 +229,9 @@ public interface DistributedIntStream extends IntStream {
      * @param action a
      *               non-interfering action to perform on the elements
      */
-    void forEach(Distributed.IntConsumer action);
+    default void forEach(Distributed.IntConsumer action) {
+        forEach((IntConsumer) action);
+    }
 
     /**
      * Performs an action for each element of this stream, guaranteeing that
@@ -232,7 +245,9 @@ public interface DistributedIntStream extends IntStream {
      *               non-interfering action to perform on the elements
      * @see #forEach(Distributed.IntConsumer)
      */
-    void forEachOrdered(Distributed.IntConsumer action);
+    default void forEachOrdered(Distributed.IntConsumer action) {
+        forEachOrdered((IntConsumer) action);
+    }
 
     /**
      * Performs a reduction on the
@@ -269,7 +284,9 @@ public interface DistributedIntStream extends IntStream {
      * @see #max()
      * @see #average()
      */
-    int reduce(int identity, Distributed.IntBinaryOperator op);
+    default int reduce(int identity, Distributed.IntBinaryOperator op) {
+        return reduce(identity, (IntBinaryOperator) op);
+    }
 
     /**
      * Performs a reduction on the
@@ -306,7 +323,9 @@ public interface DistributedIntStream extends IntStream {
      * @return the result of the reduction
      * @see #reduce(int, Distributed.IntBinaryOperator)
      */
-    OptionalInt reduce(Distributed.IntBinaryOperator op);
+    default OptionalInt reduce(Distributed.IntBinaryOperator op) {
+        return reduce((IntBinaryOperator) op);
+    }
 
     /**
      * Performs a mutable
@@ -344,8 +363,10 @@ public interface DistributedIntStream extends IntStream {
      * @return the result of the reduction
      * @see DistributedStream#collect(Distributed.Supplier, Distributed.BiConsumer, Distributed.BiConsumer)
      */
-    <R> R collect(Distributed.Supplier<R> supplier, Distributed.ObjIntConsumer<R> accumulator,
-                  Distributed.BiConsumer<R, R> combiner);
+    default <R> R collect(Distributed.Supplier<R> supplier, Distributed.ObjIntConsumer<R> accumulator,
+                          Distributed.BiConsumer<R, R> combiner) {
+        return collect((Supplier<R>) supplier, accumulator, combiner);
+    }
 
     /**
      * Returns whether any elements of this stream match the provided
@@ -362,7 +383,9 @@ public interface DistributedIntStream extends IntStream {
      * @return {@code true} if any elements of the stream match the provided
      * predicate, otherwise {@code false}
      */
-    boolean anyMatch(Distributed.IntPredicate predicate);
+    default boolean anyMatch(Distributed.IntPredicate predicate) {
+        return anyMatch((IntPredicate) predicate);
+    }
 
     /**
      * Returns whether all elements of this stream match the provided predicate.
@@ -379,7 +402,9 @@ public interface DistributedIntStream extends IntStream {
      * @return {@code true} if either all elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean allMatch(Distributed.IntPredicate predicate);
+    default boolean allMatch(Distributed.IntPredicate predicate) {
+        return allMatch((IntPredicate) predicate);
+    }
 
     /**
      * Returns whether no elements of this stream match the provided predicate.
@@ -396,7 +421,9 @@ public interface DistributedIntStream extends IntStream {
      * @return {@code true} if either no elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean noneMatch(Distributed.IntPredicate predicate);
+    default boolean noneMatch(Distributed.IntPredicate predicate) {
+        return noneMatch((IntPredicate) predicate);
+    }
 
     /**
      * Returns a {@code LongStream} consisting of the elements of this stream,
@@ -463,79 +490,47 @@ public interface DistributedIntStream extends IntStream {
     DistributedIntStream parallel();
 
     @Override
-    default IntStream filter(IntPredicate predicate) {
-        return filter((Distributed.IntPredicate) predicate);
-    }
+    DistributedIntStream filter(IntPredicate predicate);
 
     @Override
-    default IntStream map(IntUnaryOperator mapper) {
-        return map((Distributed.IntUnaryOperator) mapper);
-    }
+    DistributedIntStream map(IntUnaryOperator mapper);
 
     @Override
-    default <U> Stream<U> mapToObj(IntFunction<? extends U> mapper) {
-        return mapToObj((Distributed.IntFunction) mapper);
-    }
+    <U> DistributedStream<U> mapToObj(IntFunction<? extends U> mapper);
 
     @Override
-    default LongStream mapToLong(IntToLongFunction mapper) {
-        return mapToLong((Distributed.IntToLongFunction) mapper);
-    }
+    DistributedLongStream mapToLong(IntToLongFunction mapper);
 
     @Override
-    default DoubleStream mapToDouble(IntToDoubleFunction mapper) {
-        return mapToDouble((Distributed.IntToDoubleFunction) mapper);
-    }
+    DistributedDoubleStream mapToDouble(IntToDoubleFunction mapper);
 
     @Override
-    default IntStream flatMap(IntFunction<? extends IntStream> mapper) {
-        return flatMap((Distributed.IntFunction) mapper);
-    }
+    DistributedIntStream flatMap(IntFunction<? extends IntStream> mapper);
 
     @Override
-    default IntStream peek(IntConsumer action) {
-        return peek((Distributed.IntConsumer) action);
-    }
+    DistributedIntStream peek(IntConsumer action);
 
     @Override
-    default void forEach(IntConsumer action) {
-        forEach((Distributed.IntConsumer) action);
-    }
+    void forEach(IntConsumer action);
 
     @Override
-    default void forEachOrdered(IntConsumer action) {
-        forEachOrdered((Distributed.IntConsumer) action);
-    }
+    void forEachOrdered(IntConsumer action);
 
     @Override
-    default int reduce(int identity, IntBinaryOperator op) {
-        return reduce(identity, (Distributed.IntBinaryOperator) op);
-    }
+    int reduce(int identity, IntBinaryOperator op);
 
     @Override
-    default OptionalInt reduce(IntBinaryOperator op) {
-        return reduce((Distributed.IntBinaryOperator) op);
-    }
+    OptionalInt reduce(IntBinaryOperator op);
 
     @Override
-    default <R> R collect(Supplier<R> supplier, ObjIntConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-        return collect((Distributed.Supplier<R>) supplier,
-                (Distributed.ObjIntConsumer<R>) accumulator,
-                (Distributed.BiConsumer<R, R>) combiner);
-    }
+    <R> R collect(Supplier<R> supplier, ObjIntConsumer<R> accumulator, BiConsumer<R, R> combiner);
 
     @Override
-    default boolean anyMatch(IntPredicate predicate) {
-        return anyMatch((Distributed.IntPredicate) predicate);
-    }
+    boolean anyMatch(IntPredicate predicate);
 
     @Override
-    default boolean allMatch(IntPredicate predicate) {
-        return allMatch((Distributed.IntPredicate) predicate);
-    }
+    boolean allMatch(IntPredicate predicate);
 
     @Override
-    default boolean noneMatch(IntPredicate predicate) {
-        return noneMatch((Distributed.IntPredicate) predicate);
-    }
+    boolean noneMatch(IntPredicate predicate);
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedLongStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedLongStream.java
@@ -29,8 +29,6 @@ import java.util.function.LongToIntFunction;
 import java.util.function.LongUnaryOperator;
 import java.util.function.ObjLongConsumer;
 import java.util.function.Supplier;
-import java.util.stream.DoubleStream;
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
@@ -54,7 +52,9 @@ public interface DistributedLongStream extends LongStream {
      *                  should be included
      * @return the new stream
      */
-    DistributedLongStream filter(Distributed.LongPredicate predicate);
+    default DistributedLongStream filter(Distributed.LongPredicate predicate) {
+        return filter((LongPredicate) predicate);
+    }
 
     /**
      * Returns a stream consisting of the results of applying the given
@@ -68,7 +68,9 @@ public interface DistributedLongStream extends LongStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedLongStream map(Distributed.LongUnaryOperator mapper);
+    default DistributedLongStream map(Distributed.LongUnaryOperator mapper) {
+        return map((LongUnaryOperator) mapper);
+    }
 
     /**
      * Returns an object-valued {@code Stream} consisting of the results of
@@ -83,7 +85,9 @@ public interface DistributedLongStream extends LongStream {
      *               function to apply to each element
      * @return the new stream
      */
-    <U> DistributedStream<U> mapToObj(Distributed.LongFunction<? extends U> mapper);
+    default <U> DistributedStream<U> mapToObj(Distributed.LongFunction<? extends U> mapper) {
+        return mapToObj((LongFunction<? extends U>) mapper);
+    }
 
     /**
      * Returns an {@code IntStream} consisting of the results of applying the
@@ -97,7 +101,9 @@ public interface DistributedLongStream extends LongStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedIntStream mapToInt(Distributed.LongToIntFunction mapper);
+    default DistributedIntStream mapToInt(Distributed.LongToIntFunction mapper) {
+        return mapToInt((LongToIntFunction) mapper);
+    }
 
     /**
      * Returns a {@code DoubleStream} consisting of the results of applying the
@@ -111,7 +117,9 @@ public interface DistributedLongStream extends LongStream {
      *               function to apply to each element
      * @return the new stream
      */
-    DistributedDoubleStream mapToDouble(Distributed.LongToDoubleFunction mapper);
+    default DistributedDoubleStream mapToDouble(Distributed.LongToDoubleFunction mapper) {
+        return mapToDouble((LongToDoubleFunction) mapper);
+    }
 
     /**
      * Returns a stream consisting of the results of replacing each element of
@@ -131,7 +139,9 @@ public interface DistributedLongStream extends LongStream {
      * @return the new stream
      * @see DistributedStream#flatMap(Distributed.Function)
      */
-    DistributedLongStream flatMap(Distributed.LongFunction<? extends LongStream> mapper);
+    default DistributedLongStream flatMap(Distributed.LongFunction<? extends LongStream> mapper) {
+        return flatMap((LongFunction<? extends LongStream>) mapper);
+    }
 
     /**
      * Returns a stream consisting of the distinct elements of this stream.
@@ -174,7 +184,9 @@ public interface DistributedLongStream extends LongStream {
      *               they are consumed from the stream
      * @return the new stream
      */
-    DistributedLongStream peek(Distributed.LongConsumer action);
+    default DistributedLongStream peek(Distributed.LongConsumer action) {
+        return peek((LongConsumer) action);
+    }
 
     /**
      * Returns a stream consisting of the elements of this stream, truncated
@@ -220,7 +232,9 @@ public interface DistributedLongStream extends LongStream {
      * @param action a
      *               non-interfering action to perform on the elements
      */
-    void forEach(Distributed.LongConsumer action);
+    default void forEach(Distributed.LongConsumer action) {
+        forEach((LongConsumer) action);
+    }
 
     /**
      * Performs an action for each element of this stream, guaranteeing that
@@ -234,7 +248,9 @@ public interface DistributedLongStream extends LongStream {
      *               non-interfering action to perform on the elements
      * @see #forEach(LongConsumer)
      */
-    void forEachOrdered(Distributed.LongConsumer action);
+    default void forEachOrdered(Distributed.LongConsumer action) {
+        forEachOrdered((LongConsumer) action);
+    }
 
     /**
      * Performs a reduction on the
@@ -271,7 +287,9 @@ public interface DistributedLongStream extends LongStream {
      * @see #max()
      * @see #average()
      */
-    long reduce(long identity, Distributed.LongBinaryOperator op);
+    default long reduce(long identity, Distributed.LongBinaryOperator op) {
+        return reduce(identity, (LongBinaryOperator) op);
+    }
 
     /**
      * Performs a reduction on the
@@ -308,7 +326,9 @@ public interface DistributedLongStream extends LongStream {
      * @return the result of the reduction
      * @see #reduce(long, LongBinaryOperator)
      */
-    OptionalLong reduce(Distributed.LongBinaryOperator op);
+    default OptionalLong reduce(Distributed.LongBinaryOperator op) {
+        return reduce((LongBinaryOperator) op);
+    }
 
     /**
      * Performs a mutable
@@ -346,8 +366,10 @@ public interface DistributedLongStream extends LongStream {
      * @return the result of the reduction
      * @see Stream#collect(Supplier, BiConsumer, BiConsumer)
      */
-    <R> R collect(Distributed.Supplier<R> supplier, Distributed.ObjLongConsumer<R> accumulator,
-                  Distributed.BiConsumer<R, R> combiner);
+    default <R> R collect(Distributed.Supplier<R> supplier, Distributed.ObjLongConsumer<R> accumulator,
+                          Distributed.BiConsumer<R, R> combiner) {
+        return collect((Supplier<R>) supplier, accumulator, combiner);
+    }
 
     /**
      * Returns whether any elements of this stream match the provided
@@ -364,7 +386,9 @@ public interface DistributedLongStream extends LongStream {
      * @return {@code true} if any elements of the stream match the provided
      * predicate, otherwise {@code false}
      */
-    boolean anyMatch(Distributed.LongPredicate predicate);
+    default boolean anyMatch(Distributed.LongPredicate predicate) {
+        return anyMatch((LongPredicate) predicate);
+    }
 
     /**
      * Returns whether all elements of this stream match the provided predicate.
@@ -381,7 +405,9 @@ public interface DistributedLongStream extends LongStream {
      * @return {@code true} if either all elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean allMatch(Distributed.LongPredicate predicate);
+    default boolean allMatch(Distributed.LongPredicate predicate) {
+        return allMatch((LongPredicate) predicate);
+    }
 
     /**
      * Returns whether no elements of this stream match the provided predicate.
@@ -398,7 +424,9 @@ public interface DistributedLongStream extends LongStream {
      * @return {@code true} if either no elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean noneMatch(Distributed.LongPredicate predicate);
+    default boolean noneMatch(Distributed.LongPredicate predicate) {
+        return noneMatch((LongPredicate) predicate);
+    }
 
     /**
      * Returns a {@code DoubleStream} consisting of the elements of this stream,
@@ -452,79 +480,47 @@ public interface DistributedLongStream extends LongStream {
     DistributedLongStream parallel();
 
     @Override
-    default LongStream filter(LongPredicate predicate) {
-        return filter((Distributed.LongPredicate) predicate);
-    }
+    DistributedLongStream filter(LongPredicate predicate);
 
     @Override
-    default LongStream map(LongUnaryOperator mapper) {
-        return map((Distributed.LongUnaryOperator) mapper);
-    }
+    DistributedLongStream map(LongUnaryOperator mapper);
 
     @Override
-    default <U> Stream<U> mapToObj(LongFunction<? extends U> mapper) {
-        return mapToObj((Distributed.LongFunction) mapper);
-    }
+    <U> DistributedStream<U> mapToObj(LongFunction<? extends U> mapper);
 
     @Override
-    default IntStream mapToInt(LongToIntFunction mapper) {
-        return mapToInt((Distributed.LongToIntFunction) mapper);
-    }
+    DistributedIntStream mapToInt(LongToIntFunction mapper);
 
     @Override
-    default DoubleStream mapToDouble(LongToDoubleFunction mapper) {
-        return mapToDouble((Distributed.LongToDoubleFunction) mapper);
-    }
+    DistributedDoubleStream mapToDouble(LongToDoubleFunction mapper);
 
     @Override
-    default LongStream flatMap(LongFunction<? extends LongStream> mapper) {
-        return flatMap((Distributed.LongFunction) mapper);
-    }
+    DistributedLongStream flatMap(LongFunction<? extends LongStream> mapper);
 
     @Override
-    default LongStream peek(LongConsumer action) {
-        return peek((Distributed.LongConsumer) action);
-    }
+    DistributedLongStream peek(LongConsumer action);
 
     @Override
-    default void forEach(LongConsumer action) {
-        forEach((Distributed.LongConsumer) action);
-    }
+    void forEach(LongConsumer action);
 
     @Override
-    default void forEachOrdered(LongConsumer action) {
-        forEachOrdered((Distributed.LongConsumer) action);
-    }
+    void forEachOrdered(LongConsumer action);
 
     @Override
-    default long reduce(long identity, LongBinaryOperator op) {
-        return reduce(identity, (Distributed.LongBinaryOperator) op);
-    }
+    long reduce(long identity, LongBinaryOperator op);
 
     @Override
-    default OptionalLong reduce(LongBinaryOperator op) {
-        return reduce((Distributed.LongBinaryOperator) op);
-    }
+    OptionalLong reduce(LongBinaryOperator op);
 
     @Override
-    default <R> R collect(Supplier<R> supplier, ObjLongConsumer<R> accumulator, BiConsumer<R, R> combiner) {
-        return collect((Distributed.Supplier<R>) supplier,
-                (Distributed.ObjLongConsumer<R>) accumulator,
-                (Distributed.BiConsumer<R, R>) combiner);
-    }
+    <R> R collect(Supplier<R> supplier, ObjLongConsumer<R> accumulator, BiConsumer<R, R> combiner);
 
     @Override
-    default boolean anyMatch(LongPredicate predicate) {
-        return anyMatch((Distributed.LongPredicate) predicate);
-    }
+    boolean anyMatch(LongPredicate predicate);
 
     @Override
-    default boolean allMatch(LongPredicate predicate) {
-        return allMatch((Distributed.LongPredicate) predicate);
-    }
+    boolean allMatch(LongPredicate predicate);
 
     @Override
-    default boolean noneMatch(LongPredicate predicate) {
-        return noneMatch((Distributed.LongPredicate) predicate);
-    }
+    boolean noneMatch(LongPredicate predicate);
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedStream.java
@@ -57,7 +57,9 @@ public interface DistributedStream<T> extends Stream<T> {
      *                  should be included
      * @return the new stream
      */
-    DistributedStream<T> filter(Distributed.Predicate<? super T> predicate);
+    default DistributedStream<T> filter(Distributed.Predicate<? super T> predicate) {
+        return filter((Predicate<? super T>) predicate);
+    }
 
     /**
      * Returns a stream consisting of the results of applying the given
@@ -69,7 +71,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @param mapper a non-interfering, stateless function to apply to each element
      * @return the new stream
      */
-    <R> DistributedStream<R> map(Distributed.Function<? super T, ? extends R> mapper);
+    default <R> DistributedStream<R> map(Distributed.Function<? super T, ? extends R> mapper) {
+        return map((Function<? super T, ? extends R>) mapper);
+    }
 
     /**
      * Returns an {@code DistributedIntStream} consisting of the results of applying the
@@ -80,7 +84,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @param mapper a non-interfering, stateless function to apply to each element
      * @return the new stream
      */
-    DistributedIntStream mapToInt(Distributed.ToIntFunction<? super T> mapper);
+    default DistributedIntStream mapToInt(Distributed.ToIntFunction<? super T> mapper) {
+        return mapToInt((ToIntFunction<? super T>) mapper);
+    }
 
     /**
      * Returns a {@code DistributedLongStream} consisting of the results of applying the
@@ -91,7 +97,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @param mapper a non-interfering, stateless function to apply to each element
      * @return the new stream
      */
-    DistributedLongStream mapToLong(Distributed.ToLongFunction<? super T> mapper);
+    default DistributedLongStream mapToLong(Distributed.ToLongFunction<? super T> mapper) {
+        return mapToLong((ToLongFunction<? super T>) mapper);
+    }
 
     /**
      * Returns a {@code DistributedDoubleStream} consisting of the results of applying the
@@ -102,7 +110,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @param mapper a non-interfering, stateless function to apply to each element
      * @return the new stream
      */
-    DistributedDoubleStream mapToDouble(Distributed.ToDoubleFunction<? super T> mapper);
+    default DistributedDoubleStream mapToDouble(Distributed.ToDoubleFunction<? super T> mapper) {
+        return mapToDouble((ToDoubleFunction<? super T>) mapper);
+    }
 
     /**
      * Returns a stream consisting of the results of replacing each element of
@@ -119,7 +129,9 @@ public interface DistributedStream<T> extends Stream<T> {
      *               a stream of new values
      * @return the new stream
      */
-    <R> DistributedStream<R> flatMap(Distributed.Function<? super T, ? extends Stream<? extends R>> mapper);
+    default <R> DistributedStream<R> flatMap(Distributed.Function<? super T, ? extends Stream<? extends R>> mapper) {
+        return flatMap((Function<? super T, ? extends Stream<? extends R>>) mapper);
+    }
 
     /**
      * Returns an {@code IntStream} consisting of the results of replacing each
@@ -136,7 +148,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @return the new stream
      * @see #flatMap(Function)
      */
-    DistributedIntStream flatMapToInt(Distributed.Function<? super T, ? extends IntStream> mapper);
+    default DistributedIntStream flatMapToInt(Distributed.Function<? super T, ? extends IntStream> mapper) {
+        return flatMapToInt((Function<? super T, ? extends IntStream>) mapper);
+    }
 
     /**
      * Returns an {@code LongStream} consisting of the results of replacing each
@@ -153,7 +167,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @return the new stream
      * @see #flatMap(Function)
      */
-    DistributedLongStream flatMapToLong(Distributed.Function<? super T, ? extends LongStream> mapper);
+    default DistributedLongStream flatMapToLong(Distributed.Function<? super T, ? extends LongStream> mapper) {
+        return flatMapToLong((Function<? super T, ? extends LongStream>) mapper);
+    }
 
     /**
      * Returns an {@code DoubleStream} consisting of the results of replacing
@@ -170,36 +186,14 @@ public interface DistributedStream<T> extends Stream<T> {
      * @return the new stream
      * @see #flatMap(Function)
      */
-    DistributedDoubleStream flatMapToDouble(Distributed.Function<? super T, ? extends DoubleStream> mapper);
+    default DistributedDoubleStream flatMapToDouble(Distributed.Function<? super T, ? extends DoubleStream> mapper) {
+        return flatMapToDouble((Function<? super T, ? extends DoubleStream>) mapper);
+    }
 
-    /**
-     * Returns a stream consisting of the distinct elements (according to
-     * {@link Object#equals(Object)}) of this stream.
-     *
-     * <p>For ordered streams, the selection of distinct elements is stable
-     * (for duplicated elements, the element appearing first in the encounter
-     * order is preserved.)  For unordered streams, no stability guarantees
-     * are made.
-     *
-     * <p>This is a stateful intermediate operation.
-     *
-     * @return the new stream
-     */
+    @Override
     DistributedStream<T> distinct();
 
-    /**
-     * Returns a stream consisting of the elements of this stream, sorted
-     * according to natural order.  If the elements of this stream are not
-     * {@code Comparable}, a {@code java.lang.ClassCastException} may be thrown
-     * when the terminal operation is executed.
-     *
-     * <p>For ordered streams, the sort is stable.  For unordered streams, no
-     * stability guarantees are made.
-     *
-     * <p>This is a stateful intermediate operation.
-     *
-     * @return the new stream
-     */
+    @Override
     DistributedStream<T> sorted();
 
     /**
@@ -215,7 +209,9 @@ public interface DistributedStream<T> extends Stream<T> {
      *                   {@code Distributed.Comparator} to be used to compare stream elements
      * @return the new stream
      */
-    DistributedStream<T> sorted(Distributed.Comparator<? super T> comparator);
+    default DistributedStream<T> sorted(Distributed.Comparator<? super T> comparator) {
+        return sorted((Comparator<? super T>) comparator);
+    }
 
     /**
      * Returns a stream consisting of the elements of this stream, additionally
@@ -233,32 +229,14 @@ public interface DistributedStream<T> extends Stream<T> {
      *               they are consumed from the stream
      * @return the new stream
      */
-    DistributedStream<T> peek(Distributed.Consumer<? super T> action);
+    default DistributedStream<T> peek(Distributed.Consumer<? super T> action) {
+        return peek((Consumer<? super T>) action);
+    }
 
-    /**
-     * Returns a stream consisting of the elements of this stream, truncated
-     * to be no longer than {@code maxSize} in length.
-     *
-     * <p>This is a short-circuiting stateful intermediate operation.
-     *
-     * @param maxSize the number of elements the stream should be limited to
-     * @return the new stream
-     * @throws IllegalArgumentException if {@code maxSize} is negative
-     */
+    @Override
     DistributedStream<T> limit(long maxSize);
 
-    /**
-     * Returns a stream consisting of the remaining elements of this stream
-     * after discarding the first {@code n} elements of the stream.
-     * If this stream contains fewer than {@code n} elements then an
-     * empty stream will be returned.
-     *
-     * <p>This is a stateful intermediate operation.
-     *
-     * @param n the number of leading elements to skip
-     * @return the new stream
-     * @throws IllegalArgumentException if {@code n} is negative
-     */
+    @Override
     DistributedStream<T> skip(long n);
 
     /**
@@ -269,7 +247,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @param action a
      *               non-interfering action to perform on the elements
      */
-    void forEach(Distributed.Consumer<? super T> action);
+    default void forEach(Distributed.Consumer<? super T> action) {
+        forEach((Consumer<? super T>) action);
+    }
 
     /**
      * Performs an action for each element of this stream, in the encounter
@@ -281,7 +261,9 @@ public interface DistributedStream<T> extends Stream<T> {
      *               non-interfering action to perform on the elements
      * @see #forEach(Consumer)
      */
-    void forEachOrdered(Distributed.Consumer<? super T> action);
+    default void forEachOrdered(Distributed.Consumer<? super T> action) {
+        forEachOrdered((Consumer<? super T>) action);
+    }
 
     /**
      * Performs a reduction on the
@@ -312,7 +294,9 @@ public interface DistributedStream<T> extends Stream<T> {
      *                    function for combining two values
      * @return the result of the reduction
      */
-    T reduce(T identity, Distributed.BinaryOperator<T> accumulator);
+    default T reduce(T identity, Distributed.BinaryOperator<T> accumulator) {
+        return reduce(identity, (BinaryOperator<T>) accumulator);
+    }
 
     /**
      * Performs a reduction on the
@@ -349,7 +333,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @see #min(Distributed.Comparator)
      * @see #max(Distributed.Comparator)
      */
-    Optional<T> reduce(Distributed.BinaryOperator<T> accumulator);
+    default Optional<T> reduce(Distributed.BinaryOperator<T> accumulator) {
+        return reduce((BinaryOperator<T>) accumulator);
+    }
 
     /**
      * Performs a reduction on the
@@ -393,9 +379,11 @@ public interface DistributedStream<T> extends Stream<T> {
      * @see #reduce(Distributed.BinaryOperator)
      * @see #reduce(Object, Distributed.BinaryOperator)
      */
-    <U> U reduce(U identity,
-                 Distributed.BiFunction<U, ? super T, U> accumulator,
-                 Distributed.BinaryOperator<U> combiner);
+    default <U> U reduce(U identity,
+                         Distributed.BiFunction<U, ? super T, U> accumulator,
+                         Distributed.BinaryOperator<U> combiner) {
+        return reduce(identity, (BiFunction<U, ? super T, U>) accumulator,  combiner);
+    }
 
     /**
      * Performs a mutable
@@ -431,9 +419,11 @@ public interface DistributedStream<T> extends Stream<T> {
      *                    compatible with the accumulator function
      * @return the result of the reduction
      */
-    <R> R collect(Distributed.Supplier<R> supplier,
-                  Distributed.BiConsumer<R, ? super T> accumulator,
-                  Distributed.BiConsumer<R, R> combiner);
+    default <R> R collect(Distributed.Supplier<R> supplier,
+                          Distributed.BiConsumer<R, ? super T> accumulator,
+                          Distributed.BiConsumer<R, R> combiner) {
+        return collect((Supplier<R>) supplier, accumulator, combiner);
+    }
 
     /**
      * Performs a mutable
@@ -474,7 +464,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * or an empty {@code Optional} if the stream is empty
      * @throws NullPointerException if the minimum element is null
      */
-    Optional<T> min(Distributed.Comparator<? super T> comparator);
+    default Optional<T> min(Distributed.Comparator<? super T> comparator) {
+        return min((Comparator<? super T>) comparator);
+    }
 
     /**
      * Returns the maximum element of this stream according to the provided
@@ -490,7 +482,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * or an empty {@code Optional} if the stream is empty
      * @throws NullPointerException if the maximum element is null
      */
-    Optional<T> max(Distributed.Comparator<? super T> comparator);
+    default Optional<T> max(Distributed.Comparator<? super T> comparator) {
+        return max((Comparator<? super T>) comparator);
+    }
 
     /**
      * Returns whether any elements of this stream match the provided
@@ -506,7 +500,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @return {@code true} if any elements of the stream match the provided
      * predicate, otherwise {@code false}
      */
-    boolean anyMatch(Distributed.Predicate<? super T> predicate);
+    default boolean anyMatch(Distributed.Predicate<? super T> predicate) {
+        return anyMatch((Predicate<? super T>) predicate);
+    }
 
     /**
      * Returns whether all elements of this stream match the provided predicate.
@@ -521,7 +517,9 @@ public interface DistributedStream<T> extends Stream<T> {
      * @return {@code true} if either all elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean allMatch(Distributed.Predicate<? super T> predicate);
+    default boolean allMatch(Distributed.Predicate<? super T> predicate) {
+        return allMatch((Predicate<? super T>) predicate);
+    }
 
     /**
      * Returns whether no elements of this stream match the provided predicate.
@@ -537,161 +535,94 @@ public interface DistributedStream<T> extends Stream<T> {
      * @return {@code true} if either no elements of the stream match the
      * provided predicate or the stream is empty, otherwise {@code false}
      */
-    boolean noneMatch(Distributed.Predicate<? super T> predicate);
+    default boolean noneMatch(Distributed.Predicate<? super T> predicate) {
+        return noneMatch((Predicate<? super T>) predicate);
+    }
 
-    /**
-     * Returns an equivalent stream that is sequential.  May return
-     * itself, either because the stream was already sequential, or because
-     * the underlying stream state was modified to be sequential.
-     *
-     * <p>This is an intermediate operation.
-     *
-     * @return a sequential stream
-     */
     @Override
     DistributedStream<T> sequential();
 
-    /**
-     * Returns an equivalent stream that is parallel.  May return
-     * itself, either because the stream was already parallel, or because
-     * the underlying stream state was modified to be parallel.
-     *
-     * <p>This is an intermediate operation.
-     *
-     * @return a parallel stream
-     */
     @Override
     DistributedStream<T> parallel();
 
-    /**
-     * Returns an equivalent stream that is unordered. May return
-     * itself, either because the stream was already unordered, or because
-     * the underlying stream state was modified to be unordered.
-     *
-     * <p>This is an intermediate operation.
-     *
-     * @return an unordered stream
-     */
     @Override
     DistributedStream<T> unordered();
 
     @Override
-    default DistributedStream<T> filter(Predicate<? super T> predicate) {
-        return filter((Distributed.Predicate) predicate);
-    }
+    DistributedStream<T> filter(Predicate<? super T> predicate);
 
     @Override
-    default <R> DistributedStream<R> map(Function<? super T, ? extends R> mapper) {
-        return map((Distributed.Function) mapper);
-    }
+    <R> DistributedStream<R> map(Function<? super T, ? extends R> mapper);
 
     @Override
-    default DistributedIntStream mapToInt(ToIntFunction<? super T> mapper) {
-        return mapToInt((Distributed.ToIntFunction) mapper);
-    }
+    DistributedIntStream mapToInt(ToIntFunction<? super T> mapper);
 
     @Override
-    default DistributedLongStream mapToLong(ToLongFunction<? super T> mapper) {
-        return mapToLong((Distributed.ToLongFunction) mapper);
-    }
+    DistributedLongStream mapToLong(ToLongFunction<? super T> mapper);
 
     @Override
-    default DistributedDoubleStream mapToDouble(ToDoubleFunction<? super T> mapper) {
-        return mapToDouble((Distributed.ToDoubleFunction) mapper);
-    }
+    DistributedDoubleStream mapToDouble(ToDoubleFunction<? super T> mapper);
 
     @Override
-    default <R> DistributedStream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper) {
-        return flatMap((Distributed.Function) mapper);
-    }
+    <R> DistributedStream<R> flatMap(Function<? super T, ? extends Stream<? extends R>> mapper);
 
     @Override
-    default DistributedIntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper) {
-        return flatMapToInt((Distributed.Function) mapper);
-    }
+    DistributedIntStream flatMapToInt(Function<? super T, ? extends IntStream> mapper);
 
     @Override
-    default DistributedLongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper) {
-        return flatMapToLong((Distributed.Function) mapper);
-    }
+    DistributedLongStream flatMapToLong(Function<? super T, ? extends LongStream> mapper);
 
     @Override
-    default DistributedDoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper) {
-        return flatMapToDouble((Distributed.Function) mapper);
-    }
+    DistributedDoubleStream flatMapToDouble(Function<? super T, ? extends DoubleStream> mapper);
 
     @Override
-    default DistributedStream<T> sorted(Comparator<? super T> comparator) {
-        return sorted((Distributed.Comparator) comparator);
-    }
+    DistributedStream<T> sorted(Comparator<? super T> comparator);
 
     @Override
-    default DistributedStream<T> peek(Consumer<? super T> action) {
-        return peek((Distributed.Consumer) action);
-    }
+    DistributedStream<T> peek(Consumer<? super T> action);
 
     @Override
-    default void forEach(Consumer<? super T> action) {
-        forEach((Distributed.Consumer) action);
-    }
+    void forEach(Consumer<? super T> action);
 
     @Override
-    default void forEachOrdered(Consumer<? super T> action) {
-        forEachOrdered((Distributed.Consumer) action);
-    }
+    void forEachOrdered(Consumer<? super T> action);
 
     @Override
-    default T reduce(T identity, BinaryOperator<T> accumulator) {
-        return reduce(identity, (Distributed.BinaryOperator<T>) accumulator);
-    }
+    T reduce(T identity, BinaryOperator<T> accumulator);
 
     @Override
-    default Optional<T> reduce(BinaryOperator<T> accumulator) {
-        return reduce((Distributed.BinaryOperator<T>) accumulator);
-    }
+    Optional<T> reduce(BinaryOperator<T> accumulator);
 
     @Override
-    default <U> U reduce(U identity, BiFunction<U, ? super T, U> accumulator, BinaryOperator<U> combiner) {
-        return reduce(identity,
-                (Distributed.BiFunction<U, ? super T, U>) accumulator,
-                (Distributed.BinaryOperator<U>) combiner);
-    }
+    <U> U reduce(U identity, BiFunction<U, ? super T, U> accumulator, BinaryOperator<U> combiner);
 
     @Override
-    default <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator, BiConsumer<R, R> combiner) {
-        return collect((Distributed.Supplier<R>) supplier,
-                (Distributed.BiConsumer<R, ? super T>) accumulator,
-                (Distributed.BiConsumer<R, R>) combiner);
-    }
+    <R> R collect(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator, BiConsumer<R, R> combiner);
 
     @Override
     default <R, A> R collect(Collector<? super T, A, R> collector) {
-        return (R) collect((DistributedCollector) collector);
+        if (!(collector instanceof DistributedCollector)) {
+            throw new IllegalArgumentException("You must use DistributedCollector");
+        }
+
+        //noinspection unchecked
+        return collect((DistributedCollector<? super T, A, R>) collector);
     }
 
     @Override
-    default Optional<T> min(Comparator<? super T> comparator) {
-        return min((Distributed.Comparator) comparator);
-    }
+    Optional<T> min(Comparator<? super T> comparator);
 
     @Override
-    default Optional<T> max(Comparator<? super T> comparator) {
-        return max((Distributed.Comparator) comparator);
-    }
+
+    Optional<T> max(Comparator<? super T> comparator);
 
     @Override
-    default boolean anyMatch(Predicate<? super T> predicate) {
-        return anyMatch((Distributed.Predicate) predicate);
-    }
+    boolean anyMatch(Predicate<? super T> predicate);
 
     @Override
-    default boolean allMatch(Predicate<? super T> predicate) {
-        return allMatch((Distributed.Predicate) predicate);
-    }
+    boolean allMatch(Predicate<? super T> predicate);
 
     @Override
-    default boolean noneMatch(Predicate<? super T> predicate) {
-        return noneMatch((Distributed.Predicate) predicate);
-    }
+    boolean noneMatch(Predicate<? super T> predicate);
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/collectors/CustomStreamCollector.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/collectors/CustomStreamCollector.java
@@ -17,12 +17,14 @@
 package com.hazelcast.jet.stream.impl.collectors;
 
 import com.hazelcast.jet.DAG;
-import com.hazelcast.jet.Distributed.BiConsumer;
-import com.hazelcast.jet.Distributed.Supplier;
 import com.hazelcast.jet.Vertex;
 import com.hazelcast.jet.stream.impl.pipeline.Pipeline;
 import com.hazelcast.jet.stream.impl.pipeline.StreamContext;
 
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 import static com.hazelcast.jet.stream.impl.collectors.DistributedCollectorImpl.buildAccumulator;
 import static com.hazelcast.jet.stream.impl.collectors.DistributedCollectorImpl.buildCombiner;
 import static com.hazelcast.jet.stream.impl.collectors.DistributedCollectorImpl.execute;
@@ -35,6 +37,9 @@ public class CustomStreamCollector<T, R> extends AbstractCollector<T, R, R> {
 
     public CustomStreamCollector(Supplier<R> supplier, BiConsumer<R, ? super T> accumulator,
                                  BiConsumer<R, R> combiner) {
+        checkSerializable(supplier, "supplier");
+        checkSerializable(accumulator, "accumulator");
+        checkSerializable(combiner, "combiner");
         this.supplier = supplier;
         this.accumulator = accumulator;
         this.combiner = combiner;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/collectors/DistributedCollectorImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/collectors/DistributedCollectorImpl.java
@@ -18,14 +18,10 @@ package com.hazelcast.jet.stream.impl.collectors;
 
 import com.hazelcast.core.IList;
 import com.hazelcast.jet.DAG;
-import com.hazelcast.jet.Distributed.BiConsumer;
-import com.hazelcast.jet.Distributed.BinaryOperator;
-import com.hazelcast.jet.Distributed.Function;
-import com.hazelcast.jet.Distributed.Supplier;
+import com.hazelcast.jet.Distributed;
 import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.Processors;
 import com.hazelcast.jet.Vertex;
-import com.hazelcast.jet.Distributed;
 import com.hazelcast.jet.stream.DistributedCollector;
 import com.hazelcast.jet.stream.impl.pipeline.Pipeline;
 import com.hazelcast.jet.stream.impl.pipeline.StreamContext;
@@ -34,6 +30,10 @@ import com.hazelcast.jet.stream.impl.processor.CollectorCombinerP;
 import com.hazelcast.jet.stream.impl.processor.CombinerP;
 
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.stream.impl.StreamUtil.executeJob;
@@ -100,7 +100,7 @@ public class DistributedCollectorImpl<T, A, R> implements DistributedCollector<T
 
     static <A, R> Vertex buildCombiner(DAG dag, Vertex accumulatorVertex,
                                        Object combiner, Function<A, R> finisher) {
-        Supplier<Processor> processorSupplier = getCombinerSupplier(combiner, finisher);
+        Distributed.Supplier<Processor> processorSupplier = getCombinerSupplier(combiner, finisher);
         Vertex combinerVertex = dag.newVertex(uniqueVertexName("combiner"), processorSupplier).localParallelism(1);
         dag.edge(between(accumulatorVertex, combinerVertex)
                 .distributed()
@@ -110,7 +110,7 @@ public class DistributedCollectorImpl<T, A, R> implements DistributedCollector<T
         return combinerVertex;
     }
 
-    private static <A, R> Supplier<Processor> getCombinerSupplier(Object combiner, Function<A, R> finisher) {
+    private static <A, R> Distributed.Supplier<Processor> getCombinerSupplier(Object combiner, Function<A, R> finisher) {
         if (combiner instanceof BiConsumer) {
             return () -> new CollectorCombinerP((BiConsumer) combiner, finisher);
         } else if (combiner instanceof BinaryOperator) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/PeekPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/PeekPipeline.java
@@ -20,7 +20,9 @@ import com.hazelcast.core.IList;
 import com.hazelcast.jet.DAG;
 import com.hazelcast.jet.Processors;
 import com.hazelcast.jet.Vertex;
-import com.hazelcast.jet.Distributed;
+import com.hazelcast.jet.stream.impl.StreamUtil;
+
+import java.util.function.Consumer;
 
 import static com.hazelcast.jet.Edge.from;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
@@ -28,10 +30,11 @@ import static com.hazelcast.jet.stream.impl.StreamUtil.writerVertexName;
 
 public class PeekPipeline<T> extends AbstractIntermediatePipeline<T, T> {
 
-    private final Distributed.Consumer<? super T> consumer;
+    private final Consumer<? super T> consumer;
 
-    public PeekPipeline(StreamContext context, Pipeline<T> upstream, Distributed.Consumer<? super T> consumer) {
+    public PeekPipeline(StreamContext context, Pipeline<T> upstream, Consumer<? super T> consumer) {
         super(context, upstream.isOrdered(), upstream);
+        StreamUtil.checkSerializable(consumer, "consumer");
         this.consumer = consumer;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/terminal/Matcher.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/terminal/Matcher.java
@@ -18,14 +18,17 @@ package com.hazelcast.jet.stream.impl.terminal;
 
 import com.hazelcast.core.IList;
 import com.hazelcast.jet.DAG;
+import com.hazelcast.jet.Distributed;
 import com.hazelcast.jet.Processors;
 import com.hazelcast.jet.Vertex;
-import com.hazelcast.jet.Distributed;
 import com.hazelcast.jet.stream.impl.pipeline.Pipeline;
 import com.hazelcast.jet.stream.impl.pipeline.StreamContext;
 import com.hazelcast.jet.stream.impl.processor.AnyMatchP;
 
+import java.util.function.Predicate;
+
 import static com.hazelcast.jet.Edge.between;
+import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 import static com.hazelcast.jet.stream.impl.StreamUtil.executeJob;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueVertexName;
@@ -40,6 +43,11 @@ public class Matcher {
     }
 
     public <T> boolean anyMatch(Pipeline<T> upstream, Distributed.Predicate<? super T> predicate) {
+        return anyMatch(upstream, (java.util.function.Predicate<? super T>) predicate);
+    }
+
+    public <T> boolean anyMatch(Pipeline<T> upstream, Predicate<? super T> predicate) {
+        checkSerializable(predicate, "predicate");
         DAG dag = new DAG();
         Vertex anyMatch = dag.newVertex(uniqueVertexName("any-match"), () -> new AnyMatchP<>(predicate));
         Vertex previous = upstream.buildDAG(dag);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ComparatorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ComparatorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+
+public class ComparatorTest {
+    @Before
+    public void setUp() throws Exception {
+
+    }
+
+    @Test
+    public void naturalOrder() throws Exception {
+        checkSerializable(Distributed.Comparator.naturalOrder(), null);
+    }
+
+    @Test
+    public void reverseOrder() throws Exception {
+        checkSerializable(Distributed.Comparator.reverseOrder(), null);
+    }
+
+    @Test
+    public void thenComparing_keyExtractor() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.naturalOrder()
+                    .thenComparing(Object::toString),
+                null);
+    }
+
+    @Test
+    public void thenComparing_otherComparator() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.naturalOrder()
+                                      .thenComparing(Comparable::compareTo),
+                null);
+    }
+
+    @Test
+    public void thenComparing_keyExtractor_keyComparator() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.naturalOrder()
+                                      .thenComparing(Object::toString, Comparable::compareTo),
+                null);
+    }
+
+    @Test
+    public void thenComparingInt() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.naturalOrder()
+                                      .thenComparingInt(Object::hashCode),
+                null);
+    }
+
+    @Test
+    public void thenComparingLong() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.<Long>naturalOrder()
+                                      .thenComparingLong(Long::longValue),
+                null);
+    }
+
+    @Test
+    public void thenComparingDouble() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.<Double>naturalOrder()
+                        .thenComparingDouble(Double::doubleValue),
+                null);
+    }
+
+    @Test
+    public void nullsFirst() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.<Comparable>nullsFirst(Comparable::compareTo),
+                null);
+    }
+
+    @Test
+    public void nullsLast() throws Exception {
+        checkSerializable(
+                Distributed.Comparator.<Comparable>nullsLast(Comparable::compareTo),
+                null);
+    }
+
+    @Test
+    public void comparing_keyExtractor() throws Exception {
+        checkSerializable(Distributed.Comparator.comparing(Object::toString), null);
+    }
+
+    @Test
+    public void comparing_keyExtractor_keyComparator() throws Exception {
+        checkSerializable(Distributed.Comparator.comparing(Object::toString, String::compareTo), null);
+    }
+
+    @Test
+    public void comparingInt() throws Exception {
+        checkSerializable(Distributed.Comparator.comparingInt(Object::hashCode), null);
+    }
+
+    @Test
+    public void comparingLong() throws Exception {
+        checkSerializable(Distributed.Comparator.comparingLong(Long::longValue), null);
+    }
+
+    @Test
+    public void comparingDouble() throws Exception {
+        checkSerializable(Distributed.Comparator.comparingDouble(Double::doubleValue), null);
+    }
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamCastingTest.java
@@ -20,6 +20,7 @@ package com.hazelcast.jet.stream;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,6 +28,8 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
+
+import static org.junit.Assert.assertTrue;
 
 public class DistributedStreamCastingTest extends AbstractStreamTest {
 
@@ -38,120 +41,131 @@ public class DistributedStreamCastingTest extends AbstractStreamTest {
         stream = list.stream();
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void map() {
         stream.map(Object::toString);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void flatMap() {
         stream.flatMap(Stream::of);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void collect() {
         stream.collect(Collectors.counting());
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void collect2() {
         stream.collect(() -> new Integer[]{0},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEach() {
         stream.forEach(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEachOrdered() {
         stream.forEachOrdered(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void allMatch() {
         stream.allMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void anyMatch() {
         stream.anyMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void noneMatch() {
         stream.noneMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void filter() {
         stream.filter(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToInt() {
         stream.mapToInt(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToDouble() {
         stream.mapToDouble(m -> (double) m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToLong() {
         stream.mapToLong(m -> (long) m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void flatMapToInt() {
         stream.flatMapToInt(IntStream::of);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void flatMapToDouble() {
         stream.flatMapToDouble(DoubleStream::of);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void flatMapToLong() {
         stream.flatMapToLong(LongStream::of);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void max() {
-        stream.max(Comparator.naturalOrder());
+        Comparator<Integer> c = Integer::compareTo;
+        stream.max(c);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void min() {
-        stream.min(Comparator.naturalOrder());
+        Comparator<Integer> c = Integer::compareTo;
+        stream.min(c);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void peek() {
         stream.peek(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce() {
         stream.reduce((l, r) -> l + r);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce2() {
         stream.reduce(0, (l, r) -> l + r);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce3() {
         stream.reduce(0, (l, r) -> l + r, (l, r) -> l + r);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void sorted() {
-        stream.sorted(Comparator.naturalOrder());
+        Comparator<Integer> c = Integer::compareTo;
+        stream.sorted(c);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sorted_when_serializableButNotReally_then_fail() {
+        Comparator<Integer> comparator = Comparator.comparing(Object::toString);
+        assertTrue(comparator instanceof Serializable);
+        // Comparator.comparing returns serializable instance, however, its keyExtractor is not, so it should fail here
+        stream.sorted(comparator);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamNonDistributedFunctionsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamNonDistributedFunctionsTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.stream;
+
+
+import com.hazelcast.jet.Distributed.Function;
+import com.hazelcast.jet.Distributed.ToDoubleFunction;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+public class DistributedStreamNonDistributedFunctionsTest extends AbstractStreamTest {
+
+    private Stream<Integer> stream;
+
+    @Before
+    public void setUp() {
+        List<Integer> list = getList();
+        stream = list.stream();
+    }
+
+    @Test
+    public void map() {
+        Function<Integer, String> f = (Function<Integer, String> & Serializable) Object::toString;
+        stream.map(f);
+    }
+
+    @Test
+    public void flatMap() {
+        java.util.function.Function<Integer, Stream<? extends Integer>> f =
+                (java.util.function.Function<Integer, Stream<? extends Integer>> & Serializable) Stream::of;
+        stream.flatMap(f);
+    }
+
+    @Test
+    public void collect2() {
+        Supplier<Integer[]> supplier = (Supplier<Integer[]> & Serializable) () -> new Integer[]{0};
+        BiConsumer<Integer[], Integer> accumulator = (BiConsumer<Integer[], Integer> & Serializable) (r, e) -> r[0] += e;
+        BiConsumer<Integer[], Integer[]> combiner = (BiConsumer<Integer[], Integer[]> & Serializable) (a, b) -> a[0] += b[0];
+        stream.collect(supplier,
+                accumulator,
+                combiner);
+    }
+
+    @Test
+    public void forEach() {
+        Consumer<Integer> action = (Consumer<Integer> & Serializable) v -> {};
+        stream.forEach(action);
+    }
+
+    @Test
+    public void forEachOrdered() {
+        Consumer<Integer> action = (Consumer<Integer> & Serializable) v -> {};
+        stream.forEachOrdered(action);
+    }
+
+    @Test
+    public void allMatch() {
+        Predicate<Integer> predicate = (Predicate<Integer> & Serializable) m -> true;
+        stream.allMatch(predicate);
+    }
+
+    @Test
+    public void anyMatch() {
+        Predicate<Integer> predicate = (Predicate<Integer> & Serializable) m -> true;
+        stream.anyMatch(predicate);
+    }
+
+    @Test
+    public void noneMatch() {
+        Predicate<Integer> predicate = (Predicate<Integer> & Serializable) m -> true;
+        stream.noneMatch(predicate);
+    }
+
+    @Test
+    public void filter() {
+        Predicate<Integer> predicate = (Predicate<Integer> & Serializable) m -> true;
+        stream.filter(predicate);
+    }
+
+    @Test
+    public void mapToInt() {
+        ToIntFunction<Integer> mapper = (ToIntFunction<Integer> & Serializable) m -> m;
+        stream.mapToInt(mapper);
+    }
+
+    @Test
+    public void mapToDouble() {
+        ToDoubleFunction<Integer> mapper = (ToDoubleFunction<Integer> & Serializable) m -> m;
+        stream.mapToDouble(mapper);
+    }
+
+    @Test
+    public void mapToLong() {
+        ToLongFunction<Integer> mapper = (ToLongFunction<Integer> & Serializable) m -> (long) m;
+        stream.mapToLong(mapper);
+    }
+
+    @Test
+    public void flatMapToInt() {
+        java.util.function.Function<Integer, IntStream> function = (java.util.function.Function<Integer, IntStream> & Serializable) IntStream::of;
+        stream.flatMapToInt(function);
+    }
+
+    @Test
+    public void flatMapToDouble() {
+        java.util.function.Function<Integer, DoubleStream> function = (java.util.function.Function<Integer, DoubleStream> & Serializable) DoubleStream::of;
+        stream.flatMapToDouble(function);
+    }
+
+    @Test
+    public void flatMapToLong() {
+        java.util.function.Function<Integer, LongStream> function = (java.util.function.Function<Integer, LongStream> & Serializable) LongStream::of;
+        stream.flatMapToLong(function);
+    }
+
+    @Test
+    public void max() {
+        Comparator<Integer> comparator = (Comparator<Integer> & Serializable) Integer::compareTo;
+        stream.max(comparator);
+    }
+
+    @Test
+    public void min() {
+        Comparator<Integer> comparator = (Comparator<Integer> & Serializable) Integer::compareTo;
+        stream.min(comparator);
+    }
+
+    @Test
+    public void peek() {
+        Consumer<Integer> action = (Consumer<Integer> & Serializable) v -> {};
+        stream.peek(action);
+    }
+
+    @Test
+    public void reduce() {
+        BinaryOperator<Integer> accumulator = (BinaryOperator<Integer> & Serializable) (l, r) -> l + r;
+        stream.reduce(accumulator);
+    }
+
+    @Test
+    public void reduce2() {
+        BinaryOperator<Integer> accumulator = (BinaryOperator<Integer> & Serializable) (l, r) -> l + r;
+        stream.reduce(0, accumulator);
+    }
+
+    @Test
+    public void reduce3() {
+        BiFunction<Integer, Integer, Integer> accumulator = (BiFunction<Integer, Integer, Integer> & Serializable) (l, r) -> l + r;
+        BinaryOperator<Integer> combiner = (BinaryOperator<Integer> & Serializable) (l, r) -> l + r;
+        stream.reduce(0, accumulator, combiner);
+    }
+
+    @Test
+    public void sorted() {
+        Comparator<Integer> comparator = (Comparator<Integer> & Serializable) Integer::compareTo;
+        stream.sorted(comparator);
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamCastingTest.java
@@ -31,79 +31,79 @@ public class DoubleStreamCastingTest extends AbstractStreamTest {
         stream = list.stream().mapToDouble(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void map() {
         stream.map(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void flatMap() {
         stream.flatMap(DoubleStream::of);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void collect() {
         stream.collect(() -> new Double[]{0D},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEach() {
         stream.forEach(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEachOrdered() {
         stream.forEachOrdered(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void allMatch() {
         stream.allMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void anyMatch() {
         stream.anyMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void noneMatch() {
         stream.noneMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void filter() {
         stream.filter(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToObj() {
         stream.mapToObj(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToInt() {
         stream.mapToInt(m -> (int) m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToLong() {
         stream.mapToLong(m -> (long) m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void peek() {
         stream.peek(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce() {
         stream.reduce((l, r) -> l + r);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce2() {
         stream.reduce(0, (l, r) -> l + r);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/IntStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/IntStreamCastingTest.java
@@ -31,79 +31,79 @@ public class IntStreamCastingTest extends AbstractStreamTest {
         stream = list.stream().mapToInt(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void map() {
         stream.map(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void flatMap() {
         stream.flatMap(IntStream::of);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void collect() {
         stream.collect(() -> new Integer[]{0},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEach() {
         stream.forEach(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEachOrdered() {
         stream.forEachOrdered(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void allMatch() {
         stream.allMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void anyMatch() {
         stream.anyMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void noneMatch() {
         stream.noneMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void filter() {
         stream.filter(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToObj() {
         stream.mapToObj(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToDouble() {
         stream.mapToDouble(m -> (double) m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToLong() {
         stream.mapToLong(m -> (long) m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void peek() {
         stream.peek(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce() {
         stream.reduce((l, r) -> l + r);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce2() {
         stream.reduce(0, (l, r) -> l + r);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamCastingTest.java
@@ -32,79 +32,79 @@ public class LongStreamCastingTest extends AbstractStreamTest {
         stream = list.stream().mapToLong(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void map() {
         stream.map(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void flatMap() {
         stream.flatMap(LongStream::of);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void collect() {
         stream.collect(() -> new Long[]{0L},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEach() {
         stream.forEach(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void forEachOrdered() {
         stream.forEachOrdered(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void allMatch() {
         stream.allMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void anyMatch() {
         stream.anyMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void noneMatch() {
         stream.noneMatch(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void filter() {
         stream.filter(m -> true);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToObj() {
         stream.mapToObj(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToInt() {
         stream.mapToInt(m -> (int) m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapToDouble() {
         stream.mapToDouble(m -> m);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void peek() {
         stream.peek(System.out::println);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce() {
         stream.reduce((l, r) -> l + r);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void reduce2() {
         stream.reduce(0, (l, r) -> l + r);
     }


### PR DESCRIPTION
Currently, equivalents of `java.util.function` interfaces in `Distributed`
class are required as parameters to `DistributedStream`. Technically, we only
need to ensure, that the provided implementations are serializable and not
require implementing our interface.

The `Distributed` versions are to be used as overloaded parameter type, so
that lambda expressions need not be casted.