### PR TITLE
Added jet-cache-manager to conceal cache-api

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
@@ -23,7 +23,6 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.stream.IStreamCache;
 import com.hazelcast.jet.stream.IStreamList;
 import com.hazelcast.jet.stream.IStreamMap;
-import com.hazelcast.jet.stream.impl.CacheDecorator;
 import com.hazelcast.jet.stream.impl.ListDecorator;
 import com.hazelcast.jet.stream.impl.MapDecorator;
 
@@ -58,7 +57,7 @@ abstract class AbstractJetInstance implements JetInstance {
 
     @Override
     public <K, V> IStreamCache<K, V> getCache(String name) {
-        return new CacheDecorator<>(hazelcastInstance.getCacheManager().getCache(name), this);
+        return JetCacheManager.getCache(this, name);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetCacheManager.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetCacheManager.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.stream.IStreamCache;
+import com.hazelcast.jet.stream.impl.CacheDecorator;
+
+/**
+ * This class is necessary to conceal the cache-api
+ */
+public final class JetCacheManager {
+
+    private JetCacheManager() {
+    }
+
+    public static <K, V> IStreamCache<K, V> getCache(JetInstance instance, String name) {
+        return new CacheDecorator<>(instance.getHazelcastInstance().getCacheManager().getCache(name), instance);
+    }
+}


### PR DESCRIPTION
creating `CacheDecorator` in the `getCache` method of `JetInstance` triggers the loading of cache-api. 