### PR TITLE
Do not fail job when new members join

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadIMapP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadIMapP.java
@@ -32,6 +32,7 @@ import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.nio.Address;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -213,7 +214,7 @@ public final class ReadIMapP extends AbstractProcessor {
 
         LocalClusterProcessorSupplier(String mapName, List<Integer> ownedPartitions, int fetchSize) {
             this.mapName = mapName;
-            this.ownedPartitions = ownedPartitions;
+            this.ownedPartitions = ownedPartitions != null ? ownedPartitions : Collections.emptyList();
             this.fetchSize = fetchSize;
         }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TopologyChangeSplitClusterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TopologyChangeSplitClusterTest.java
@@ -16,7 +16,8 @@
 
 package com.hazelcast.jet;
 
-import com.hazelcast.test.AssertTask;
+import com.hazelcast.jet.TopologyChangeTest.MockSupplier;
+import com.hazelcast.jet.TopologyChangeTest.StuckProcessor;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
@@ -75,14 +76,11 @@ public class TopologyChangeSplitClusterTest extends JetSplitBrainTestSupport {
         // Then
         assertEquals(NODE_COUNT, MockSupplier.initCount.get());
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertEquals(NODE_COUNT, MockSupplier.completeCount.get());
-                assertEquals(NODE_COUNT, MockSupplier.completeErrors.size());
-                for (int i = 0; i < NODE_COUNT; i++) {
-                    assertInstanceOf(TopologyChangedException.class, MockSupplier.completeErrors.get(i));
-                }
+        assertTrueEventually(() -> {
+            assertEquals(NODE_COUNT, MockSupplier.completeCount.get());
+            assertEquals(NODE_COUNT, MockSupplier.completeErrors.size());
+            for (int i = 0; i < NODE_COUNT; i++) {
+                assertInstanceOf(TopologyChangedException.class, MockSupplier.completeErrors.get(i));
             }
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock.version}</version>


### PR DESCRIPTION
Do not fail job when new members join after execution is planned and even when those new members are removed.

PS: *According to our latest meeting on Friday, this change should target 0.3.1.*