### PR TITLE
Add glob to StreamFilesP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
@@ -284,7 +284,7 @@ public final class Processors {
      */
     @Nonnull
     public static DistributedSupplier<Processor> streamTextSocket(@Nonnull String host, int port) {
-        return streamTextSocket(host, port, null);
+        return streamTextSocket(host, port, StandardCharsets.UTF_8);
     }
 
     /**
@@ -303,8 +303,10 @@ public final class Processors {
      * @param charset Character set used to decode the stream
      */
     @Nonnull
-    public static DistributedSupplier<Processor> streamTextSocket(@Nonnull String host, int port, Charset charset) {
-        return StreamTextSocketP.supplier(host, port, charset != null ? charset.name() : null);
+    public static DistributedSupplier<Processor> streamTextSocket(@Nonnull String host, int port,
+                                                                  @Nonnull Charset charset
+    ) {
+        return StreamTextSocketP.supplier(host, port, charset.name());
     }
 
     /**
@@ -313,7 +315,7 @@ public final class Processors {
      */
     @Nonnull
     public static ProcessorSupplier readFiles(@Nonnull String directory) {
-        return readFiles(directory, StandardCharsets.UTF_8, null);
+        return readFiles(directory, StandardCharsets.UTF_8, "*");
     }
 
     /**
@@ -328,16 +330,16 @@ public final class Processors {
      * directory shared over the network).
      *
      * @param directory parent directory of the files
-     * @param charset charset to use to decode the files, or {@code null} to use UTF-8
+     * @param charset charset to use to decode the files
      * @param glob the globbing mask, see {@link
-     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()},
-     *             match all files, if {@code null}
+     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
+     *             Use {@code "*"} for all files.
      */
     @Nonnull
     public static ProcessorSupplier readFiles(
-            @Nonnull String directory, @Nullable Charset charset, @Nullable String glob
+            @Nonnull String directory, @Nonnull Charset charset, @Nonnull String glob
     ) {
-        return ReadFilesP.supplier(directory, charset == null ? "utf-8" : charset.name(), glob);
+        return ReadFilesP.supplier(directory, charset.name(), glob);
     }
 
     /**
@@ -345,7 +347,7 @@ public final class Processors {
      * default charset (UTF-8) and default glob (match all files).
      */
     public static ProcessorSupplier streamFiles(@Nonnull String watchedDirectory) {
-        return streamFiles(watchedDirectory, null, null);
+        return streamFiles(watchedDirectory, StandardCharsets.UTF_8, "*");
     }
 
     /**
@@ -384,15 +386,15 @@ public final class Processors {
      * latest version.
      *
      * @param watchedDirectory The directory where we watch files
-     * @param charset charset to use to decode the files, or {@code null} to use UTF-8
+     * @param charset charset to use to decode the files
      * @param glob the globbing mask, see {@link
-     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()},
-     *             match all files, if {@code null}
+     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
+     *             Use {@code "*"} for all files.
      */
     public static ProcessorSupplier streamFiles(
-            @Nonnull String watchedDirectory, @Nullable Charset charset, @Nullable String glob
+            @Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob
     ) {
-        return StreamFilesP.supplier(watchedDirectory, charset == null ? null : charset.toString(), glob);
+        return StreamFilesP.supplier(watchedDirectory, charset.name(), glob);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
@@ -308,7 +308,8 @@ public final class Processors {
     }
 
     /**
-     * See {@link #readFiles(String, Charset, String)}.
+     * Convenience for {@link #readFiles(String, Charset, String)} with default
+     * charset (UTF-8) and default glob (match all files).
      */
     @Nonnull
     public static ProcessorSupplier readFiles(@Nonnull String directory) {
@@ -328,8 +329,9 @@ public final class Processors {
      *
      * @param directory parent directory of the files
      * @param charset charset to use to decode the files, or {@code null} to use UTF-8
-     * @param glob the file filter, see {@link
-     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}
+     * @param glob the globbing mask, see {@link
+     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()},
+     *             match all files, if {@code null}
      */
     @Nonnull
     public static ProcessorSupplier readFiles(
@@ -339,7 +341,8 @@ public final class Processors {
     }
 
     /**
-     * See {@link #streamFiles(String, Charset, String)}
+     * Convenience for {@link #streamFiles(String, Charset, String)} with
+     * default charset (UTF-8) and default glob (match all files).
      */
     public static ProcessorSupplier streamFiles(@Nonnull String watchedDirectory) {
         return streamFiles(watchedDirectory, null, null);
@@ -382,8 +385,9 @@ public final class Processors {
      *
      * @param watchedDirectory The directory where we watch files
      * @param charset charset to use to decode the files, or {@code null} to use UTF-8
-     * @param glob the file filter, see {@link
-     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}
+     * @param glob the globbing mask, see {@link
+     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()},
+     *             match all files, if {@code null}
      */
     public static ProcessorSupplier streamFiles(
             @Nonnull String watchedDirectory, @Nullable Charset charset, @Nullable String glob

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -58,7 +58,7 @@ public class ReadFilesP extends AbstractProcessor {
     public boolean complete() {
         try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directory, glob)) {
             StreamSupport.stream(directoryStream.spliterator(), false)
-                    .filter(this::shouldProcessEventAndNotDir)
+                    .filter(this::shouldProcessEvent)
                     .forEach(this::processFile);
         } catch (IOException e) {
             throw sneakyThrow(e);
@@ -67,7 +67,7 @@ public class ReadFilesP extends AbstractProcessor {
         return true;
     }
 
-    private boolean shouldProcessEventAndNotDir(Path file) {
+    private boolean shouldProcessEvent(Path file) {
         if (Files.isDirectory(file)) {
             return false;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -24,7 +24,6 @@ import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -57,9 +56,9 @@ public class ReadFilesP extends AbstractProcessor {
 
     @Override
     public boolean complete() {
-        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directory, glob == null ? "*" : glob)) {
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(directory, glob)) {
             StreamSupport.stream(directoryStream.spliterator(), false)
-                    .filter(this::shouldProcessEvent)
+                    .filter(this::shouldProcessEventAndNotDir)
                     .forEach(this::processFile);
         } catch (IOException e) {
             throw sneakyThrow(e);
@@ -68,7 +67,10 @@ public class ReadFilesP extends AbstractProcessor {
         return true;
     }
 
-    private boolean shouldProcessEvent(Path file) {
+    private boolean shouldProcessEventAndNotDir(Path file) {
+        if (Files.isDirectory(file)) {
+            return false;
+        }
         int hashCode = file.hashCode();
         return ((hashCode & Integer.MAX_VALUE) % parallelism) == id;
     }
@@ -95,14 +97,14 @@ public class ReadFilesP extends AbstractProcessor {
     /**
      * @see com.hazelcast.jet.Processors#readFiles(String, Charset, String)
      */
-    public static ProcessorSupplier supplier(String directory, String charset, String glob) {
+    public static ProcessorSupplier supplier(@Nonnull String directory, @Nonnull String charset, @Nonnull String glob) {
         return new ProcessorSupplier() {
             static final long serialVersionUID = 1L;
 
             @Nonnull
             @Override
             public Collection<? extends Processor> get(int count) {
-                Charset charsetObj = charset == null ? StandardCharsets.UTF_8 : Charset.forName(charset);
+                Charset charsetObj = Charset.forName(charset);
                 return IntStream.range(0, count)
                         .mapToObj(i -> new ReadFilesP(directory, charsetObj, glob, count, i))
                         .collect(Collectors.toList());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -86,10 +85,12 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
     private FileInputStream currentInputStream;
     private Reader currentReader;
 
-    StreamFilesP(String watchedDirectory, Charset charset, String glob, int parallelism, int id) {
+    StreamFilesP(@Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob,
+                 int parallelism, int id
+    ) {
         this.watchedDirectory = Paths.get(watchedDirectory);
         this.charset = charset;
-        this.glob = FileSystems.getDefault().getPathMatcher("glob:" + (glob == null ? "*" : glob));
+        this.glob = FileSystems.getDefault().getPathMatcher("glob:" + glob);
         this.parallelism = parallelism;
         this.id = id;
         setCooperative(false);
@@ -309,11 +310,13 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
     /**
      * @see com.hazelcast.jet.Processors#streamFiles(String, Charset, String)
      */
-    public static ProcessorSupplier supplier(String watchedDirectory, String charset, String glob) {
+    public static ProcessorSupplier supplier(@Nonnull String watchedDirectory, @Nonnull String charset,
+                                             @Nonnull String glob
+    ) {
         return new Supplier(watchedDirectory, charset, glob);
     }
 
-    private static class Supplier implements ProcessorSupplier {
+    private static final class Supplier implements ProcessorSupplier {
 
         static final long serialVersionUID = 1L;
         private final String watchedDirectory;
@@ -322,7 +325,7 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
 
         private transient ArrayList<StreamFilesP> processors;
 
-        Supplier(String watchedDirectory, String charset, String glob) {
+        private Supplier(String watchedDirectory, String charset, String glob) {
             this.watchedDirectory = watchedDirectory;
             this.charset = charset;
             this.glob = glob;
@@ -331,7 +334,7 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
         @Override @Nonnull
         public List<StreamFilesP> get(int count) {
             processors = new ArrayList<>(count);
-            Charset charsetObj = charset == null ? StandardCharsets.UTF_8 : Charset.forName(charset);
+            Charset charsetObj = Charset.forName(charset);
             for (int i = 0; i < count; i++) {
                 processors.add(new StreamFilesP(watchedDirectory, charsetObj, glob, count, i));
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamTextSocketP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamTextSocketP.java
@@ -17,8 +17,8 @@
 package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.jet.AbstractProcessor;
-import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.jet.Processor;
+import com.hazelcast.jet.function.DistributedSupplier;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
@@ -34,14 +33,14 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 /**
  * @see com.hazelcast.jet.Processors#streamTextSocket(String, int, Charset)
  */
-public class StreamTextSocketP extends AbstractProcessor {
+public final class StreamTextSocketP extends AbstractProcessor {
 
     private final String host;
     private final int port;
     private final Charset charset;
     private CompletableFuture<Void> jobFuture;
 
-    StreamTextSocketP(String host, int port, Charset charset) {
+    private StreamTextSocketP(String host, int port, Charset charset) {
         this.host = host;
         this.port = port;
         this.charset = charset;
@@ -86,8 +85,7 @@ public class StreamTextSocketP extends AbstractProcessor {
         return host + ':' + port;
     }
 
-    public static DistributedSupplier<Processor> supplier(String host, int port, String charset) {
-        return () -> new StreamTextSocketP(host, port,
-                charset == null ? StandardCharsets.UTF_8 : Charset.forName(charset));
+    public static DistributedSupplier<Processor> supplier(String host, int port, @Nonnull String charset) {
+        return () -> new StreamTextSocketP(host, port, Charset.forName(charset));
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -66,7 +66,6 @@ public class StreamFilesPTest extends JetTestSupport {
     @Before
     public void before() throws Exception {
         workDir = Files.createTempDirectory("jet-test-streamFilesPTest").toFile();
-        processor = new StreamFilesP(workDir.getAbsolutePath(), UTF_8, 1, 0);
         driverThread = new Thread(this::driveProcessor,
                 "Driving StreamFileP (" + testName.getMethodName() + ')');
     }
@@ -80,14 +79,14 @@ public class StreamFilesPTest extends JetTestSupport {
 
     @Test
     public void supplier() {
-        ProcessorSupplier supplier = StreamFilesP.supplier(workDir.getAbsolutePath(), null);
+        ProcessorSupplier supplier = StreamFilesP.supplier(workDir.getAbsolutePath(), null, null);
         assertEquals(1, supplier.get(1).size());
         supplier.complete(null);
     }
 
     @Test
     public void when_writeOneFile_then_seeAllLines() throws Exception {
-        initializeProcessor();
+        initializeProcessor(null);
         driverThread.start();
         try (PrintWriter w = new PrintWriter(new FileWriter(new File(workDir, "a.txt")))) {
             for (int i = 0; i < LINE_COUNT; i++) {
@@ -101,7 +100,7 @@ public class StreamFilesPTest extends JetTestSupport {
     @Test
     public void when_writeTwoFiles_then_seeAllLines() throws Exception {
         // Given
-        initializeProcessor();
+        initializeProcessor(null);
         driverThread.start();
         try (PrintWriter w1 = new PrintWriter(new FileWriter(new File(workDir, "a.txt")));
              PrintWriter w2 = new PrintWriter(new FileWriter(new File(workDir, "b.txt")))
@@ -120,6 +119,27 @@ public class StreamFilesPTest extends JetTestSupport {
     }
 
     @Test
+    public void when_glob_then_onlyMatchingProcessed() throws Exception {
+        // Given
+        initializeProcessor("a.*");
+        driverThread.start();
+        try (PrintWriter w1 = new PrintWriter(new FileWriter(new File(workDir, "a.txt")));
+                PrintWriter w2 = new PrintWriter(new FileWriter(new File(workDir, "b.txt")))
+        ) {
+            // When
+            for (int i = 0; i < LINE_COUNT; i++) {
+                w1.println(i);
+                w1.flush();
+                w2.println(i);
+                w2.flush();
+            }
+
+            // Then
+            assertEmittedCountEventually(LINE_COUNT);
+        }
+    }
+
+    @Test
     public void when_preExistingFile_then_seeAppendedLines() throws Exception {
         // Given
         try (PrintWriter w = new PrintWriter(new FileWriter(new File(workDir, "a.txt")))) {
@@ -128,7 +148,7 @@ public class StreamFilesPTest extends JetTestSupport {
             }
             w.write("incomplete line");
             w.flush();
-            initializeProcessor();
+            initializeProcessor(null);
             // Directory watch service is apparently initialized asynchronously so we
             // have to give it some time. This is a hacky, non-repeatable test.
             Thread.sleep(1000);
@@ -156,7 +176,7 @@ public class StreamFilesPTest extends JetTestSupport {
                 w.println(i);
             }
         }
-        initializeProcessor();
+        initializeProcessor(null);
         // Directory watch service is apparently initialized asynchronously so we
         // have to give it some time. This is a hacky, non-repeatable test.
         Thread.sleep(1000);
@@ -177,7 +197,7 @@ public class StreamFilesPTest extends JetTestSupport {
                 w.println(i);
             }
         }
-        initializeProcessor();
+        initializeProcessor(null);
         updateFileOffsetsSize();
         assertEquals(1, fileOffsetsSize);
         driverThread.start();
@@ -192,7 +212,7 @@ public class StreamFilesPTest extends JetTestSupport {
     @Test
     public void when_watchedDirDeleted_then_complete() throws Exception {
         // Given
-        initializeProcessor();
+        initializeProcessor(null);
         driverThread.start();
 
         // When
@@ -214,7 +234,8 @@ public class StreamFilesPTest extends JetTestSupport {
         fileOffsetsSize = processor.fileOffsets.size();
     }
 
-    private void initializeProcessor() {
+    private void initializeProcessor(String glob) {
+        processor = new StreamFilesP(workDir.getAbsolutePath(), UTF_8, glob, 1, 0);
         Outbox outbox = mock(Outbox.class);
         when(outbox.offer(any())).thenAnswer(item -> {
             emittedCount++;
@@ -231,7 +252,8 @@ public class StreamFilesPTest extends JetTestSupport {
     // 3. Wait a bit more
     // 4. Ensure the value hasn't increased
     private void assertEmittedCountEventually(long expected) throws Exception {
-        assertTrueEventually(() -> assertTrue(emittedCount >= expected), ASSERT_COUNT_TIMEOUT_SECONDS);
+        assertTrueEventually(() -> assertTrue("emittedCount=" + emittedCount + ", expected=" + expected,
+                emittedCount >= expected), ASSERT_COUNT_TIMEOUT_SECONDS);
         assertEquals(expected, emittedCount);
         Thread.sleep(2000);
         assertEquals(expected, emittedCount);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.jet.JetTestSupport;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor.Context;
 import com.hazelcast.jet.ProcessorSupplier;
+import com.hazelcast.jet.Processors;
 import com.hazelcast.logging.Log4jFactory;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -79,7 +80,7 @@ public class StreamFilesPTest extends JetTestSupport {
 
     @Test
     public void supplier() {
-        ProcessorSupplier supplier = StreamFilesP.supplier(workDir.getAbsolutePath(), null, null);
+        ProcessorSupplier supplier = Processors.streamFiles(workDir.getAbsolutePath());
         assertEquals(1, supplier.get(1).size());
         supplier.complete(null);
     }
@@ -235,6 +236,9 @@ public class StreamFilesPTest extends JetTestSupport {
     }
 
     private void initializeProcessor(String glob) {
+        if (glob == null) {
+            glob = "*";
+        }
         processor = new StreamFilesP(workDir.getAbsolutePath(), UTF_8, glob, 1, 0);
         Outbox outbox = mock(Outbox.class);
         when(outbox.offer(any())).thenAnswer(item -> {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastParallelClassRunner.class)
 public class StreamFilesP_readCompleteLineTest {
 
-    private StreamFilesP p = new StreamFilesP("", StandardCharsets.UTF_8, 0, 0);
+    private StreamFilesP p = new StreamFilesP("", StandardCharsets.UTF_8, null, 0, 0);
 
     @Test
     public void when_emptyFile_then_null() throws Exception {


### PR DESCRIPTION
This makes StreamFilesP in-line with ReadFilesP which has that option.

It also allows for use case where users create `.tmp` files and then rename them to real file name and only then want them to be processed, as mentioned in the PRD.