### PR TITLE
Test coverage and minor improvements

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperation.java
@@ -46,9 +46,9 @@ import java.util.Objects;
  *     accumulator's intermediate result into the final result
  * </li></ol>
  *
- * @param <T> the type of the stream item
- * @param <A> the type of the accumulator
- * @param <R> the type of the final result
+ * @param <T> the type of the stream item &mdash; contravariant
+ * @param <A> the type of the accumulator &mdash; invariant
+ * @param <R> the type of the final result &mdash; covariant
  */
 public interface WindowOperation<T, A, R> extends Serializable {
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowingProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowingProcessors.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.windowing;
 
 import com.hazelcast.jet.Distributed;
+import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.stream.DistributedCollector;
 
 import javax.annotation.Nonnull;
@@ -38,7 +39,7 @@ public final class WindowingProcessors {
      *
      * @param <T> the type of stream item
      */
-    public static <T> Distributed.Supplier<InsertPunctuationP<T>> insertPunctuation(
+    public static <T> Distributed.Supplier<Processor> insertPunctuation(
             @Nonnull Distributed.ToLongFunction<T> extractEventSeqF,
             @Nonnull Distributed.Supplier<PunctuationPolicy> newPuncPolicyF
     ) {
@@ -59,7 +60,7 @@ public final class WindowingProcessors {
      * @param <F> type of accumulator returned from {@code windowOperation.
      *            createAccumulatorF()}
      */
-    public static <T, K, F> Distributed.Supplier<GroupByFrameP<T, K, F>> groupByFrame(
+    public static <T, K, F> Distributed.Supplier<Processor> groupByFrame(
             Distributed.Function<? super T, K> extractKeyF,
             Distributed.ToLongFunction<? super T> extractTimestampF,
             WindowDefinition windowDef,
@@ -74,7 +75,7 @@ public final class WindowingProcessors {
      * groupByFrame(extractKeyF, extractTimestampF, windowDef, collector)}
      * which doesn't group by key.
      */
-    public static <T, F> Distributed.Supplier<GroupByFrameP<T, String, F>> groupByFrame(
+    public static <T, F> Distributed.Supplier<Processor> groupByFrame(
             Distributed.ToLongFunction<? super T> extractTimestampF,
             WindowDefinition windowDef,
             WindowOperation<? super T, F, ?> collector
@@ -88,11 +89,10 @@ public final class WindowingProcessors {
      * sliding windows. Applies the finisher function to produce its emitted
      * output.
      *
-     * @param <K> type of the grouping key
      * @param <F> type of accumulator
      * @param <R> type of the result derived from a frame
      */
-    public static <K, F, R> Distributed.Supplier<SlidingWindowP<K, F, R>> slidingWindow(
+    public static <F, R> Distributed.Supplier<Processor> slidingWindow(
             WindowDefinition windowDef, WindowOperation<?, F, R> windowOperation) {
         return () -> new SlidingWindowP<>(windowDef, windowOperation);
     }
@@ -120,7 +120,7 @@ public final class WindowingProcessors {
      * @param <A> type of the container of accumulated value
      * @param <R> type of the result value for a session window
      */
-    public static <T, K, A, R> Distributed.Supplier<SessionWindowP<T, K, A, R>> sessionWindow(
+    public static <T, K, A, R> Distributed.Supplier<Processor> sessionWindow(
             long maxSeqGap,
             Distributed.ToLongFunction<? super T> extractEventSeqF,
             Distributed.Function<? super T, K> extractKeyF,

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/GroupByFramePTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/GroupByFramePTest.java
@@ -44,13 +44,14 @@ public class GroupByFramePTest extends StreamingTestSupport {
     private GroupByFrameP<Entry<Long, Long>, Long, ?> processor;
 
     @Before
+    @SuppressWarnings("unchecked")
     public void before() {
-        processor = WindowingProcessors.groupByFrame(
-                (Entry<Long, Long> x) -> KEY,
+        processor = new GroupByFrameP<>(
+                x -> KEY,
                 Entry::getKey,
                 new WindowDefinition(4, 0, 4),
                 WindowOperations.summingToLong((Entry<Long, Long> e) -> e.getValue())
-        ).get();
+        );
         processor.init(outbox, mock(Context.class));
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/windowing/SlidingWindowPTest.java
@@ -37,9 +37,9 @@ import java.util.List;
 import java.util.stream.LongStream;
 
 import static com.hazelcast.jet.Distributed.Function.identity;
-import static com.hazelcast.jet.windowing.WindowingProcessors.slidingWindow;
 import static java.util.Arrays.asList;
 import static java.util.Collections.shuffle;
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -98,7 +98,7 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                     identity());
         }
 
-        processor = slidingWindow(windowDef, operation).get();
+        processor = new SlidingWindowP<>(windowDef, operation);
         processor.init(outbox, mock(Context.class));
     }
 
@@ -111,7 +111,7 @@ public class SlidingWindowPTest extends StreamingTestSupport {
     @Test
     public void when_noFramesReceived_then_onlyEmitPunc() {
         // Given
-        inbox.addAll(asList(
+        inbox.addAll(singletonList(
                 punc(1)
         ));
 
@@ -120,7 +120,7 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         assertTrue(inbox.isEmpty());
 
         // Then
-        assertOutbox(asList(
+        assertOutbox(singletonList(
                 punc(1)
         ));
     }
@@ -141,7 +141,7 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 punc(5),
                 punc(6),
                 punc(7),
-                punc(8) // extra punc to trigger lazy clean-up
+                punc(8) // extra punc to evict the dangling frame
         ));
 
         // When
@@ -185,7 +185,7 @@ public class SlidingWindowPTest extends StreamingTestSupport {
                 punc(5),
                 punc(6),
                 punc(7),
-                punc(8) // extra punc to trigger lazy clean-up
+                punc(8) // extra punc to evict the dangling frame
         ));
 
         // When
@@ -347,7 +347,7 @@ public class SlidingWindowPTest extends StreamingTestSupport {
         return new Frame<>(seq, 77L, isMutableFrame ? MutableLong.valueOf(value) : value);
     }
 
-    private Frame<Long, ?> outboxFrame(long seq, long value) {
+    private static Frame<Long, ?> outboxFrame(long seq, long value) {
         return new Frame<>(seq, 77L, value);
     }
 }


### PR DESCRIPTION
- improve `AbstractProcessorTest` to cover 100% lines of `AbstractProcessor`
- use `Supplier<Processor>` for the return type of factory methods
- simplify `ProcessorsTest` to focus on the business logic of specific processors (cooperative emission is tested through `AbstractProcessorTest`)
- some Javadoc