### PR TITLE
Increase test coverage for SlidingWP and GBFP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
@@ -125,6 +125,27 @@ public interface Traverser<T> {
     }
 
     /**
+     * Returns a traverser that will emit the same items as this traverser and
+     * will additionally run the supplied action first time this traverser
+     * returns {@code null}.
+     */
+    @Nonnull
+    default Traverser<T> onFirstNull(@Nonnull Runnable action) {
+        return new Traverser<T>() {
+            private Runnable action2 = action;
+            @Override
+            public T next() {
+                T t = Traverser.this.next();
+                if (t == null && action2 != null) {
+                    action2.run();
+                    action2 = null;
+                }
+                return t;
+            }
+        };
+    }
+
+    /**
      * Returns a traverser that will emit the same items as this traverser,
      * additionally passing each item to the supplied consumer. A {@code null}
      * return value is not passed to the action.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
@@ -125,27 +125,6 @@ public interface Traverser<T> {
     }
 
     /**
-     * Returns a traverser that will emit the same items as this traverser and
-     * will additionally run the supplied action first time this traverser
-     * returns {@code null}.
-     */
-    @Nonnull
-    default Traverser<T> onFirstNull(@Nonnull Runnable action) {
-        return new Traverser<T>() {
-            private Runnable action2 = action;
-            @Override
-            public T next() {
-                T t = Traverser.this.next();
-                if (t == null && action2 != null) {
-                    action2.run();
-                    action2 = null;
-                }
-                return t;
-            }
-        };
-    }
-
-    /**
      * Returns a traverser that will emit the same items as this traverser,
      * additionally passing each item to the supplied consumer. A {@code null}
      * return value is not passed to the action.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/SlidingWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/SlidingWindowP.java
@@ -39,7 +39,7 @@ import static java.lang.Math.min;
 /**
  * Sliding window processor. See {@link
  * WindowingProcessors#slidingWindow(WindowDefinition, WindowOperation)
- * slidingWindow(frameLength, framesPerWindow, windowToolkit)} for
+ * slidingWindow(windowDef, windowOperation)} for
  * documentation.
  *
  * @param <K> type of the grouping key
@@ -63,7 +63,7 @@ class SlidingWindowP<K, F, R> extends AbstractProcessor {
 
     private long nextFrameSeqToEmit = Long.MIN_VALUE;
 
-    SlidingWindowP(WindowDefinition winDef, @Nonnull WindowOperation<K, F, R> winOp) {
+    SlidingWindowP(WindowDefinition winDef, @Nonnull WindowOperation<?, F, R> winOp) {
         this.wDef = winDef;
         this.createF = winOp.createAccumulatorF();
         this.combineF = winOp.combineAccumulatorsF();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/SlidingWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/SlidingWindowP.java
@@ -37,7 +37,7 @@ import static java.lang.Math.min;
 
 /**
  * Sliding window processor. See {@link
- * WindowingProcessors#slidingWindow(WindowDefinition, WindowOperation, boolean)
+ * WindowingProcessors#slidingWindow(WindowDefinition, WindowOperation)
  * slidingWindow(frameLength, framesPerWindow, windowToolkit)} for
  * documentation.
  *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperations.java
@@ -105,8 +105,8 @@ public final class WindowOperations {
      *             function
      * @param combineF a function that combines a new item with the current result
      *                 and returns the new result
-     * @param deductF a function that deducts the contribution of an item from the
-     *                current result and returns the new result
+     * @param deductF an optional function that deducts the contribution of an
+     *                item from the current result and returns the new result
      * @param <T> type of the stream item
      * @param <U> type of the reduced result
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowingProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowingProcessors.java
@@ -90,12 +90,9 @@ public final class WindowingProcessors {
      * @param <K> type of the grouping key
      * @param <F> type of the frame
      * @param <R> type of the result derived from a frame
-     * @param emitPunctuation If {@code true}, punctuation will be emitted when window
-     *                        is closed. Enable, if downstream vertex needs to know,
-     *                        that it has received all keys for a particular window.
      */
     public static <K, F, R> Distributed.Supplier<SlidingWindowP<K, F, R>> slidingWindow(
-            WindowDefinition windowDef, WindowOperation<K, F, R> windowOperation, boolean emitPunctuation) {
+            WindowDefinition windowDef, WindowOperation<K, F, R> windowOperation) {
         return () -> new SlidingWindowP<>(windowDef, windowOperation);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowingProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowingProcessors.java
@@ -56,27 +56,28 @@ public final class WindowingProcessors {
      *
      * @param <T> item type
      * @param <K> type of key returned from {@code extractKeyF}
-     * @param <F> type of frame returned from {@code sc.supplier()}
+     * @param <F> type of accumulator returned from {@code windowOperation.
+     *            createAccumulatorF()}
      */
     public static <T, K, F> Distributed.Supplier<GroupByFrameP<T, K, F>> groupByFrame(
             Distributed.Function<? super T, K> extractKeyF,
             Distributed.ToLongFunction<? super T> extractTimestampF,
             WindowDefinition windowDef,
-            WindowOperation<T, F, ?> collector
+            WindowOperation<? super T, F, ?> windowOperation
     ) {
-        return () -> new GroupByFrameP<>(extractKeyF, extractTimestampF, windowDef, collector);
+        return () -> new GroupByFrameP<>(extractKeyF, extractTimestampF, windowDef, windowOperation);
     }
 
     /**
      * Convenience for {@link #groupByFrame(
      * Distributed.Function, Distributed.ToLongFunction, WindowDefinition, WindowOperation)
-     * groupByFrame(extractKeyF, extractTimeStampF, frameLength, frameOffset, collector)}
+     * groupByFrame(extractKeyF, extractTimestampF, windowDef, collector)}
      * which doesn't group by key.
      */
     public static <T, F> Distributed.Supplier<GroupByFrameP<T, String, F>> groupByFrame(
             Distributed.ToLongFunction<? super T> extractTimestampF,
             WindowDefinition windowDef,
-            WindowOperation<T, F, ?> collector
+            WindowOperation<? super T, F, ?> collector
     ) {
         return groupByFrame(t -> "global", extractTimestampF, windowDef, collector);
     }
@@ -88,11 +89,11 @@ public final class WindowingProcessors {
      * output.
      *
      * @param <K> type of the grouping key
-     * @param <F> type of the frame
+     * @param <F> type of accumulator
      * @param <R> type of the result derived from a frame
      */
     public static <K, F, R> Distributed.Supplier<SlidingWindowP<K, F, R>> slidingWindow(
-            WindowDefinition windowDef, WindowOperation<K, F, R> windowOperation) {
+            WindowDefinition windowDef, WindowOperation<?, F, R> windowOperation) {
         return () -> new SlidingWindowP<>(windowDef, windowOperation);
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/GroupByFramePTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/GroupByFramePTest.java
@@ -74,7 +74,7 @@ public class GroupByFramePTest extends StreamingTestSupport {
                 entry(0L, 1L), // to frame 4
                 entry(1L, 1L), // to frame 4
                 punc(3), // does not close anything
-                entry(2L, 1L), // to frame 4, still accepted, even after punc(3)
+                entry(2L, 1L), // to frame 4, still accepted, even though it's late after punc(3)
                 punc(4), // closes frame 4
                 entry(4L, 1L), // to frame 8
                 entry(5L, 1L), // to frame 8

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowIntegrationTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.windowing;
+
+import com.hazelcast.core.IList;
+import com.hazelcast.jet.AbstractProcessor;
+import com.hazelcast.jet.DAG;
+import com.hazelcast.jet.Distributed.Function;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestSupport;
+import com.hazelcast.jet.ProcessorMetaSupplier;
+import com.hazelcast.jet.Processors.NoopP;
+import com.hazelcast.jet.Vertex;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static com.hazelcast.jet.Edge.between;
+import static com.hazelcast.jet.Processors.writeList;
+import static com.hazelcast.jet.windowing.PunctuationPolicies.cappingEventSeqLagAndLull;
+import static com.hazelcast.jet.windowing.StreamingTestSupport.streamToString;
+import static com.hazelcast.jet.windowing.WindowDefinition.slidingWindowDef;
+import static com.hazelcast.jet.windowing.WindowingProcessors.groupByFrame;
+import static com.hazelcast.jet.windowing.WindowingProcessors.insertPunctuation;
+import static com.hazelcast.jet.windowing.WindowingProcessors.slidingWindow;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class SlidingWindowIntegrationTest extends JetTestSupport {
+
+    @After
+    public void shutdownAll() {
+        shutdownFactory();
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        runTest(
+                Collections.singletonList(new MockEvent("a", 10, 1)),
+                Arrays.asList(
+                        new Frame(1000, "a", 1L),
+                        new Frame(2000, "a", 1L)
+                ));
+    }
+
+    public void runTest(List<MockEvent> sourceEvents, List<Frame> expectedOutput) throws InterruptedException {
+        JetInstance instance = super.createJetMember();
+
+        WindowDefinition wDef = slidingWindowDef(2000, 1000);
+        WindowOperation<MockEvent, ?, ?> wOperation = WindowOperations.counting();
+
+        DAG dag = new DAG();
+        Vertex source = dag.newVertex("source", streamList(sourceEvents)).localParallelism(1);
+        Vertex insertPP = dag.newVertex("insertPP", insertPunctuation(MockEvent::getEventSeq,
+                () -> cappingEventSeqLagAndLull(500, 1000).throttleByFrame(wDef)))
+                .localParallelism(1);
+        Vertex gbfp = dag.newVertex("gbfp", groupByFrame(MockEvent::getKey, MockEvent::getEventSeq, wDef, wOperation));
+        Vertex sliwp = dag.newVertex("sliwp", slidingWindow(wDef, wOperation));
+        Vertex sink = dag.newVertex("sink", writeList("sink"));
+
+        dag
+                .edge(between(source, insertPP).oneToMany())
+                .edge(between(insertPP, gbfp).partitioned(MockEvent::getKey))
+                .edge(between(gbfp, sliwp).partitioned((Function<Frame, Object>) Frame::getKey).distributed())
+                .edge(between(sliwp, sink).oneToMany());
+
+        instance.newJob(dag).execute();
+
+        IList<Frame> sinkList = instance.getList("sink");
+
+        assertTrueEventually(() -> assertTrue(sinkList.size() == expectedOutput.size()));
+        // wait little more and make sure, that there are no more frames
+        Thread.sleep(2000);
+
+        String expected = streamToString(expectedOutput.stream());
+        String actual = streamToString(new ArrayList<>(sinkList).stream());
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Returns a {@link ProcessorMetaSupplier}, that will emit contents of a list and the NOT complete.
+     * Emits from single node and single processor instance.
+     */
+    private ProcessorMetaSupplier streamList(List<?> sourceList) {
+        return addresses -> address -> count ->
+                IntStream.range(0, count)
+                        .mapToObj(i -> i == 0 ? new StreamListP(sourceList) : new NoopP())
+                        .collect(toList());
+    }
+
+    private static class MockEvent implements Serializable {
+        private final String key;
+        private final long eventSeq;
+        private final long value;
+
+        private MockEvent(String key, long eventSeq, long value) {
+            this.key = key;
+            this.eventSeq = eventSeq;
+            this.value = value;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public long getEventSeq() {
+            return eventSeq;
+        }
+
+        public long getValue() {
+            return value;
+        }
+    }
+
+    private class StreamListP extends AbstractProcessor {
+        private final List<?> list;
+
+        public StreamListP(List<?> list) {
+            this.list = list;
+        }
+
+        @Override
+        public boolean complete() {
+            for (Object o : list) {
+                emit(o);
+            }
+            // sleep forever
+            try {
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException ignored) {
+            }
+            return true;
+        }
+
+        @Override
+        public boolean isCooperative() {
+            return false;
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowIntegrationTest.java
@@ -74,7 +74,7 @@ public class SlidingWindowIntegrationTest extends JetTestSupport {
         JetInstance instance = super.createJetMember();
 
         WindowDefinition wDef = slidingWindowDef(2000, 1000);
-        WindowOperation<MockEvent, ?, ?> wOperation = WindowOperations.counting();
+        WindowOperation<Object, ?, Long> wOperation = WindowOperations.counting();
 
         DAG dag = new DAG();
         Vertex source = dag.newVertex("source", streamList(sourceEvents)).localParallelism(1);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
@@ -93,7 +93,7 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                     identity());
         }
 
-        processor = slidingWindow(windowDef, operation, true).get();
+        processor = slidingWindow(windowDef, operation).get();
         processor.init(outbox, mock(Context.class));
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
@@ -17,10 +17,14 @@
 package com.hazelcast.jet.windowing;
 
 import com.hazelcast.jet.Processor.Context;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.MutableLong;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -40,8 +44,9 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@Category(QuickTest.class)
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(Parameterized.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 public class SlidingWindowPTest extends StreamingTestSupport {
 
     @Parameter

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
@@ -53,9 +53,9 @@ public class SlidingWindowPTest extends StreamingTestSupport {
     public boolean hasDeduct;
 
     @Parameter(1)
-    public  boolean isMutableFrame;
+    public boolean isMutableFrame;
 
-    @Parameters
+    @Parameters(name = "hasDeduct={0}, isMutableFrame={1}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][]{
                 {true, true},

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
@@ -135,7 +135,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 punc(4),
                 punc(5),
                 punc(6),
-                punc(7)
+                punc(7),
+                punc(8) // extra punc to trigger lazy clean-up
         ));
 
         // When
@@ -158,7 +159,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 outboxFrame(6, 2),
                 punc(6),
                 outboxFrame(7, 1),
-                punc(7)
+                punc(7),
+                punc(8)
         ));
     }
 
@@ -177,7 +179,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 punc(4),
                 punc(5),
                 punc(6),
-                punc(7)
+                punc(7),
+                punc(8) // extra punc to trigger lazy clean-up
         ));
 
         // When
@@ -200,7 +203,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 outboxFrame(6, 2),
                 punc(6),
                 outboxFrame(7, 1),
-                punc(7)
+                punc(7),
+                punc(8)
         ));
     }
 
@@ -259,7 +263,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 frame(11, 1),
                 punc(15),
                 frame(16, 3),
-                punc(19)
+                punc(19),
+                punc(20) // extra punc to trigger lazy clean-up
         ));
 
         // When
@@ -284,7 +289,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 outboxFrame(17, 3),
                 outboxFrame(18, 3),
                 outboxFrame(19, 3),
-                punc(19)
+                punc(19),
+                punc(20)
         ));
     }
 
