### PR TITLE
Fix NPE when releasing uninitialized ResourceStore

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/TimestampedEntry.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/TimestampedEntry.java
@@ -17,6 +17,8 @@
 package com.hazelcast.jet;
 
 import javax.annotation.Nonnull;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Map;
 
 /**
@@ -82,6 +84,8 @@ public final class TimestampedEntry<K, V> implements Map.Entry<K, V> {
 
     @Override
     public String toString() {
-        return "TimestampedEntry{timestamp=" + timestamp + ", key=" + key + ", value=" + value + '}';
+        return "TimestampedEntry{timestamp="
+                + Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).toLocalTime()
+                + ", key=" + key + ", value=" + value + '}';
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Watermark.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Watermark.java
@@ -17,6 +17,8 @@
 package com.hazelcast.jet;
 
 import java.io.Serializable;
+import java.time.Instant;
+import java.time.ZoneId;
 
 /**
  * Watermark is an item occasionally inserted into a disordered
@@ -58,6 +60,6 @@ public final class Watermark implements Serializable {
 
     @Override
     public String toString() {
-        return "Watermark{timestamp=" + timestamp + '}';
+        return "Watermark{timestamp=" + Instant.ofEpochMilli(timestamp).atZone(ZoneId.systemDefault()).toLocalTime() + '}';
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -160,7 +160,9 @@ public class JetService
         }
         classLoaders.remove(executionId);
         ResourceStore store = resourceStores.remove(executionId);
-        store.destroy();
+        if (store != null) {
+            store.destroy();
+        }
     }
 
     public JetInstance getJetInstance() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.processor;
 
 import com.hazelcast.jet.Processor.Context;
+import com.hazelcast.jet.Watermark;
 import com.hazelcast.jet.impl.util.ArrayDequeOutbox;
 import com.hazelcast.jet.impl.util.ProgressTracker;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -130,7 +131,7 @@ public class InsertWatermarksPTest {
             clock.advance();
         }
 
-        assertEquals(toString(Arrays.asList(expected)), toString(resultToCheck));
+        assertEquals(listToString(Arrays.asList(expected)), listToString(resultToCheck));
     }
 
     private void tryProcessAndDrain(Item item) throws Exception {
@@ -141,11 +142,17 @@ public class InsertWatermarksPTest {
 
     private void drainOutbox() {
         for (Object o; (o = outbox.queueWithOrdinal(0).poll()) != null; ) {
-            resultToCheck.add(o.toString());
+            resultToCheck.add(myToString(o));
         }
     }
 
-    private static String toString(List<String> actual) {
+    private String myToString(Object o) {
+        return o instanceof Watermark
+                ? "Watermark{timestamp=" + ((Watermark) o).timestamp() + "}"
+                : o.toString();
+    }
+
+    private static String listToString(List<String> actual) {
         return actual.stream().collect(Collectors.joining("\n"));
     }
 


### PR DESCRIPTION
ResourceStore is lazily initialized, it might happen that job completes
before it happens. In my case, missing class (that should have been
added with addClass()) caused it.

Also includes unrelated formatting of timestamp in TimestampedEntry.