### PR TITLE
Add mandatory map/list name parameter to collector

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedCollectors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedCollectors.java
@@ -1048,17 +1048,19 @@ public abstract class DistributedCollectors {
      * @param <T>         the type of the input elements
      * @param <K>         the output type of the key mapping function
      * @param <U>         the output type of the value mapping function
+     * @param mapName Name of the map to store the results
      * @param keyMapper   a mapping function to produce keys
      * @param valueMapper a mapping function to produce values
      * @return a {@code Reducer} which collects elements into a {@code IMap}
      * whose keys and values are the result of applying mapping functions to
      * the input elements
-     * @see #toIMap(Distributed.Function, Distributed.Function, Distributed.BinaryOperator)
+     * @see #toIMap(String, Distributed.Function, Distributed.Function, Distributed.BinaryOperator)
      */
     public static <T, K, U> Reducer<T, IStreamMap<K, U>>
-    toIMap(Distributed.Function<? super T, ? extends K> keyMapper,
+    toIMap(String mapName,
+           Distributed.Function<? super T, ? extends K> keyMapper,
            Distributed.Function<? super T, ? extends U> valueMapper) {
-        return new IMapReducer<>(keyMapper, valueMapper);
+        return new IMapReducer<>(mapName, keyMapper, valueMapper);
     }
 
     /**
@@ -1076,14 +1078,15 @@ public abstract class DistributedCollectors {
      *
      * @param <K> The type of the key in {@code Map.Entry}
      * @param <U> The type of the value in {@code Map.Entry}
+     * @param mapName Name of the map to store the results
      * @return a {@code Reducer} that accumulates elements into a
      * Hazelcast {@code IMap} whose keys and values are the keys and values of the corresponding
      * {@code Map.Entry}.
-     * @see #toIMap(Distributed.Function, Distributed.Function)
-     * @see #toIMap(Distributed.Function, Distributed.Function, Distributed.BinaryOperator)
+     * @see #toIMap(String, Distributed.Function, Distributed.Function)
+     * @see #toIMap(String, Distributed.Function, Distributed.Function, Distributed.BinaryOperator)
      */
-    public static <K, U> Reducer<Entry<K, U>, IStreamMap<K, U>> toIMap() {
-        return toIMap(Map.Entry::getKey, Map.Entry::getValue);
+    public static <K, U> Reducer<Entry<K, U>, IStreamMap<K, U>> toIMap(String mapName) {
+        return toIMap(mapName, Map.Entry::getKey, Map.Entry::getValue);
     }
 
     /**
@@ -1101,6 +1104,7 @@ public abstract class DistributedCollectors {
      * @param <T>           the type of the input elements
      * @param <K>           the output type of the key mapping function
      * @param <U>           the output type of the value mapping function
+     * @param mapName Name of the map to store the results
      * @param keyMapper     a mapping function to produce keys
      * @param valueMapper   a mapping function to produce values
      * @param mergeFunction a merge function, used to resolve collisions between
@@ -1112,13 +1116,14 @@ public abstract class DistributedCollectors {
      * elements, and whose values are the result of applying a value mapping
      * function to all input elements equal to the key and combining them
      * using the merge function
-     * @see #toIMap(Distributed.Function, Distributed.Function)
+     * @see #toIMap(String, Distributed.Function, Distributed.Function)
      */
     public static <T, K, U> Reducer<T, IStreamMap<K, U>>
-    toIMap(Distributed.Function<? super T, ? extends K> keyMapper,
+    toIMap(String mapName,
+           Distributed.Function<? super T, ? extends K> keyMapper,
            Distributed.Function<? super T, ? extends U> valueMapper,
            Distributed.BinaryOperator<U> mergeFunction) {
-        return new MergingIMapReducer<>(keyMapper, valueMapper, mergeFunction);
+        return new MergingIMapReducer<>(mapName, keyMapper, valueMapper, mergeFunction);
     }
 
     /**
@@ -1128,11 +1133,12 @@ public abstract class DistributedCollectors {
      * The returned collector may not be used as a downstream collector.
      *
      * @param <T> the type of the input elements
+     * @param listName Name of the list to store the results
      * @return a {@code Distributed.Collector} which collects all the input elements into a
      * Hazelcast {@code IList}, in encounter order
      */
-    public static <T> Reducer<T, IStreamList<T>> toIList() {
-        return new IListReducer<>();
+    public static <T> Reducer<T, IStreamList<T>> toIList(String listName) {
+        return new IListReducer<>(listName);
     }
 
     /**
@@ -1152,13 +1158,14 @@ public abstract class DistributedCollectors {
      *
      * @param <T>        the type of the input elements
      * @param <K>        the type of the keys
+     * @param mapName Name of the map to store the results
      * @param classifier the classifier function mapping input elements to keys
      * @return a {@code Reducer} implementing the group-by operation
-     * @see #groupingByToIMap(Distributed.Function, DistributedCollector)
+     * @see #groupingByToIMap(String, Distributed.Function, DistributedCollector)
      */
     public static <T, K> Reducer<T, IMap<K, List<T>>>
-    groupingByToIMap(Distributed.Function<? super T, ? extends K> classifier) {
-        return groupingByToIMap(classifier, toList());
+    groupingByToIMap(String mapName, Distributed.Function<? super T, ? extends K> classifier) {
+        return groupingByToIMap(mapName, classifier, toList());
     }
 
     /**
@@ -1184,14 +1191,16 @@ public abstract class DistributedCollectors {
      * @param <K>        the type of the keys
      * @param <A>        the intermediate accumulation type of the downstream collector
      * @param <D>        the result type of the downstream reduction
+     * @param mapName Name of the map to store the results
      * @param classifier a classifier function mapping input elements to keys
      * @param downstream a {@code Distributed.Collector} implementing the downstream reduction
      * @return a {@code Reducer} implementing the cascaded group-by operation
-     * @see #groupingByToIMap(Distributed.Function)
+     * @see #groupingByToIMap(String, Distributed.Function)
      */
     public static <T, K, A, D>
-    Reducer<T, IMap<K, D>> groupingByToIMap(Distributed.Function<? super T, ? extends K> classifier,
+    Reducer<T, IMap<K, D>> groupingByToIMap(String mapName,
+                                            Distributed.Function<? super T, ? extends K> classifier,
                                             DistributedCollector<? super T, A, D> downstream) {
-        return new GroupingIMapReducer<>(classifier, downstream);
+        return new GroupingIMapReducer<>(mapName, classifier, downstream);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import static com.hazelcast.jet.Traversers.traverseStream;
 import static com.hazelcast.jet.stream.DistributedCollectors.toIList;
 import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static com.hazelcast.util.Preconditions.checkTrue;
 
 @SuppressWarnings(value = {"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
@@ -163,7 +164,7 @@ abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     @Override
     public void forEach(Consumer<? super E_OUT> action) {
-        IList<E_OUT> list = this.collect(toIList());
+        IList<E_OUT> list = this.collect(toIList(uniqueListName()));
         list.forEach(action::accept);
         list.destroy();
     }
@@ -175,7 +176,7 @@ abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     @Override
     public Object[] toArray() {
-        IList<E_OUT> list = collect(toIList());
+        IList<E_OUT> list = collect(toIList(uniqueListName()));
         Object[] array = list.toArray();
         list.destroy();
         return array;
@@ -183,7 +184,7 @@ abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     @Override
     public <A> A[] toArray(IntFunction<A[]> generator) {
-        IList<E_OUT> list = collect(toIList());
+        IList<E_OUT> list = collect(toIList(uniqueListName()));
         A[] array = generator.apply(list.size());
         array = list.toArray(array);
         list.destroy();
@@ -274,7 +275,7 @@ abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     @Override
     public Optional<E_OUT> findFirst() {
-        IList<E_OUT> first = this.limit(1).collect(toIList());
+        IList<E_OUT> first = this.limit(1).collect(toIList(uniqueListName()));
         Optional<E_OUT> value = first.size() == 0 ? Optional.empty() : Optional.of(first.get(0));
         first.destroy();
         return value;
@@ -287,7 +288,7 @@ abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     @Override
     public Iterator<E_OUT> iterator() {
-        IList<E_OUT> list = collect(toIList());
+        IList<E_OUT> list = collect(toIList(uniqueListName()));
         Iterator<E_OUT> iterator = list.iterator();
         list.destroy();
         return iterator;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
@@ -44,6 +44,7 @@ import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
 @SuppressWarnings("checkstyle:methodcount")
 class DoublePipeline implements DistributedDoubleStream {
@@ -133,15 +134,19 @@ class DoublePipeline implements DistributedDoubleStream {
 
     @Override
     public double[] toArray() {
-        IList<Double> list = inner.collect(DistributedCollectors.toIList());
-        double[] array = new double[list.size()];
+        IList<Double> list = inner.collect(DistributedCollectors.toIList(uniqueListName()));
+        try {
+            double[] array = new double[list.size()];
 
-        Iterator<Double> iterator = list.iterator();
-        int index = 0;
-        while (iterator.hasNext()) {
-            array[index++] = iterator.next();
+            int index = 0;
+            for (Double d : list) {
+                array[index++] = d;
+            }
+
+            return array;
+        } finally {
+            list.destroy();
         }
-        return array;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
@@ -45,6 +45,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
 @SuppressWarnings("checkstyle:methodcount")
 class IntPipeline implements DistributedIntStream {
@@ -134,15 +135,18 @@ class IntPipeline implements DistributedIntStream {
 
     @Override
     public int[] toArray() {
-        IList<Integer> list = inner.collect(DistributedCollectors.toIList());
-        int[] array = new int[list.size()];
+        IList<Integer> list = inner.collect(DistributedCollectors.toIList(uniqueListName()));
+        try {
+            int[] array = new int[list.size()];
 
-        Iterator<Integer> iterator = list.iterator();
-        int index = 0;
-        while (iterator.hasNext()) {
-            array[index++] = iterator.next();
+            int index = 0;
+            for (Integer i : list) {
+                array[index++] = i;
+            }
+            return array;
+        } finally {
+            list.destroy();
         }
-        return array;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
@@ -45,6 +45,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
 @SuppressWarnings("checkstyle:methodcount")
 class LongPipeline implements DistributedLongStream {
@@ -134,15 +135,18 @@ class LongPipeline implements DistributedLongStream {
 
     @Override
     public long[] toArray() {
-        IList<Long> list = inner.collect(DistributedCollectors.toIList());
-        long[] array = new long[list.size()];
+        IList<Long> list = inner.collect(DistributedCollectors.toIList(uniqueListName()));
+        try {
+            long[] array = new long[list.size()];
 
-        Iterator<Long> iterator = list.iterator();
-        int index = 0;
-        while (iterator.hasNext()) {
-            array[index++] = iterator.next();
+            int index = 0;
+            for (Long l : list) {
+                array[index++] = l;
+            }
+            return array;
+        } finally {
+            list.destroy();
         }
-        return array;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/GroupingIMapReducer.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/GroupingIMapReducer.java
@@ -18,9 +18,7 @@ package com.hazelcast.jet.stream.impl.reducers;
 
 import com.hazelcast.core.IMap;
 import com.hazelcast.jet.DAG;
-import com.hazelcast.jet.Distributed;
 import com.hazelcast.jet.Vertex;
-import com.hazelcast.jet.stream.DistributedCollector;
 import com.hazelcast.jet.stream.DistributedCollector.Reducer;
 import com.hazelcast.jet.stream.impl.pipeline.Pipeline;
 import com.hazelcast.jet.stream.impl.pipeline.StreamContext;
@@ -35,7 +33,6 @@ import static com.hazelcast.jet.KeyExtractors.entryKey;
 import static com.hazelcast.jet.Partitioner.HASH_CODE;
 import static com.hazelcast.jet.Processors.writeMap;
 import static com.hazelcast.jet.stream.impl.StreamUtil.executeJob;
-import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueMapName;
 
 public class GroupingIMapReducer<T, A, K, D> implements Reducer<T, IMap<K, D>> {
 
@@ -43,12 +40,7 @@ public class GroupingIMapReducer<T, A, K, D> implements Reducer<T, IMap<K, D>> {
     private final Function<? super T, ? extends K> classifier;
     private final Collector<? super T, A, D> collector;
 
-    public GroupingIMapReducer(Distributed.Function<? super T, ? extends K> classifier,
-                               DistributedCollector<? super T, A, D> downstream) {
-        this(uniqueMapName(), classifier, downstream);
-    }
-
-    private GroupingIMapReducer(String mapName, Function<? super T, ? extends K> classifier,
+    public GroupingIMapReducer(String mapName, Function<? super T, ? extends K> classifier,
                                 Collector<? super T, A, D> collector) {
         this.mapName = mapName;
         this.classifier = classifier;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/IListReducer.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/IListReducer.java
@@ -21,17 +21,11 @@ import com.hazelcast.jet.ProcessorMetaSupplier;
 import com.hazelcast.jet.Processors;
 import com.hazelcast.jet.stream.IStreamList;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
-
 public class IListReducer<T> extends AbstractSinkReducer<T, IStreamList<T>> {
 
     private final String listName;
 
-    public IListReducer() {
-        this(uniqueListName());
-    }
-
-    private IListReducer(String listName) {
+    public IListReducer(String listName) {
         this.listName = listName;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/IMapReducer.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/IMapReducer.java
@@ -23,21 +23,13 @@ import com.hazelcast.jet.stream.IStreamMap;
 
 import java.util.function.Function;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueMapName;
-
 public class IMapReducer<T, K, V> extends AbstractSinkReducer<T, IStreamMap<K, V>> {
 
     final String mapName;
     final Function<? super T, ? extends K> keyMapper;
     final Function<? super T, ? extends V> valueMapper;
 
-
-    public IMapReducer(Function<? super T, ? extends K> keyMapper,
-                       Function<? super T, ? extends V> valueMapper) {
-        this(uniqueMapName(), keyMapper, valueMapper);
-    }
-
-    IMapReducer(String mapName, Function<? super T, ? extends K> keyMapper,
+    public IMapReducer(String mapName, Function<? super T, ? extends K> keyMapper,
                 Function<? super T, ? extends V> valueMapper) {
         this.mapName = mapName;
         this.keyMapper = keyMapper;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/MergingIMapReducer.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/reducers/MergingIMapReducer.java
@@ -31,21 +31,12 @@ import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.KeyExtractors.entryKey;
 import static com.hazelcast.jet.Partitioner.HASH_CODE;
 import static com.hazelcast.jet.stream.impl.StreamUtil.executeJob;
-import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueMapName;
 
 public class MergingIMapReducer<T, K, V> extends IMapReducer<T, K, V> {
 
     private final BinaryOperator<V> mergeFunction;
 
     public MergingIMapReducer(
-            Function<? super T, ? extends K> keyMapper,
-            Function<? super T, ? extends V> valueMapper,
-            BinaryOperator<V> mergeFunction
-    ) {
-        this(uniqueMapName(), keyMapper, valueMapper, mergeFunction);
-    }
-
-    private MergingIMapReducer(
             String mapName,
             Function<? super T, ? extends K> keyMapper,
             Function<? super T, ? extends V> valueMapper,

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/Demo.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/Demo.java
@@ -25,6 +25,8 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
+
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
 @Ignore
@@ -39,7 +41,7 @@ public class Demo extends AbstractStreamTest {
                 .map(Map.Entry::getValue)
                 .filter(e -> (int) Math.sqrt(e) == Math.sqrt(e))
                 .sorted()
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         for (Integer integer : list) {
             System.out.println(integer);
@@ -68,7 +70,7 @@ public class Demo extends AbstractStreamTest {
                 .map(Map.Entry::getValue)
                 .map(m -> m % 10)
                 .distinct()
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         for (Integer integer : distinct) {
             System.out.println(integer);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistinctTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistinctTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.stream;
 import com.hazelcast.core.IList;
 import org.junit.Test;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -33,7 +34,7 @@ public class DistinctTest extends AbstractStreamTest {
         IList<Integer> result = list
                 .stream()
                 .distinct()
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(modulus, result.size());
 
@@ -52,7 +53,7 @@ public class DistinctTest extends AbstractStreamTest {
                 .stream()
                 .map(f -> f.getValue() % modulus)
                 .distinct()
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(modulus, result.size());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamTest.java
@@ -31,6 +31,7 @@ import java.util.OptionalDouble;
 import java.util.PrimitiveIterator;
 import java.util.stream.DoubleStream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -96,7 +97,7 @@ public class DoubleStreamTest extends AbstractStreamTest {
     public void boxed() {
         DistributedStream<Double> boxed = stream.boxed();
 
-        IList<Double> list = boxed.collect(DistributedCollectors.toIList());
+        IList<Double> list = boxed.collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, list.size());
     }
@@ -258,7 +259,7 @@ public class DoubleStreamTest extends AbstractStreamTest {
 
     @Test
     public void mapToObj() {
-        IList<Double> list = stream.mapToObj(m -> (Double) m).collect(DistributedCollectors.toIList());
+        IList<Double> list = stream.mapToObj(m -> (Double) m).collect(DistributedCollectors.toIList(uniqueListName()));
 
         Object[] array = list.toArray();
         Arrays.sort(array);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/FilterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/FilterTest.java
@@ -20,6 +20,8 @@ import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import org.junit.Test;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueMapName;
 import static org.junit.Assert.assertEquals;
 
 public class FilterTest extends AbstractStreamTest {
@@ -31,7 +33,7 @@ public class FilterTest extends AbstractStreamTest {
 
         IMap<String, Integer> result = map.stream()
                                           .filter(f -> f.getValue() < 10)
-                                          .collect(DistributedCollectors.toIMap());
+                                          .collect(DistributedCollectors.toIMap(uniqueMapName()));
 
         assertEquals(10, result.size());
 
@@ -49,7 +51,7 @@ public class FilterTest extends AbstractStreamTest {
         IList<Integer> result = list
                 .stream()
                 .filter(f -> f < 100)
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(100, result.size());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/FlatMapTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/FlatMapTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.function.IntUnaryOperator;
 import java.util.stream.IntStream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 
 public class FlatMapTest extends AbstractStreamTest {
@@ -38,7 +39,7 @@ public class FlatMapTest extends AbstractStreamTest {
                                    .flatMap(e -> IntStream.iterate(e.getValue(), IntUnaryOperator.identity())
                                                           .limit(repetitions)
                                                           .boxed())
-                                   .collect(DistributedCollectors.toIList());
+                                   .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT * repetitions, result.size());
 
@@ -62,7 +63,7 @@ public class FlatMapTest extends AbstractStreamTest {
                                     .flatMap(i -> IntStream.iterate(i, IntUnaryOperator.identity())
                                                            .limit(repetitions)
                                                            .boxed())
-                                    .collect(DistributedCollectors.toIList());
+                                    .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT * repetitions, result.size());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/IntStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/IntStreamTest.java
@@ -33,6 +33,7 @@ import java.util.PrimitiveIterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -114,7 +115,7 @@ public class IntStreamTest extends AbstractStreamTest {
     public void boxed() {
         DistributedStream<Integer> boxed = stream.boxed();
 
-        IList<Integer> list = boxed.collect(DistributedCollectors.toIList());
+        IList<Integer> list = boxed.collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, list.size());
     }
@@ -276,7 +277,7 @@ public class IntStreamTest extends AbstractStreamTest {
 
     @Test
     public void mapToObj() {
-        IList<Integer> list = stream.mapToObj(m -> m).collect(DistributedCollectors.toIList());
+        IList<Integer> list = stream.mapToObj(m -> m).collect(DistributedCollectors.toIList(uniqueListName()));
 
         Object[] array = list.toArray();
         Arrays.sort(array);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/JetCollectorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/JetCollectorTest.java
@@ -28,6 +28,8 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueMapName;
 import static com.hazelcast.jet.stream.DistributedCollectors.groupingByToIMap;
 import static com.hazelcast.jet.stream.DistributedCollectors.toIList;
 import static org.junit.Assert.assertArrayEquals;
@@ -41,7 +43,7 @@ public class JetCollectorTest extends AbstractStreamTest {
         IStreamMap<String, Integer> map = getMap();
         fillMap(map);
 
-        IMap<String, Integer> collected = map.stream().collect(DistributedCollectors.toIMap());
+        IMap<String, Integer> collected = map.stream().collect(DistributedCollectors.toIMap(uniqueMapName()));
 
         assertEquals(COUNT, collected.size());
         for (int i = 0; i < COUNT; i++) {
@@ -56,7 +58,7 @@ public class JetCollectorTest extends AbstractStreamTest {
         fillMap(map);
 
         IMap<Integer, Integer> collected = map.stream()
-                .collect(DistributedCollectors.toIMap(e -> Integer.parseInt(e.getKey().split("-")[1]),
+                .collect(DistributedCollectors.toIMap(uniqueMapName(), e -> Integer.parseInt(e.getKey().split("-")[1]),
                         e -> e.getValue() * 2, (l, r) -> l));
 
         assertEquals(COUNT, collected.size());
@@ -78,7 +80,7 @@ public class JetCollectorTest extends AbstractStreamTest {
         IMap<Integer, List<Integer>> collected = map
                 .stream()
                 .map(Map.Entry::getValue)
-                .collect(groupingByToIMap(m -> m % mod));
+                .collect(groupingByToIMap(uniqueMapName(), m -> m % mod));
 
         assertEquals(mod, collected.size());
 
@@ -102,6 +104,7 @@ public class JetCollectorTest extends AbstractStreamTest {
                 .stream()
                 .map(Map.Entry::getValue)
                 .collect(groupingByToIMap(
+                        uniqueMapName(),
                         m -> m < COUNT / 2 ? 0 : 1,
                         DistributedCollectors.groupingBy(m -> m % mod)));
 
@@ -130,7 +133,7 @@ public class JetCollectorTest extends AbstractStreamTest {
 
         IMap<Integer, List<Integer>> collected = list
                 .stream()
-                .collect(groupingByToIMap(m -> m % mod));
+                .collect(groupingByToIMap(uniqueMapName(), m -> m % mod));
 
         assertEquals(mod, collected.size());
 
@@ -153,7 +156,7 @@ public class JetCollectorTest extends AbstractStreamTest {
 
         IMap<String, Integer> collected = map.stream()
                 .flatMap(m -> Stream.of(m.getValue().split("\\s")))
-                .collect(DistributedCollectors.toIMap(v -> v, v -> 1, (l, r) -> l + r));
+                .collect(DistributedCollectors.toIMap(uniqueMapName(), v -> v, v -> 1, (l, r) -> l + r));
 
         assertEquals(10, collected.size());
 
@@ -172,7 +175,7 @@ public class JetCollectorTest extends AbstractStreamTest {
 
         IMap<String, Integer> collected = list.stream()
                                               .flatMap(m -> Stream.of(m.split("\\s")))
-                                              .collect(DistributedCollectors.toIMap(v -> v, v -> 1, (l, r) -> l + r));
+                                              .collect(DistributedCollectors.toIMap(uniqueMapName(), v -> v, v -> 1, (l, r) -> l + r));
 
         assertEquals(10, collected.size());
 
@@ -186,7 +189,7 @@ public class JetCollectorTest extends AbstractStreamTest {
         IStreamList<Integer> list = getList();
         fillList(list);
 
-        IStreamList<Integer> collected = list.stream().collect(toIList());
+        IStreamList<Integer> collected = list.stream().collect(toIList(uniqueListName()));
 
         assertArrayEquals(list.toArray(), collected.toArray());
     }
@@ -196,7 +199,7 @@ public class JetCollectorTest extends AbstractStreamTest {
         IStreamMap<String, Integer> map = getMap();
         fillMap(map);
 
-        IList<Map.Entry<String, Integer>> collected = map.stream().collect(toIList());
+        IList<Map.Entry<String, Integer>> collected = map.stream().collect(toIList(uniqueListName()));
 
         Map.Entry<String, Integer>[] expecteds = map.entrySet().toArray(new Map.Entry[0]);
         Map.Entry<String, Integer>[] actuals = collected.toArray(new Map.Entry[0]);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LimitTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LimitTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 
 public class LimitTest extends AbstractStreamTest {
@@ -33,7 +34,7 @@ public class LimitTest extends AbstractStreamTest {
         int limit = 10;
         IList list = map.stream()
                         .limit(limit)
-                        .collect(DistributedCollectors.toIList());
+                        .collect(DistributedCollectors.toIList(uniqueListName()));
 
 
         assertEquals(limit, list.size());
@@ -48,7 +49,7 @@ public class LimitTest extends AbstractStreamTest {
         IList list = map.stream()
                         .map(Map.Entry::getValue)
                         .limit(limit)
-                        .collect(DistributedCollectors.toIList());
+                        .collect(DistributedCollectors.toIList(uniqueListName()));
 
 
         assertEquals(limit, list.size());
@@ -62,7 +63,7 @@ public class LimitTest extends AbstractStreamTest {
         int limit = 10;
         IList<Integer> result = list.stream()
                                     .limit(limit)
-                                    .collect(DistributedCollectors.toIList());
+                                    .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(limit, result.size());
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamTest.java
@@ -33,6 +33,7 @@ import java.util.PrimitiveIterator;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.LongStream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -109,7 +110,7 @@ public class LongStreamTest extends AbstractStreamTest {
     public void boxed() {
         DistributedStream<Long> boxed = stream.boxed();
 
-        IList<Long> list = boxed.collect(DistributedCollectors.toIList());
+        IList<Long> list = boxed.collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, list.size());
     }
@@ -271,7 +272,7 @@ public class LongStreamTest extends AbstractStreamTest {
 
     @Test
     public void mapToObj() {
-        IList<Long> list = stream.mapToObj(m -> (Long) m).collect(DistributedCollectors.toIList());
+        IList<Long> list = stream.mapToObj(m -> (Long) m).collect(DistributedCollectors.toIList(uniqueListName()));
 
         Object[] array = list.toArray();
         Arrays.sort(array);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/MapTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/MapTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 
 public class MapTest extends AbstractStreamTest {
@@ -32,7 +33,7 @@ public class MapTest extends AbstractStreamTest {
 
         IList<Integer> list = map.stream()
                                  .map(e -> e.getValue() * e.getValue())
-                                 .collect(DistributedCollectors.toIList());
+                                 .collect(DistributedCollectors.toIList(uniqueListName()));
 
 
         assertEquals(COUNT, list.size());
@@ -52,7 +53,7 @@ public class MapTest extends AbstractStreamTest {
 
         IList<Integer> result = list.stream()
                                     .map(i -> i * i)
-                                    .collect(DistributedCollectors.toIList());
+                                    .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, result.size());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/MultipleTransformsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/MultipleTransformsTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 
 public class MultipleTransformsTest extends AbstractStreamTest {
@@ -37,7 +38,7 @@ public class MultipleTransformsTest extends AbstractStreamTest {
                                  .map(Entry::getValue)
                                  .filter(e -> e < count)
                                  .flatMap(Stream::of)
-                                 .collect(DistributedCollectors.toIList());
+                                 .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(count, list.size());
         Integer[] result = list.toArray(new Integer[count]);
@@ -58,7 +59,7 @@ public class MultipleTransformsTest extends AbstractStreamTest {
                                     .filter(e -> e < count)
                                     .map(e -> e * e)
                                     .flatMap(Stream::of)
-                                    .collect(DistributedCollectors.toIList());
+                                    .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(count, result.size());
 
@@ -79,7 +80,7 @@ public class MultipleTransformsTest extends AbstractStreamTest {
                                  .map(Entry::getValue)
                                  .filter(e -> e < count)
                                  .flatMap(Stream::of)
-                                 .collect(DistributedCollectors.toIList());
+                                 .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(count, list.size());
         Integer[] result = list.toArray(new Integer[count]);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/PeekTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/PeekTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueMapName;
 import static org.junit.Assert.assertEquals;
 
 public class PeekTest extends AbstractStreamTest {
@@ -37,7 +39,7 @@ public class PeekTest extends AbstractStreamTest {
         final AtomicInteger runningTotal = new AtomicInteger(0);
         IMap<String, Integer> collected = map.stream()
                                              .peek(e -> runningTotal.addAndGet(e.getValue()))
-                                             .collect(DistributedCollectors.toIMap());
+                                             .collect(DistributedCollectors.toIMap(uniqueMapName()));
 
         assertEquals((COUNT - 1) * (COUNT) / 2, runningTotal.get());
         assertEquals(COUNT, collected.size());
@@ -51,7 +53,7 @@ public class PeekTest extends AbstractStreamTest {
         final List<Integer> result = new ArrayList<>();
         IList<Integer> collected = list.stream()
                                        .peek(result::add)
-                                       .collect(DistributedCollectors.toIList());
+                                       .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, result.size());
         assertEquals(COUNT, collected.size());
@@ -70,7 +72,7 @@ public class PeekTest extends AbstractStreamTest {
         IList<Integer> collected = map.stream()
                                       .map(Entry::getValue)
                                       .peek(runningTotal::addAndGet)
-                                      .collect(DistributedCollectors.toIList());
+                                      .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals((COUNT - 1) * (COUNT) / 2, runningTotal.get());
         assertEquals(COUNT, collected.size());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/SkipTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/SkipTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 
 public class SkipTest extends AbstractStreamTest {
@@ -33,7 +34,7 @@ public class SkipTest extends AbstractStreamTest {
         int skip = 10;
         IList list = map.stream()
                         .skip(skip)
-                        .collect(DistributedCollectors.toIList());
+                        .collect(DistributedCollectors.toIList(uniqueListName()));
 
 
         assertEquals(COUNT - skip, list.size());
@@ -48,7 +49,7 @@ public class SkipTest extends AbstractStreamTest {
         IList list = map.stream()
                         .map(Map.Entry::getValue)
                         .skip(skip)
-                        .collect(DistributedCollectors.toIList());
+                        .collect(DistributedCollectors.toIList(uniqueListName()));
 
 
         assertEquals(COUNT - skip, list.size());
@@ -62,7 +63,7 @@ public class SkipTest extends AbstractStreamTest {
         int skip = 1024;
         IList<Integer> result = list.stream()
                                     .skip(skip)
-                                    .collect(DistributedCollectors.toIList());
+                                    .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT - skip, result.size());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/SortTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/SortTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.IntStream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 
 public class SortTest extends AbstractStreamTest {
@@ -35,7 +36,7 @@ public class SortTest extends AbstractStreamTest {
         IList<Integer> result = list
                 .stream()
                 .sorted()
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, result.size());
 
@@ -54,7 +55,7 @@ public class SortTest extends AbstractStreamTest {
                 .stream()
                 .map(Entry::getValue)
                 .sorted()
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, result.size());
 
@@ -73,7 +74,7 @@ public class SortTest extends AbstractStreamTest {
                 .stream()
                 .map(Entry::getValue)
                 .sorted((left, right) -> right.compareTo(left))
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, result.size());
 
@@ -93,7 +94,7 @@ public class SortTest extends AbstractStreamTest {
                 .map(Map.Entry::getValue)
                 .sorted(Integer::compareTo)
                 .map(i -> i * i)
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, result.size());
         for (int i = 0; i < COUNT; i++) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/UnorderedTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/UnorderedTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Map;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static org.junit.Assert.assertEquals;
 
 public class UnorderedTest extends AbstractStreamTest {
@@ -34,7 +35,7 @@ public class UnorderedTest extends AbstractStreamTest {
         IList<Integer> collected = list.stream()
                 .unordered()
                 .map(i -> i)
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, collected.size());
         Integer[] result = collected.toArray(new Integer[COUNT]);
@@ -56,7 +57,7 @@ public class UnorderedTest extends AbstractStreamTest {
                 .map(i -> i)
                 .unordered()
                 .map(i -> i)
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, collected.size());
         Integer[] result = collected.toArray(new Integer[COUNT]);
@@ -78,7 +79,7 @@ public class UnorderedTest extends AbstractStreamTest {
         IList<Integer> collected = map.stream()
                 .unordered()
                 .map(Map.Entry::getValue)
-                .collect(DistributedCollectors.toIList());
+                .collect(DistributedCollectors.toIList(uniqueListName()));
 
         assertEquals(COUNT, collected.size());
         Integer[] result = collected.toArray(new Integer[COUNT]);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/benchmark/WordCountTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/benchmark/WordCountTest.java
@@ -42,6 +42,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueMapName;
 import static org.junit.Assert.assertEquals;
 
 @Category(NightlyTest.class)
@@ -101,7 +102,7 @@ public class WordCountTest extends AbstractStreamTest implements Serializable {
             long start = System.currentTimeMillis();
             wordCounts = map.stream()
                             .flatMap(m -> Stream.of(space.split(m.getValue())))
-                            .collect(DistributedCollectors.groupingByToIMap(m -> m, DistributedCollectors.counting()));
+                            .collect(DistributedCollectors.groupingByToIMap(uniqueMapName(), m -> m, DistributedCollectors.counting()));
             long time = System.currentTimeMillis() - start;
             times.add(time);
             System.out.println("java.util.stream: totalTime=" + time);


### PR DESCRIPTION
For real use cases, the name is required. At least, the user is aware, that a new map/list
is created.

Fixes #174