### PR TITLE
Add fair distribution of tasklets

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
@@ -116,7 +116,7 @@ public class ExecutionService {
         Arrays.setAll(trackersByThread, i -> new ArrayList());
         for (Tasklet t : tasklets) {
             t.init(jobFuture);
-            trackersByThread[Math.floorMod(cooperativeThreadIndex.incrementAndGet(), trackersByThread.length)]
+            trackersByThread[Math.floorMod(cooperativeThreadIndex.getAndIncrement(), trackersByThread.length)]
                     .add(new TaskletTracker(t, jobFuture, jobClassLoader));
         }
         for (int i = 0; i < trackersByThread.length; i++) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
@@ -116,7 +116,7 @@ public class ExecutionService {
         Arrays.setAll(trackersByThread, i -> new ArrayList());
         for (Tasklet t : tasklets) {
             t.init(jobFuture);
-            trackersByThread[cooperativeThreadIndex.incrementAndGet() % trackersByThread.length]
+            trackersByThread[Math.floorMod(cooperativeThreadIndex.incrementAndGet(), trackersByThread.length)]
                     .add(new TaskletTracker(t, jobFuture, jobClassLoader));
         }
         for (int i = 0; i < trackersByThread.length; i++) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
@@ -58,6 +58,7 @@ public class ExecutionService {
     private final Thread[] cooperativeThreadPool;
     private final String hzInstanceName;
     private final ILogger logger;
+    private final AtomicInteger cooperativeThreadIndex = new AtomicInteger();
 
     private volatile boolean isShutdown;
 
@@ -113,12 +114,12 @@ public class ExecutionService {
         ensureThreadsStarted();
         final List<TaskletTracker>[] trackersByThread = new List[cooperativeWorkers.length];
         Arrays.setAll(trackersByThread, i -> new ArrayList());
-        int i = 0;
         for (Tasklet t : tasklets) {
             t.init(jobFuture);
-            trackersByThread[i++ % trackersByThread.length].add(new TaskletTracker(t, jobFuture, jobClassLoader));
+            trackersByThread[cooperativeThreadIndex.incrementAndGet() % trackersByThread.length]
+                    .add(new TaskletTracker(t, jobFuture, jobClassLoader));
         }
-        for (i = 0; i < trackersByThread.length; i++) {
+        for (int i = 0; i < trackersByThread.length; i++) {
             cooperativeWorkers[i].trackers.addAll(trackersByThread[i]);
         }
         Arrays.stream(cooperativeThreadPool).forEach(LockSupport::unpark);


### PR DESCRIPTION
Previously, tasklets for a job were assigned to cooperative workers always
starting from worker 0. This could lead to the last worker to have less
tasklets assigned, or even none in extreme cases (such as many small DAGs with
local parallelism of 1 on all vertices, a setting typical if there are many
jobs).

This change makes the starting index global. Work stealing didn't help here
because it only takes place when worker dismissed some tasklet, which works
with assumption that it was balanced before.