### PR TITLE
ReadFileStreamP should not emit incomplete lines

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -37,9 +37,9 @@ import java.util.stream.StreamSupport;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 
 /**
- * @see com.hazelcast.jet.Processors#readFile(String, Charset, String)
+ * @see com.hazelcast.jet.Processors#readFiles(String, Charset, String)
  */
-public class ReadFileP extends AbstractProcessor {
+public class ReadFilesP extends AbstractProcessor {
 
     private final Charset charset;
     private final int parallelism;
@@ -47,7 +47,7 @@ public class ReadFileP extends AbstractProcessor {
     private final Path directory;
     private final String glob;
 
-    ReadFileP(String directory, Charset charset, String glob, int parallelism, int id) {
+    ReadFilesP(String directory, Charset charset, String glob, int parallelism, int id) {
         this.directory = Paths.get(directory);
         this.glob = glob;
         this.charset = charset;
@@ -93,7 +93,7 @@ public class ReadFileP extends AbstractProcessor {
     }
 
     /**
-     * @see com.hazelcast.jet.Processors#readFile(String, Charset, String)
+     * @see com.hazelcast.jet.Processors#readFiles(String, Charset, String)
      */
     public static ProcessorSupplier supplier(String directory, String charset, String glob) {
         return new ProcessorSupplier() {
@@ -104,7 +104,7 @@ public class ReadFileP extends AbstractProcessor {
             public Collection<? extends Processor> get(int count) {
                 Charset charsetObj = charset == null ? StandardCharsets.UTF_8 : Charset.forName(charset);
                 return IntStream.range(0, count)
-                        .mapToObj(i -> new ReadFileP(directory, charsetObj, glob, count, i))
+                        .mapToObj(i -> new ReadFilesP(directory, charsetObj, glob, count, i))
                         .collect(Collectors.toList());
             }
         };

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFileStreamPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFileStreamPTest.java
@@ -20,35 +20,40 @@ import com.hazelcast.jet.DAG;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestSupport;
 import com.hazelcast.jet.Vertex;
-import com.hazelcast.jet.impl.connector.ReadFileStreamP.WatchType;
 import com.hazelcast.jet.stream.IStreamList;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashSet;
+import java.util.Collections;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.Processors.writeList;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
-@Ignore
 public class ReadFileStreamPTest extends JetTestSupport {
 
     private JetInstance instance;
@@ -63,112 +68,8 @@ public class ReadFileStreamPTest extends JetTestSupport {
     }
 
     @Test
-    public void when_watchType_new_then_ignorePreexisting() throws IOException, InterruptedException, ExecutionException {
-        DAG dag = buildDag(WatchType.NEW);
-
-        // this is a pre-existing file, should not be picked up
-        File file = createNewFile();
-        appendToFile(file,   "hello", "pre-existing");
-        sleepAtLeastMillis(50);
-
-        Future<Void> jobFuture = instance.newJob(dag).execute();
-        // wait for the processor to initialize and pickup what it wants to
-        sleepAtLeastSeconds(2);
-
-        // check that nothing is picked up
-        assertEquals(0, list.size());
-
-        finishDirectory(jobFuture, file);
-    }
-
-    @Test
-    @Ignore //this does not work reliably due to ENTRY_CREATE might be reported before contents is written
-    public void when_watchType_new_then_pickupNew() throws IOException, InterruptedException, ExecutionException {
-        DAG dag = buildDag(WatchType.NEW);
-
-        Future<Void> jobFuture = instance.newJob(dag).execute();
-        // wait for the processor to initialize
-        sleepAtLeastSeconds(2);
-
-        File file = new File(directory, randomName());
-        appendToFile(file, "hello");
-
-        assertTrueEventually(() -> assertEquals(1, list.size()), 2);
-
-        finishDirectory(jobFuture, file);
-    }
-
-    @Test
-    @Ignore //this does not work reliably due to ENTRY_CREATE might be reported before contents is written
-    public void when_watchType_new_then_doNotPickupModifications() throws IOException, InterruptedException, ExecutionException {
-        DAG dag = buildDag(WatchType.NEW);
-
-        Future<Void> jobFuture = instance.newJob(dag).execute();
-        // wait for the processor to initialize
-        sleepAtLeastSeconds(2);
-
-        File file = new File(directory, randomName());
-        appendToFile(file, "hello", "pre-existing");
-
-        assertTrueEventually(() -> assertEquals(2, list.size()), 2);
-
-        appendToFile(file, "third line");
-
-        // wait for the processor to pickup what it wants to
-        sleepAtLeastSeconds(1);
-
-        // the list should not have the third line
-        assertEquals(2, list.size());
-
-        finishDirectory(jobFuture, file);
-    }
-
-    @Test
-    public void when_watchType_reProcess_then_pickupPreexistingAfterModify() throws IOException, InterruptedException, ExecutionException {
-        DAG dag = buildDag(WatchType.REPROCESS);
-
-        // this is a pre-existing file, should not be picked up
-        File file = createNewFile();
-        appendToFile(file, "hello", "pre-existing");
-        sleepAtLeastMillis(50);
-
-        Future<Void> jobFuture = instance.newJob(dag).execute();
-        // wait for the processor to initialize
-        sleepAtLeastSeconds(2);
-        // check that nothing was picked up
-        assertEquals(0, list.size());
-
-        // append more lines to the file, these should not be picked up
-        appendToFile(file, "third line");
-        assertTrueEventually(() -> assertCountDistinct(3, list), 2);
-
-        finishDirectory(jobFuture, file);
-    }
-
-    @Test
-    public void when_watchType_reProcess_then_pickupNewAndModified() throws IOException, InterruptedException, ExecutionException {
-        DAG dag = buildDag(WatchType.REPROCESS);
-
-        Future<Void> jobFuture = instance.newJob(dag).execute();
-        // wait for the processor to initialize
-        sleepAtLeastSeconds(2);
-
-        File file = new File(directory, randomName());
-        appendToFile(file, "hello", "pre-existing");
-        assertTrueEventually(() -> assertCountDistinct(2, list), 2);
-
-        // append third line to the file, now all three lines should be picked again
-        appendToFile(file, "third line");
-        assertTrueEventually(() -> assertCountDistinct(3, list), 2);
-        // the size should be at least five, because the first two appended lines must have been picked up at least twice
-        assertTrueEventually(() -> assertTrue(list.size() >= 5), 2);
-
-        finishDirectory(jobFuture, file);
-    }
-
-    @Test
-    public void when_watchType_appendedOnly_appendingToPreexisting_then_pickupEntirely() throws IOException, InterruptedException, ExecutionException {
-        DAG dag = buildDag(WatchType.APPENDED_ONLY);
+    public void when_appendingToPreexisting_then_pickupNewLines() throws IOException, InterruptedException, ExecutionException {
+        DAG dag = buildDag();
 
         // this is a pre-existing file, should not be picked up
         File file = createNewFile();
@@ -183,14 +84,71 @@ public class ReadFileStreamPTest extends JetTestSupport {
         assertEquals(0, list.size());
         appendToFile(file, "third line");
         // now, all three lines are picked up
-        assertTrueEventually(() -> assertEquals(3, list.size()), 2);
+        assertTrueEventually(() -> assertEquals(1, list.size()), 2);
 
         finishDirectory(jobFuture, file);
     }
 
     @Test
-    public void when_watchType_appendedOnly_newAndModified_then_pickupAddition() throws IOException, InterruptedException, ExecutionException {
-        DAG dag = buildDag(WatchType.APPENDED_ONLY);
+    public void when_appendingToPreexistingIncompleteLine_then_pickupCompleteLines() throws IOException, InterruptedException, ExecutionException {
+        DAG dag = buildDag();
+
+        // this is a pre-existing file, should not be picked up
+        File file = createNewFile();
+        try (PrintWriter writer = new PrintWriter(new FileOutputStream(file, true))) {
+            // note: no newline appended
+            writer.write("hello");
+        }
+        sleepAtLeastMillis(50);
+
+        Future<Void> jobFuture = instance.newJob(dag).execute();
+        // wait for the processor to initialize
+        sleepAtLeastSeconds(2);
+
+        // pre-existing file should not be picked up
+        assertEquals(0, list.size());
+        // this completes the first line and a second one - only the second one should be picked
+        appendToFile(file, "world", "second line");
+        // now, all three lines are picked up
+        assertTrueEventually(() -> assertEquals(1, list.size()), 2);
+        assertEquals("second line", list.get(0));
+
+        finishDirectory(jobFuture, file);
+    }
+
+    @Test
+    public void when_withCrlf_then_pickupCompleteLines() throws IOException, InterruptedException, ExecutionException {
+        DAG dag = buildDag();
+
+        // this is a pre-existing file, should not be picked up
+        File file = createNewFile();
+        try (PrintWriter writer = new PrintWriter(new FileOutputStream(file, true))) {
+            // note: no newline appended
+            writer.write("hello world\r");
+        }
+        sleepAtLeastMillis(50);
+
+        Future<Void> jobFuture = instance.newJob(dag).execute();
+        // wait for the processor to initialize
+        sleepAtLeastSeconds(2);
+
+        // pre-existing file should not be picked up
+        assertEquals(0, list.size());
+        // this completes the first line and a second one - only the second one should be picked
+        try (PrintWriter writer = new PrintWriter(new FileOutputStream(file, true))) {
+            // note: no newline appended
+            writer.write("\nsecond line\r\n");
+        }
+        // now, all three lines are picked up
+        assertTrueEventually(() -> assertEquals(1, list.size()), 2);
+        assertEquals("second line", list.get(0));
+
+        finishDirectory(jobFuture, file);
+    }
+
+    @Test
+    public void when_newAndModified_then_pickupAddition() throws IOException, InterruptedException, ExecutionException {
+        DAG dag = buildDag();
 
         Future<Void> jobFuture = instance.newJob(dag).execute();
         // wait for the processor to initialize
@@ -208,9 +166,106 @@ public class ReadFileStreamPTest extends JetTestSupport {
         finishDirectory(jobFuture, file);
     }
 
-    private DAG buildDag(WatchType type) {
+    @Test
+    public void when_fileWithManyLines_then_emitCooperatively() throws IOException, InterruptedException, ExecutionException {
+        DAG dag = buildDag();
+
+        Future<Void> jobFuture = instance.newJob(dag).execute();
+        // wait for the processor to initialize
+        sleepAtLeastSeconds(2);
+
+        assertEquals(0, list.size());
+        File subdir = new File(directory, "subdir");
+        assertTrue(subdir.mkdir());
+        File fileInSubdir = new File(subdir, randomName());
+        appendToFile(fileInSubdir, IntStream.range(0, 5000).mapToObj(String::valueOf).collect(Collectors.toList()).toArray(new String[0]));
+
+        // move the file to watchedDirectory
+        File file = new File(directory, fileInSubdir.getName());
+        assertTrue(fileInSubdir.renameTo(file));
+
+        assertTrueEventually(() -> assertEquals(5000, list.size()), 10);
+
+        finishDirectory(jobFuture, file, subdir);
+    }
+
+    @Test
+    public void stressTest() throws InterruptedException, ExecutionException {
+        // Here, I will start the job and in two separate threads I'll write fixed number of lines
+        // to two different log files, with few ms hiccups between each line.
+        // At the end, I'll check, if all the contents matches.
+        DAG dag = buildDag();
+
+        Future<Void> jobFuture = instance.newJob(dag).execute();
+        // wait for the processor to initialize
+        sleepAtLeastSeconds(2);
+        int numLines = 100_000;
+        File file1 = new File(directory, "file1.log");
+        File file2 = new File(directory, "file2.log");
+        Thread t1 = new Thread(new RandomWriter(file1, numLines, "file0"));
+        Thread t2 = new Thread(new RandomWriter(file2, numLines, "file1"));
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+
+        // wait for the list to be full
+        assertTrueEventually(() -> assertEquals(2 * numLines, list.size()));
+
+        // check the list
+        Set<Integer>[] expectedNumbers = new Set[] {
+                IntStream.range(0, numLines).boxed().collect(Collectors.toSet()),
+                IntStream.range(0, numLines).boxed().collect(Collectors.toSet())};
+
+        for (String logLine : list) {
+            // logLine has the form "fileN M ...", N is fileIndex, M is line number
+            int fileIndex = logLine.charAt(4) - '0';
+            int lineIndex = Integer.parseInt(logLine.split(" ", 3)[1]);
+            assertTrue(expectedNumbers[fileIndex].remove(lineIndex));
+        }
+
+        assertEquals(Collections.emptySet(), expectedNumbers[0]);
+        assertEquals(Collections.emptySet(), expectedNumbers[1]);
+
+        finishDirectory(jobFuture, file1, file2);
+    }
+
+    private static class RandomWriter implements Runnable {
+
+        private final File file;
+        private final int numLines;
+        private final String prefix;
+        private final Random random = new Random();
+
+        RandomWriter(File file, int numLines, String prefix) {
+            this.file = file;
+            this.numLines = numLines;
+            this.prefix = prefix;
+        }
+
+        @Override
+        public void run() {
+            try (FileOutputStream fos = new FileOutputStream(file);
+                    OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+                    BufferedWriter bw = new BufferedWriter(osw)
+            ) {
+                for (int i = 0; i < numLines; i++) {
+                    bw.write(prefix + " " + i + " Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua\n");
+                    bw.flush();
+                    osw.flush();
+                    fos.flush();
+                    if (random.nextInt(100) < 5)
+                        LockSupport.parkNanos(1_000_000); // 1ms
+                }
+            } catch (IOException e) {
+                throw sneakyThrow(e);
+            }
+        }
+    }
+
+    private DAG buildDag() {
         DAG dag = new DAG();
-        Vertex reader = dag.newVertex("reader", ReadFileStreamP.supplier(directory.getPath(), type))
+        Vertex reader = dag.newVertex("reader", ReadFileStreamP.supplier(directory.getPath()))
                            .localParallelism(1);
         Vertex writer = dag.newVertex("writer", writeList(list.getName())).localParallelism(1);
         dag.edge(between(reader, writer));
@@ -240,21 +295,13 @@ public class ReadFileStreamPTest extends JetTestSupport {
 
     private void finishDirectory(Future<Void> jobFuture, File ... files) throws InterruptedException, ExecutionException {
         for (File file : files) {
-            assertTrue(file.delete());
+            System.out.println("deleting " + file + "...");
+            assertTrueEventually(() -> assertTrue("Failed to delete " + file, file.delete()), 2);
+            System.out.println("deleted " + file);
         }
-        assertTrue(directory.delete());
+        assertTrueEventually(() -> assertTrue("Failed to delete " + directory, directory.delete()), 2);
         assertTrueEventually(() -> assertTrue("job should complete eventually", jobFuture.isDone()), 5);
         // called for side-effect of throwing exception, if the job failed
         jobFuture.get();
-    }
-
-    /**
-     * Asserts the count of distinct elements. We use this, because reprocess might pick-up single line
-     * multiple times due to multiple {@link java.nio.file.StandardWatchEventKinds#ENTRY_MODIFY}
-     * events fired during writing to the file.
-     */
-    private <T> void assertCountDistinct(int expected, IStreamList<T> list) {
-        Set<T> set = new HashSet<>(list);
-        assertEquals(expected, set.size());
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFileStream_readCompleteLineTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFileStream_readCompleteLineTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector;
+
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+public class ReadFileStream_readCompleteLineTest {
+
+    private ReadFileStreamP p = new ReadFileStreamP("", StandardCharsets.UTF_8, 0, 0);
+
+    @Test
+    public void when_emptyFile_then_null() throws Exception {
+        assertEquals(null, p.readCompleteLine(new StringReader("")));
+    }
+
+    @Test
+    public void when_nonTerminatedSingleLine_then_null() throws Exception {
+        assertEquals(null, p.readCompleteLine(new StringReader("blabla")));
+    }
+
+    @Test
+    public void when_terminatedSingleLine_then_singleLine() throws Exception {
+        StringReader reader = new StringReader("blabla\n");
+
+        assertEquals("blabla", p.readCompleteLine(reader));
+    }
+
+    @Test
+    public void when_nonTerminatedSecondLine_then_singleLine() throws Exception {
+        StringReader reader = new StringReader("blabla\nbla");
+
+        assertEquals("blabla", p.readCompleteLine(reader));
+        assertEquals(null, p.readCompleteLine(reader));
+    }
+
+    @Test
+    public void when_terminatedSecondLine_then_twoLines() throws Exception {
+        StringReader reader = new StringReader("blabla\nbla\n");
+
+        assertEquals("blabla", p.readCompleteLine(reader));
+        assertEquals("bla", p.readCompleteLine(reader));
+    }
+
+    @Test
+    public void when_emptyLine_then_emptyLine() throws Exception {
+        StringReader reader = new StringReader("\nbla\n");
+
+        assertEquals("", p.readCompleteLine(reader));
+        assertEquals("bla", p.readCompleteLine(reader));
+    }
+
+    @Test
+    public void when_twoEmptyLines_then_emptyLine() throws Exception {
+        StringReader reader = new StringReader("\n\nbla\n");
+
+        assertEquals("", p.readCompleteLine(reader));
+        assertEquals("", p.readCompleteLine(reader));
+        assertEquals("bla", p.readCompleteLine(reader));
+    }
+
+    @Test
+    public void test_windowsEndLines() throws Exception {
+        StringReader reader = new StringReader("blabla\r\nbla\r\n");
+
+        assertEquals("blabla", p.readCompleteLine(reader));
+        assertEquals("bla", p.readCompleteLine(reader));
+    }
+
+    @Test
+    public void test_mac9EndLines() throws Exception {
+        StringReader reader = new StringReader("blabla\rbla\r");
+
+        assertEquals("blabla", p.readCompleteLine(reader));
+        assertEquals("bla", p.readCompleteLine(reader));
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFilesPTest.java
@@ -41,14 +41,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Edge.between;
-import static com.hazelcast.jet.Processors.readFile;
+import static com.hazelcast.jet.Processors.readFiles;
 import static com.hazelcast.jet.Processors.writeList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
-public class ReadFilePTest extends JetTestSupport {
+public class ReadFilesPTest extends JetTestSupport {
 
     private JetInstance instance;
     private File directory;
@@ -108,7 +108,7 @@ public class ReadFilePTest extends JetTestSupport {
 
     private DAG buildDag(String glob) {
         DAG dag = new DAG();
-        Vertex reader = dag.newVertex("reader", readFile(directory.getPath(), StandardCharsets.UTF_8, glob))
+        Vertex reader = dag.newVertex("reader", readFiles(directory.getPath(), StandardCharsets.UTF_8, glob))
                 .localParallelism(1);
         Vertex writer = dag.newVertex("writer", writeList(list.getName())).localParallelism(1);
         dag.edge(between(reader, writer));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.connector;
 import com.hazelcast.jet.DAG;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestSupport;
+import com.hazelcast.jet.Processors;
 import com.hazelcast.jet.Vertex;
 import com.hazelcast.jet.stream.IStreamList;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -54,7 +55,7 @@ import static org.junit.Assert.assertTrue;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
-public class ReadFileStreamPTest extends JetTestSupport {
+public class StreamFilesPTest extends JetTestSupport {
 
     private JetInstance instance;
     private File directory;
@@ -265,7 +266,7 @@ public class ReadFileStreamPTest extends JetTestSupport {
 
     private DAG buildDag() {
         DAG dag = new DAG();
-        Vertex reader = dag.newVertex("reader", ReadFileStreamP.supplier(directory.getPath()))
+        Vertex reader = dag.newVertex("reader", Processors.streamFiles(directory.getPath()))
                            .localParallelism(1);
         Vertex writer = dag.newVertex("writer", writeList(list.getName())).localParallelism(1);
         dag.edge(between(reader, writer));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -85,7 +85,7 @@ public class StreamFilesPTest extends JetTestSupport {
         assertEquals(0, list.size());
         appendToFile(file, "third line");
         // now, all three lines are picked up
-        assertTrueEventually(() -> assertEquals(1, list.size()), 2);
+        assertTrueEventually(() -> assertEquals(1, list.size()));
 
         finishDirectory(jobFuture, file);
     }
@@ -111,7 +111,7 @@ public class StreamFilesPTest extends JetTestSupport {
         // this completes the first line and a second one - only the second one should be picked
         appendToFile(file, "world", "second line");
         // now, all three lines are picked up
-        assertTrueEventually(() -> assertEquals(1, list.size()), 2);
+        assertTrueEventually(() -> assertEquals(1, list.size()));
         assertEquals("second line", list.get(0));
 
         finishDirectory(jobFuture, file);
@@ -141,7 +141,7 @@ public class StreamFilesPTest extends JetTestSupport {
             writer.write("\nsecond line\r\n");
         }
         // now, all three lines are picked up
-        assertTrueEventually(() -> assertEquals(1, list.size()), 2);
+        assertTrueEventually(() -> assertEquals(1, list.size()));
         assertEquals("second line", list.get(0));
 
         finishDirectory(jobFuture, file);
@@ -158,11 +158,11 @@ public class StreamFilesPTest extends JetTestSupport {
         assertEquals(0, list.size());
         File file = new File(directory, randomName());
         appendToFile(file, "hello", "world");
-        assertTrueEventually(() -> assertEquals(2, list.size()), 2);
+        assertTrueEventually(() -> assertEquals(2, list.size()));
 
         // now add one more line, only this line should be picked up
         appendToFile(file, "third line");
-        assertTrueEventually(() -> assertEquals(3, list.size()), 2);
+        assertTrueEventually(() -> assertEquals(3, list.size()));
 
         finishDirectory(jobFuture, file);
     }
@@ -185,7 +185,7 @@ public class StreamFilesPTest extends JetTestSupport {
         File file = new File(directory, fileInSubdir.getName());
         assertTrue(fileInSubdir.renameTo(file));
 
-        assertTrueEventually(() -> assertEquals(5000, list.size()), 10);
+        assertTrueEventually(() -> assertEquals(5000, list.size()));
 
         finishDirectory(jobFuture, file, subdir);
     }
@@ -275,7 +275,7 @@ public class StreamFilesPTest extends JetTestSupport {
 
     private File createNewFile() {
         File file = new File(directory, randomName());
-        assertTrueEventually(() -> assertTrue(file.createNewFile()), 2);
+        assertTrueEventually(() -> assertTrue(file.createNewFile()));
         return file;
     }
 
@@ -297,11 +297,11 @@ public class StreamFilesPTest extends JetTestSupport {
     private void finishDirectory(Future<Void> jobFuture, File ... files) throws InterruptedException, ExecutionException {
         for (File file : files) {
             System.out.println("deleting " + file + "...");
-            assertTrueEventually(() -> assertTrue("Failed to delete " + file, file.delete()), 2);
+            assertTrueEventually(() -> assertTrue("Failed to delete " + file, file.delete()));
             System.out.println("deleted " + file);
         }
-        assertTrueEventually(() -> assertTrue("Failed to delete " + directory, directory.delete()), 2);
-        assertTrueEventually(() -> assertTrue("job should complete eventually", jobFuture.isDone()), 5);
+        assertTrueEventually(() -> assertTrue("Failed to delete " + directory, directory.delete()));
+        assertTrueEventually(() -> assertTrue("job should complete eventually", jobFuture.isDone()));
         // called for side-effect of throwing exception, if the job failed
         jobFuture.get();
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
@@ -23,9 +23,9 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 
-public class ReadFileStream_readCompleteLineTest {
+public class StreamFilesP_readCompleteLineTest {
 
-    private ReadFileStreamP p = new ReadFileStreamP("", StandardCharsets.UTF_8, 0, 0);
+    private StreamFilesP p = new StreamFilesP("", StandardCharsets.UTF_8, 0, 0);
 
     @Test
     public void when_emptyFile_then_null() throws Exception {


### PR DESCRIPTION
Previously, lines from appended files could be emitted in two chunks, if we
read the file with concurrent writing. Also, only appended lines from
pre-existing files will be read.