### PR TITLE
Fix class unloading

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -37,12 +37,6 @@ import static com.hazelcast.jet.impl.config.XmlJetConfigBuilder.getClientConfig;
  */
 public final class Jet {
 
-    static {
-        // This cache interferes loading and unloading classes with JetClassLoader
-        // and needs to be disabled.
-        System.setProperty("hazelcast.compat.classloading.cache.disabled", "true");
-    }
-
     private Jet() {
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -37,6 +37,12 @@ import static com.hazelcast.jet.impl.config.XmlJetConfigBuilder.getClientConfig;
  */
 public final class Jet {
 
+    static {
+        // This cache interferes loading and unloading classes with JetClassLoader
+        // and needs to be disabled.
+        System.setProperty("hazelcast.compat.classloading.cache.disabled", "true");
+    }
+
     private Jet() {
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
@@ -16,11 +16,7 @@
 
 package com.hazelcast.jet.config;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
+import javax.annotation.Nonnull;
 
 /**
  * General configuration options pertaining to a Jet instance.
@@ -52,7 +48,7 @@ public class InstanceConfig {
     }
 
     /**
-     * Sets the directory where Jet can place its temporary working files.
+     * Sets the directory where Jet can place its temporary working directories.
      */
     public InstanceConfig setTempDir(String tempDir) {
         this.tempDir = tempDir;
@@ -60,19 +56,12 @@ public class InstanceConfig {
     }
 
     /**
-     * Returns Jet's temp directory.
+     * Returns Jet's temp directory. Defaults to {@code java.io.tmpdir} system
+     * property.
      */
+    @Nonnull
     public String getTempDir() {
-        if (tempDir == null) {
-            try {
-                Path tempDirectory = Files.createTempDirectory("hazelcast-jet");
-                tempDirectory.toFile().deleteOnExit();
-                tempDir = tempDirectory.toString();
-            } catch (IOException e) {
-                throw rethrow(e);
-            }
-        }
-        return tempDir;
+        return tempDir == null ? System.getProperty("java.io.tmpdir") : tempDir;
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AggregateOperationImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AggregateOperationImpl.java
@@ -31,6 +31,11 @@ public class AggregateOperationImpl<T, A, R> implements AggregateOperation<T, A,
     private final DistributedBiConsumer<? super A, ? super A> deductAccumulatorF;
     private final DistributedFunction<? super A, R> finishAccumulationF;
 
+    /**
+     * Use {@link AggregateOperation#of(DistributedSupplier,
+     * DistributedBiConsumer, DistributedBiConsumer, DistributedBiConsumer,
+     * DistributedFunction)} instead.
+     */
     public AggregateOperationImpl(
             @Nonnull DistributedSupplier<A> createAccumulatorF,
             @Nonnull DistributedBiConsumer<? super A, T> accumulateItemF,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -48,6 +48,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PacketHandler;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Map;
@@ -155,6 +156,9 @@ public class JetService
         if (context != null) {
             context.complete(error);
         }
+        classLoaders.remove(executionId);
+        ResourceStore store = resourceStores.remove(executionId);
+        store.destroy();
     }
 
     public JetInstance getJetInstance() {
@@ -171,7 +175,7 @@ public class JetService
 
     public ResourceStore getResourceStore(long executionId) {
         return resourceStores.computeIfAbsent(executionId,
-                k -> new ResourceStore(config.getInstanceConfig().getTempDir()));
+                k -> new ResourceStore(Paths.get(config.getInstanceConfig().getTempDir(), String.valueOf(executionId))));
     }
 
     public ClassLoader getClassLoader(long executionId) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -56,6 +56,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.hazelcast.jet.impl.util.Util.uncheckCall;
+
 public class JetService
         implements ManagedService, ConfigurableService<JetConfig>, PacketHandler, LiveOperationsTracker,
         CanCancelOperations, MembershipAwareService {
@@ -175,8 +177,8 @@ public class JetService
 
     public ResourceStore getResourceStore(long executionId) {
         return resourceStores.computeIfAbsent(executionId,
-                k -> new ResourceStore(Paths.get(config.getInstanceConfig().getTempDir(), String.valueOf(executionId))));
-    }
+                k -> uncheckCall(() -> new ResourceStore(Paths.get(config.getInstanceConfig().getTempDir()), nodeEngine)));
+}
 
     public ClassLoader getClassLoader(long executionId) {
         return classLoaders.computeIfAbsent(executionId, k -> AccessController.doPrivileged(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/ResourceStore.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/ResourceStore.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.impl.deployment;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.util.UuidUtil;
 
 import java.io.BufferedInputStream;
@@ -51,7 +51,7 @@ public class ResourceStore {
     private final Map<String, ClassLoaderEntry> dataEntries = new ConcurrentHashMap<>();
     private final Map<String, ClassLoaderEntry> classEntries = new ConcurrentHashMap<>();
 
-    public ResourceStore(Path rootDir, NodeEngineImpl nodeEngine) {
+    public ResourceStore(Path rootDir, NodeEngine nodeEngine) {
         this.log = nodeEngine.getLogger(getClass());
         this.storageDirectory = uncheckCall(() -> Files.createTempDirectory(rootDir, "hazelcast-jet-resources"));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -76,13 +76,15 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
 
     private Address[] partitionOwners;
     private List<VertexDef> vertices = new ArrayList<>();
+
     private final Map<String, ConcurrentConveyor<Object>[]> localConveyorMap = new HashMap<>();
     private final Map<String, Map<Address, ConcurrentConveyor<Object>>> edgeSenderConveyorMap = new HashMap<>();
+    private final List<Processor> processors = new ArrayList<>();
+
     private PartitionArrangement ptionArrgmt;
 
     private NodeEngine nodeEngine;
     private long executionId;
-
 
     ExecutionPlan() {
     }
@@ -109,7 +111,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
 
                 // Disabled due to causing memory leak: it keeps referencing the p.getClass()
                 // and prevents the classloader from being unloaded.
-                // TODO re-enable once the fix is merged to Hazelcast and released
+                // TODO re-enable after 3.8.3 with PR #10725 is released
                 // String probePrefix = String.format("jet.job.%d.%s#%d", executionId, srcVertex.name(), processorIdx);
                 // ((NodeEngineImpl) nodeEngine).getMetricsRegistry().scanAndRegister(p, probePrefix);
 
@@ -121,6 +123,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                         ? new CooperativeProcessorTasklet(context, p, inboundStreams, outboundStreams)
                         : new BlockingProcessorTasklet(context, p, inboundStreams, outboundStreams)
                 );
+                processors.add(p);
                 processorIdx++;
             }
         }
@@ -389,5 +392,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         return inboundStreams;
     }
 
+    public List<Processor> getProcessors() {
+        return processors;
+    }
 }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -45,7 +45,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;
 
 import java.io.IOException;
@@ -107,8 +106,12 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                         nodeEngine.getLogger(p.getClass().getName() + '.' + srcVertex.name() + '#' + processorIdx);
                 ProcCtx context =
                         new ProcCtx(instance, logger, srcVertex.name(), processorIdx + srcVertex.getProcIdxOffset());
-                String probePrefix = String.format("jet.job.%d.%s#%d", executionId, srcVertex.name(), processorIdx);
-                ((NodeEngineImpl) nodeEngine).getMetricsRegistry().scanAndRegister(p, probePrefix);
+
+                // Disabled due to causing memory leak: it keeps referencing the p.getClass()
+                // and prevents the classloader from being unloaded.
+                // String probePrefix = String.format("jet.job.%d.%s#%d", executionId, srcVertex.name(), processorIdx);
+                // ((NodeEngineImpl) nodeEngine).getMetricsRegistry().scanAndRegister(p, probePrefix);
+
                 // createOutboundEdgeStreams() populates localConveyorMap and edgeSenderConveyorMap.
                 // Also populates instance fields: senderMap, receiverMap, tasklets.
                 List<OutboundEdgeStream> outboundStreams = createOutboundEdgeStreams(srcVertex, processorIdx);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -109,6 +109,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
 
                 // Disabled due to causing memory leak: it keeps referencing the p.getClass()
                 // and prevents the classloader from being unloaded.
+                // TODO re-enable once the fix is merged to Hazelcast and released
                 // String probePrefix = String.format("jet.job.%d.%s#%d", executionId, srcVertex.name(), processorIdx);
                 // ((NodeEngineImpl) nodeEngine).getMetricsRegistry().scanAndRegister(p, probePrefix);
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -111,7 +111,7 @@ public final class Util {
     }
 
     @Nonnull
-    public static byte[] read(@Nonnull InputStream in) throws IOException {
+    public static byte[] readFully(@Nonnull InputStream in) throws IOException {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             byte[] b = new byte[BUFFER_SIZE];
             for (int len; (len = in.read(b)) != -1; ) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.nio.Address;
@@ -178,20 +179,20 @@ public final class Util {
             if (!(object instanceof Serializable)) {
                 throw new IllegalArgumentException("\"" + objectName + "\" must be serializable");
             }
-            try  (ObjectOutputStream os  = new ObjectOutputStream(new NullOutputStream())) {
+            try  (ObjectOutputStream os = new ObjectOutputStream(new NullOutputStream())) {
                 os.writeObject(object);
             } catch (NotSerializableException | InvalidClassException e) {
                 throw new IllegalArgumentException("\"" + objectName + "\" must be serializable", e);
             } catch (IOException e) {
                 // never really thrown, as the underlying stream never throws it
-                throw new RuntimeException(e);
+                throw new JetException(e);
             }
         }
     }
 
     private static class NullOutputStream extends OutputStream {
         @Override
-        public void write(int b) throws IOException {
+        public void write(int b) {
             // do nothing
         }
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ProcessorsTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet;
 
 import com.hazelcast.jet.Processor.Context;
 import com.hazelcast.jet.function.DistributedSupplier;
-import com.hazelcast.jet.impl.AggregateOperationImpl;
 import com.hazelcast.jet.impl.util.ArrayDequeInbox;
 import com.hazelcast.jet.impl.util.ArrayDequeOutbox;
 import com.hazelcast.jet.impl.util.ProgressTracker;
@@ -297,7 +296,7 @@ public class ProcessorsTest {
     }
 
     private static <T> AggregateOperation<T, List<T>, String> aggregateToListAndString() {
-        return new AggregateOperationImpl<>(
+        return AggregateOperation.of(
                 ArrayList::new,
                 List::add,
                 List::addAll,

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/config/XmlConfigTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/config/XmlConfigTest.java
@@ -69,7 +69,7 @@ public class XmlConfigTest {
         File tempFile = File.createTempFile("jet", ".xml");
         try (FileOutputStream os = new FileOutputStream(tempFile)) {
             InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(TEST_XML_1);
-            os.write(Util.read(resourceAsStream));
+            os.write(Util.readFully(resourceAsStream));
         }
 
         Properties properties = new Properties();
@@ -89,7 +89,7 @@ public class XmlConfigTest {
         File tempFile = File.createTempFile("imdg", ".xml");
         try (FileOutputStream os = new FileOutputStream(tempFile)) {
             InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(TEST_XML_2);
-            os.write(Util.read(resourceAsStream));
+            os.write(Util.readFully(resourceAsStream));
         }
 
         Properties properties = new Properties();


### PR DESCRIPTION
There were 3 references to JetClassLoader kept:

- from `JetService` by not cleaning the `JetClassLoader` and
`resourceStores` map

- from `ClassLoaderWeakCache`, which keeps reference to class loader as
a key

- from MetricsRegistry, because it keeps references to Class objects
