### PR TITLE
Move specific newNullTraverser out from public API

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traversers.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traversers.java
@@ -37,7 +37,7 @@ public final class Traversers {
      * Returns a traverser that always returns null.
      */
     @Nonnull
-    public static <T> Traverser<T> nullTraverser() {
+    public static <T> Traverser<T> empty() {
         return () -> null;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traversers.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traversers.java
@@ -34,14 +34,11 @@ public final class Traversers {
     }
 
     /**
-     * Returns an empty traverser equivalent to {@code () -> null}, but with
-     * guaranteed unique identity. Such a traverser is useful in a <em>null
-     * object</em> pattern, which relies on identity checks with {@code ==}
-     * against a private object.
+     * Returns a traverser that always returns null.
      */
     @Nonnull
-    public static <T> Traverser<T> newNullTraverser() {
-        return new NullTraverser<>();
+    public static <T> Traverser<T> nullTraverser() {
+        return () -> null;
     }
 
     /**
@@ -180,13 +177,6 @@ public final class Traversers {
         @Override
         public T next() {
             return i < array.length && i >= 0 ? array[i++] : null;
-        }
-    }
-
-    private static final class NullTraverser<T> implements Traverser<T> {
-        @Override
-        public T next() {
-            return null;
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/FlatMappingTraverser.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/FlatMappingTraverser.java
@@ -20,13 +20,19 @@ import com.hazelcast.jet.Traverser;
 
 import java.util.function.Function;
 
-import static com.hazelcast.jet.Traversers.newNullTraverser;
-
 /**
  * A flat-mapping decorator over a traverser.
  */
 public class FlatMappingTraverser<T, R> implements Traverser<R> {
-    private static final Traverser NULL_TRAVERSER = newNullTraverser();
+
+    // Do not replace with lambda as we rely on the NULL_TRAVERSER to be our
+    // own unique instance, which is not guaranteed with lambda.
+    private static final Traverser NULL_TRAVERSER = new Traverser() {
+        @Override
+        public Object next() {
+            return null;
+        }
+    };
 
     private final Traverser<T> wrapped;
     private final Function<? super T, ? extends Traverser<? extends R>> mapper;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/InsertPunctuationP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/InsertPunctuationP.java
@@ -24,7 +24,7 @@ import com.hazelcast.jet.Traversers.ResettableSingletonTraverser;
 import javax.annotation.Nonnull;
 import java.util.function.ToLongFunction;
 
-import static com.hazelcast.jet.Traversers.nullTraverser;
+import static com.hazelcast.jet.Traversers.empty;
 
 /**
  * A processor that inserts punctuation into a data stream. See
@@ -79,7 +79,7 @@ public class InsertPunctuationP<T> extends AbstractProcessor {
         long timestamp = extractTimestampF.applyAsLong((T) item);
         if (timestamp < currPunc) {
             // drop late event
-            return nullTraverser();
+            return empty();
         }
         long newPunc = punctuationPolicy.reportEvent(timestamp);
         singletonTraverser.accept(item);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/InsertPunctuationP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/InsertPunctuationP.java
@@ -19,11 +19,12 @@ package com.hazelcast.jet.windowing;
 import com.hazelcast.jet.AbstractProcessor;
 import com.hazelcast.jet.Punctuation;
 import com.hazelcast.jet.Traverser;
-import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.Traversers.ResettableSingletonTraverser;
 
 import javax.annotation.Nonnull;
 import java.util.function.ToLongFunction;
+
+import static com.hazelcast.jet.Traversers.nullTraverser;
 
 /**
  * A processor that inserts punctuation into a data stream. See
@@ -39,7 +40,6 @@ public class InsertPunctuationP<T> extends AbstractProcessor {
     private final ToLongFunction<T> extractTimestampF;
     private final PunctuationPolicy punctuationPolicy;
     private final ResettableSingletonTraverser<Object> singletonTraverser;
-    private final Traverser<Object> nullTraverser = Traversers.newNullTraverser();
     private final FlatMapper<Object, Object> flatMapper;
 
     private long currPunc = Long.MIN_VALUE;
@@ -79,7 +79,7 @@ public class InsertPunctuationP<T> extends AbstractProcessor {
         long timestamp = extractTimestampF.applyAsLong((T) item);
         if (timestamp < currPunc) {
             // drop late event
-            return nullTraverser;
+            return nullTraverser();
         }
         long newPunc = punctuationPolicy.reportEvent(timestamp);
         singletonTraverser.accept(item);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/FlatMappingTraverserTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/FlatMappingTraverserTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+import static com.hazelcast.jet.Traverser.over;
+import static com.hazelcast.jet.Traversers.nullTraverser;
+import static com.hazelcast.jet.Traversers.traverseStream;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class FlatMappingTraverserTest {
+
+    @Test
+    public void smokeTest() {
+        FlatMappingTraverser<Integer, Integer> trav = new FlatMappingTraverser<>(
+                over(0, 1, 2, 3),
+                numItems -> traverseStream(IntStream.range(0, numItems).boxed()));
+
+        assertEquals(0, (int) trav.next());
+        assertEquals(0, (int) trav.next());
+        assertEquals(1, (int) trav.next());
+        assertEquals(0, (int) trav.next());
+        assertEquals(1, (int) trav.next());
+        assertEquals(2, (int) trav.next());
+        assertNull(trav.next());
+        assertNull(trav.next());
+    }
+
+    @Test
+    public void when_flatMapToNullTraverser_then_skipOverToNext() {
+        // This test would fail, if the internal FlatMappingTraverser.NULL_TRAVERSER instance
+        // would be the same (as per == operator) as the instance returned by Traversers.nullTraverser()
+        FlatMappingTraverser<Integer, String> trav =
+                new FlatMappingTraverser<>(over(1, 2, 3), item -> item != 3 ? nullTraverser() : over("a"));
+
+        assertEquals("a", trav.next());
+        assertNull(trav.next());
+        assertNull(trav.next());
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/FlatMappingTraverserTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/FlatMappingTraverserTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Traverser.over;
-import static com.hazelcast.jet.Traversers.nullTraverser;
+import static com.hazelcast.jet.Traversers.empty;
 import static com.hazelcast.jet.Traversers.traverseStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -47,9 +47,9 @@ public class FlatMappingTraverserTest {
     @Test
     public void when_flatMapToNullTraverser_then_skipOverToNext() {
         // This test would fail, if the internal FlatMappingTraverser.NULL_TRAVERSER instance
-        // would be the same (as per == operator) as the instance returned by Traversers.nullTraverser()
+        // would be the same (as per == operator) as the instance returned by Traversers.empty()
         FlatMappingTraverser<Integer, String> trav =
-                new FlatMappingTraverser<>(over(1, 2, 3), item -> item != 3 ? nullTraverser() : over("a"));
+                new FlatMappingTraverser<>(over(1, 2, 3), item -> item != 3 ? empty() : over("a"));
 
         assertEquals("a", trav.next());
         assertNull(trav.next());


### PR DESCRIPTION
The `newNullTraverser()` was required to always create an unique
instance. This requirement is specific to `FlatMappingTraverser`,
however, a `nullTraverser() ` method returning a singleton is useful in
public API.