@@ -301,7 +307,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 frame(4, 1),
                 punc(4),
                 punc(12),
-                punc(15)
+                punc(15),
+                punc(16) // extra punc to trigger lazy clean-up
         ));
 
         // When
@@ -326,7 +333,8 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 outboxFrame(13, 3),
                 outboxFrame(14, 2),
                 outboxFrame(15, 1),
-                punc(15)
+                punc(15),
+                punc(16)
         ));
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
@@ -17,11 +17,13 @@
 package com.hazelcast.jet.windowing;
 
 import com.hazelcast.jet.Processor.Context;
+import com.hazelcast.util.MutableLong;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.util.ArrayList;
@@ -42,29 +44,55 @@ import static org.mockito.Mockito.mock;
 @RunWith(HazelcastParallelClassRunner.class)
 public class SlidingWindowPTest extends StreamingTestSupport {
 
-    private final boolean hasDeduct;
-    private SlidingWindowP<Object, Long, Long> processor;
+    @Parameter
+    public boolean hasDeduct;
+
+    @Parameter(1)
+    public  boolean isMutableFrame;
 
     @Parameters
-    public static Collection<Boolean> parameters() {
-        return Arrays.asList(true, false);
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {true, true},
+                {true, false},
+                {false, true},
+                {false, false}
+        });
     }
 
