### PR TITLE
Do not require forEach action to be serializable

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedStream.java
@@ -241,32 +241,6 @@ public interface DistributedStream<T> extends Stream<T> {
     DistributedStream<T> skip(long n);
 
     /**
-     * Performs an action for each element of this stream.
-     *
-     * <p>This is a terminal operation.
-     *
-     * @param action a
-     *               non-interfering action to perform on the elements
-     */
-    default void forEach(Distributed.Consumer<? super T> action) {
-        forEach((Consumer<? super T>) action);
-    }
-
-    /**
-     * Performs an action for each element of this stream, in the encounter
-     * order of the stream if the stream has a defined encounter order.
-     *
-     * <p>This is a terminal operation.
-     *
-     * @param action a
-     *               non-interfering action to perform on the elements
-     * @see #forEach(Consumer)
-     */
-    default void forEachOrdered(Distributed.Consumer<? super T> action) {
-        forEachOrdered((Consumer<? super T>) action);
-    }
-
-    /**
      * Performs a reduction on the
      * elements of this stream, using the provided identity value and an
      * associative
@@ -596,12 +570,6 @@ public interface DistributedStream<T> extends Stream<T> {
 
     @Override
     DistributedStream<T> peek(Consumer<? super T> action);
-
-    @Override
-    void forEach(Consumer<? super T> action);
-
-    @Override
-    void forEachOrdered(Consumer<? super T> action);
 
     @Override
     T reduce(T identity, BinaryOperator<T> accumulator);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
@@ -163,7 +163,6 @@ abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     @Override
     public void forEach(Consumer<? super E_OUT> action) {
-        checkSerializable(action, "action");
         IList<E_OUT> list = this.collect(toIList());
         list.forEach(action::accept);
         list.destroy();
@@ -171,8 +170,6 @@ abstract class AbstractPipeline<E_OUT> implements Pipeline<E_OUT> {
 
     @Override
     public void forEachOrdered(Consumer<? super E_OUT> action) {
-        checkSerializable(action, "action");
-
         forEach(action);
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamCastingTest.java
@@ -64,16 +64,6 @@ public class DistributedStreamCastingTest extends AbstractStreamTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void forEach() {
-        stream.forEach(System.out::println);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void forEachOrdered() {
-        stream.forEachOrdered(System.out::println);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void allMatch() {
         stream.allMatch(m -> true);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamCastingTest.java
@@ -49,16 +49,6 @@ public class DoubleStreamCastingTest extends AbstractStreamTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void forEach() {
-        stream.forEach(System.out::println);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void forEachOrdered() {
-        stream.forEachOrdered(System.out::println);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
     public void allMatch() {
         stream.allMatch(m -> true);
     }


### PR DESCRIPTION
forEach is executed locally, so no need to check serializability