### PR TITLE
Add mutable accumulators and fix equals for WindowOps.reducing

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Accumulators.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Accumulators.java
@@ -31,7 +31,10 @@ public final class Accumulators {
      */
     public static class MutableInteger {
 
-        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
+        /**
+         * Internal value.
+         */
+        @SuppressWarnings("checkstyle:visibilitymodifier")
         public int value;
 
         /**
@@ -90,7 +93,10 @@ public final class Accumulators {
      */
     public static class MutableLong {
 
-        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
+        /**
+         * Internal value.
+         */
+        @SuppressWarnings("checkstyle:visibilitymodifier")
         public long value;
 
         /**
@@ -148,7 +154,10 @@ public final class Accumulators {
      */
     public static class MutableDouble {
 
-        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
+        /**
+         * Internal value.
+         */
+        @SuppressWarnings("checkstyle:visibilitymodifier")
         public double value;
 
         /**
@@ -208,7 +217,10 @@ public final class Accumulators {
      */
     public static class MutableReference<T> {
 
-        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
+        /**
+         * Internal value.
+         */
+        @SuppressWarnings("checkstyle:visibilitymodifier")
         public T value;
 
         /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Accumulators.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Accumulators.java
@@ -31,7 +31,7 @@ public final class Accumulators {
      */
     public static class MutableInteger {
 
-        @SuppressWarnings({"checkstyle:javadocvariable"})
+        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
         public int value;
 
         /**
@@ -90,7 +90,7 @@ public final class Accumulators {
      */
     public static class MutableLong {
 
-        @SuppressWarnings({"checkstyle:javadocvariable"})
+        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
         public long value;
 
         /**
@@ -148,7 +148,7 @@ public final class Accumulators {
      */
     public static class MutableDouble {
 
-        @SuppressWarnings({"checkstyle:javadocvariable"})
+        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
         public double value;
 
         /**
@@ -203,22 +203,24 @@ public final class Accumulators {
 
     /**
      * Mutable object container.
+     *
+     * @param <T> referenced object type
      */
-    public static class MutableObject<T> {
+    public static class MutableReference<T> {
 
-        @SuppressWarnings({"checkstyle:javadocvariable"})
+        @SuppressWarnings({"checkstyle:javadocvariable", "checkstyle:visibilitymodifier"})
         public T value;
 
         /**
          * Create new instance with {@code null} value.
          */
-        public MutableObject() {
+        public MutableReference() {
         }
 
         /**
          * Create new instance with specified value.
          */
-        public MutableObject(T value) {
+        public MutableReference(T value) {
             this.value = value;
         }
 
@@ -244,7 +246,7 @@ public final class Accumulators {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            return Objects.equals(value, ((MutableObject<?>) o).value);
+            return Objects.equals(value, ((MutableReference<?>) o).value);
         }
 
         @Override
@@ -254,7 +256,7 @@ public final class Accumulators {
 
         @Override
         public String toString() {
-            return "MutableObject(" + value + ')';
+            return "MutableReference(" + value + ')';
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Accumulators.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Accumulators.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet;
+
+import java.util.Objects;
+
+/**
+ * Collection of mutable primitive types and values.
+ */
+public final class Accumulators {
+
+    private Accumulators() {
+    }
+
+    /**
+     * Mutable {@code int} container.
+     */
+    public static class MutableInteger {
+
+        @SuppressWarnings({"checkstyle:javadocvariable"})
+        public int value;
+
+        /**
+         * Create new instance with {@code value == 0}.
+         */
+        public MutableInteger() {
+        }
+
+        /**
+         * Create new instance with specified value.
+         */
+        public MutableInteger(int value) {
+            this.value = value;
+        }
+
+        /**
+         * Get the value
+         */
+        public int getValue() {
+            return value;
+        }
+
+        /**
+         * Set the value
+         */
+        public void setValue(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MutableInteger that = (MutableInteger) o;
+            return value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(value);
+        }
+
+        @Override
+        public String toString() {
+            return "MutableInteger(" + value + ')';
+        }
+    }
+
+
+    /**
+     * Mutable {@code long} container.
+     */
+    public static class MutableLong {
+
+        @SuppressWarnings({"checkstyle:javadocvariable"})
+        public long value;
+
+        /**
+         * Create new instance with {@code value == 0}.
+         */
+        public MutableLong() {
+        }
+
+        /**
+         * Create new instance with specified value.
+         */
+        public MutableLong(long value) {
+            this.value = value;
+        }
+
+        /**
+         * Get the value
+         */
+        public long getValue() {
+            return value;
+        }
+
+        /**
+         * Set the value
+         */
+        public void setValue(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MutableLong that = (MutableLong) o;
+            return value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Long.hashCode(value);
+        }
+
+        @Override
+        public String toString() {
+            return "MutableLong(" + value + ')';
+        }
+    }
+
+    /**
+     * Mutable {@code double} container.
+     */
+    public static class MutableDouble {
+
+        @SuppressWarnings({"checkstyle:javadocvariable"})
+        public double value;
+
+        /**
+         * Create new instance with {@code value == 0}.
+         */
+        public MutableDouble() {
+        }
+
+        /**
+         * Create new instance with specified value.
+         */
+        public MutableDouble(double value) {
+            this.value = value;
+        }
+
+        /**
+         * Get the value
+         */
+        public double getValue() {
+            return value;
+        }
+
+        /**
+         * Set the value
+         */
+        public void setValue(double value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MutableDouble that = (MutableDouble) o;
+            return value == that.value;
+        }
+
+        @Override
+        public int hashCode() {
+            return Double.hashCode(value);
+        }
+
+        @Override
+        public String toString() {
+            return "MutableDouble(" + value + ')';
+        }
+    }
+
+    /**
+     * Mutable object container.
+     */
+    public static class MutableObject<T> {
+
+        @SuppressWarnings({"checkstyle:javadocvariable"})
+        public T value;
+
+        /**
+         * Create new instance with {@code null} value.
+         */
+        public MutableObject() {
+        }
+
+        /**
+         * Create new instance with specified value.
+         */
+        public MutableObject(T value) {
+            this.value = value;
+        }
+
+        /**
+         * Get the value
+         */
+        public T getValue() {
+            return value;
+        }
+
+        /**
+         * Set the value
+         */
+        public void setValue(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return Objects.equals(value, ((MutableObject<?>) o).value);
+        }
+
+        @Override
+        public int hashCode() {
+            return value != null ? value.hashCode() : 0;
+        }
+
+        @Override
+        public String toString() {
+            return "MutableObject(" + value + ')';
+        }
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetSerializerHook.java
@@ -17,13 +17,16 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
+import com.hazelcast.jet.Accumulators.MutableDouble;
+import com.hazelcast.jet.Accumulators.MutableInteger;
+import com.hazelcast.jet.Accumulators.MutableLong;
+import com.hazelcast.jet.Accumulators.MutableObject;
 import com.hazelcast.jet.windowing.Frame;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.SerializerHook;
 import com.hazelcast.nio.serialization.StreamSerializer;
-import com.hazelcast.util.MutableLong;
 
 import java.io.IOException;
 import java.util.Map;
@@ -44,7 +47,10 @@ public final class JetSerializerHook {
     public static final int CUSTOM_CLASS_LOADED_OBJECT = -301;
     public static final int OBJECT_ARRAY = -302;
     public static final int FRAME = -303;
-    public static final int MUTABLE_LONG = -304;
+    public static final int MUTABLE_INTEGER = -304;
+    public static final int MUTABLE_LONG = -305;
+    public static final int MUTABLE_DOUBLE = -306;
+    public static final int MUTABLE_OBJECT = -307;
 
     // reserved for hadoop module -380 to -390
 
@@ -184,6 +190,44 @@ public final class JetSerializerHook {
         }
     }
 
+    public static final class MutableIntegerSerializer implements SerializerHook<MutableInteger> {
+
+        @Override
+        public Class<MutableInteger> getSerializationType() {
+            return MutableInteger.class;
+        }
+
+        @Override
+        public Serializer createSerializer() {
+            return new StreamSerializer<MutableInteger>() {
+                @Override
+                public int getTypeId() {
+                    return MUTABLE_INTEGER;
+                }
+
+                @Override
+                public void destroy() {
+
+                }
+
+                @Override
+                public void write(ObjectDataOutput out, MutableInteger object) throws IOException {
+                    out.writeInt(object.value);
+                }
+
+                @Override
+                public MutableInteger read(ObjectDataInput in) throws IOException {
+                    return new MutableInteger(in.readInt());
+                }
+            };
+        }
+
+        @Override
+        public boolean isOverwritable() {
+            return true;
+        }
+    }
+
     public static final class MutableLongSerializer implements SerializerHook<MutableLong> {
 
         @Override
@@ -211,7 +255,7 @@ public final class JetSerializerHook {
 
                 @Override
                 public MutableLong read(ObjectDataInput in) throws IOException {
-                    return MutableLong.valueOf(in.readLong());
+                    return new MutableLong(in.readLong());
                 }
             };
         }
@@ -221,4 +265,81 @@ public final class JetSerializerHook {
             return true;
         }
     }
+
+    public static final class MutableDoubleSerializer implements SerializerHook<MutableDouble> {
+
+        @Override
+        public Class<MutableDouble> getSerializationType() {
+            return MutableDouble.class;
+        }
+
+        @Override
+        public Serializer createSerializer() {
+            return new StreamSerializer<MutableDouble>() {
+                @Override
+                public int getTypeId() {
+                    return MUTABLE_DOUBLE;
+                }
+
+                @Override
+                public void destroy() {
+
+                }
+
+                @Override
+                public void write(ObjectDataOutput out, MutableDouble object) throws IOException {
+                    out.writeDouble(object.value);
+                }
+
+                @Override
+                public MutableDouble read(ObjectDataInput in) throws IOException {
+                    return new MutableDouble(in.readDouble());
+                }
+            };
+        }
+
+        @Override
+        public boolean isOverwritable() {
+            return true;
+        }
+    }
+
+    public static final class MutableObjectSerializer implements SerializerHook<MutableObject> {
+
+        @Override
+        public Class<MutableObject> getSerializationType() {
+            return MutableObject.class;
+        }
+
+        @Override
+        public Serializer createSerializer() {
+            return new StreamSerializer<MutableObject>() {
+                @Override
+                public int getTypeId() {
+                    return MUTABLE_OBJECT;
+                }
+
+                @Override
+                public void destroy() {
+
+                }
+
+                @Override
+                public void write(ObjectDataOutput out, MutableObject object) throws IOException {
+                    out.writeObject(object.value);
+                }
+
+                @Override
+                public MutableObject read(ObjectDataInput in) throws IOException {
+                    return new MutableObject(in.readObject());
+                }
+            };
+        }
+
+        @Override
+        public boolean isOverwritable() {
+            return true;
+        }
+    }
+
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetSerializerHook.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.serialization.impl.SerializationConstants;
 import com.hazelcast.jet.Accumulators.MutableDouble;
 import com.hazelcast.jet.Accumulators.MutableInteger;
 import com.hazelcast.jet.Accumulators.MutableLong;
-import com.hazelcast.jet.Accumulators.MutableObject;
+import com.hazelcast.jet.Accumulators.MutableReference;
 import com.hazelcast.jet.windowing.Frame;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -50,7 +50,7 @@ public final class JetSerializerHook {
     public static final int MUTABLE_INTEGER = -304;
     public static final int MUTABLE_LONG = -305;
     public static final int MUTABLE_DOUBLE = -306;
-    public static final int MUTABLE_OBJECT = -307;
+    public static final int MUTABLE_REFERENCE = -307;
 
     // reserved for hadoop module -380 to -390
 
@@ -304,19 +304,19 @@ public final class JetSerializerHook {
         }
     }
 
-    public static final class MutableObjectSerializer implements SerializerHook<MutableObject> {
+    public static final class MutableObjectSerializer implements SerializerHook<MutableReference> {
 
         @Override
-        public Class<MutableObject> getSerializationType() {
-            return MutableObject.class;
+        public Class<MutableReference> getSerializationType() {
+            return MutableReference.class;
         }
 
         @Override
         public Serializer createSerializer() {
-            return new StreamSerializer<MutableObject>() {
+            return new StreamSerializer<MutableReference>() {
                 @Override
                 public int getTypeId() {
-                    return MUTABLE_OBJECT;
+                    return MUTABLE_REFERENCE;
                 }
 
                 @Override
@@ -325,13 +325,13 @@ public final class JetSerializerHook {
                 }
 
                 @Override
-                public void write(ObjectDataOutput out, MutableObject object) throws IOException {
+                public void write(ObjectDataOutput out, MutableReference object) throws IOException {
                     out.writeObject(object.value);
                 }
 
                 @Override
-                public MutableObject read(ObjectDataInput in) throws IOException {
-                    return new MutableObject(in.readObject());
+                public MutableReference read(ObjectDataInput in) throws IOException {
+                    return new MutableReference(in.readObject());
                 }
             };
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperation.java
@@ -111,6 +111,12 @@ public interface WindowOperation<T, A, R> extends Serializable {
      * Returns a new {@code WindowOperation} object composed from the provided
      * primitives.
      *
+     * @param createAccumulatorF see {@link #createAccumulatorF()}()
+     * @param accumulateItemF see {@link #accumulateItemF()}
+     * @param combineAccumulatorsF see {@link #combineAccumulatorsF()}
+     * @param deductAccumulatorF see {@link #deductAccumulatorF()}
+     * @param finishAccumulationF see {@link #finishAccumulationF()}
+     *
      * @param <T> the type of the stream item
      * @param <A> the type of the accumulator
      * @param <R> the type of the final result

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperations.java
@@ -17,7 +17,7 @@
 package com.hazelcast.jet.windowing;
 
 import com.hazelcast.jet.Accumulators.MutableLong;
-import com.hazelcast.jet.Accumulators.MutableObject;
+import com.hazelcast.jet.Accumulators.MutableReference;
 import com.hazelcast.jet.Distributed;
 import com.hazelcast.jet.Distributed.BinaryOperator;
 
@@ -120,7 +120,7 @@ public final class WindowOperations {
                     return a;
                 },
                 deductF != null
-                        ? (BinaryOperator<MutableObject<U>>) (a, b) -> {
+                        ? (BinaryOperator<MutableReference<U>>) (a, b) -> {
                             a.value = deductF.apply(a.value, b.value);
                             return a;
                         }
@@ -128,7 +128,7 @@ public final class WindowOperations {
                 a -> a.value);
     }
 
-    private static <T> Distributed.Supplier<MutableObject<T>> boxSupplier(T identity) {
-        return () -> new MutableObject<>(identity);
+    private static <T> Distributed.Supplier<MutableReference<T>> boxSupplier(T identity) {
+        return () -> new MutableReference<>(identity);
     }
 }

--- a/hazelcast-jet-core/src/main/resources/META-INF/services/com.hazelcast.SerializerHook
+++ b/hazelcast-jet-core/src/main/resources/META-INF/services/com.hazelcast.SerializerHook
@@ -1,5 +1,8 @@
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$MapEntry
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$ObjectArray
-com.hazelcast.jet.impl.execution.init.JetSerializerHook$MutableLongSerializer
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$FrameSerializer
+com.hazelcast.jet.impl.execution.init.JetSerializerHook$MutableIntegerSerializer
+com.hazelcast.jet.impl.execution.init.JetSerializerHook$MutableLongSerializer
+com.hazelcast.jet.impl.execution.init.JetSerializerHook$MutableDoubleSerializer
+com.hazelcast.jet.impl.execution.init.JetSerializerHook$MutableObjectSerializer
 com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject$Hook

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.execution.init;
+
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.jet.Accumulators.MutableDouble;
+import com.hazelcast.jet.Accumulators.MutableInteger;
+import com.hazelcast.jet.Accumulators.MutableLong;
+import com.hazelcast.jet.Accumulators.MutableObject;
+import com.hazelcast.jet.windowing.Frame;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.Serializable;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+
+@Category(QuickTest.class)
+public class JetSerializerHookTest {
+
+    @Test
+    public void testSerialization() throws Exception {
+        // this test tries to serialize and deserialize all types defined in JetSerializerHook
+        for (Object instance : Arrays.asList(
+                new String[] {"a", "b", "c"},
+                new SimpleImmutableEntry<>("key", "value"),
+                new Frame(1, "key", "value"),
+                new MutableInteger(1),
+                new MutableLong(2),
+                new MutableDouble(3),
+                new MutableObject("foo")
+        )) {
+            System.out.println("type: " + instance.getClass());
+            doTest(instance);
+        }
+    }
+
+    private void doTest(Object instance) throws Exception {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+        Data serialized = serializationService.toData(instance);
+        Object deserialized = serializationService.toObject(serialized);
+
+        if (!(instance instanceof Map.Entry) && !(instance instanceof Object[])) {
+            assertFalse("Type implements java.io.Serializable", instance instanceof Serializable);
+        }
+        assertNotSame("serialization/deserialization didn't take place", instance, deserialized);
+        if (instance instanceof Object[]) {
+            assertArrayEquals("objects are not equal after serialize/deserialize",
+                    (Object[]) instance, (Object[]) deserialized);
+        } else {
+            assertEquals("objects are not equal after serialize/deserialize", instance, deserialized);
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
@@ -27,10 +27,15 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 import java.io.Serializable;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -38,27 +43,29 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 
+@RunWith(Parameterized.class)
 @Category(QuickTest.class)
 public class JetSerializerHookTest {
 
-    @Test
-    public void testSerialization() throws Exception {
-        // this test tries to serialize and deserialize all types defined in JetSerializerHook
-        for (Object instance : Arrays.asList(
-                new String[] {"a", "b", "c"},
+    @Parameter
+    public Object instance;
+
+    @Parameters
+    public static Collection<Object> data() throws Exception {
+        return Arrays.asList(
+                new Object[]{new String[]{"a", "b", "c"}},
                 new SimpleImmutableEntry<>("key", "value"),
                 new Frame(1, "key", "value"),
                 new MutableInteger(1),
                 new MutableLong(2),
                 new MutableDouble(3),
                 new MutableObject("foo")
-        )) {
-            System.out.println("type: " + instance.getClass());
-            doTest(instance);
-        }
+        );
     }
 
-    private void doTest(Object instance) throws Exception {
+    @Test
+    public void testSerialization() throws Exception {
+        // this test tries to serialize and deserialize all types defined in JetSerializerHook
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
 
         Data serialized = serializationService.toData(instance);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
@@ -24,6 +24,8 @@ import com.hazelcast.jet.Accumulators.MutableReference;
 import com.hazelcast.jet.windowing.Frame;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,7 +46,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 
 @RunWith(Parameterized.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 public class JetSerializerHookTest {
 
     @Parameter

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetSerializerHookTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.jet.Accumulators.MutableDouble;
 import com.hazelcast.jet.Accumulators.MutableInteger;
 import com.hazelcast.jet.Accumulators.MutableLong;
-import com.hazelcast.jet.Accumulators.MutableObject;
+import com.hazelcast.jet.Accumulators.MutableReference;
 import com.hazelcast.jet.windowing.Frame;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -59,7 +59,7 @@ public class JetSerializerHookTest {
                 new MutableInteger(1),
                 new MutableLong(2),
                 new MutableDouble(3),
-                new MutableObject("foo")
+                new MutableReference("foo")
         );
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/WindowOperationsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/WindowOperationsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.windowing;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class WindowOperationsTest {
+
+    @Parameter
+    public WindowOperation<?, ?, ?> operation;
+
+    @Parameters
+    public static Collection<WindowOperation<?, ?, ?>> data() {
+        return Arrays.asList(
+                WindowOperations.counting(),
+                WindowOperations.summingToLong(),
+                WindowOperations.reducing(1, null, null, null)
+        );
+    }
+
+    @Test
+    public void testTwoAccumulatorsEqual() {
+        Object accumulator1 = operation.createAccumulatorF();
+        Object accumulator2 = operation.createAccumulatorF();
+
+        assertEquals("two empty accumulators not equal", accumulator1, accumulator2);
+    }
+
+}


### PR DESCRIPTION
SlidingWindowP, if it has deductF, compares current accumulated value with
empty accumulator, and if it's equal, then removes the corresponding key.
`Object[]` doesn't implement equals, so I replaced it with MutableObject