-    public SlidingWindowPTest(boolean hasDeduct) {
-        this.hasDeduct = hasDeduct;
-    }
+    private SlidingWindowP<Object, ?, Long> processor;
 
     @Before
     public void before() {
         WindowDefinition windowDef = new WindowDefinition(1, 0, 4);
-        WindowOperation<Object, Long, Long> operation = WindowOperation.of(
-                () -> 0L,
-                (acc, val) -> {
-                    throw new UnsupportedOperationException();
-                },
-                (acc1, acc2) -> acc1 + acc2,
-                hasDeduct ? (acc1, acc2) -> (Long) acc1 - acc2 : null,
-                identity());
+        WindowOperation<Object, ?, Long> operation;
+
+        if (isMutableFrame) {
+            operation = WindowOperation.<Object, MutableLong, Long>of(
+                    MutableLong::new,
+                    (acc, val) -> {
+                        throw new UnsupportedOperationException();
+                    },
+                    (acc1, acc2) -> {
+                        acc1.value += acc2.value;
+                        return acc1;
+                    },
+                    hasDeduct ? (acc1, acc2) -> {
+                        acc1.value -= acc2.value;
+                        return acc1;
+                    } : null,
+                    acc -> acc.value);
+        } else {
+            operation = WindowOperation.of(
+                    () -> 0L,
+                    (acc, val) -> {
+                        throw new UnsupportedOperationException();
+                    },
+                    (acc1, acc2) -> acc1 + acc2,
+                    hasDeduct ? (acc1, acc2) -> (Long) acc1 - acc2 : null,
+                    identity());
+        }
+
         processor = slidingWindow(windowDef, operation, true).get();
         processor.init(outbox, mock(Context.class));
     }
