### PR TITLE
Do not require forEach action be serializable (2)

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedIntStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedIntStream.java
@@ -214,42 +214,6 @@ public interface DistributedIntStream extends IntStream {
     DistributedIntStream skip(long n);
 
     /**
-     * Performs an action for each element of this stream.
-     *
-     * <p>This is a terminal
-     * operation.
-     *
-     * <p>For parallel stream pipelines, this operation does <em>not</em>
-     * guarantee to respect the encounter order of the stream, as doing so
-     * would sacrifice the benefit of parallelism.  For any given element, the
-     * action may be performed at whatever time and in whatever thread the
-     * library chooses.  If the action accesses shared state, it is
-     * responsible for providing the required synchronization.
-     *
-     * @param action a
-     *               non-interfering action to perform on the elements
-     */
-    default void forEach(Distributed.IntConsumer action) {
-        forEach((IntConsumer) action);
-    }
-
-    /**
-     * Performs an action for each element of this stream, guaranteeing that
-     * each element is processed in encounter order for streams that have a
-     * defined encounter order.
-     *
-     * <p>This is a terminal
-     * operation.
-     *
-     * @param action a
-     *               non-interfering action to perform on the elements
-     * @see #forEach(Distributed.IntConsumer)
-     */
-    default void forEachOrdered(Distributed.IntConsumer action) {
-        forEachOrdered((IntConsumer) action);
-    }
-
-    /**
      * Performs a reduction on the
      * elements of this stream, using the provided identity value and an
      * associative
@@ -509,12 +473,6 @@ public interface DistributedIntStream extends IntStream {
 
     @Override
     DistributedIntStream peek(IntConsumer action);
-
-    @Override
-    void forEach(IntConsumer action);
-
-    @Override
-    void forEachOrdered(IntConsumer action);
 
     @Override
     int reduce(int identity, IntBinaryOperator op);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedLongStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/DistributedLongStream.java
@@ -217,42 +217,6 @@ public interface DistributedLongStream extends LongStream {
     DistributedLongStream skip(long n);
 
     /**
-     * Performs an action for each element of this stream.
-     *
-     * <p>This is a terminal
-     * operation.
-     *
-     * <p>For parallel stream pipelines, this operation does <em>not</em>
-     * guarantee to respect the encounter order of the stream, as doing so
-     * would sacrifice the benefit of parallelism.  For any given element, the
-     * action may be performed at whatever time and in whatever thread the
-     * library chooses.  If the action accesses shared state, it is
-     * responsible for providing the required synchronization.
-     *
-     * @param action a
-     *               non-interfering action to perform on the elements
-     */
-    default void forEach(Distributed.LongConsumer action) {
-        forEach((LongConsumer) action);
-    }
-
-    /**
-     * Performs an action for each element of this stream, guaranteeing that
-     * each element is processed in encounter order for streams that have a
-     * defined encounter order.
-     *
-     * <p>This is a terminal
-     * operation.
-     *
-     * @param action a
-     *               non-interfering action to perform on the elements
-     * @see #forEach(LongConsumer)
-     */
-    default void forEachOrdered(Distributed.LongConsumer action) {
-        forEachOrdered((LongConsumer) action);
-    }
-
-    /**
      * Performs a reduction on the
      * elements of this stream, using the provided identity value and an
      * associative
@@ -499,12 +463,6 @@ public interface DistributedLongStream extends LongStream {
 
     @Override
     DistributedLongStream peek(LongConsumer action);
-
-    @Override
-    void forEach(LongConsumer action);
-
-    @Override
-    void forEachOrdered(LongConsumer action);
 
     @Override
     long reduce(long identity, LongBinaryOperator op);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
@@ -108,7 +108,6 @@ class DoublePipeline implements DistributedDoubleStream {
 
     @Override
     public DistributedDoubleStream peek(DoubleConsumer action) {
-        checkSerializable(action, "action");
         return wrap(inner.peek(action::accept));
     }
 
@@ -129,7 +128,6 @@ class DoublePipeline implements DistributedDoubleStream {
 
     @Override
     public void forEachOrdered(DoubleConsumer action) {
-        checkSerializable(action, "action");
         inner.forEachOrdered(action::accept);
     }
 
@@ -148,15 +146,11 @@ class DoublePipeline implements DistributedDoubleStream {
 
     @Override
     public double reduce(double identity, DoubleBinaryOperator op) {
-        checkSerializable(op, "op");
-
         return inner.reduce(identity, op::applyAsDouble);
     }
 
     @Override
     public OptionalDouble reduce(DoubleBinaryOperator op) {
-        checkSerializable(op, "op");
-
         Optional<Double> result = inner.reduce(op::applyAsDouble);
         return result.isPresent() ? OptionalDouble.of(result.get()) : OptionalDouble.empty();
     }
@@ -165,7 +159,6 @@ class DoublePipeline implements DistributedDoubleStream {
     public <R> R collect(Supplier<R> supplier,
                          ObjDoubleConsumer<R> accumulator,
                          BiConsumer<R, R> combiner) {
-        checkSerializable(accumulator, "accumulator");
         Distributed.BiConsumer<R, Double> boxedAccumulator = accumulator::accept;
         return inner.collect(supplier, boxedAccumulator, combiner);
     }
@@ -214,19 +207,16 @@ class DoublePipeline implements DistributedDoubleStream {
 
     @Override
     public boolean anyMatch(DoublePredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.anyMatch(predicate::test);
     }
 
     @Override
     public boolean allMatch(DoublePredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.allMatch(predicate::test);
     }
 
     @Override
     public boolean noneMatch(DoublePredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.noneMatch(predicate::test);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
@@ -109,7 +109,6 @@ class IntPipeline implements DistributedIntStream {
 
     @Override
     public DistributedIntStream peek(IntConsumer action) {
-        checkSerializable(action, "action");
         return wrap(inner.peek(action::accept));
     }
 
@@ -125,13 +124,11 @@ class IntPipeline implements DistributedIntStream {
 
     @Override
     public void forEach(IntConsumer action) {
-        checkSerializable(action, "action");
         inner.forEach(action::accept);
     }
 
     @Override
     public void forEachOrdered(IntConsumer action) {
-        checkSerializable(action, "action");
         inner.forEachOrdered(action::accept);
     }
 
@@ -150,14 +147,11 @@ class IntPipeline implements DistributedIntStream {
 
     @Override
     public int reduce(int identity, IntBinaryOperator op) {
-        checkSerializable(op, "op");
         return inner.reduce(identity, op::applyAsInt);
     }
 
     @Override
     public OptionalInt reduce(IntBinaryOperator op) {
-        checkSerializable(op, "op");
-
         Optional<Integer> result = inner.reduce(op::applyAsInt);
         return result.isPresent() ? OptionalInt.of(result.get()) : OptionalInt.empty();
     }
@@ -166,7 +160,6 @@ class IntPipeline implements DistributedIntStream {
     public <R> R collect(Supplier<R> supplier,
                          ObjIntConsumer<R> accumulator,
                          BiConsumer<R, R> combiner) {
-        checkSerializable(accumulator, "accumulator");
         Distributed.BiConsumer<R, Integer> boxedAccumulator = accumulator::accept;
         return inner.collect(supplier, boxedAccumulator, combiner);
     }
@@ -215,19 +208,16 @@ class IntPipeline implements DistributedIntStream {
 
     @Override
     public boolean anyMatch(IntPredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.anyMatch(predicate::test);
     }
 
     @Override
     public boolean allMatch(IntPredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.allMatch(predicate::test);
     }
 
     @Override
     public boolean noneMatch(IntPredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.noneMatch(predicate::test);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
@@ -109,7 +109,6 @@ class LongPipeline implements DistributedLongStream {
 
     @Override
     public DistributedLongStream peek(LongConsumer action) {
-        checkSerializable(action, "action");
         return wrap(inner.peek(action::accept));
     }
 
@@ -125,13 +124,11 @@ class LongPipeline implements DistributedLongStream {
 
     @Override
     public void forEach(LongConsumer action) {
-        checkSerializable(action, "action");
         inner.forEach(action::accept);
     }
 
     @Override
     public void forEachOrdered(LongConsumer action) {
-        checkSerializable(action, "action");
         inner.forEachOrdered(action::accept);
     }
 
@@ -150,13 +147,11 @@ class LongPipeline implements DistributedLongStream {
 
     @Override
     public long reduce(long identity, LongBinaryOperator op) {
-        checkSerializable(op, "op");
         return inner.<Long>reduce(identity, op::applyAsLong);
     }
 
     @Override
     public OptionalLong reduce(LongBinaryOperator op) {
-        checkSerializable(op, "op");
         Optional<Long> result = inner.reduce(op::applyAsLong);
         return result.isPresent() ? OptionalLong.of(result.get()) : OptionalLong.empty();
     }
@@ -165,7 +160,6 @@ class LongPipeline implements DistributedLongStream {
     public <R> R collect(Supplier<R> supplier,
                          ObjLongConsumer<R> accumulator,
                          BiConsumer<R, R> combiner) {
-        checkSerializable(accumulator, "accumulator");
         Distributed.BiConsumer<R, Long> boxedAccumulator = accumulator::accept;
         return inner.collect(supplier, boxedAccumulator, combiner);
     }
@@ -214,19 +208,16 @@ class LongPipeline implements DistributedLongStream {
 
     @Override
     public boolean anyMatch(LongPredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.anyMatch(predicate::test);
     }
 
     @Override
     public boolean allMatch(LongPredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.allMatch(predicate::test);
     }
 
     @Override
     public boolean noneMatch(LongPredicate predicate) {
-        checkSerializable(predicate, "predicate");
         return inner.noneMatch(predicate::test);
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DistributedStreamCastingTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -42,113 +43,229 @@ public class DistributedStreamCastingTest extends AbstractStreamTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void map() {
-        stream.map(Object::toString);
+    public void map_when_notSerializable_then_fail() {
+        stream.map(m -> m);
+    }
+
+    @Test
+    public void map_when_notDistributedButSerializable_then_proceed() {
+        stream.map((Serializable & java.util.function.UnaryOperator<Integer>) m -> m);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void flatMap() {
+    public void flatMap_when_notSerializable_then_fail() {
         stream.flatMap(Stream::of);
     }
 
+    @Test
+    public void flatMap_when_notDistributedButSerializable_then_proceed() {
+        stream.flatMap((Serializable & Function<Integer, Stream<? extends Integer>>) Stream::of);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void collect() {
+    public void collect_when_notSerializable_then_fail() {
         stream.collect(Collectors.counting());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void collect2() {
+    public void collect2_when_notSerializable_then_fail() {
         stream.collect(() -> new Integer[]{0},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
+    @Test
+    public void collect2_when_notDistributedButSerializable_then_proceed() {
+        stream.collect((Serializable & java.util.function.Supplier<Integer[]>) () -> new Integer[]{0},
+                (Serializable & java.util.function.BiConsumer<Integer[], Integer>) (r, e) -> r[0] += e,
+                (Serializable & java.util.function.BiConsumer<Integer[], Integer[]>) (a, b) -> a[0] += b[0]);
+    }
+
+    public void forEach_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.Consumer action = System.out::println;
+        stream.forEach(action);
+    }
+
+    public void forEachOrdered_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.Consumer action = System.out::println;
+        stream.forEachOrdered(action);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void allMatch() {
+    public void allMatch_when_notSerializable_then_fail() {
         stream.allMatch(m -> true);
     }
 
+    @Test
+    public void allMatch_when_notDistributedButSerializable_then_proceed() {
+        stream.allMatch((Serializable & java.util.function.Predicate<Integer>) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void anyMatch() {
+    public void anyMatch_when_notSerializable_then_fail() {
         stream.anyMatch(m -> true);
     }
 
+    @Test
+    public void anyMatch_when_notDistributedButSerializable_then_proceed() {
+        stream.anyMatch((Serializable & java.util.function.Predicate<Integer>) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void noneMatch() {
+    public void noneMatch_when_notSerializable_then_fail() {
         stream.noneMatch(m -> true);
     }
 
+    @Test
+    public void noneMatch_when_notDistributedButSerializable_then_proceed() {
+        stream.noneMatch((Serializable & java.util.function.Predicate<Integer>) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void filter() {
+    public void filter_when_notSerializable_then_fail() {
         stream.filter(m -> true);
     }
 
+    @Test
+    public void filter_anyMatch_when_notDistributedButSerializable_then_proceed() {
+        stream.filter((Serializable & java.util.function.Predicate<Integer>) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToInt() {
+    public void mapToInt_when_notSerializable_then_fail() {
         stream.mapToInt(m -> m);
     }
 
+    @Test
+    public void mapToInt_when_notDistributedButSerializable_then_proceed() {
+        stream.mapToInt((Serializable & java.util.function.ToIntFunction<Integer>) m -> m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToDouble() {
+    public void mapToDouble_when_notSerializable_then_fail() {
         stream.mapToDouble(m -> (double) m);
     }
 
+    @Test
+    public void mapToDouble_when_notDistributedButSerializable_then_proceed() {
+        stream.mapToDouble((Serializable & java.util.function.ToDoubleFunction<Integer>) m -> (double) m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToLong() {
+    public void mapToLong_when_notSerializable_then_fail() {
         stream.mapToLong(m -> (long) m);
     }
 
+    @Test
+    public void mapToLong_when_notDistributedButSerializable_then_proceed() {
+        stream.mapToLong((Serializable & java.util.function.ToLongFunction<Integer>) m -> (long) m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void flatMapToInt() {
+    public void flatMapToInt_when_notSerializable_then_fail() {
         stream.flatMapToInt(IntStream::of);
     }
 
+    @Test
+    public void flatMapToInt_when_notDistributedButSerializable_then_proceed() {
+        stream.flatMapToInt((Serializable & Function<Integer, IntStream>) IntStream::of);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void flatMapToDouble() {
+    public void flatMapToDouble_when_notSerializable_then_fail() {
         stream.flatMapToDouble(DoubleStream::of);
     }
 
+    @Test
+    public void flatMapToDouble_when_notDistributedButSerializable_then_proceed() {
+        stream.flatMapToDouble((Serializable & Function<Integer, DoubleStream>) DoubleStream::of);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void flatMapToLong() {
+    public void flatMapToLong_when_notSerializable_then_fail() {
         stream.flatMapToLong(LongStream::of);
     }
 
+    @Test
+    public void flatMapToLong_when_notDistributedButSerializable_then_proceed() {
+        stream.flatMapToLong((Serializable & Function<Integer, LongStream>) LongStream::of);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void max() {
-        Comparator<Integer> c = Integer::compareTo;
+    public void max_when_notSerializable_then_fail() {
+        java.util.Comparator<Integer> c = Integer::compareTo;
         stream.max(c);
     }
 
+    @Test
+    public void max_when_notDistributedButSerializable_then_proceed() {
+        stream.max((Serializable & java.util.Comparator<Integer>) Integer::compareTo);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void min() {
-        Comparator<Integer> c = Integer::compareTo;
+    public void min_when_notSerializable_then_fail() {
+        java.util.Comparator<Integer> c = Integer::compareTo;
         stream.min(c);
     }
 
+    @Test
+    public void min_when_notDistributedButSerializable_then_proceed() {
+        stream.min((Serializable & java.util.Comparator<Integer>) Integer::compareTo);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void peek() {
+    public void peek_when_notSerializable_then_fail() {
         stream.peek(System.out::println);
     }
 
+    @Test
+    public void peek_when_notDistributedButSerializable_then_proceed() {
+        stream.peek((Serializable & java.util.function.Consumer<Integer>) (x) -> System.out.println(x));
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void reduce() {
+    public void reduce_when_notSerializable_then_fail() {
         stream.reduce((l, r) -> l + r);
     }
 
+    @Test
+    public void reduce_when_notDistributedButSerializable_then_proceed() {
+        stream.reduce((Serializable & java.util.function.BinaryOperator<Integer>) (l, r) -> l + r);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void reduce2() {
+    public void reduce2_when_notSerializable_then_fail() {
         stream.reduce(0, (l, r) -> l + r);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void reduce3() {
-        stream.reduce(0, (l, r) -> l + r, (l, r) -> l + r);
+    @Test
+    public void reduce2_when_notDistributedButSerializable_then_proceed() {
+        stream.reduce(0, (Serializable & java.util.function.BinaryOperator<Integer>) (l, r) -> l + r);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void sorted() {
+    public void reduce3_when_notSerializable_then_fail() {
+        stream.reduce(0, (l, r) -> l + r, (l, r) -> l + r);
+    }
+
+    @Test
+    public void reduce3_when_notDistributedButSerializable_then_proceed() {
+        stream.reduce(0,
+                (Serializable & java.util.function.BiFunction<Integer, Integer, Integer>) (l, r) -> l + r,
+                (Serializable & java.util.function.BinaryOperator<Integer>) (l, r) -> l + r);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void sorted_when_notSerializable_then_fail() {
         Comparator<Integer> c = Integer::compareTo;
         stream.sorted(c);
+    }
+
+    @Test
+    public void sorted_when_notDistributedButSerializable_then_proceed() {
+        stream.sorted((Serializable & Comparator<Integer>) Integer::compareTo);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/DoubleStreamCastingTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.stream;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.util.stream.DoubleStream;
 
 public class DoubleStreamCastingTest extends AbstractStreamTest {
@@ -32,69 +33,148 @@ public class DoubleStreamCastingTest extends AbstractStreamTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void map() {
+    public void map_when_notSerializable_then_fail() {
         stream.map(m -> m);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void flatMap() {
-        stream.flatMap(DoubleStream::of);
+    @Test
+    public void map_notDistributedButSerializable_then_proceed() {
+        stream.map((Serializable & java.util.function.DoubleUnaryOperator) m -> m);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void collect() {
-        stream.collect(() -> new Double[]{0D},
+    public void flatMap_when_notSerializable_then_fail() {
+        stream.flatMap(DoubleStream::of);
+    }
+
+    @Test
+    public void flatMap_notDistributedButSerializable_then_proceed() {
+        stream.flatMap((Serializable & java.util.function.DoubleFunction<DoubleStream>) DoubleStream::of);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void collect_when_notSerializable_then_fail() {
+        stream.collect(() -> new Double[]{0.0},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
+    @Test
+    public void collect_notDistributedButSerializable_then_proceed() {
+        stream.collect((Serializable & java.util.function.Supplier<Double[]>) () -> new Double[]{0.0},
+                (Serializable & java.util.function.ObjDoubleConsumer<Double[]>) (r, e) -> r[0] += e,
+                (Serializable & java.util.function.BiConsumer<Double[], Double[]>) (a, b) -> a[0] += b[0]);
+    }
+
+    public void forEach_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.DoubleConsumer action = System.out::println;
+        stream.forEach(action);
+    }
+
+    public void forEachOrdered_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.DoubleConsumer action = System.out::println;
+        stream.forEachOrdered(action);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void allMatch() {
+    public void allMatch_when_notSerializable_then_fail() {
         stream.allMatch(m -> true);
     }
 
+    @Test
+    public void allMatch_notDistributedButSerializable_then_proceed() {
+        stream.allMatch((Serializable & java.util.function.DoublePredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void anyMatch() {
+    public void anyMatch_when_notSerializable_then_fail() {
         stream.anyMatch(m -> true);
     }
 
+    @Test
+    public void anyMatch_notDistributedButSerializable_then_proceed() {
+        stream.anyMatch((Serializable & java.util.function.DoublePredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void noneMatch() {
+    public void noneMatch_when_notSerializable_then_fail() {
         stream.noneMatch(m -> true);
     }
 
+    @Test
+    public void noneMatch_notDistributedButSerializable_then_proceed() {
+        stream.noneMatch((Serializable & java.util.function.DoublePredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void filter() {
+    public void filter_when_notSerializable_then_fail() {
         stream.filter(m -> true);
     }
 
+    @Test
+    public void filter_anyMatch_notDistributedButSerializable_then_proceed() {
+        stream.filter((Serializable & java.util.function.DoublePredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToObj() {
+    public void mapToObj_when_notSerializable_then_fail() {
         stream.mapToObj(m -> m);
     }
 
+    @Test
+    public void mapToObj_notDistributedButSerializable_then_proceed() {
+        stream.mapToObj((Serializable & java.util.function.DoubleFunction<Double>) m -> m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToInt() {
+    public void mapToInt_when_notSerializable_then_fail() {
         stream.mapToInt(m -> (int) m);
     }
 
+    @Test
+    public void mapToInt_notDistributedButSerializable_then_proceed() {
+        stream.mapToInt((Serializable & java.util.function.DoubleToIntFunction) m -> (int) m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToLong() {
+    public void mapToLong_when_notSerializable_then_fail() {
         stream.mapToLong(m -> (long) m);
     }
 
+    @Test
+    public void mapToLong_notDistributedButSerializable_then_proceed() {
+        stream.mapToLong((Serializable & java.util.function.DoubleToLongFunction) m -> (long) m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void peek() {
+    public void peek_when_notSerializable_then_fail() {
         stream.peek(System.out::println);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void reduce() {
-        stream.reduce((l, r) -> l + r);
+    @Test
+    public void peek_notDistributedButSerializable_then_proceed() {
+        stream.peek((Serializable & java.util.function.DoubleConsumer) (x) -> System.out.println(x));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void reduce2() {
+    public void reduce_when_notSerializable_then_fail() {
+        stream.reduce((l, r) -> l + r);
+    }
+
+    @Test
+    public void reduce_notDistributedButSerializable_then_proceed() {
+        stream.reduce((Serializable & java.util.function.DoubleBinaryOperator) (l, r) -> l + r);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void reduce2_when_notSerializable_then_fail() {
         stream.reduce(0, (l, r) -> l + r);
+    }
+
+    @Test
+    public void reduce2_notDistributedButSerializable_then_proceed() {
+        stream.reduce(0, (Serializable & java.util.function.DoubleBinaryOperator) (l, r) -> l + r);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/IntStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/IntStreamCastingTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.stream;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.util.stream.IntStream;
 
 public class IntStreamCastingTest extends AbstractStreamTest {
@@ -32,79 +33,148 @@ public class IntStreamCastingTest extends AbstractStreamTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void map() {
+    public void map_when_notSerializable_then_fail() {
         stream.map(m -> m);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void flatMap() {
-        stream.flatMap(IntStream::of);
+    @Test
+    public void map_notDistributedButSerializable_then_proceed() {
+        stream.map((Serializable & java.util.function.IntUnaryOperator) m -> m);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void collect() {
+    public void flatMap_when_notSerializable_then_fail() {
+        stream.flatMap(IntStream::of);
+    }
+
+    @Test
+    public void flatMap_notDistributedButSerializable_then_proceed() {
+        stream.flatMap((Serializable & java.util.function.IntFunction<IntStream>) IntStream::of);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void collect_when_notSerializable_then_fail() {
         stream.collect(() -> new Integer[]{0},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void forEach() {
-        stream.forEach(System.out::println);
+    @Test
+    public void collect_notDistributedButSerializable_then_proceed() {
+        stream.collect((Serializable & java.util.function.Supplier<Integer[]>) () -> new Integer[]{0},
+                (Serializable & java.util.function.ObjIntConsumer<Integer[]>) (r, e) -> r[0] += e,
+                (Serializable & java.util.function.BiConsumer<Integer[], Integer[]>) (a, b) -> a[0] += b[0]);
+    }
+
+    public void forEach_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.IntConsumer action = System.out::println;
+        stream.forEach(action);
+    }
+
+    public void forEachOrdered_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.IntConsumer action = System.out::println;
+        stream.forEachOrdered(action);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void forEachOrdered() {
-        stream.forEachOrdered(System.out::println);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void allMatch() {
+    public void allMatch_when_notSerializable_then_fail() {
         stream.allMatch(m -> true);
     }
 
+    @Test
+    public void allMatch_notDistributedButSerializable_then_proceed() {
+        stream.allMatch((Serializable & java.util.function.IntPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void anyMatch() {
+    public void anyMatch_when_notSerializable_then_fail() {
         stream.anyMatch(m -> true);
     }
 
+    @Test
+    public void anyMatch_notDistributedButSerializable_then_proceed() {
+        stream.anyMatch((Serializable & java.util.function.IntPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void noneMatch() {
+    public void noneMatch_when_notSerializable_then_fail() {
         stream.noneMatch(m -> true);
     }
 
+    @Test
+    public void noneMatch_notDistributedButSerializable_then_proceed() {
+        stream.noneMatch((Serializable & java.util.function.IntPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void filter() {
+    public void filter_when_notSerializable_then_fail() {
         stream.filter(m -> true);
     }
 
+    @Test
+    public void filter_anyMatch_notDistributedButSerializable_then_proceed() {
+        stream.filter((Serializable & java.util.function.IntPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToObj() {
+    public void mapToObj_when_notSerializable_then_fail() {
         stream.mapToObj(m -> m);
     }
 
+    @Test
+    public void mapToObj_notDistributedButSerializable_then_proceed() {
+        stream.mapToObj((Serializable & java.util.function.IntFunction<Integer>) m -> m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToDouble() {
+    public void mapToDouble_when_notSerializable_then_fail() {
         stream.mapToDouble(m -> (double) m);
     }
 
+    @Test
+    public void mapToDouble_notDistributedButSerializable_then_proceed() {
+        stream.mapToDouble((Serializable & java.util.function.IntToDoubleFunction) m -> (double) m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToLong() {
+    public void mapToLong_when_notSerializable_then_fail() {
         stream.mapToLong(m -> (long) m);
     }
 
+    @Test
+    public void mapToLong_notDistributedButSerializable_then_proceed() {
+        stream.mapToLong((Serializable & java.util.function.IntToLongFunction) m -> (long) m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void peek() {
+    public void peek_when_notSerializable_then_fail() {
         stream.peek(System.out::println);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void reduce() {
-        stream.reduce((l, r) -> l + r);
+    @Test
+    public void peek_notDistributedButSerializable_then_proceed() {
+        stream.peek((Serializable & java.util.function.IntConsumer) (x) -> System.out.println(x));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void reduce2() {
+    public void reduce_when_notSerializable_then_fail() {
+        stream.reduce((l, r) -> l + r);
+    }
+
+    @Test
+    public void reduce_notDistributedButSerializable_then_proceed() {
+        stream.reduce((Serializable & java.util.function.IntBinaryOperator) (l, r) -> l + r);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void reduce2_when_notSerializable_then_fail() {
         stream.reduce(0, (l, r) -> l + r);
+    }
+
+    @Test
+    public void reduce2_notDistributedButSerializable_then_proceed() {
+        stream.reduce(0, (Serializable & java.util.function.IntBinaryOperator) (l, r) -> l + r);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamCastingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/stream/LongStreamCastingTest.java
@@ -20,6 +20,7 @@ package com.hazelcast.jet.stream;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.Serializable;
 import java.util.stream.LongStream;
 
 public class LongStreamCastingTest extends AbstractStreamTest {
@@ -33,79 +34,149 @@ public class LongStreamCastingTest extends AbstractStreamTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void map() {
+    public void map_when_notSerializable_then_fail() {
         stream.map(m -> m);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void flatMap() {
-        stream.flatMap(LongStream::of);
+    @Test
+    public void map_notDistributedButSerializable_then_proceed() {
+        stream.map((Serializable & java.util.function.LongUnaryOperator) m -> m);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void collect() {
+    public void flatMap_when_notSerializable_then_fail() {
+        stream.flatMap(LongStream::of);
+    }
+
+    @Test
+    public void flatMap_notDistributedButSerializable_then_proceed() {
+        stream.flatMap((Serializable & java.util.function.LongFunction<LongStream>) LongStream::of);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void collect_when_notSerializable_then_fail() {
         stream.collect(() -> new Long[]{0L},
                 (r, e) -> r[0] += e,
                 (a, b) -> a[0] += b[0]);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void forEach() {
-        stream.forEach(System.out::println);
+    @Test
+    public void collect_notDistributedButSerializable_then_proceed() {
+        stream.collect((Serializable & java.util.function.Supplier<Long[]>) () -> new Long[]{0L},
+                (Serializable & java.util.function.ObjLongConsumer<Long[]>) (r, e) -> r[0] += e,
+                (Serializable & java.util.function.BiConsumer<Long[], Long[]>) (a, b) -> a[0] += b[0]);
+    }
+
+    public void forEach_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.LongConsumer action = System.out::println;
+        stream.forEach(action);
+    }
+
+    public void forEachOrdered_when_notSerializable_then_proceed() {
+        // here, non-serializable should be allowed
+        java.util.function.LongConsumer action = System.out::println;
+        stream.forEachOrdered(action);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void forEachOrdered() {
-        stream.forEachOrdered(System.out::println);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void allMatch() {
+    public void allMatch_when_notSerializable_then_fail() {
         stream.allMatch(m -> true);
     }
 
+    @Test
+    public void allMatch_notDistributedButSerializable_then_proceed() {
+        stream.allMatch((Serializable & java.util.function.LongPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void anyMatch() {
+    public void anyMatch_when_notSerializable_then_fail() {
         stream.anyMatch(m -> true);
     }
 
+    @Test
+    public void anyMatch_notDistributedButSerializable_then_proceed() {
+        stream.anyMatch((Serializable & java.util.function.LongPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void noneMatch() {
+    public void noneMatch_when_notSerializable_then_fail() {
         stream.noneMatch(m -> true);
     }
 
+    @Test
+    public void noneMatch_notDistributedButSerializable_then_proceed() {
+        stream.noneMatch((Serializable & java.util.function.LongPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void filter() {
+    public void filter_when_notSerializable_then_fail() {
         stream.filter(m -> true);
     }
 
+    @Test
+    public void filter_anyMatch_notDistributedButSerializable_then_proceed() {
+        stream.filter((Serializable & java.util.function.LongPredicate) m -> true);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToObj() {
+    public void mapToObj_when_notSerializable_then_fail() {
         stream.mapToObj(m -> m);
     }
 
+    @Test
+    public void mapToObj_notDistributedButSerializable_then_proceed() {
+        stream.mapToObj((Serializable & java.util.function.LongFunction<Long>) m -> m);
+    }
+
     @Test(expected = IllegalArgumentException.class)
-    public void mapToInt() {
+    public void mapToDouble_when_notSerializable_then_fail() {
+        stream.mapToDouble(m -> (double) m);
+    }
+
+    @Test
+    public void mapToDouble_notDistributedButSerializable_then_proceed() {
+        stream.mapToDouble((Serializable & java.util.function.LongToDoubleFunction) m -> (double) m);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void mapToInt_when_notSerializable_then_fail() {
         stream.mapToInt(m -> (int) m);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void mapToDouble() {
-        stream.mapToDouble(m -> m);
+    @Test
+    public void mapToInt_notDistributedButSerializable_then_proceed() {
+        stream.mapToInt((Serializable & java.util.function.LongToIntFunction) m -> (int) m);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void peek() {
+    public void peek_when_notSerializable_then_fail() {
         stream.peek(System.out::println);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void reduce() {
-        stream.reduce((l, r) -> l + r);
+    @Test
+    public void peek_notDistributedButSerializable_then_proceed() {
+        stream.peek((Serializable & java.util.function.LongConsumer) (x) -> System.out.println(x));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void reduce2() {
+    public void reduce_when_notSerializable_then_fail() {
+        stream.reduce((l, r) -> l + r);
+    }
+
+    @Test
+    public void reduce_notDistributedButSerializable_then_proceed() {
+        stream.reduce((Serializable & java.util.function.LongBinaryOperator) (l, r) -> l + r);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void reduce2_when_notSerializable_then_fail() {
         stream.reduce(0, (l, r) -> l + r);
     }
+
+    @Test
+    public void reduce2_notDistributedButSerializable_then_proceed() {
+        stream.reduce(0, (Serializable & java.util.function.LongBinaryOperator) (l, r) -> l + r);
+    }
+
 }


### PR DESCRIPTION
- Remove checkSerializable in forEach in IntStream and LongStream
- Add testing of functionality without using the interfaces in Distributed
  class
- Remove duplicate checkSerializable, when delegating