### PR TITLE
Refactored Kafka read/write processors

### DIFF
--- a/hazelcast-jet-kafka/pom.xml
+++ b/hazelcast-jet-kafka/pom.xml
@@ -29,7 +29,6 @@
             <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-core</artifactId>
@@ -38,8 +37,8 @@
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.10</artifactId>
-            <version>0.10.0.1</version>
+            <artifactId>kafka_2.11</artifactId>
+            <version>0.10.0.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -48,16 +47,11 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>3.5.1-alpha</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>0.10.0.0</version>
         </dependency>
+
 
         <!-- TEST -->
         <dependency>
@@ -76,11 +70,26 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.charithe</groupId>
-            <artifactId>kafka-junit</artifactId>
-            <version>3.0.0</version>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.11</artifactId>
+            <version>0.10.0.0</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>0.10.0.0</version>
+            <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/connector/kafka/ReadKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/connector/kafka/ReadKafkaP.java
@@ -16,41 +16,29 @@
 
 package com.hazelcast.jet.connector.kafka;
 
-import com.hazelcast.core.Member;
 import com.hazelcast.jet.AbstractProcessor;
 import com.hazelcast.jet.Distributed.Function;
-import com.hazelcast.jet.Distributed.Optional;
 import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.ProcessorMetaSupplier;
 import com.hazelcast.jet.ProcessorSupplier;
-import com.hazelcast.jet.Processors.NoopP;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.nio.Address;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 import javax.annotation.Nonnull;
 import java.io.Closeable;
 import java.util.AbstractMap;
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.stream.IntStream;
 
