### PR TITLE
Fix WindowOperations.allOf hz-serializability

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetSerializerHook.java
@@ -53,7 +53,7 @@ public final class JetSerializerHook {
     public static final int LONG_ACC = -304;
     public static final int DOUBLE_ACC = -305;
     public static final int MUTABLE_REFERENCE = -306;
-    public static final int LIN_REG_ACC = -307;
+    public static final int LIN_TREND_ACC = -307;
     public static final int LONG_LONG_ACC = -308;
     public static final int LONG_DOUBLE_ACC = -309;
 
@@ -309,7 +309,7 @@ public final class JetSerializerHook {
         }
     }
 
-    public static final class LinRegAccSerializer implements SerializerHook<LinTrendAccumulator> {
+    public static final class LinTrendAccSerializer implements SerializerHook<LinTrendAccumulator> {
 
         @Override
         public Class<LinTrendAccumulator> getSerializationType() {
@@ -321,7 +321,7 @@ public final class JetSerializerHook {
             return new StreamSerializer<LinTrendAccumulator>() {
                 @Override
                 public int getTypeId() {
-                    return LIN_REG_ACC;
+                    return LIN_TREND_ACC;
                 }
 
                 @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/windowing/WindowOperations.java
@@ -30,7 +30,7 @@ import com.hazelcast.jet.function.DistributedToLongFunction;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -251,7 +251,7 @@ public final class WindowOperations {
                         res[i] = untypedOps[i].createAccumulatorF().get();
                     }
                     // wrap to List to have equals() implemented
-                    return Arrays.asList(res);
+                    return toArrayList(res);
                 },
                 (accs, item) -> {
                     for (int i = 0; i < untypedOps.length; i++) {
@@ -279,9 +279,17 @@ public final class WindowOperations {
                     for (int i = 0; i < untypedOps.length; i++) {
                         res[i] = untypedOps[i].finishAccumulationF().apply(accs.get(i));
                     }
-                    return Arrays.asList(res);
+                    return toArrayList(res);
                 }
         );
+    }
+
+    private static <T> ArrayList<T> toArrayList(T[] array) {
+        ArrayList<T> res = new ArrayList<>(array.length);
+        for (T t : array) {
+            res.add(t);
+        }
+        return res;
     }
 
     /**

--- a/hazelcast-jet-core/src/main/resources/META-INF/services/com.hazelcast.SerializerHook
+++ b/hazelcast-jet-core/src/main/resources/META-INF/services/com.hazelcast.SerializerHook
@@ -4,7 +4,7 @@ com.hazelcast.jet.impl.execution.init.JetSerializerHook$TimestampedEntrySerializ
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$LongAccSerializer
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$DoubleAccSerializer
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$MutableReferenceSerializer
-com.hazelcast.jet.impl.execution.init.JetSerializerHook$LinRegAccSerializer
+com.hazelcast.jet.impl.execution.init.JetSerializerHook$LinTrendAccSerializer
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$LongLongAccSerializer
 com.hazelcast.jet.impl.execution.init.JetSerializerHook$LongDoubleAccSerializer
 com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject$Hook


### PR DESCRIPTION
`WindowOperation`'s accumulator needs to correctly implements `equals`. For
this reason we cannot use `Object[]`. We used `Arrays.asList`, however this
class is not hz-serializable, and cannot be made one because it returns a
private class. So we replace with `ArrayList`.