### PR TITLE
TransformP in terms of Traverser

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traversers.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traversers.java
@@ -104,6 +104,31 @@ public final class Traversers {
         return new LazyTraverser<>(supplierOfTraverser);
     }
 
+    /**
+     * Traverses over a single item which can be set from the outside, by using this
+     * traverser as a {@code Consumer<T>}. Another item can be set at any time and the
+     * subsequent {@code next()} call will consume it.
+     *
+     * @param <T> item type
+     */
+    public static class ResettableSingletonTraverser<T> implements Traverser<T>, Consumer<T> {
+        T item;
+
+        @Override
+        public T next() {
+            try {
+                return item;
+            } finally {
+                item = null;
+            }
+        }
+
+        @Override
+        public void accept(T t) {
+            item = t;
+        }
+    }
+
     private static final class LazyTraverser<T> implements Traverser<T> {
         private Supplier<Traverser<T>> supplierOfTraverser;
         private Traverser<T> traverser;
@@ -123,24 +148,6 @@ public final class Traversers {
             } finally {
                 supplierOfTraverser = null;
             }
-        }
-    }
-
-    static final class ResettableSingletonTraverser<T> implements Traverser<T>, Consumer<T> {
-        T item;
-
-        @Override
-        public T next() {
-            try {
-                return item;
-            } finally {
-                item = null;
-            }
-        }
-
-        @Override
-        public void accept(T t) {
-            item = t;
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractIntermediatePipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractIntermediatePipeline.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.jet.stream.impl.pipeline;
 
-public abstract class AbstractIntermediatePipeline<E_IN, E_OUT> extends AbstractPipeline<E_OUT> {
+abstract class AbstractIntermediatePipeline<E_IN, E_OUT> extends AbstractPipeline<E_OUT> {
 
-    protected final Pipeline<E_IN> upstream;
+    final Pipeline<E_IN> upstream;
 
     AbstractIntermediatePipeline(StreamContext context, boolean isOrdered, Pipeline<E_IN> upstream) {
         super(context, isOrdered);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
@@ -54,7 +54,7 @@ import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 import static com.hazelcast.util.Preconditions.checkTrue;
 
 @SuppressWarnings(value = {"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
-public abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
+abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     protected final StreamContext context;
     private final boolean isOrdered;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DistinctPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DistinctPipeline.java
@@ -27,9 +27,9 @@ import static com.hazelcast.jet.KeyExtractors.wholeItem;
 import static com.hazelcast.jet.Partitioner.HASH_CODE;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueVertexName;
 
-public class DistinctPipeline<T> extends AbstractIntermediatePipeline<T, T> {
+class DistinctPipeline<T> extends AbstractIntermediatePipeline<T, T> {
 
-    public DistinctPipeline(StreamContext context, Pipeline<T> upstream) {
+    DistinctPipeline(StreamContext context, Pipeline<T> upstream) {
         super(context, upstream.isOrdered(), upstream);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
@@ -46,12 +46,12 @@ import java.util.stream.Stream;
 import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 
 @SuppressWarnings("checkstyle:methodcount")
-public class DoublePipeline implements DistributedDoubleStream {
+class DoublePipeline implements DistributedDoubleStream {
 
     private final StreamContext context;
     private final Pipeline<Double> inner;
 
-    public DoublePipeline(StreamContext context, Pipeline<Double> inner) {
+    DoublePipeline(StreamContext context, Pipeline<Double> inner) {
         this.context = context;
         this.inner = inner;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
@@ -47,12 +47,12 @@ import java.util.stream.Stream;
 import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 
 @SuppressWarnings("checkstyle:methodcount")
-public class IntPipeline implements DistributedIntStream {
+class IntPipeline implements DistributedIntStream {
 
     private final StreamContext context;
     private final Pipeline<Integer> inner;
 
-    public IntPipeline(StreamContext context, Pipeline<Integer> inner) {
+    IntPipeline(StreamContext context, Pipeline<Integer> inner) {
         this.context = context;
         this.inner = inner;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LimitPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LimitPipeline.java
@@ -23,10 +23,10 @@ import com.hazelcast.jet.stream.impl.processor.LimitP;
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueVertexName;
 
-public class LimitPipeline<T> extends AbstractIntermediatePipeline<T, T> {
+class LimitPipeline<T> extends AbstractIntermediatePipeline<T, T> {
     private final long limit;
 
-    public LimitPipeline(StreamContext context, Pipeline<T> upstream, long limit) {
+    LimitPipeline(StreamContext context, Pipeline<T> upstream, long limit) {
         super(context, upstream.isOrdered(), upstream);
         this.limit = limit;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
@@ -47,12 +47,12 @@ import java.util.stream.Stream;
 import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 
 @SuppressWarnings("checkstyle:methodcount")
-public class LongPipeline implements DistributedLongStream {
+class LongPipeline implements DistributedLongStream {
 
     private final StreamContext context;
     private final Pipeline<Long> inner;
 
-    public LongPipeline(StreamContext context, Pipeline<Long> inner) {
+    LongPipeline(StreamContext context, Pipeline<Long> inner) {
         this.context = context;
         this.inner = inner;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/PeekPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/PeekPipeline.java
@@ -27,11 +27,11 @@ import java.util.function.Consumer;
 import static com.hazelcast.jet.Edge.from;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
-public class PeekPipeline<T> extends AbstractIntermediatePipeline<T, T> {
+class PeekPipeline<T> extends AbstractIntermediatePipeline<T, T> {
 
     private final Consumer<? super T> consumer;
 
-    public PeekPipeline(StreamContext context, Pipeline<T> upstream, Consumer<? super T> consumer) {
+    PeekPipeline(StreamContext context, Pipeline<T> upstream, Consumer<? super T> consumer) {
         super(context, upstream.isOrdered(), upstream);
         StreamUtil.checkSerializable(consumer, "consumer");
         this.consumer = consumer;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/SkipPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/SkipPipeline.java
@@ -24,10 +24,10 @@ import com.hazelcast.jet.stream.impl.processor.SkipP;
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueVertexName;
 
-public class SkipPipeline<T> extends AbstractIntermediatePipeline<T, T> {
+class SkipPipeline<T> extends AbstractIntermediatePipeline<T, T> {
     private final long skip;
 
-    public SkipPipeline(StreamContext context, Pipeline<T> upstream, long skip) {
+    SkipPipeline(StreamContext context, Pipeline<T> upstream, long skip) {
         super(context, upstream.isOrdered(), upstream);
         this.skip = skip;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/SortPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/SortPipeline.java
@@ -25,11 +25,11 @@ import java.util.Comparator;
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueVertexName;
 
-public class SortPipeline<T> extends AbstractIntermediatePipeline<T, T> {
+class SortPipeline<T> extends AbstractIntermediatePipeline<T, T> {
 
     private final Comparator<? super T> comparator;
 
-    public SortPipeline(Pipeline<T> upstream, StreamContext context, Comparator<? super T> comparator) {
+    SortPipeline(Pipeline<T> upstream, StreamContext context, Comparator<? super T> comparator) {
         super(context, true, upstream);
         this.comparator = comparator;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/TransformPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/TransformPipeline.java
@@ -28,13 +28,11 @@ import java.util.List;
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueVertexName;
 
-public class TransformPipeline extends AbstractIntermediatePipeline {
+class TransformPipeline extends AbstractIntermediatePipeline {
 
     private final List<TransformOperation> operations = new ArrayList<>();
 
-    public TransformPipeline(StreamContext context,
-                             Pipeline upstream,
-                             TransformOperation operation) {
+    TransformPipeline(StreamContext context, Pipeline upstream, TransformOperation operation) {
         super(context, upstream.isOrdered(), upstream);
         operations.add(operation);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/TransformPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/TransformPipeline.java
@@ -40,14 +40,14 @@ class TransformPipeline extends AbstractIntermediatePipeline {
     @Override
     public Vertex buildDAG(DAG dag) {
         Vertex previous = upstream.buildDAG(dag);
-        // required final for lambda variable capture
-        final List<TransformOperation> ops = operations;
+        // the lambda below must not capture `this`, therefore the instance variable
+        // must first be loaded into a local variable
+        List<TransformOperation> ops = this.operations;
         Vertex transform = dag.newVertex(uniqueVertexName("transform"), () -> new TransformP(ops));
         if (upstream.isOrdered()) {
             transform.localParallelism(1);
         }
         dag.edge(between(previous, transform));
-
         return transform;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/UnorderedPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/UnorderedPipeline.java
@@ -19,8 +19,8 @@ package com.hazelcast.jet.stream.impl.pipeline;
 import com.hazelcast.jet.DAG;
 import com.hazelcast.jet.Vertex;
 
-public class UnorderedPipeline<T> extends AbstractIntermediatePipeline<T, T> {
-    public UnorderedPipeline(StreamContext context, Pipeline<T> upstream) {
+class UnorderedPipeline<T> extends AbstractIntermediatePipeline<T, T> {
+    UnorderedPipeline(StreamContext context, Pipeline<T> upstream) {
         super(context, false, upstream);
     }
 


### PR DESCRIPTION
`TransformP` implemented the same logic that was later encapsulated into `Traverser` and `AbstractProcessor`. This PR redoes the logic in terms of existing API.