### PR TITLE
Improve error message with duplicate ordinal

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/DAG.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/DAG.java
@@ -157,12 +157,16 @@ public class DAG implements IdentifiedDataSerializable, Iterable<Vertex> {
         if (getInboundEdges(edge.getDestName())
                 .stream().anyMatch(e -> e.getDestOrdinal() == edge.getDestOrdinal())) {
             throw new IllegalArgumentException("Vertex '" + edge.getDestName()
-                    + "' already has an inbound edge at ordinal " + edge.getDestOrdinal());
+                    + "' already has an inbound edge at ordinal " + edge.getDestOrdinal()
+                    + (edge.getSourceOrdinal() == 0 && edge.getDestOrdinal() == 0
+                            ? ", use Edge.from().to() to specify another ordinal" : ""));
         }
         if (getOutboundEdges(edge.getSourceName())
                 .stream().anyMatch(e -> e.getSourceOrdinal() == edge.getSourceOrdinal())) {
             throw new IllegalArgumentException("Vertex '" + edge.getSourceName()
-                    + "' already has an outbound edge at ordinal " + edge.getSourceOrdinal());
+                    + "' already has an outbound edge at ordinal " + edge.getSourceOrdinal()
+                    + (edge.getSourceOrdinal() == 0 && edge.getDestOrdinal() == 0
+                            ? ", use Edge.from().to() to specify another ordinal" : ""));
         }
         edges.add(edge);
         return this;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/DAGTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/DAGTest.java
@@ -31,6 +31,8 @@ import java.util.Set;
 import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.Edge.from;
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
@@ -321,6 +323,38 @@ public class DAGTest {
 
         // When
         dag.edge(from(a, 1).to(b, 1));
+    }
+
+    @Test
+    public void when_betweenUsedDuplicitly_then_errorMessageContainsEdgeFromTo() {
+        DAG dag = new DAG();
+        Vertex a = dag.newVertex("a", PROCESSOR_SUPPLIER);
+        Vertex b = dag.newVertex("b", PROCESSOR_SUPPLIER);
+        Vertex c = dag.newVertex("c", PROCESSOR_SUPPLIER);
+        dag.edge(between(a, c));
+
+        // Then
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("Edge.from().to()");
+
+        // When
+        dag.edge(between(b, c));
+    }
+
+    @Test
+    public void when_duplicateNonZeroOrdinal_then_errorMessageNotContainingEdgeFromTo() {
+        DAG dag = new DAG();
+        Vertex a = dag.newVertex("a", PROCESSOR_SUPPLIER);
+        Vertex b = dag.newVertex("b", PROCESSOR_SUPPLIER);
+        Vertex c = dag.newVertex("c", PROCESSOR_SUPPLIER);
+        dag.edge(from(a).to(c, 1));
+
+        // Then
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage(not(containsString("Edge.from().to()")));
+
+        // When
+        dag.edge(from(b).to(c, 1));
     }
 
     private static class TestProcessor extends AbstractProcessor {


### PR DESCRIPTION
Refers the user to use `Edge.from().to()` instead of `Edge.between()`.
Intended to help for begginer users, who just don't yet know of edge ordinals.