### PR TITLE
Reorganize batch processor factories

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/AggregateOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/AggregateOperation.java
@@ -69,7 +69,7 @@ public interface AggregateOperation<T, A, R> extends Serializable {
      * A primitive that updates the accumulator state to account for a new item.
      */
     @Nonnull
-    DistributedBiConsumer<A, T> accumulateItemF();
+    DistributedBiConsumer<? super A, T> accumulateItemF();
 
     /**
      * A primitive that accepts two accumulators and updates the state of the
@@ -77,7 +77,7 @@ public interface AggregateOperation<T, A, R> extends Serializable {
      * The right-hand accumulator remains unchanged.
      */
     @Nonnull
-    DistributedBiConsumer<A, A> combineAccumulatorsF();
+    DistributedBiConsumer<? super A, ? super A> combineAccumulatorsF();
 
     /**
      * A primitive that accepts two accumulators and updates the state of the
@@ -103,14 +103,14 @@ public interface AggregateOperation<T, A, R> extends Serializable {
      * step, the more pronounced the difference in computation effort will be.
      */
     @Nullable
-    DistributedBiConsumer<A, A> deductAccumulatorF();
+    DistributedBiConsumer<? super A, ? super A> deductAccumulatorF();
 
     /**
      * A primitive that finishes the accumulation process by transforming
      * the accumulator object into the final result.
      */
     @Nonnull
-    DistributedFunction<A, R> finishAccumulationF();
+    DistributedFunction<? super A, R> finishAccumulationF();
 
     /**
      * Returns a copy of this aggregate operation with the {@code finish}
@@ -120,10 +120,10 @@ public interface AggregateOperation<T, A, R> extends Serializable {
      * @param <R1> the result type of the {@code finish} primitive
      */
     default <R1> AggregateOperation<T, A, R1> withFinish(
-            @Nonnull DistributedFunction<A, R1> finishAccumulationF
+            @Nonnull DistributedFunction<? super A, R1> finishAccumulationF
     ) {
-        return of(createAccumulatorF(), accumulateItemF(), combineAccumulatorsF(), deductAccumulatorF(),
-                finishAccumulationF);
+        return of(createAccumulatorF(), accumulateItemF(), combineAccumulatorsF(),
+                deductAccumulatorF(), finishAccumulationF);
     }
 
     /**
@@ -156,10 +156,10 @@ public interface AggregateOperation<T, A, R> extends Serializable {
     @Nonnull
     static <T, A, R> AggregateOperation<T, A, R> of(
             @Nonnull DistributedSupplier<A> createAccumulatorF,
-            @Nonnull DistributedBiConsumer<A, T> accumulateItemF,
-            @Nonnull DistributedBiConsumer<A, A> combineAccumulatorsF,
-            @Nullable DistributedBiConsumer<A, A> deductAccumulatorF,
-            @Nonnull DistributedFunction<A, R> finishAccumulationF
+            @Nonnull DistributedBiConsumer<? super A, T> accumulateItemF,
+            @Nonnull DistributedBiConsumer<? super A, ? super A> combineAccumulatorsF,
+            @Nullable DistributedBiConsumer<? super A, ? super A> deductAccumulatorF,
+            @Nonnull DistributedFunction<? super A, R> finishAccumulationF
     ) {
         Objects.requireNonNull(createAccumulatorF);
         Objects.requireNonNull(accumulateItemF);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/accumulator/LongAccumulator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/accumulator/LongAccumulator.java
@@ -52,6 +52,22 @@ public class LongAccumulator {
     }
 
     /**
+     * Adds the supplied value to this accumulator.
+     */
+    public LongAccumulator add(long value) {
+        this.value += value;
+        return this;
+    }
+
+    /**
+     * Adds the value of the supplied accumulator to this accumulator.
+     */
+    public LongAccumulator add(LongAccumulator that) {
+        this.value += that.value;
+        return this;
+    }
+
+    /**
      * Uses {@link Math#addExact(long, long) Math.addExact()} to add the
      * supplied value to this accumulator.
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
@@ -63,9 +63,9 @@ public final class DistributedFunctions {
     }
 
     /**
-     * Returns a function that always returns the {@link #CONSTANT_KEY}. This is
-     * useful as a key extractor in group-by operations where no classification
-     * by key is desired.
+     * Returns a function that always evaluates to the {@link #CONSTANT_KEY}.
+     * This is useful as a key extractor in group-by operations where no
+     * classification by key is desired.
      */
     @Nonnull
     public static <T> DistributedFunction<T, String> constantKey() {
@@ -82,7 +82,7 @@ public final class DistributedFunctions {
     }
 
     /**
-     * Returns a predicate that always returns {@code true}.
+     * Returns a predicate that always evaluates to {@code true}.
      */
     @Nonnull
     public static <T> DistributedPredicate<T> alwaysTrue() {
@@ -90,7 +90,7 @@ public final class DistributedFunctions {
     }
 
     /**
-     * Returns a predicate that always returns {@code false}.
+     * Return sa predicate that always evaluates to {@code false}.
      */
     @Nonnull
     public static <T> DistributedPredicate<T> alwaysFalse() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AggregateOperationImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AggregateOperationImpl.java
@@ -26,17 +26,17 @@ import javax.annotation.Nullable;
 
 public class AggregateOperationImpl<T, A, R> implements AggregateOperation<T, A, R> {
     private final DistributedSupplier<A> createAccumulatorF;
-    private final DistributedBiConsumer<A, T> accumulateItemF;
-    private final DistributedBiConsumer<A, A> combineAccumulatorsF;
-    private final DistributedBiConsumer<A, A> deductAccumulatorF;
-    private final DistributedFunction<A, R> finishAccumulationF;
+    private final DistributedBiConsumer<? super A, T> accumulateItemF;
+    private final DistributedBiConsumer<? super A, ? super A> combineAccumulatorsF;
+    private final DistributedBiConsumer<? super A, ? super A> deductAccumulatorF;
+    private final DistributedFunction<? super A, R> finishAccumulationF;
 
     public AggregateOperationImpl(
-            DistributedSupplier<A> createAccumulatorF,
-            DistributedBiConsumer<A, T> accumulateItemF,
-            DistributedBiConsumer<A, A> combineAccumulatorsF,
-            DistributedBiConsumer<A, A> deductAccumulatorF,
-            DistributedFunction<A, R> finishAccumulationF
+            @Nonnull DistributedSupplier<A> createAccumulatorF,
+            @Nonnull DistributedBiConsumer<? super A, T> accumulateItemF,
+            @Nonnull DistributedBiConsumer<? super A, ? super A> combineAccumulatorsF,
+            @Nullable DistributedBiConsumer<? super A, ? super A> deductAccumulatorF,
+            @Nonnull DistributedFunction<? super A, R> finishAccumulationF
     ) {
         this.createAccumulatorF = createAccumulatorF;
         this.accumulateItemF = accumulateItemF;
@@ -51,22 +51,22 @@ public class AggregateOperationImpl<T, A, R> implements AggregateOperation<T, A,
     }
 
     @Override @Nonnull
-    public DistributedBiConsumer<A, T> accumulateItemF() {
+    public DistributedBiConsumer<? super A, T> accumulateItemF() {
         return accumulateItemF;
     }
 
     @Override @Nonnull
-    public DistributedBiConsumer<A, A> combineAccumulatorsF() {
+    public DistributedBiConsumer<? super A, ? super A> combineAccumulatorsF() {
         return combineAccumulatorsF;
     }
 
     @Override @Nullable
-    public DistributedBiConsumer<A, A> deductAccumulatorF() {
+    public DistributedBiConsumer<? super A, ? super A> deductAccumulatorF() {
         return deductAccumulatorF;
     }
 
     @Override @Nonnull
-    public DistributedFunction<A, R> finishAccumulationF() {
+    public DistributedFunction<? super A, R> finishAccumulationF() {
         return finishAccumulationF;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AggregateP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AggregateP.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.AbstractProcessor;
+import com.hazelcast.jet.AggregateOperation;
+import com.hazelcast.jet.function.DistributedBiConsumer;
+import com.hazelcast.jet.function.DistributedFunction;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Batch processor that computes the supplied aggregate operation
+ * on all received items.
+ */
+public class AggregateP<T, K, A, R> extends AbstractProcessor {
+    private final DistributedBiConsumer<? super A, ? super T> accumulateF;
+    private final DistributedFunction<? super A, R> finishF;
+    private final A acc;
+    private R result;
+
+    public AggregateP(
+            @Nonnull AggregateOperation<? super T, A, R> aggregateOperation
+    ) {
+        this.accumulateF = aggregateOperation.accumulateItemF();
+        this.finishF = aggregateOperation.finishAccumulationF();
+        this.acc = aggregateOperation.createAccumulatorF().get();
+    }
+
+    @Override
+    protected boolean tryProcess(int ordinal, @Nonnull Object item) throws Exception {
+        accumulateF.accept(acc, (T) item);
+        return true;
+    }
+
+    @Override
+    public boolean complete() {
+        if (result == null) {
+            result = finishF.apply(acc);
+        }
+        return tryEmit(result);
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/GroupByKeyP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/GroupByKeyP.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.AbstractProcessor;
+import com.hazelcast.jet.AggregateOperation;
+import com.hazelcast.jet.Traverser;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.hazelcast.jet.Traversers.traverseStream;
+import static com.hazelcast.jet.Util.entry;
+
+/**
+ * Batch processor that groups items by key and computes the supplied
+ * aggregate operation on each group.
+ */
+public class GroupByKeyP<T, K, A, R> extends AbstractProcessor {
+    private final Function<? super T, ? extends K> getKeyF;
+    private final AggregateOperation<? super T, A, R> aggrOp;
+
+    private final Map<K, A> groups = new HashMap<>();
+    private final Traverser<Map.Entry<K, R>> resultTraverser;
+
+    public GroupByKeyP(
+            @Nonnull Function<? super T, ? extends K> getKeyF,
+            @Nonnull AggregateOperation<? super T, A, R> aggregateOperation
+    ) {
+        this.getKeyF = getKeyF;
+        this.aggrOp = aggregateOperation;
+        this.resultTraverser = traverseStream(groups
+                .entrySet().stream()
+                .map(e -> entry(e.getKey(), aggrOp.finishAccumulationF().apply(e.getValue()))));
+    }
+
+    @Override
+    protected boolean tryProcess(int ordinal, @Nonnull Object item) throws Exception {
+        final A acc = groups.computeIfAbsent(getKeyF.apply((T) item), k -> aggrOp.createAccumulatorF().get());
+        aggrOp.accumulateItemF().accept(acc, (T) item);
+        return true;
+    }
+
+    @Override
+    public boolean complete() {
+        return emitFromTraverser(resultTraverser);
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SessionWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SessionWindowP.java
@@ -65,8 +65,8 @@ public class SessionWindowP<T, K, A, R> extends AbstractProcessor {
     private final DistributedFunction<? super T, K> getKeyF;
     private final DistributedSupplier<A> newAccumulatorF;
     private final BiConsumer<? super A, ? super T> accumulateF;
-    private final DistributedFunction<A, R> finishAccumulationF;
-    private final DistributedBiConsumer<A, A> combineAccF;
+    private final DistributedFunction<? super A, R> finishAccumulationF;
+    private final DistributedBiConsumer<? super A, ? super A> combineAccF;
     private final FlatMapper<Punctuation, Session<K, R>> expiredSessionFlatmapper;
 
     public SessionWindowP(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
@@ -150,7 +150,7 @@ public class SlidingWindowP<T, A, R> extends AbstractProcessor {
         }
     }
 
-    private void patchSlidingWindow(BiConsumer<A, A> patchOp, Map<Object, A> patchingFrame) {
+    private void patchSlidingWindow(BiConsumer<? super A, ? super A> patchOp, Map<Object, A> patchingFrame) {
         if (patchingFrame == null) {
             return;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformP.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.AbstractProcessor;
+import com.hazelcast.jet.Traverser;
+import com.hazelcast.jet.function.DistributedFunction;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Processor which, for each received item, emits all the items from the
+ * traverser returned by the given item-to-traverser function.
+ *
+ * @param <T> received item type
+ * @param <R> emitted item type
+ */
+public class TransformP<T, R> extends AbstractProcessor {
+    private final FlatMapper<T, R> flatMapper;
+
+    /**
+     * Constructs a processor with the given mapping function.
+     */
+    public TransformP(@Nonnull DistributedFunction<T, ? extends Traverser<? extends R>> mapper) {
+        this.flatMapper = flatMapper(mapper);
+    }
+
+    @Override
+    protected boolean tryProcess(int ordinal, @Nonnull Object item) throws Exception {
+        return flatMapper.tryProcess((T) item);
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/AggregateOperationsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/AggregateOperationsTest.java
@@ -125,10 +125,10 @@ public class AggregateOperationsTest {
         AggregateOperation<Entry<Long, Long>, LinTrendAccumulator, Double> op =
                 linearTrend(Entry::getKey, Entry::getValue);
         Supplier<LinTrendAccumulator> newF = op.createAccumulatorF();
-        BiConsumer<LinTrendAccumulator, Entry<Long, Long>> accF = op.accumulateItemF();
-        BiConsumer<LinTrendAccumulator, LinTrendAccumulator> combineF = op.combineAccumulatorsF();
-        BiConsumer<LinTrendAccumulator, LinTrendAccumulator> deductF = op.deductAccumulatorF();
-        Function<LinTrendAccumulator, Double> finishF = op.finishAccumulationF();
+        BiConsumer<? super LinTrendAccumulator, Entry<Long, Long>> accF = op.accumulateItemF();
+        BiConsumer<? super LinTrendAccumulator, ? super LinTrendAccumulator> combineF = op.combineAccumulatorsF();
+        BiConsumer<? super LinTrendAccumulator, ? super LinTrendAccumulator> deductF = op.deductAccumulatorF();
+        Function<? super LinTrendAccumulator, Double> finishF = op.finishAccumulationF();
         assertNotNull(deductF);
 
         // When
@@ -189,7 +189,7 @@ public class AggregateOperationsTest {
             R expectFinished
     ) {
         // Given
-        BiConsumer<A, A> deductAccF = op.deductAccumulatorF();
+        BiConsumer<? super A, ? super A> deductAccF = op.deductAccumulatorF();
         assertNotNull(deductAccF);
 
         // When


### PR DESCRIPTION
- align group-by-key processors with those in windowing (single-stage, two-stage)
- use `AggregateOperation` in batch processors
- extract private static processor classes to top level
- reorder factories, improve javadoc
