### PR TITLE
Fail fast when adding non-serializable processor supplier

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Edge.java
@@ -30,6 +30,7 @@ import java.io.Serializable;
 
 import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
 import static com.hazelcast.jet.Partitioner.defaultPartitioner;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 /**
  * Represents an edge between two {@link Vertex vertices} in a {@link DAG}.
@@ -239,6 +240,8 @@ public class Edge implements IdentifiedDataSerializable {
      * is applied to the result of the {@code keyExtractor} function.
      */
     public <T, K> Edge partitioned(DistributedFunction<T, K> keyExtractor, Partitioner<? super K> partitioner) {
+        checkSerializable(keyExtractor, "keyExtractor");
+        checkSerializable(partitioner, "partitioner");
         this.routingPolicy = RoutingPolicy.PARTITIONED;
         this.partitioner = new KeyPartitioner<>(keyExtractor, partitioner);
         return this;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Vertex.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Vertex.java
@@ -26,7 +26,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Vertex.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Vertex.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 
+import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -74,11 +75,7 @@ public class Vertex implements IdentifiedDataSerializable {
      * @param processorSupplier the simple, parameterless supplier of {@code Processor} instances
      */
     public Vertex(@Nonnull String name, @Nonnull DistributedSupplier<? extends Processor> processorSupplier) {
-        checkNotNull(name, "name");
-        checkNotNull(processorSupplier, "supplier");
-
-        this.supplier = ProcessorMetaSupplier.of(processorSupplier);
-        this.name = name;
+        this(name, ProcessorMetaSupplier.of(processorSupplier));
     }
 
     /**
@@ -88,11 +85,7 @@ public class Vertex implements IdentifiedDataSerializable {
      * @param processorSupplier the supplier of {@code Processor} instances which will be used on all members
      */
     public Vertex(@Nonnull String name, @Nonnull ProcessorSupplier processorSupplier) {
-        checkNotNull(name, "name");
-        checkNotNull(processorSupplier, "supplier");
-
-        this.supplier = ProcessorMetaSupplier.of(processorSupplier);
-        this.name = name;
+        this(name, ProcessorMetaSupplier.of(processorSupplier));
     }
 
     /**
@@ -105,6 +98,7 @@ public class Vertex implements IdentifiedDataSerializable {
     public Vertex(@Nonnull String name, @Nonnull ProcessorMetaSupplier metaSupplier) {
         checkNotNull(name, "name");
         checkNotNull(metaSupplier, "supplier");
+        checkSerializable(metaSupplier, "metaSupplier");
 
         this.supplier = metaSupplier;
         this.name = name;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedComparator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedComparator.java
@@ -29,7 +29,7 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 /**
  * A comparison function, which imposes a <i>total ordering</i> on some

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -40,6 +40,7 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 
 import static com.hazelcast.jet.impl.util.Util.getJetInstance;
+import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -81,6 +82,7 @@ public final class ExecutionPlanBuilder {
             int procIdxOffset = 0;
             for (Entry<Member, ExecutionPlan> e : plans.entrySet()) {
                 final ProcessorSupplier processorSupplier = procSupplierFn.apply(e.getKey().getAddress());
+                checkSerializable(processorSupplier, "ProcessorSupplier in vertex " + vertex.getName());
                 final VertexDef vertexDef = new VertexDef(vertexId, vertex.getName(), processorSupplier,
                         procIdxOffset, localParallelism);
                 vertexDef.addInboundEdges(inbound);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -40,7 +40,7 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 
 import static com.hazelcast.jet.impl.util.Util.getJetInstance;
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -165,23 +165,23 @@ public final class Util {
     }
 
     /**
-     * Checks, that {@code argument} implements {@link Serializable}.
-     * It also checks, if the {@code argument} is actually serializable by trying to serialize it.
-     * This will reveal early, if all it's fields are serializable.
+     * Checks that the {@code object} implements {@link Serializable} and is
+     * correctly serializable by actually trying to serialize it. This will
+     * reveal some non-serializable field early.
      *
-     * @param argument Object to check
-     * @param argumentName Argument name for the exception
-     * @throws IllegalArgumentException If {@code argument} is not serializable.
+     * @param object object to check
+     * @param objectName object description for the exception
+     * @throws IllegalArgumentException if {@code object} is not serializable
      */
-    public static void checkSerializable(Object argument, String argumentName) {
-        if (argument != null) {
-            if (!(argument instanceof Serializable)) {
-                throw new IllegalArgumentException("\"" + argumentName + "\" must be serializable");
+    public static void checkSerializable(Object object, String objectName) {
+        if (object != null) {
+            if (!(object instanceof Serializable)) {
+                throw new IllegalArgumentException("\"" + objectName + "\" must be serializable");
             }
             try  (ObjectOutputStream os  = new ObjectOutputStream(new NullOutputStream())) {
-                os.writeObject(argument);
+                os.writeObject(object);
             } catch (NotSerializableException | InvalidClassException e) {
-                throw new IllegalArgumentException("\"" + argumentName + "\" must be serializable", e);
+                throw new IllegalArgumentException("\"" + objectName + "\" must be serializable", e);
             } catch (IOException e) {
                 // never really thrown, as the underlying stream never throws it
                 throw new RuntimeException(e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/StreamUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/StreamUtil.java
@@ -86,12 +86,12 @@ public final class StreamUtil {
     public static void checkSerializable(Object argument, String argumentName) {
         if (argument != null) {
             if (!(argument instanceof Serializable)) {
-                throw new IllegalArgumentException("Argument \"" + argumentName + "\" must be serializable");
+                throw new IllegalArgumentException("\"" + argumentName + "\" must be serializable");
             }
             try  (ObjectOutputStream os  = new ObjectOutputStream(new NullOutputStream())) {
                 os.writeObject(argument);
             } catch (NotSerializableException | InvalidClassException e) {
-                throw new IllegalArgumentException("Argument \"" + argumentName + "\" must be serializable", e);
+                throw new IllegalArgumentException("\"" + argumentName + "\" must be serializable", e);
             } catch (IOException e) {
                 // never really thrown, as the underlying stream never throws it
                 throw new RuntimeException(e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/StreamUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/StreamUtil.java
@@ -22,12 +22,6 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.stream.impl.pipeline.StreamContext;
 import com.hazelcast.util.UuidUtil;
 
-import java.io.IOException;
-import java.io.InvalidClassException;
-import java.io.NotSerializableException;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
-import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.concurrent.ExecutionException;
 
@@ -74,35 +68,4 @@ public final class StreamUtil {
         return UuidUtil.newUnsecureUUID().toString();
     }
 
-    /**
-     * Checks, that {@code argument} implements {@link Serializable}.
-     * It also checks, if the {@code argument} is actually serializable by trying to serialize it.
-     * This will reveal early, if all it's fields are serializable.
-     *
-     * @param argument Object to check
-     * @param argumentName Argument name for the exception
-     * @throws IllegalArgumentException If {@code argument} is not serializable.
-     */
-    public static void checkSerializable(Object argument, String argumentName) {
-        if (argument != null) {
-            if (!(argument instanceof Serializable)) {
-                throw new IllegalArgumentException("\"" + argumentName + "\" must be serializable");
-            }
-            try  (ObjectOutputStream os  = new ObjectOutputStream(new NullOutputStream())) {
-                os.writeObject(argument);
-            } catch (NotSerializableException | InvalidClassException e) {
-                throw new IllegalArgumentException("\"" + argumentName + "\" must be serializable", e);
-            } catch (IOException e) {
-                // never really thrown, as the underlying stream never throws it
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    private static class NullOutputStream extends OutputStream {
-        @Override
-        public void write(int b) throws IOException {
-            // do nothing
-        }
-    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/AbstractPipeline.java
@@ -52,7 +52,7 @@ import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Traversers.traverseStream;
 import static com.hazelcast.jet.stream.DistributedCollectors.toIList;
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 import static com.hazelcast.util.Preconditions.checkTrue;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/DoublePipeline.java
@@ -45,7 +45,7 @@ import java.util.function.Supplier;
 import java.util.stream.DoubleStream;
 import java.util.stream.Stream;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
 @SuppressWarnings("checkstyle:methodcount")

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/IntPipeline.java
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
 @SuppressWarnings("checkstyle:methodcount")

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/LongPipeline.java
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
 @SuppressWarnings("checkstyle:methodcount")

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/PeekPipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/stream/impl/pipeline/PeekPipeline.java
@@ -18,13 +18,13 @@ package com.hazelcast.jet.stream.impl.pipeline;
 
 import com.hazelcast.core.IList;
 import com.hazelcast.jet.DAG;
-import com.hazelcast.jet.processor.Sinks;
 import com.hazelcast.jet.Vertex;
-import com.hazelcast.jet.stream.impl.StreamUtil;
+import com.hazelcast.jet.processor.Sinks;
 
 import java.util.function.Consumer;
 
 import static com.hazelcast.jet.Edge.from;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.stream.impl.StreamUtil.uniqueListName;
 
 class PeekPipeline<T> extends AbstractIntermediatePipeline<T, T> {
@@ -33,7 +33,7 @@ class PeekPipeline<T> extends AbstractIntermediatePipeline<T, T> {
 
     PeekPipeline(StreamContext context, Pipeline<T> upstream, Consumer<? super T> consumer) {
         super(context, upstream.isOrdered(), upstream);
-        StreamUtil.checkSerializable(consumer, "consumer");
+        checkSerializable(consumer, "consumer");
         this.consumer = consumer;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedComparatorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedComparatorTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.jet.stream.impl.StreamUtil.checkSerializable;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 @Category(QuickTest.class)
 @RunWith(HazelcastParallelClassRunner.class)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
@@ -120,21 +120,7 @@ public class WriteBufferedPTest extends JetTestSupport {
         );
     }
 
-    private static class MyAbstractProcessor extends AbstractProcessor {
-        @Override
-        public boolean complete() {
-            // sleep forever - we'll cancel the job
-            try {
-                Thread.sleep(Long.MAX_VALUE);
-            } catch (InterruptedException e) {
-                fail();
-            }
-            return false;
-        }
-    }
-
     private static class SleepForeverProcessor extends AbstractProcessor {
-
         SleepForeverProcessor() {
             setCooperative(false);
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 
-import static com.hazelcast.jet.processor.Processors.nonCooperative;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -90,18 +89,7 @@ public class WriteBufferedPTest extends JetTestSupport {
         JetInstance instance = createJetMember();
         try {
             DAG dag = new DAG();
-            Vertex source = dag.newVertex("source", nonCooperative(() -> new AbstractProcessor() {
-                @Override
-                public boolean complete() {
-                    // sleep forever - we'll cancel the job
-                    try {
-                        Thread.sleep(Long.MAX_VALUE);
-                    } catch (InterruptedException e) {
-                        fail();
-                    }
-                    return false;
-                }
-            }));
+            Vertex source = dag.newVertex("source", SleepForeverProcessor::new);
             Vertex sink = dag.newVertex("sink", getLoggingBufferedWriter()).localParallelism(1);
 
             dag.edge(Edge.between(source, sink));
@@ -120,14 +108,46 @@ public class WriteBufferedPTest extends JetTestSupport {
 
     private ProcessorSupplier getLoggingBufferedWriter() {
         // returns a processor that will not write anywhere, just log the events instead
+        List<String> localEvents = events;
         return Sinks.writeBuffered(
                 idx -> {
-                    events.add("new");
+                    localEvents.add("new");
                     return null;
                 },
-                (buffer, item) -> events.add("add:" + item),
-                buffer -> events.add("flush"),
-                buffer -> events.add("dispose")
+                (buffer, item) -> localEvents.add("add:" + item),
+                buffer -> localEvents.add("flush"),
+                buffer -> localEvents.add("dispose")
         );
+    }
+
+    private static class MyAbstractProcessor extends AbstractProcessor {
+        @Override
+        public boolean complete() {
+            // sleep forever - we'll cancel the job
+            try {
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException e) {
+                fail();
+            }
+            return false;
+        }
+    }
+
+    private static class SleepForeverProcessor extends AbstractProcessor {
+
+        SleepForeverProcessor() {
+            setCooperative(false);
+        }
+
+        @Override
+        public boolean complete() {
+            // sleep forever - we'll cancel the job
+            try {
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException e) {
+                fail();
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
ProcessorMetaSupplier must be serializable. Out-of-the-box metasuppliers can become non-serializable if they are passed a non-serializable lambda. Currently the job fails if run on multiple instances and the problem is harder to spot, because it fails when serializing the ExecutionPlan, which might contain lot of lambda expressions.

This PR makes this problem easier to spot and will also make the job fail even when using single Jet member.