@@ -116,20 +144,20 @@ public class SlidingWindowPTest extends StreamingTestSupport {
 
         // Then
         assertOutbox(asList(
-                frame(0, 1),
-                frame(1, 2),
+                outboxFrame(0, 1),
+                outboxFrame(1, 2),
                 punc(1),
-                frame(2, 3),
+                outboxFrame(2, 3),
                 punc(2),
-                frame(3, 4),
+                outboxFrame(3, 4),
                 punc(3),
-                frame(4, 4),
+                outboxFrame(4, 4),
                 punc(4),
-                frame(5, 3),
+                outboxFrame(5, 3),
                 punc(5),
-                frame(6, 2),
+                outboxFrame(6, 2),
                 punc(6),
-                frame(7, 1),
+                outboxFrame(7, 1),
                 punc(7)
         ));
     }
@@ -158,20 +186,20 @@ public class SlidingWindowPTest extends StreamingTestSupport {
 
         // Then
         assertOutbox(asList(
-                frame(0, 1),
-                frame(1, 2),
+                outboxFrame(0, 1),
+                outboxFrame(1, 2),
                 punc(1),
-                frame(2, 3),
+                outboxFrame(2, 3),
                 punc(2),
-                frame(3, 4),
+                outboxFrame(3, 4),
                 punc(3),
-                frame(4, 4),
+                outboxFrame(4, 4),
                 punc(4),
-                frame(5, 3),
+                outboxFrame(5, 3),
                 punc(5),
-                frame(6, 2),
+                outboxFrame(6, 2),
                 punc(6),
-                frame(7, 1),
+                outboxFrame(7, 1),
                 punc(7)
         ));
     }
