### PR TITLE
Minor improvements

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Processors.java
@@ -901,10 +901,11 @@ public final class Processors {
      * recommended for this vertex.
      *
      * @param toStringF Function to convert item to String.
+     * @param <T> input item type
      */
     @Nonnull
-    public static DistributedSupplier<Processor> writeLogger(
-            @Nonnull DistributedFunction<Object, String> toStringF
+    public static <T> DistributedSupplier<Processor> writeLogger(
+            @Nonnull DistributedFunction<T, String> toStringF
     ) {
         return () -> new WriteLoggerP(toStringF);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteLoggerP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteLoggerP.java
@@ -24,17 +24,17 @@ import javax.annotation.Nonnull;
 /**
  * See {@link com.hazelcast.jet.Processors#writeLogger()}
  */
-public class WriteLoggerP extends AbstractProcessor {
+public class WriteLoggerP<T> extends AbstractProcessor {
 
-    private DistributedFunction<Object, String> toStringF;
+    private DistributedFunction<T, String> toStringF;
 
-    public WriteLoggerP(DistributedFunction<Object, String> toStringF) {
+    public WriteLoggerP(DistributedFunction<T, String> toStringF) {
         this.toStringF = toStringF;
     }
 
     @Override
     protected boolean tryProcess(int ordinal, @Nonnull Object item) throws Exception {
-        getLogger().info(toStringF.apply(item));
+        getLogger().info(toStringF.apply((T) item));
         return true;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionService.java
@@ -116,7 +116,7 @@ public class ExecutionService {
         Arrays.setAll(trackersByThread, i -> new ArrayList());
         for (Tasklet t : tasklets) {
             t.init(jobFuture);
-            trackersByThread[Math.floorMod(cooperativeThreadIndex.getAndIncrement(), trackersByThread.length)]
+            trackersByThread[cooperativeThreadIndex.getAndUpdate(i -> (i + 1) % trackersByThread.length)]
                     .add(new TaskletTracker(t, jobFuture, jobClassLoader));
         }
         for (int i = 0; i < trackersByThread.length; i++) {


### PR DESCRIPTION
- `Processors.writeLogger()` accepts `Function<T, String>` instead of
  `Function<Object, String>`. This is not applicable to `toStringF` in
  `peekInput`, because it can see both items and `Punctuation`s.
- test for adding two cooperative tasklets in two jobs to different threads
- bit simpler code in ExecutionService