### PR TITLE
Fix termination of blocking workers on shutdown

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -122,6 +122,7 @@ public class JetService
     public void shutdown(boolean terminate) {
         networking.destroy();
         executionService.shutdown();
+        liveOperationRegistry.shutdown();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/LiveOperationRegistry.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/LiveOperationRegistry.java
@@ -61,4 +61,9 @@ public class LiveOperationRegistry {
         return operation.isPresent();
     }
 
+    public void shutdown() {
+        liveOperations.values().stream()
+                .flatMap(e -> e.values().stream())
+                .forEach(AsyncExecutionOperation::cancel);
+    }
 }


### PR DESCRIPTION
On shutdown, cooperative a and blocking workers are attempted to quit. For
blocking workers, we called `blockingTaskletExecutor.shutdown()`, which,
however, only prevents further tasks from being submitted. The existing tasks
are untouched, so the blocking workers remain running.

Solution is to cancel the jobFutures on shutdown.