@@ -195,24 +223,24 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         // Then
         List<Object> expectedOutbox = new ArrayList<>();
         expectedOutbox.addAll(Arrays.asList(
-                frame(0, 1),
-                frame(1, 2),
+                outboxFrame(0, 1),
+                outboxFrame(1, 2),
                 punc(1),
-                frame(2, 3),
+                outboxFrame(2, 3),
                 punc(2),
-                frame(3, 4),
+                outboxFrame(3, 4),
                 punc(3)
         ));
         for (long seq = 4; seq < 100; seq++) {
-            expectedOutbox.add(frame(seq, 4));
+            expectedOutbox.add(outboxFrame(seq, 4));
             expectedOutbox.add(punc(seq));
         }
         expectedOutbox.addAll(Arrays.asList(
-                frame(100, 3),
+                outboxFrame(100, 3),
                 punc(100),
-                frame(101, 2),
+                outboxFrame(101, 2),
                 punc(101),
-                frame(102, 1),
+                outboxFrame(102, 1),
                 punc(102),
                 punc(103),
                 punc(104),
@@ -240,22 +268,22 @@ public class SlidingWindowPTest extends StreamingTestSupport {
 
         // Then
         assertOutbox(asList(
-                frame(0, 1),
-                frame(1, 1),
-                frame(2, 1),
-                frame(3, 1),
+                outboxFrame(0, 1),
+                outboxFrame(1, 1),
+                outboxFrame(2, 1),
+                outboxFrame(3, 1),
 
-                frame(10, 1),
-                frame(11, 2),
-                frame(12, 2),
-                frame(13, 2),
-                frame(14, 1),
+                outboxFrame(10, 1),
+                outboxFrame(11, 2),
+                outboxFrame(12, 2),
+                outboxFrame(13, 2),
+                outboxFrame(14, 1),
 
                 punc(15),
-                frame(16, 3),
-                frame(17, 3),
-                frame(18, 3),
-                frame(19, 3),
+                outboxFrame(16, 3),
+                outboxFrame(17, 3),
+                outboxFrame(18, 3),
+                outboxFrame(19, 3),
                 punc(19)
         ));
     }
@@ -283,26 +311,30 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         // Then
         assertOutbox(asList(
                 punc(1),
-                frame(2, 1),
-                frame(3, 2),
-                frame(4, 3),
+                outboxFrame(2, 1),
+                outboxFrame(3, 2),
+                outboxFrame(4, 3),
                 punc(4),
-                frame(5, 3),
-                frame(6, 2),
-                frame(7, 1),
-                frame(10, 1),
+                outboxFrame(5, 3),
+                outboxFrame(6, 2),
+                outboxFrame(7, 1),
+                outboxFrame(10, 1),
 
-                frame(11, 2),
-                frame(12, 3),
+                outboxFrame(11, 2),
+                outboxFrame(12, 3),
                 punc(12),
-                frame(13, 3),
-                frame(14, 2),
-                frame(15, 1),
+                outboxFrame(13, 3),
+                outboxFrame(14, 2),
+                outboxFrame(15, 1),
                 punc(15)
         ));
     }
 
-    private static Frame<Long, Long> frame(long seq, long value) {
+    private Frame<Long, ?> frame(long seq, long value) {
+        return new Frame<>(seq, 77L, isMutableFrame ? MutableLong.valueOf(value) : value);
+    }
+
+    private Frame<Long, ?> outboxFrame(long seq, long value) {
         return new Frame<>(seq, 77L, value);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
@@ -117,7 +117,6 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         // Then
         assertOutbox(asList(
                 frame(0, 1),
-                punc(0),
                 frame(1, 2),
                 punc(1),
                 frame(2, 3),
@@ -160,7 +159,6 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         // Then
         assertOutbox(asList(
                 frame(0, 1),
-                punc(0),
                 frame(1, 2),
                 punc(1),
                 frame(2, 3),
@@ -196,27 +194,30 @@ public class SlidingWindowPTest extends StreamingTestSupport {
 
         // Then
         List<Object> expectedOutbox = new ArrayList<>();
-        expectedOutbox.add(frame(0, 1));
-        expectedOutbox.add(punc(0));
-        expectedOutbox.add(frame(1, 2));
-        expectedOutbox.add(punc(1));
-        expectedOutbox.add(frame(2, 3));
-        expectedOutbox.add(punc(2));
-        expectedOutbox.add(frame(3, 4));
-        expectedOutbox.add(punc(3));
+        expectedOutbox.addAll(Arrays.asList(
+                frame(0, 1),
+                frame(1, 2),
+                punc(1),
+                frame(2, 3),
+                punc(2),
+                frame(3, 4),
+                punc(3)
+        ));
         for (long seq = 4; seq < 100; seq++) {
             expectedOutbox.add(frame(seq, 4));
             expectedOutbox.add(punc(seq));
         }
-        expectedOutbox.add(frame(100, 3));
-        expectedOutbox.add(punc(100));
-        expectedOutbox.add(frame(101, 2));
-        expectedOutbox.add(punc(101));
-        expectedOutbox.add(frame(102, 1));
-        expectedOutbox.add(punc(102));
-        expectedOutbox.add(punc(103));
-        expectedOutbox.add(punc(104));
-        expectedOutbox.add(punc(105));
+        expectedOutbox.addAll(Arrays.asList(
+                frame(100, 3),
+                punc(100),
+                frame(101, 2),
+                punc(101),
+                frame(102, 1),
+                punc(102),
+                punc(103),
+                punc(104),
+                punc(105)
+        ));
 
         assertOutbox(expectedOutbox);
     }
@@ -240,32 +241,20 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         // Then
         assertOutbox(asList(
                 frame(0, 1),
-                punc(0),
                 frame(1, 1),
-                punc(1),
                 frame(2, 1),
-                punc(2),
                 frame(3, 1),
-                punc(3),
 
                 frame(10, 1),
-                punc(10),
                 frame(11, 2),
-                punc(11),
                 frame(12, 2),
-                punc(12),
                 frame(13, 2),
-                punc(13),
                 frame(14, 1),
-                punc(14),
 
                 punc(15),
                 frame(16, 3),
-                punc(16),
                 frame(17, 3),
-                punc(17),
                 frame(18, 3),
-                punc(18),
                 frame(19, 3),
                 punc(19)
         ));
@@ -295,28 +284,19 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         assertOutbox(asList(
                 punc(1),
                 frame(2, 1),
-                punc(2),
                 frame(3, 2),
-                punc(3),
                 frame(4, 3),
                 punc(4),
                 frame(5, 3),
-                punc(5),
                 frame(6, 2),
-                punc(6),
                 frame(7, 1),
-                punc(7),
                 frame(10, 1),
-                punc(10),
 
                 frame(11, 2),
-                punc(11),
                 frame(12, 3),
                 punc(12),
                 frame(13, 3),
-                punc(13),
                 frame(14, 2),
-                punc(14),
                 frame(15, 1),
                 punc(15)
         ));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/StreamingTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/StreamingTestSupport.java
@@ -22,6 +22,8 @@ import com.hazelcast.jet.impl.util.ArrayDequeOutbox;
 import com.hazelcast.jet.impl.util.ProgressTracker;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -34,9 +36,17 @@ class StreamingTestSupport {
     }
 
     void assertOutbox(List<?> items) {
-        for (Object item : items) {
-            assertEquals(item, pollOutbox());
-        }
+        String expected = streamToString(items.stream());
+        String actual = streamToString(outbox.queueWithOrdinal(0).stream());
+        outbox.queueWithOrdinal(0).clear();
+
+        assertEquals(expected, actual);
+    }
+
+    private String streamToString(Stream<?> stream) {
+        return stream
+                .map(String::valueOf)
+                .collect(Collectors.joining("\n"));
     }
 
     Object pollOutbox() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/StreamingTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/StreamingTestSupport.java
@@ -43,7 +43,7 @@ class StreamingTestSupport {
         assertEquals(expected, actual);
     }
 
-    private String streamToString(Stream<?> stream) {
+    public static String streamToString(Stream<?> stream) {
         return stream
                 .map(String::valueOf)
                 .collect(Collectors.joining("\n"));

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 
     <properties>
         <argLine> <!-- surefire parameters -->
-            -Xmx2G
+            -Xmx4G
             -Dhazelcast.phone.home.enabled=false
             -Dhazelcast.mancenter.enabled=false
             -Dhazelcast.logging.type=log4j


### PR DESCRIPTION
Improve tests:

- always check for memory leaks
- test SlidingWindowP with both with and without `deductF`
- compare expected and actual outbox as long string: easier to see differences