-import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
+import static java.util.Collections.singletonMap;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
 
 
 /**
@@ -60,41 +48,42 @@ import static java.util.stream.Collectors.toList;
  * @param <V> type of the message value
  */
 public final class ReadKafkaP<K, V> extends AbstractProcessor implements Closeable {
+
     private static final int POLL_TIMEOUT_MS = 100;
     private final Properties properties;
     private final String topic;
-    private final List<Integer> partitions;
-    private KafkaConsumer<byte[], byte[]> consumer;
-    private long[] partitionOffsets;
-    private final Function<byte[], K> deserializeKey;
-    private final Function<byte[], V> deserializeValue;
+    private KafkaConsumer<K, V> consumer;
 
-    private ReadKafkaP(String topic, Properties properties, List<Integer> partitions,
-                       Function<byte[], K> deserializeKey, Function<byte[], V> deserializeValue) {
+    private ReadKafkaP(String topic, Properties properties) {
         this.topic = topic;
         this.properties = properties;
-        this.partitions = partitions;
-        this.partitionOffsets = new long[partitions.stream().max(Comparator.naturalOrder()).get() + 1];
-        this.deserializeKey = deserializeKey;
-        this.deserializeValue = deserializeValue;
-        Arrays.fill(partitionOffsets, -1L);
 
+    }
+
+    /**
+     * Returns a meta-supplier of processors that consume a kafka topic and emit
+     * items from it as {@code Map.Entry} instances.
+     * <p>
+     * <p>
+     * You can specify a partition to offset mapper to mark the start offset of each partition.
+     * Any negative value as an offset will throw {@code IllegalArgumentException}
+     * </p>
+     *
+     * @param <K>        type of keys read
+     * @param <V>        type of values read
+     * @param topicId    kafka topic name
+     * @param properties consumer properties which should contain consumer group name,
+     *                   broker address and key/value deserializers
+     */
+    public static <K, V> ProcessorMetaSupplier readKafka(String topicId, Properties properties) {
+        return new MetaSupplier<>(topicId, properties);
     }
 
     @Override
     protected void init(@Nonnull Context context) throws Exception {
+        properties.put("enable.auto.commit", false);
         consumer = new KafkaConsumer<>(properties);
-        consumer.assign(partitions.stream().map(i -> new TopicPartition(topic, i)).collect(toList()));
-    }
-
-    private static Properties getProperties(String zkAddress, String groupId, String brokerConnectionString) {
-        Properties props = new Properties();
-        props.put("zookeeper.connect", zkAddress);
-        props.put("group.id", groupId);
-        props.put("bootstrap.servers", brokerConnectionString);
-        props.put("key.deserializer", ByteArrayDeserializer.class.getCanonicalName());
-        props.put("value.deserializer", ByteArrayDeserializer.class.getCanonicalName());
-        return props;
+        consumer.subscribe(Collections.singleton(topic));
     }
 
     @Override
@@ -104,27 +93,32 @@ public final class ReadKafkaP<K, V> extends AbstractProcessor implements Closeab
 
     @Override
     public boolean complete() {
-        ConsumerRecords<byte[], byte[]> records = consumer.poll(POLL_TIMEOUT_MS);
+        ConsumerRecords<K, V> records = consumer.poll(POLL_TIMEOUT_MS);
         if (records.isEmpty()) {
             return false;
         }
-        for (ConsumerRecord<byte[], byte[]> record : records) {
-            K key = Optional.ofNullable(record.key()).map(deserializeKey).orElse(null);
-            V value = deserializeValue.apply(record.value());
-
-            partitionOffsets[record.partition()] = record.offset();
-            emit(new AbstractMap.SimpleImmutableEntry<>(key, value));
-            if (getOutbox().isHighWater()) {
-                for (int p = 0; p < partitionOffsets.length; p++) {
-                    long offset = partitionOffsets[p];
-                    if (offset != -1) {
-                        consumer.seek(new TopicPartition(topic, p), offset);
-                    }
+        for (TopicPartition topicPartition : records.partitions()) {
+            List<ConsumerRecord<K, V>> partitionRecords = records.records(topicPartition);
+            long latestOffset = -1;
+            for (ConsumerRecord<K, V> record : partitionRecords) {
+                K key = record.key();
+                V value = record.value();
+                emit(new AbstractMap.SimpleImmutableEntry<>(key, value));
+                latestOffset = record.offset();
+                if (getOutbox().isHighWater()) {
+                    commitPartition(topicPartition, latestOffset);
+                    return false;
                 }
-                return false;
             }
+            commitPartition(topicPartition, latestOffset);
         }
         return false;
+    }
+
+    private void commitPartition(TopicPartition topicPartition, long latestOffset) {
+        if (latestOffset != -1) {
+            consumer.commitSync(singletonMap(topicPartition, new OffsetAndMetadata(latestOffset + 1)));
+        }
     }
 
     @Override
@@ -132,67 +126,25 @@ public final class ReadKafkaP<K, V> extends AbstractProcessor implements Closeab
         consumer.close();
     }
 
-    /**
-     * Returns a meta-supplier of processors that consume a kafka topic and emit
-     * items from it as {@code Map.Entry} instances.
-     *
-     * @param <K>                    type of keys read
-     * @param <V>                    type of values read
-     * @param zkAddress              zookeeper address
-     * @param groupId                kafka consumer group name
-     * @param topicId                kafka topic name
-     * @param brokerConnectionString kafka broker address
-     * @param deserializeKey         function for deserializing keys
-     * @param deserializeValue       function for deserializing values
-     */
-    static <K, V> ProcessorMetaSupplier readKafka(String zkAddress, String groupId, String topicId,
-                                                  String brokerConnectionString,
-                                                  Function<byte[], K> deserializeKey,
-                                                  Function<byte[], V> deserializeValue) {
-        return new MetaSupplier<>(topicId,
-                getProperties(zkAddress, groupId, brokerConnectionString),
-                deserializeKey, deserializeValue);
-    }
-
-
     private static final class MetaSupplier<K, V> implements ProcessorMetaSupplier {
 
         static final long serialVersionUID = 1L;
         private final String topicId;
         private Properties properties;
-        private final Function<byte[], K> deserializeKey;
-        private final Function<byte[], V> deserializeValue;
 
-        private transient Map<Address, List<Integer>> partitionMap;
-
-        private MetaSupplier(String topicId, Properties properties,
-                             Function<byte[], K> deserializeKey,
-                             Function<byte[], V> deserializeValue) {
+        private MetaSupplier(String topicId, Properties properties) {
             this.topicId = topicId;
             this.properties = properties;
-            this.deserializeKey = deserializeKey;
-            this.deserializeValue = deserializeValue;
+            this.properties.put("enable.auto.commit", false);
         }
 
         @Override
         public void init(@Nonnull Context context) {
-            partitionMap = new HashMap<>();
-            Member[] members = context.jetInstance().getCluster().getMembers().toArray(new Member[0]);
-            KafkaConsumer<byte[], byte[]> consumer = new KafkaConsumer<>(properties);
-            List<PartitionInfo> partitions = consumer.partitionsFor(topicId);
-            int memberSize = members.length;
-            for (int i = 0; i < partitions.size(); i++) {
-                PartitionInfo partition = partitions.get(i);
-                Member member = members[i % memberSize];
-                partitionMap.computeIfAbsent(member.getAddress(), v -> new ArrayList<>()).add(partition.partition());
-            }
-            consumer.close();
         }
 
         @Override @Nonnull
         public Function<Address, ProcessorSupplier> get(@Nonnull List<Address> addresses) {
-            return address -> new Supplier<>(topicId, properties, partitionMap.get(address),
-                    deserializeKey, deserializeValue);
+            return address -> new Supplier<>(topicId, properties);
         }
     }
 
@@ -202,38 +154,18 @@ public final class ReadKafkaP<K, V> extends AbstractProcessor implements Closeab
 
         private final String topicId;
         private final Properties properties;
-        private List<Integer> ownedPartitions;
-        private final Function<byte[], K> deserializeKey;
-        private final Function<byte[], V> deserializeValue;
-
         private transient List<Processor> processors;
 
-        Supplier(String topicId, Properties properties, List<Integer> ownedPartitions,
-                 Function<byte[], K> deserializeKey, Function<byte[], V> deserializeValue) {
+        Supplier(String topicId, Properties properties) {
             this.properties = properties;
             this.topicId = topicId;
-            this.ownedPartitions = ownedPartitions;
-            this.deserializeKey = deserializeKey;
-            this.deserializeValue = deserializeValue;
         }
 
         @Override @Nonnull
         public List<Processor> get(int count) {
-            Map<Integer, List<Integer>> processorToPartitions =
-                    IntStream.range(0, ownedPartitions.size()).boxed()
-                             .map(i -> new SimpleImmutableEntry<>(i, ownedPartitions.get(i)))
-                             .collect(groupingBy(e -> e.getKey() % count,
-                                     mapping(Entry::getValue, toList())));
-            IntStream.range(0, count)
-                     .forEach(processor -> processorToPartitions.computeIfAbsent(processor, x -> emptyList()));
-
-            return (processors = processorToPartitions
-                    .values().stream()
-                    .map(partitions -> !partitions.isEmpty()
-                            ? new ReadKafkaP<>(topicId, properties, partitions, deserializeKey, deserializeValue)
-                            : new NoopP()
-                    )
-                    .collect(toList()));
+            return processors = range(0, count)
+                    .mapToObj(i -> new ReadKafkaP<>(topicId, properties))
+                    .collect(toList());
         }
 
         @Override

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/connector/kafka/KafkaTestSupport.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/connector/kafka/KafkaTestSupport.java
@@ -1,0 +1,106 @@
+package com.hazelcast.jet.connector.kafka;
+
+import com.hazelcast.jet.JetTestSupport;
+import kafka.admin.AdminUtils;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.utils.MockTime;
+import kafka.utils.TestUtils;
+import kafka.utils.Time;
+import kafka.utils.ZKStringSerializer$;
+import kafka.utils.ZkUtils;
+import kafka.zk.EmbeddedZookeeper;
+import org.I0Itec.zkclient.ZkClient;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.After;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.Future;
+
+import static kafka.admin.RackAwareMode.Disabled$.MODULE$;
+
+public class KafkaTestSupport extends JetTestSupport {
+
+    private static final String ZK_HOST = "127.0.0.1";
+    private static final String BROKER_HOST = "127.0.0.1";
+    private static final int BROKER_PORT = 9092;
+    private static final int SESSION_TIMEOUT = 30000;
+    private static final int CONNECTION_TIMEOUT = 30000;
+
+    private EmbeddedZookeeper zkServer;
+    private ZkUtils zkUtils;
+    private KafkaServer kafkaServer;
+    private KafkaProducer<Integer, String> producer;
+
+    @After
+    public void shutdownKafkaCluster() {
+        if (kafkaServer != null) {
+            kafkaServer.shutdown();
+            zkUtils.close();
+            zkServer.shutdown();
+            if (producer != null) {
+                producer.close();
+            }
+        }
+    }
+
+    protected final String createKafkaCluster() throws IOException {
+        zkServer = new EmbeddedZookeeper();
+        String zkConnect = ZK_HOST + ":" + zkServer.port();
+        ZkClient zkClient = new ZkClient(zkConnect, SESSION_TIMEOUT, CONNECTION_TIMEOUT, ZKStringSerializer$.MODULE$);
+        zkUtils = ZkUtils.apply(zkClient, false);
+
+        Properties brokerProps = new Properties();
+        brokerProps.setProperty("zookeeper.connect", zkConnect);
+        brokerProps.setProperty("broker.id", "0");
+        brokerProps.setProperty("log.dirs", Files.createTempDirectory("kafka-").toAbsolutePath().toString());
+        brokerProps.setProperty("listeners", "PLAINTEXT://" + BROKER_HOST + ":" + BROKER_PORT);
+        KafkaConfig config = new KafkaConfig(brokerProps);
+        Time mock = new MockTime();
+        kafkaServer = TestUtils.createServer(config, mock);
+
+        return BROKER_HOST + ":" + BROKER_PORT;
+    }
+
+    protected void createTopic(String topicId, int partitions, int replicationFactor) {
+        AdminUtils.createTopic(zkUtils, topicId, partitions, replicationFactor, new Properties(), MODULE$);
+    }
+
+    protected Future<RecordMetadata> produce(String topic, Integer key, String value) {
+        return getProducer().send(new ProducerRecord<Integer, String>(topic, key, value));
+    }
+
+    protected KafkaProducer<Integer, String> getProducer() {
+        if (producer == null) {
+            Properties producerProps = new Properties();
+            producerProps.setProperty("bootstrap.servers", BROKER_HOST + ":" + BROKER_PORT);
+            producerProps.setProperty("key.serializer", IntegerSerializer.class.getCanonicalName());
+            producerProps.setProperty("value.serializer", StringSerializer.class.getCanonicalName());
+            producer = new KafkaProducer<>(producerProps);
+        }
+        return producer;
+    }
+
+    protected KafkaConsumer<String, String> createConsumer(String brokerConnectionString, String topic) {
+        Properties consumerProps = new Properties();
+        consumerProps.setProperty("bootstrap.servers", brokerConnectionString);
+        consumerProps.setProperty("group.id", "group0");
+        consumerProps.setProperty("client.id", "consumer0");
+        consumerProps.setProperty("key.deserializer", StringDeserializer.class.getCanonicalName());
+        consumerProps.setProperty("value.deserializer", StringDeserializer.class.getCanonicalName());
+        consumerProps.put("auto.offset.reset", "earliest");  // to make sure the consumer starts from the beginning of the topic
+        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(Collections.singleton(topic));
+        return consumer;
+    }
+}

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/connector/kafka/ReadKafkaPTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/connector/kafka/ReadKafkaPTest.java
@@ -17,94 +17,69 @@
 package com.hazelcast.jet.connector.kafka;
 
 
-import com.github.charithe.kafka.EphemeralKafkaBroker;
-import com.github.charithe.kafka.KafkaJunitRule;
 import com.hazelcast.core.IList;
 import com.hazelcast.jet.DAG;
-import com.hazelcast.jet.Distributed.Function;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestSupport;
 import com.hazelcast.jet.Vertex;
-import com.hazelcast.jet.impl.connector.WriteIListP;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.AbstractMap;
-import java.util.List;
 import java.util.Properties;
-import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.Processors.writeList;
 import static com.hazelcast.jet.connector.kafka.ReadKafkaP.readKafka;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(QuickTest.class)
-@RunWith(HazelcastParallelClassRunner.class)
-public class ReadKafkaPTest extends JetTestSupport {
-
-    @ClassRule
-    public static KafkaJunitRule kafkaRule = new KafkaJunitRule(EphemeralKafkaBroker.create(-1, -1,
-            new Properties() {{
-                put("num.partitions", "100");
-            }}));
-    private static String zkConnStr;
-    private static String brokerConnectionString;
-
-    @BeforeClass
-    public static void setUp() throws Exception {
-        zkConnStr = kafkaRule.helper().zookeeperConnectionString();
-        brokerConnectionString = "localhost:" + kafkaRule.helper().kafkaPort();
-    }
+@RunWith(HazelcastSerialClassRunner.class)
+public class ReadKafkaPTest extends KafkaTestSupport {
 
     @Test
     public void testReadTopic() throws Exception {
+        String brokerConnectionString = createKafkaCluster();
+
         final String topic = randomName();
         int messageCount = 20;
         final String consumerGroupId = "test";
         JetInstance instance = createJetMember();
         DAG dag = new DAG();
-        Function<byte[], String> deserializeString = String::new;
+
+        Properties properties = new Properties();
+        properties.setProperty("group.id", consumerGroupId);
+        properties.setProperty("bootstrap.servers", brokerConnectionString);
+        properties.setProperty("key.deserializer", IntegerDeserializer.class.getName());
+        properties.setProperty("value.deserializer", StringDeserializer.class.getName());
+        properties.setProperty("auto.offset.reset", "earliest");
 
         Vertex source = dag.newVertex("source",
-                readKafka(zkConnStr, consumerGroupId, topic, brokerConnectionString,
-                        deserializeString, deserializeString))
-                             .localParallelism(4);
+                readKafka(topic, properties)).localParallelism(4);
 
         Vertex sink = dag.newVertex("sink", writeList("sink"))
-                             .localParallelism(1);
+                         .localParallelism(1);
 
         dag.edge(between(source, sink));
 
         instance.newJob(dag).execute();
         sleepAtLeastSeconds(3);
-        List<String> numbers = IntStream.range(0, messageCount).mapToObj(Integer::toString).collect(toList());
-        send(topic, numbers);
+        range(0, messageCount).forEach(i -> produce(topic, i, Integer.toString(i)));
         IList<Object> list = instance.getList("sink");
 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
                 assertEquals(messageCount, list.size());
-                assertTrue(numbers.stream().allMatch(n -> list.contains(new AbstractMap.SimpleImmutableEntry<>(null, n))));
+                range(0, messageCount).forEach(i -> assertTrue(list.contains(new AbstractMap.SimpleImmutableEntry<>(i, Integer.toString(i)))));
             }
         });
-    }
-
-    public void send(String topic, List<String> values) {
-        KafkaProducer<byte[], byte[]> byteProducer = kafkaRule.helper().createByteProducer();
-        for (String value : values) {
-            byteProducer.send(new ProducerRecord<>(topic, value.getBytes()));
-        }
     }
 }


### PR DESCRIPTION
refactored ReadKafkaP to make use new consumer API
removed serializer/deserializer functions from ReadKafkaP/WriteKafkaP
refactored tests so that we rely on internal kafka test classes rather than an external project