### PR TITLE
Add support for adding Probes to Processors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,6 @@ performance*.log
 */src/test/resources/data/result*
 dependency-reduced-pom.xml
 *.jfr
-
+diagnostics-*.log
 # Hadoop files
 *.crc


### PR DESCRIPTION
Processors are now registered to MetricsRegistry and will be scanned
for probes during creation. The output of probes can be viewed by
enabling the `-Dhazelcast.diagnostics.enabled=true` option.