### PR TITLE
Fix, rename and improve socket connectors

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
@@ -32,16 +32,16 @@ import java.util.concurrent.CompletableFuture;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 
 /**
- * @see Sources#streamTextSocket(String, int, Charset)
+ * @see Sources#streamSocket(String, int, Charset)
  */
-public final class StreamTextSocketP extends AbstractProcessor {
+public final class StreamSocketP extends AbstractProcessor {
 
     private final String host;
     private final int port;
     private final Charset charset;
     private CompletableFuture<Void> jobFuture;
 
-    private StreamTextSocketP(String host, int port, Charset charset) {
+    private StreamSocketP(String host, int port, Charset charset) {
         this.host = host;
         this.port = port;
         this.charset = charset;
@@ -87,6 +87,6 @@ public final class StreamTextSocketP extends AbstractProcessor {
     }
 
     public static DistributedSupplier<Processor> supplier(String host, int port, @Nonnull String charset) {
-        return () -> new StreamTextSocketP(host, port, Charset.forName(charset));
+        return () -> new StreamSocketP(host, port, Charset.forName(charset));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
@@ -16,16 +16,21 @@
 
 package com.hazelcast.jet.impl.connector;
 
-import com.hazelcast.jet.function.DistributedBiConsumer;
-import com.hazelcast.jet.function.DistributedConsumer;
-import com.hazelcast.jet.function.DistributedIntFunction;
 import com.hazelcast.jet.Inbox;
 import com.hazelcast.jet.Outbox;
 import com.hazelcast.jet.Processor;
+import com.hazelcast.jet.ProcessorSupplier;
 import com.hazelcast.jet.Punctuation;
-import com.hazelcast.jet.function.DistributedSupplier;
+import com.hazelcast.jet.function.DistributedBiConsumer;
+import com.hazelcast.jet.function.DistributedConsumer;
+import com.hazelcast.jet.function.DistributedIntFunction;
 
 import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
 
 public final class WriteBufferedP<B, T> implements Processor {
 
@@ -50,14 +55,40 @@ public final class WriteBufferedP<B, T> implements Processor {
         this.buffer = newBuffer.apply(context.globalProcessorIndex());
     }
 
+    /**
+     * Use {@link
+     * com.hazelcast.jet.processor.Sinks#writeBuffered(DistributedIntFunction,
+     * DistributedBiConsumer, DistributedConsumer, DistributedConsumer)
+     * Sinks.writeBuffered()} instead of this one.
+     */
     @Nonnull
-    public static <B, T> DistributedSupplier<Processor> writeBuffered(
-            DistributedIntFunction<B> newBuffer,
-            DistributedBiConsumer<B, T> addToBuffer,
-            DistributedConsumer<B> consumeBuffer,
-            DistributedConsumer<B> closeBuffer
+    public static <B, T> ProcessorSupplier supplier(
+            DistributedIntFunction<B> newBufferF,
+            DistributedBiConsumer<B, T> addToBufferF,
+            DistributedConsumer<B> flushBufferF,
+            DistributedConsumer<B> disposeBufferF
     ) {
-        return () -> new WriteBufferedP<>(newBuffer, addToBuffer, consumeBuffer, closeBuffer);
+        return new ProcessorSupplier() {
+            private List<WriteBufferedP<B, T>> processors;
+
+            @Nonnull
+            @Override
+            public Collection<? extends Processor> get(int count) {
+                return processors = IntStream.range(0, count)
+                        .mapToObj(i -> new WriteBufferedP<>(newBufferF, addToBufferF, flushBufferF, disposeBufferF))
+                        .collect(toList());
+            }
+
+            @Override
+            public void complete(Throwable error) {
+                if (processors == null) {
+                    return;
+                }
+                for (WriteBufferedP<B, T> p : processors) {
+                    p.close();
+                }
+            }
+        };
     }
 
     @Override
@@ -72,9 +103,12 @@ public final class WriteBufferedP<B, T> implements Processor {
 
     @Override
     public boolean complete() {
-        flushBuffer.accept(buffer);
-        disposeBuffer.accept(buffer);
+        close();
         return true;
+    }
+
+    public void close() {
+        disposeBuffer.accept(buffer);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
@@ -69,7 +69,7 @@ public final class WriteBufferedP<B, T> implements Processor {
             DistributedConsumer<B> disposeBufferF
     ) {
         return new ProcessorSupplier() {
-            private List<WriteBufferedP<B, T>> processors;
+            private transient List<WriteBufferedP<B, T>> processors;
 
             @Nonnull
             @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/processor/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/processor/Sources.java
@@ -25,7 +25,7 @@ import com.hazelcast.jet.impl.connector.ReadFilesP;
 import com.hazelcast.jet.impl.connector.ReadIListP;
 import com.hazelcast.jet.impl.connector.ReadWithPartitionIteratorP;
 import com.hazelcast.jet.impl.connector.StreamFilesP;
-import com.hazelcast.jet.impl.connector.StreamTextSocketP;
+import com.hazelcast.jet.impl.connector.StreamSocketP;
 
 import javax.annotation.Nonnull;
 import java.nio.charset.Charset;
@@ -128,12 +128,12 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #streamTextSocket(String, int, Charset)} with
+     * Convenience for {@link #streamSocket(String, int, Charset)} with
      * the UTF-8 character set.
      */
     @Nonnull
-    public static DistributedSupplier<Processor> streamTextSocket(@Nonnull String host, int port) {
-        return streamTextSocket(host, port, StandardCharsets.UTF_8);
+    public static DistributedSupplier<Processor> streamSocket(@Nonnull String host, int port) {
+        return streamSocket(host, port, StandardCharsets.UTF_8);
     }
 
     /**
@@ -153,10 +153,10 @@ public final class Sources {
      * @param charset Character set used to decode the stream
      */
     @Nonnull
-    public static DistributedSupplier<Processor> streamTextSocket(
+    public static DistributedSupplier<Processor> streamSocket(
             @Nonnull String host, int port, @Nonnull Charset charset
     ) {
-        return StreamTextSocketP.supplier(host, port, charset.name());
+        return StreamSocketP.supplier(host, port, charset.name());
     }
 
     /**

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.mock;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
-public class StreamTextSocketPTest extends JetTestSupport {
+public class StreamSocketPTest extends JetTestSupport {
 
     private Queue<Object> bucket;
     private ArrayDequeOutbox outbox;
@@ -72,7 +72,7 @@ public class StreamTextSocketPTest extends JetTestSupport {
             }));
             thread.start();
 
-            Processor processor = Sources.streamTextSocket("localhost", serverSocket.getLocalPort()).get();
+            Processor processor = Sources.streamSocket("localhost", serverSocket.getLocalPort()).get();
             processor.init(outbox, context);
 
             assertTrue(processor.complete());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketP_integrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketP_integrationTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.DAG;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestSupport;
 import com.hazelcast.jet.Vertex;
+import com.hazelcast.jet.processor.Sources;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -40,13 +41,12 @@ import static com.hazelcast.jet.Edge.between;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static com.hazelcast.jet.processor.Processors.noop;
 import static com.hazelcast.jet.processor.Sinks.writeList;
-import static com.hazelcast.jet.processor.Sources.streamTextSocket;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
-public class StreamTextSocketP_integrationTest extends JetTestSupport {
+public class StreamSocketP_integrationTest extends JetTestSupport {
 
     private static final String HOST = "localhost";
     private static final int PORT = 8888;
@@ -85,7 +85,7 @@ public class StreamTextSocketP_integrationTest extends JetTestSupport {
             })).start();
 
             DAG dag = new DAG();
-            Vertex producer = dag.newVertex("producer", streamTextSocket(HOST, PORT)).localParallelism(2);
+            Vertex producer = dag.newVertex("producer", Sources.streamSocket(HOST, PORT)).localParallelism(2);
             Vertex consumer = dag.newVertex("consumer", writeList("consumer")).localParallelism(1);
             dag.edge(between(producer, consumer));
 
@@ -106,7 +106,7 @@ public class StreamTextSocketP_integrationTest extends JetTestSupport {
             AtomicReference<Socket> accept = new AtomicReference<>();
             CountDownLatch acceptationLatch = new CountDownLatch(1);
             // Cancellation only works, if there are data on socket. Without data, SocketInputStream.read()
-            // blocks indefinitely. The StreamTextSocketP should be improved to use NIO.
+            // blocks indefinitely. The StreamSocketP should be improved to use NIO.
             new Thread(() -> uncheckRun(() -> {
                 accept.set(socket.accept());
                 acceptationLatch.countDown();
@@ -120,7 +120,7 @@ public class StreamTextSocketP_integrationTest extends JetTestSupport {
                 }
             })).start();
 
-            Vertex producer = new Vertex("producer", streamTextSocket(HOST, PORT)).localParallelism(1);
+            Vertex producer = new Vertex("producer", Sources.streamSocket(HOST, PORT)).localParallelism(1);
             Vertex sink = new Vertex("sink", noop()).localParallelism(1);
             DAG dag = new DAG()
                     .vertex(producer)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
@@ -16,9 +16,19 @@
 
 package com.hazelcast.jet.impl.connector;
 
+import com.hazelcast.jet.AbstractProcessor;
+import com.hazelcast.jet.DAG;
+import com.hazelcast.jet.Edge;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestSupport;
 import com.hazelcast.jet.Outbox;
+import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.Processor.Context;
+import com.hazelcast.jet.ProcessorSupplier;
+import com.hazelcast.jet.Punctuation;
+import com.hazelcast.jet.Vertex;
 import com.hazelcast.jet.impl.util.ArrayDequeInbox;
+import com.hazelcast.jet.processor.Sinks;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
@@ -26,35 +36,98 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.Future;
 
+import static com.hazelcast.jet.processor.Processors.nonCooperative;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
-public class WriteBufferedPTest {
+public class WriteBufferedPTest extends JetTestSupport {
 
-    private static final int ENTRY_COUNT = 5;
+    private List<String> events = new ArrayList<>();
 
     @Test
-    public void test() {
-        WriteBufferedP<List<Integer>, Integer> p = new WriteBufferedP<>(
-                index -> new ArrayList<>(),
-                List::add,
-                list -> assertEquals(ENTRY_COUNT, list.size()),
-                map -> { }
-        );
-        p.init(mock(Outbox.class), mock(Context.class));
-
+    public void writeBuffered_smokeTest() throws Exception {
+        Processor p = getLoggingBufferedWriter().get(1).iterator().next();
+        Outbox outbox = mock(Outbox.class);
+        p.init(outbox, mock(Context.class));
         ArrayDequeInbox inbox = new ArrayDequeInbox();
-        Map<Integer, Integer> map = new HashMap<>();
-        for (int i = 0; i < ENTRY_COUNT; i++) {
-            map.put(i, i);
-        }
-        inbox.addAll(map.keySet());
+        inbox.add(1);
+        inbox.add(2);
         p.process(0, inbox);
+        inbox.add(3);
+        inbox.add(4);
+        inbox.add(new Punctuation(0)); // punctuation should not be written
+        p.process(0, inbox);
+        p.process(0, inbox); // empty flush
+        p.complete();
+
+        assertEquals(asList(
+                "new",
+                "add:1",
+                "add:2",
+                "flush",
+                "add:3",
+                "add:4",
+                "flush",
+                "flush",
+                "dispose"
+        ), events);
+
+        assertEquals(0, inbox.size());
+        verifyZeroInteractions(outbox);
+    }
+
+    @Test
+    public void when_writeBufferedJobFailed_then_bufferDisposed() throws Exception {
+        JetInstance instance = createJetMember();
+        try {
+            DAG dag = new DAG();
+            Vertex source = dag.newVertex("source", nonCooperative(() -> new AbstractProcessor() {
+                @Override
+                public boolean complete() {
+                    // sleep forever - we'll cancel the job
+                    try {
+                        Thread.sleep(Long.MAX_VALUE);
+                    } catch (InterruptedException e) {
+                        fail();
+                    }
+                    return false;
+                }
+            }));
+            Vertex sink = dag.newVertex("sink", getLoggingBufferedWriter()).localParallelism(1);
+
+            dag.edge(Edge.between(source, sink));
+
+            Future<Void> future = instance.newJob(dag).execute();
+            // wait for the job to initialize
+            Thread.sleep(500);
+            future.cancel(true);
+
+            assertTrueEventually(() -> assertTrue("No \"dispose\", only: " + events, events.contains("dispose")), 60);
+            System.out.println(events);
+        } finally {
+            instance.shutdown();
+        }
+    }
+
+    private ProcessorSupplier getLoggingBufferedWriter() {
+        // returns a processor that will not write anywhere, just log the events instead
+        return Sinks.writeBuffered(
+                idx -> {
+                    events.add("new");
+                    return null;
+                },
+                (buffer, item) -> events.add("add:" + item),
+                buffer -> events.add("flush"),
+                buffer -> events.add("dispose")
+        );
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteSocketTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteSocketTest.java
@@ -66,7 +66,7 @@ public class WriteSocketTest extends JetTestSupport {
         })).start();
 
         ArrayDequeInbox inbox = new ArrayDequeInbox();
-        range(0, ITEM_COUNT).forEach(i -> inbox.add(i + "\n"));
+        range(0, ITEM_COUNT).forEach(inbox::add);
 
         Processor p = writeSocket("localhost", serverSocket.getLocalPort()).get(1).iterator().next();
         p.init(mock(Outbox.class), new ProcCtx(null, null, null, 0));
@@ -99,7 +99,7 @@ public class WriteSocketTest extends JetTestSupport {
         JetInstance jetInstance = createJetMember();
         createJetMember();
         IStreamMap<Integer, String> map = jetInstance.getMap("map");
-        range(0, ITEM_COUNT).forEach(i -> map.put(i, i + "\n"));
+        range(0, ITEM_COUNT).forEach(i -> map.put(i, String.valueOf(i)));
 
         DAG dag = new DAG();
         Vertex source = dag.newVertex("source", readMap("map"));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteSocketTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteSocketTest.java
@@ -19,7 +19,11 @@ package com.hazelcast.jet.impl.connector;
 import com.hazelcast.jet.DAG;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestSupport;
+import com.hazelcast.jet.Outbox;
+import com.hazelcast.jet.Processor;
 import com.hazelcast.jet.Vertex;
+import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
+import com.hazelcast.jet.impl.util.ArrayDequeInbox;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -31,35 +35,62 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.jet.Edge.between;
-import static com.hazelcast.jet.processor.Sources.readMap;
-import static com.hazelcast.jet.processor.Sinks.writeSocket;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
+import static com.hazelcast.jet.processor.Sinks.writeSocket;
+import static com.hazelcast.jet.processor.Sources.readMap;
 import static java.util.stream.IntStream.range;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
 public class WriteSocketTest extends JetTestSupport {
 
-    private static final String HOST = "localhost";
-    private static final int PORT = 8787;
     private static final int ITEM_COUNT = 1000;
 
     @Test
-    public void test() throws Exception {
-        ServerSocket socket = new ServerSocket(PORT);
-        CountDownLatch latch = new CountDownLatch(ITEM_COUNT);
+    public void unitTest() throws Exception {
+        AtomicInteger counter = new AtomicInteger();
+        ServerSocket serverSocket = new ServerSocket(0);
         new Thread(() -> uncheckRun(() -> {
-            while (!socket.isClosed()) {
-                Socket accept = socket.accept();
+            Socket socket = serverSocket.accept();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+                while (reader.readLine() != null) {
+                    counter.incrementAndGet();
+                }
+            }
+        })).start();
+
+        ArrayDequeInbox inbox = new ArrayDequeInbox();
+        range(0, ITEM_COUNT).forEach(i -> inbox.add(i + "\n"));
+
+        Processor p = writeSocket("localhost", serverSocket.getLocalPort()).get(1).iterator().next();
+        p.init(mock(Outbox.class), new ProcCtx(null, null, null, 0));
+        p.process(0, inbox);
+        p.complete();
+        serverSocket.close();
+        assertTrueEventually(() -> assertTrue(counter.get() >= ITEM_COUNT));
+        // wait a little to check, if the counter doesn't get too far
+        Thread.sleep(500);
+        assertEquals(ITEM_COUNT, counter.get());
+    }
+
+    @Test
+    public void integrationTest() throws Exception {
+        AtomicInteger counter = new AtomicInteger();
+        ServerSocket serverSocket = new ServerSocket(0);
+        new Thread(() -> uncheckRun(() -> {
+            while (!serverSocket.isClosed()) {
+                Socket socket = serverSocket.accept();
                 new Thread(() -> uncheckRun(() -> {
-                    BufferedReader reader = new BufferedReader(new InputStreamReader(accept.getInputStream()));
-                    String line = reader.readLine();
-                    while (line != null) {
-                        line = reader.readLine();
-                        latch.countDown();
+                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
+                        while (reader.readLine() != null) {
+                            counter.incrementAndGet();
+                        }
                     }
                 })).start();
             }
@@ -68,17 +99,17 @@ public class WriteSocketTest extends JetTestSupport {
         JetInstance jetInstance = createJetMember();
         createJetMember();
         IStreamMap<Integer, String> map = jetInstance.getMap("map");
-        range(0, 1000).forEach(i -> map.put(i, i + "\n"));
+        range(0, ITEM_COUNT).forEach(i -> map.put(i, i + "\n"));
 
         DAG dag = new DAG();
         Vertex source = dag.newVertex("source", readMap("map"));
-        Vertex sink = dag.newVertex("sink", writeSocket(HOST, PORT));
+        Vertex sink = dag.newVertex("sink", writeSocket("localhost", serverSocket.getLocalPort()));
 
         dag.edge(between(source, sink));
 
         jetInstance.newJob(dag).execute().get();
-        assertOpenEventually(latch);
-        socket.close();
+        serverSocket.close();
+        assertEquals(ITEM_COUNT, counter.get());
     }
 
 }


### PR DESCRIPTION
- rename `streamTextSocket()` to `streamSocket()`: analogous to other "text" connectors
- add `toStringF` and `charset` parameters to `writeSocket()`
- fix closing of socket & file when the job is cancelled