### PR TITLE
Change vertex logger to include complete class name

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -186,8 +186,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                 // Also populates instance fields: senderMap, receiverMap, tasklets.
                 final List<OutboundEdgeStream> outboundStreams = createOutboundEdgeStreams(srcVertex, processorIdx);
                 final List<InboundEdgeStream> inboundStreams = createInboundEdgeStreams(srcVertex, processorIdx);
-                ILogger logger = nodeEngine.getLogger(
-                        srcVertex.name() + '(' + p.getClass().getSimpleName() + ")#" + processorIdx);
+                ILogger logger = nodeEngine.getLogger(p.getClass().getName() + '.'
+                        + srcVertex.name() + '(' + p.getClass().getSimpleName() + ")#" + processorIdx);
                 ProcCtx context = new ProcCtx(instance, logger, srcVertex.name(), processorIdx);
                 tasklets.add(new ProcessorTasklet(srcVertex.name(), context, p, inboundStreams, outboundStreams));
             }


### PR DESCRIPTION
Before, it was just e.g. `reader(ReadFileStreamP)#0`. This way, it wasn't
possible to enable the logger by its class name.

Now is changed to:
`com.hazelcast.jet.impl.connector.ReadFileStreamP.reader(ReadFileStreamP)#0`.
Our default setting is to display only the parte after last '.'. This way, we
see vertex name and class name and vertex instance id, this is importoant for
eventual logs from customres.