### PR TITLE
Supplier<Processor> instead of ProcessorSupplier

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.jet.impl.connector;
 
+import com.hazelcast.jet.Distributed;
 import com.hazelcast.jet.Distributed.BiConsumer;
 import com.hazelcast.jet.Distributed.Consumer;
 import com.hazelcast.jet.Distributed.IntFunction;
 import com.hazelcast.jet.Inbox;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
-import com.hazelcast.jet.ProcessorSupplier;
 import com.hazelcast.jet.Punctuation;
 
 import javax.annotation.Nonnull;
@@ -51,11 +51,13 @@ public final class WriteBufferedP<B, T> implements Processor {
     }
 
     @Nonnull
-    public static <B, T> ProcessorSupplier writeBuffered(IntFunction<B> newBuffer,
-                                                         BiConsumer<B, T> addToBuffer,
-                                                         Consumer<B> consumeBuffer,
-                                                         Consumer<B> closeBuffer) {
-        return ProcessorSupplier.of(() -> new WriteBufferedP<>(newBuffer, addToBuffer, consumeBuffer, closeBuffer));
+    public static <B, T> Distributed.Supplier<Processor> writeBuffered(
+            IntFunction<B> newBuffer,
+            BiConsumer<B, T> addToBuffer,
+            Consumer<B> consumeBuffer,
+            Consumer<B> closeBuffer
+    ) {
+        return () -> new WriteBufferedP<>(newBuffer, addToBuffer, consumeBuffer, closeBuffer);
     }
 
     @Override

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ProcessorsTest.java
@@ -35,6 +35,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.jet.Util.entry;
@@ -284,8 +285,8 @@ public class ProcessorsTest {
         testComplete.accept(result);
     }
 
-    private Processor processorFrom(ProcessorSupplier supplier) {
-        Processor p = supplier.get(1).iterator().next();
+    private Processor processorFrom(Supplier<Processor> supplier) {
+        Processor p = supplier.get();
         p.init(outbox, context);
         return p;
 


### PR DESCRIPTION
Some factory methods used `ProcessorSupplier` even though they could have used the simpler `Supplier<Processor>`.