### PR TITLE
JobFuture in Processor.Context

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processor.java
@@ -154,12 +154,12 @@ public interface Processor {
          * after each blocking call (note, that blocking calls are allowed only
          * in {@link #isCooperative() non-cooperative} processors). In this case,
          * the methods should regularly check the {@code jobFuture}'s
-         * {@link CompletableFuture#isCompletedExceptionally()} and return, when
-         * it returns {@code true}:
+         * {@link CompletableFuture#isDone() isDone()} and return, when it returns
+         * {@code true}:
          *
          * <pre>
          * public boolean complete() {
-         *     while (!jobFuture.isCompletedExceptionally()) {
+         *     while (!jobFuture.isDone()) {
          *         // we should not block indefinitely, but rather with a timeout
          *         Collection data = blockingRead(timeout);
          *         for (Object item : data) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processor.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet;
 import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Does the computation needed to transform zero or more input data streams
@@ -144,5 +145,29 @@ public interface Processor {
          */
         @Nonnull
         String vertexName();
+
+        /**
+         * Returns the future to check for cancellation status.
+         * <p>
+         * This is only necessary, if the {@link #complete()} method never returns and blocks
+         * indefinitely, which is only legal for {@link #isCooperative() non-cooperative} processors.
+         * In this case, the {@link #complete()} should check regularly the {@code jobFuture}'s
+         * {@link CompletableFuture#isCompletedExceptionally()} and return, when it returns
+         * {@code true}:
+         *
+         * <pre>
+         * public boolean complete() {
+         *     while (!jobFuture.isCompletedExceptionally()) {
+         *         // we should not block indefinitely, but rather with a timeout
+         *         Collection data = blockingRead(timeout);
+         *         for (Object item : data) {
+         *             emit(item);
+         *         }
+         *     }
+         * }
+         * </pre>
+         */
+        @Nonnull
+        CompletableFuture<Void> jobFuture();
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processor.java
@@ -149,11 +149,13 @@ public interface Processor {
         /**
          * Returns the future to check for cancellation status.
          * <p>
-         * This is only necessary, if the {@link #complete()} method never returns and blocks
-         * indefinitely, which is only legal for {@link #isCooperative() non-cooperative} processors.
-         * In this case, the {@link #complete()} should check regularly the {@code jobFuture}'s
-         * {@link CompletableFuture#isCompletedExceptionally()} and return, when it returns
-         * {@code true}:
+         * This is necessary, if the {@link #complete()} or
+         * {@link #process(int, Inbox) process()} methods do not return promptly
+         * after each blocking call (note, that blocking calls are allowed only
+         * in {@link #isCooperative() non-cooperative} processors). In this case,
+         * the methods should regularly check the {@code jobFuture}'s
+         * {@link CompletableFuture#isCompletedExceptionally()} and return, when
+         * it returns {@code true}:
          *
          * <pre>
          * public boolean complete() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/BlockingProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/BlockingProcessorTasklet.java
@@ -16,12 +16,10 @@
 
 package com.hazelcast.jet.impl.execution;
 
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
 import com.hazelcast.jet.impl.util.ProgressState;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.Preconditions;
 
 import javax.annotation.Nonnull;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/BlockingProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/BlockingProcessorTasklet.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
+import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.Preconditions;
@@ -39,10 +40,10 @@ public class BlockingProcessorTasklet extends ProcessorTaskletBase {
     private CompletableFuture<?> jobFuture;
 
     public BlockingProcessorTasklet(
-            String vertexName, JetInstance instance, ILogger logger, int processorIdx, Processor processor,
-            List<InboundEdgeStream> instreams, List<OutboundEdgeStream> outstreams
+            ProcCtx context, Processor processor, List<InboundEdgeStream> instreams,
+            List<OutboundEdgeStream> outstreams
     ) {
-        super(vertexName, instance, logger, processor, processorIdx, instreams, outstreams);
+        super(context, processor, instreams, outstreams);
         Preconditions.checkFalse(processor.isCooperative(), "Processor is cooperative");
         outbox = new BlockingOutbox();
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/CooperativeProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/CooperativeProcessorTasklet.java
@@ -16,11 +16,10 @@
 
 package com.hazelcast.jet.impl.execution;
 
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Processor;
+import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
 import com.hazelcast.jet.impl.util.ArrayDequeOutbox;
 import com.hazelcast.jet.impl.util.ProgressState;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.Preconditions;
 
 import javax.annotation.Nonnull;
@@ -38,10 +37,9 @@ public class CooperativeProcessorTasklet extends ProcessorTaskletBase {
     private final ArrayDequeOutbox outbox;
     private boolean processorCompleted;
 
-    public CooperativeProcessorTasklet(String vertexName, JetInstance instance, ILogger logger,
-                                       int processorIdx, Processor processor, List<InboundEdgeStream> instreams,
-                                       List<OutboundEdgeStream> outstreams) {
-        super(vertexName, instance, logger, processor, processorIdx, instreams, outstreams);
+    public CooperativeProcessorTasklet(ProcCtx context, Processor processor,
+                                       List<InboundEdgeStream> instreams, List<OutboundEdgeStream> outstreams) {
+        super(context, processor, instreams, outstreams);
         Preconditions.checkTrue(processor.isCooperative(), "Processor is non-cooperative");
         int[] bucketCapacities = Stream.of(this.outstreams).mapToInt(OutboundEdgeStream::getOutboxCapacity).toArray();
         this.outbox = new ArrayDequeOutbox(outstreams.size(), bucketCapacities, progTracker);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
@@ -101,7 +101,6 @@ public class ExecutionService {
 
     private void submitBlockingTasklets(JobFuture jobFuture, List<Tasklet> tasklets) {
         jobFuture.blockingFutures = tasklets.stream()
-                                            .peek(t -> t.init(jobFuture))
                                             .map(t -> new BlockingWorker(new TaskletTracker(t, jobFuture)))
                                             .map(blockingTaskletExecutor::submit)
                                             .collect(toList());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface Tasklet extends Callable<ProgressState> {
 
-    default void init(CompletableFuture<?> jobFuture) {
+    default void init(CompletableFuture<Void> jobFuture) {
     }
 
     @Override @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -23,24 +23,28 @@ import com.hazelcast.jet.ProcessorSupplier;
 import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
 
-final class Contexts {
+public final class Contexts {
 
     private Contexts() {
     }
 
-    static class ProcCtx implements Processor.Context {
+    public static class ProcCtx implements Processor.Context {
 
         private final JetInstance instance;
         private final ILogger logger;
         private final String vertexName;
         private final int index;
+        private final CompletableFuture<Void> jobFuture;
 
-        ProcCtx(JetInstance instance, ILogger logger, String vertexName, int index) {
+        public ProcCtx(JetInstance instance, ILogger logger, String vertexName, int index,
+                       CompletableFuture<Void> jobFuture) {
             this.instance = instance;
             this.logger = logger;
             this.vertexName = vertexName;
             this.index = index;
+            this.jobFuture = jobFuture;
         }
 
         @Nonnull
@@ -64,6 +68,12 @@ final class Contexts {
         @Override
         public String vertexName() {
             return vertexName;
+        }
+
+        @Nonnull
+        @Override
+        public CompletableFuture<Void> jobFuture() {
+            return jobFuture;
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -36,15 +36,13 @@ public final class Contexts {
         private final ILogger logger;
         private final String vertexName;
         private final int index;
-        private final CompletableFuture<Void> jobFuture;
+        private CompletableFuture<Void> jobFuture;
 
-        public ProcCtx(JetInstance instance, ILogger logger, String vertexName, int index,
-                       CompletableFuture<Void> jobFuture) {
+        public ProcCtx(JetInstance instance, ILogger logger, String vertexName, int index) {
             this.instance = instance;
             this.logger = logger;
             this.vertexName = vertexName;
             this.index = index;
-            this.jobFuture = jobFuture;
         }
 
         @Nonnull
@@ -70,10 +68,20 @@ public final class Contexts {
             return vertexName;
         }
 
+        /**
+         * Note that method is marked sa {@link Nonnull}, however, it's only
+         * non-null after {@link #initJobFuture(CompletableFuture)} is called,
+         * which means it's <i>practically non-null</i>.
+         */
         @Nonnull
         @Override
         public CompletableFuture<Void> jobFuture() {
             return jobFuture;
+        }
+
+        public void initJobFuture(CompletableFuture<Void> jobFuture) {
+            assert this.jobFuture == null;
+            this.jobFuture = jobFuture;
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -80,7 +80,7 @@ public final class Contexts {
         }
 
         public void initJobFuture(CompletableFuture<Void> jobFuture) {
-            assert this.jobFuture == null;
+            assert this.jobFuture == null : "jobFuture already initialized";
             this.jobFuture = jobFuture;
         }
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -38,16 +38,15 @@ import com.hazelcast.jet.impl.execution.ConcurrentInboundEdgeStream;
 import com.hazelcast.jet.impl.execution.ConveyorCollector;
 import com.hazelcast.jet.impl.execution.ConveyorCollectorWithPartition;
 import com.hazelcast.jet.impl.execution.ConveyorEmitter;
+import com.hazelcast.jet.impl.execution.CooperativeProcessorTasklet;
 import com.hazelcast.jet.impl.execution.InboundEdgeStream;
 import com.hazelcast.jet.impl.execution.InboundEmitter;
 import com.hazelcast.jet.impl.execution.OutboundCollector;
 import com.hazelcast.jet.impl.execution.OutboundEdgeStream;
-import com.hazelcast.jet.impl.execution.CooperativeProcessorTasklet;
 import com.hazelcast.jet.impl.execution.ReceiverTasklet;
 import com.hazelcast.jet.impl.execution.SenderTasklet;
 import com.hazelcast.jet.impl.execution.Tasklet;
 import com.hazelcast.jet.impl.execution.init.Contexts.MetaSupplierCtx;
-import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
 import com.hazelcast.jet.impl.execution.init.Contexts.ProcSupplierCtx;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -189,10 +188,12 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                 final List<InboundEdgeStream> inboundStreams = createInboundEdgeStreams(srcVertex, processorIdx);
                 ILogger logger = nodeEngine.getLogger(p.getClass().getName() + '.'
                         + srcVertex.name() + '(' + p.getClass().getSimpleName() + ")#" + processorIdx);
-                ProcCtx context = new ProcCtx(instance, logger, srcVertex.name(), processorIdx);
+
                 tasklets.add(p.isCooperative()
-                        ? new CooperativeProcessorTasklet(srcVertex.name(), context, p, inboundStreams, outboundStreams)
-                        : new BlockingProcessorTasklet(srcVertex.name(), context, p, inboundStreams, outboundStreams)
+                        ? new CooperativeProcessorTasklet(srcVertex.name(), instance, logger, processorIdx, p,
+                                inboundStreams, outboundStreams)
+                        : new BlockingProcessorTasklet(srcVertex.name(), instance, logger, processorIdx, p,
+                                inboundStreams, outboundStreams)
                 );
             }
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamTextSocketPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamTextSocketPTest.java
@@ -71,78 +71,79 @@ public class StreamTextSocketPTest extends JetTestSupport {
     public void when_dataWrittenToSocket_then_dataImmediatelyEmitted() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         // Given
-        ServerSocket socket = new ServerSocket(PORT);
-        new Thread(() -> uncheckRun(() -> {
-            Socket accept1 = socket.accept();
-            Socket accept2 = socket.accept();
-            PrintWriter writer1 = new PrintWriter(accept1.getOutputStream());
-            writer1.write("hello1 \n");
-            writer1.flush();
-            PrintWriter writer2 = new PrintWriter(accept2.getOutputStream());
-            writer2.write("hello2 \n");
-            writer2.flush();
+        try (ServerSocket socket = new ServerSocket(PORT)) {
+            new Thread(() -> uncheckRun(() -> {
+                Socket accept1 = socket.accept();
+                Socket accept2 = socket.accept();
+                PrintWriter writer1 = new PrintWriter(accept1.getOutputStream());
+                writer1.write("hello1 \n");
+                writer1.flush();
+                PrintWriter writer2 = new PrintWriter(accept2.getOutputStream());
+                writer2.write("hello2 \n");
+                writer2.flush();
 
-            assertOpenEventually(latch);
-            writer1.write("world1 \n");
-            writer1.write("jet1 \n");
-            writer1.flush();
-            writer2.write("world2 \n");
-            writer2.write("jet2 \n");
-            writer2.flush();
+                assertOpenEventually(latch);
+                writer1.write("world1 \n");
+                writer1.write("jet1 \n");
+                writer1.flush();
+                writer2.write("world2 \n");
+                writer2.write("jet2 \n");
+                writer2.flush();
 
-            accept1.close();
-            accept2.close();
-            socket.close();
-        })).start();
+                accept1.close();
+                accept2.close();
+            })).start();
 
-        DAG dag = new DAG();
-        Vertex producer = dag.newVertex("producer", streamTextSocket(HOST, PORT)).localParallelism(2);
-        Vertex consumer = dag.newVertex("consumer", writeList("consumer")).localParallelism(1);
-        dag.edge(between(producer, consumer));
+            DAG dag = new DAG();
+            Vertex producer = dag.newVertex("producer", streamTextSocket(HOST, PORT)).localParallelism(2);
+            Vertex consumer = dag.newVertex("consumer", writeList("consumer")).localParallelism(1);
+            dag.edge(between(producer, consumer));
 
-        // When
-        Future<Void> job = instance.newJob(dag).execute();
-        IList<Object> list = instance.getList("consumer");
+            // When
+            Future<Void> job = instance.newJob(dag).execute();
+            IList<Object> list = instance.getList("consumer");
 
-        assertTrueEventually(() -> assertEquals(2, list.size()));
-        latch.countDown();
-        job.get();
-        assertEquals(6, list.size());
+            assertTrueEventually(() -> assertEquals(2, list.size()));
+            latch.countDown();
+            job.get();
+            assertEquals(6, list.size());
+        }
     }
 
     @Test
     public void when_jobCancelled_then_readerClosed() throws Exception {
-        ServerSocket socket = new ServerSocket(PORT);
-        AtomicReference<Socket> accept = new AtomicReference<>();
-        CountDownLatch acceptationLatch = new CountDownLatch(1);
-        // Cancellation only works, if there are data on socket. Without data, SocketInputStream.read()
-        // blocks indefinitely. The StreamTextSocketP should be improved to use NIO.
-        new Thread(() -> uncheckRun(() -> {
-            accept.set(socket.accept());
-            acceptationLatch.countDown();
-            byte[] word = "jet\n".getBytes();
-            try (OutputStream outputStream = accept.get().getOutputStream()) {
-                while (true) {
-                    outputStream.write(word);
-                    outputStream.flush();
-                    Thread.sleep(1000);
+        try (ServerSocket socket = new ServerSocket(PORT)) {
+            AtomicReference<Socket> accept = new AtomicReference<>();
+            CountDownLatch acceptationLatch = new CountDownLatch(1);
+            // Cancellation only works, if there are data on socket. Without data, SocketInputStream.read()
+            // blocks indefinitely. The StreamTextSocketP should be improved to use NIO.
+            new Thread(() -> uncheckRun(() -> {
+                accept.set(socket.accept());
+                acceptationLatch.countDown();
+                byte[] word = "jet\n".getBytes();
+                try (OutputStream outputStream = accept.get().getOutputStream()) {
+                    while (true) {
+                        outputStream.write(word);
+                        outputStream.flush();
+                        Thread.sleep(1000);
+                    }
                 }
-            }
-        })).start();
+            })).start();
 
-        Vertex producer = new Vertex("producer", Processors.streamTextSocket(HOST, PORT)).localParallelism(1);
-        Vertex sink = new Vertex("sink", NoopP::new).localParallelism(1);
-        DAG dag = new DAG()
-                .vertex(producer)
-                .vertex(sink)
-                .edge(between(producer, sink));
+            Vertex producer = new Vertex("producer", Processors.streamTextSocket(HOST, PORT)).localParallelism(1);
+            Vertex sink = new Vertex("sink", NoopP::new).localParallelism(1);
+            DAG dag = new DAG()
+                    .vertex(producer)
+                    .vertex(sink)
+                    .edge(between(producer, sink));
 
-        Future<Void> job = instance.newJob(dag).execute();
-        acceptationLatch.await();
-        job.cancel(true);
+            Future<Void> job = instance.newJob(dag).execute();
+            acceptationLatch.await();
+            job.cancel(true);
 
-        assertTrueEventually(() -> {
-            assertTrue("Socket not closed", accept.get().isClosed());
-        });
+            assertTrueEventually(() -> {
+                assertTrue("Socket not closed", accept.get().isClosed());
+            });
+        }
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/CooperativeProcessorTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/CooperativeProcessorTaskletTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.jet.Inbox;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
+import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -35,10 +36,8 @@ import java.util.stream.IntStream;
 import static com.hazelcast.jet.impl.util.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.NO_PROGRESS;
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category(QuickTest.class)
@@ -50,12 +49,13 @@ public class CooperativeProcessorTaskletTest {
     private List<InboundEdgeStream> instreams;
     private List<OutboundEdgeStream> outstreams;
     private PassThroughProcessor processor;
-
+    private ProcCtx context;
 
     @Before
     public void setUp() {
         this.mockInput = IntStream.range(0, MOCK_INPUT_LENGTH).boxed().collect(toList());
         this.processor = new PassThroughProcessor();
+        this.context = new ProcCtx(null, null, null, 0);
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
     }
@@ -156,7 +156,7 @@ public class CooperativeProcessorTaskletTest {
 
     private Tasklet createTasklet() {
         final CooperativeProcessorTasklet t = new CooperativeProcessorTasklet(
-                "mock", null, null, 0, processor, instreams, outstreams);
+                context, processor, instreams, outstreams);
         t.init(new CompletableFuture<>());
         return t;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/CooperativeProcessorTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/CooperativeProcessorTaskletTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.jet.Inbox;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
-import com.hazelcast.jet.Processor.Context;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -41,7 +40,6 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 @Category(QuickTest.class)
 public class CooperativeProcessorTaskletTest {
@@ -52,14 +50,12 @@ public class CooperativeProcessorTaskletTest {
     private List<InboundEdgeStream> instreams;
     private List<OutboundEdgeStream> outstreams;
     private PassThroughProcessor processor;
-    private Context context;
 
 
     @Before
     public void setUp() {
         this.mockInput = IntStream.range(0, MOCK_INPUT_LENGTH).boxed().collect(toList());
         this.processor = new PassThroughProcessor();
-        this.context = mock(Context.class);
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
     }
@@ -160,7 +156,7 @@ public class CooperativeProcessorTaskletTest {
 
     private Tasklet createTasklet() {
         final CooperativeProcessorTasklet t = new CooperativeProcessorTasklet(
-                "mock", context, processor, instreams, outstreams);
+                "mock", null, null, 0, processor, instreams, outstreams);
         t.init(new CompletableFuture<>());
         return t;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ExecutionServiceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ExecutionServiceTest.java
@@ -308,7 +308,7 @@ public class ExecutionServiceTest extends JetTestSupport {
         }
 
         @Override
-        public void init(CompletableFuture<?> jobFuture) {
+        public void init(CompletableFuture<Void> jobFuture) {
             if (initFails) {
                 throw new RuntimeException("mock init failure");
             }

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/connector/kafka/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/connector/kafka/StreamKafkaP.java
@@ -78,7 +78,7 @@ public final class StreamKafkaP extends AbstractProcessor {
         try (KafkaConsumer<?, ?> consumer = new KafkaConsumer<>(properties)) {
             consumer.subscribe(Arrays.asList(topicIds));
 
-            while (!jobFuture.isCompletedExceptionally()) {
+            while (!jobFuture.isDone()) {
                 ConsumerRecords<?, ?> records = consumer.poll(POLL_TIMEOUT_MS);
 
                 for (ConsumerRecord<?, ?> r : records) {

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/connector/kafka/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/connector/kafka/StreamKafkaP.java
@@ -24,8 +24,10 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Util.entry;
 
@@ -34,9 +36,10 @@ import static com.hazelcast.jet.Util.entry;
  */
 public final class StreamKafkaP extends AbstractProcessor {
 
-    private static final int POLL_TIMEOUT_MS = 100;
+    private static final int POLL_TIMEOUT_MS = 1000;
     private final Properties properties;
     private final String[] topicIds;
+    private CompletableFuture<Void> jobFuture;
 
     private StreamKafkaP(String[] topicIds, Properties properties) {
         this.topicIds = topicIds;
@@ -66,12 +69,18 @@ public final class StreamKafkaP extends AbstractProcessor {
     }
 
     @Override
+    protected void init(@Nonnull Context context) throws Exception {
+        jobFuture = context.jobFuture();
+    }
+
+    @Override
     public boolean complete() {
         try (KafkaConsumer<?, ?> consumer = new KafkaConsumer<>(properties)) {
             consumer.subscribe(Arrays.asList(topicIds));
 
-            while (!Thread.currentThread().isInterrupted()) {
+            while (!jobFuture.isCompletedExceptionally()) {
                 ConsumerRecords<?, ?> records = consumer.poll(POLL_TIMEOUT_MS);
+
                 for (ConsumerRecord<?, ?> r : records) {
                     emit(entry(r.key(), r.value()));
                 }


### PR DESCRIPTION
The need is to allow for non-cooperative processor to check for job cancellation/failure, without returning from `complete()` method.

Solution moves the call to `Processor.init` from `Tasklet` constructor, which is called from `ExecutionPlan.initialize()` to `Tasklet.init()` method, because only then the `jobFuture` is available.