### PR TITLE
Fix bug in PeekWrappedP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorMetaSupplier.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.util;
 import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.ProcessorMetaSupplier;
 import com.hazelcast.jet.ProcessorSupplier;
+import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.nio.Address;
 
 import javax.annotation.Nonnull;
@@ -32,10 +33,10 @@ import java.util.function.Function;
  */
 public final class WrappingProcessorMetaSupplier implements ProcessorMetaSupplier {
     private ProcessorMetaSupplier wrapped;
-    private Function<Processor, Processor> wrapperSupplier;
+    private DistributedFunction<Processor, Processor> wrapperSupplier;
 
     public WrappingProcessorMetaSupplier(ProcessorMetaSupplier wrapped,
-                                         Function<Processor, Processor> wrapperSupplier) {
+                                         DistributedFunction<Processor, Processor> wrapperSupplier) {
         this.wrapped = wrapped;
         this.wrapperSupplier = wrapperSupplier;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/WrappingProcessorSupplier.java
@@ -18,10 +18,10 @@ package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.ProcessorSupplier;
+import com.hazelcast.jet.function.DistributedFunction;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
-import java.util.function.Function;
 
 import static java.util.stream.Collectors.toList;
 
@@ -31,9 +31,11 @@ import static java.util.stream.Collectors.toList;
  */
 public final class WrappingProcessorSupplier implements ProcessorSupplier {
     private ProcessorSupplier wrapped;
-    private Function<Processor, Processor> wrapperSupplier;
+    private DistributedFunction<Processor, Processor> wrapperSupplier;
 
-    public WrappingProcessorSupplier(ProcessorSupplier wrapped, Function<Processor, Processor> wrapperSupplier) {
+    public WrappingProcessorSupplier(ProcessorSupplier wrapped,
+                                     DistributedFunction<Processor, Processor> wrapperSupplier
+    ) {
         this.wrapped = wrapped;
         this.wrapperSupplier = wrapperSupplier;
     }


### PR DESCRIPTION
It worked correctly when inbox was drained using peek+remove. If it was
drained using `poll()` there was an `NPE` and secondly, `poll()` returned
`true` instead of the polled object.

Second improvement is that when using peek+remove, the item is logged in
`peek`, not in `remove`, which is called after processing the item in
`AbstractProcessor`, which in turn caused the output items being logged before
input items in case of `peekInput(peekOutput(processor))`.

Another bug was not using `Distributed` version of function.

Also updated the test to test these scenarios.