### PR TITLE
Simplify adjacency map logic

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/TopologicalSorter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/TopologicalSorter.java
@@ -28,7 +28,6 @@ import java.util.function.Function;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.stream.DistributedCollectors.toList;
 import static java.lang.Math.min;
-import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
 
@@ -69,12 +68,6 @@ public final class TopologicalSorter<V> {
     public static <V> Iterable<V> topologicalSort(
             @Nonnull Map<V, List<V>> adjacencyMap, @Nonnull Function<V, String> vertexNameFn
     ) {
-        // fill in missing map entries
-        adjacencyMap.values().stream()
-                    .flatMap(List::stream)
-                    .collect(toList())
-                    .forEach(v -> adjacencyMap.putIfAbsent(v, emptyList()));
-
         // decorate all the vertices with Tarjan vertices, which hold the
         // metadata needed by the algorithm
         Map<V, TarjanVertex<V>> tarjanVertices =

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/impl/AbstractStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/impl/AbstractStage.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.jet.pipeline.impl;
 
-import com.hazelcast.jet.pipeline.Stage;
 import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Stage;
 import com.hazelcast.jet.pipeline.Transform;
 
 import java.util.List;
@@ -28,10 +28,11 @@ public abstract class AbstractStage implements Stage {
     final List<Stage> upstream;
     final Transform transform;
 
-    AbstractStage(List<Stage> upstream, Transform transform, PipelineImpl pipelineImpl) {
+    AbstractStage(List<Stage> upstream, List<Stage> downstream, Transform transform, PipelineImpl pipelineImpl) {
         this.upstream = upstream;
         this.transform = transform;
         this.pipelineImpl = pipelineImpl;
+        pipelineImpl.register(this, downstream);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/impl/ComputeStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/impl/ComputeStageImpl.java
@@ -25,14 +25,12 @@ import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedPredicate;
 import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.jet.pipeline.ComputeStage;
-import com.hazelcast.jet.pipeline.SinkStage;
 import com.hazelcast.jet.pipeline.JoinClause;
-import com.hazelcast.jet.pipeline.impl.transform.MultiTransform;
 import com.hazelcast.jet.pipeline.Sink;
+import com.hazelcast.jet.pipeline.SinkStage;
 import com.hazelcast.jet.pipeline.Source;
 import com.hazelcast.jet.pipeline.Stage;
 import com.hazelcast.jet.pipeline.Transform;
-import com.hazelcast.jet.pipeline.impl.transform.UnaryTransform;
 import com.hazelcast.jet.pipeline.datamodel.Tuple2;
 import com.hazelcast.jet.pipeline.datamodel.Tuple3;
 import com.hazelcast.jet.pipeline.impl.transform.CoGroupTransform;
@@ -41,7 +39,9 @@ import com.hazelcast.jet.pipeline.impl.transform.FlatMapTransform;
 import com.hazelcast.jet.pipeline.impl.transform.GroupByTransform;
 import com.hazelcast.jet.pipeline.impl.transform.HashJoinTransform;
 import com.hazelcast.jet.pipeline.impl.transform.MapTransform;
+import com.hazelcast.jet.pipeline.impl.transform.MultiTransform;
 import com.hazelcast.jet.pipeline.impl.transform.ProcessorTransform;
+import com.hazelcast.jet.pipeline.impl.transform.UnaryTransform;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,8 +57,7 @@ import static java.util.stream.Collectors.toList;
 public class ComputeStageImpl<E> extends AbstractStage implements ComputeStage<E> {
 
     ComputeStageImpl(List<Stage> upstream, Transform transform, PipelineImpl pipeline) {
-        super(upstream, transform, pipeline);
-        pipeline.adjacencyMap.put(this, new ArrayList<>());
+        super(upstream, new ArrayList<>(), transform, pipeline);
     }
 
     ComputeStageImpl(Source<E> source, PipelineImpl pipeline) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/impl/SinkStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/impl/SinkStageImpl.java
@@ -16,15 +16,16 @@
 
 package com.hazelcast.jet.pipeline.impl;
 
-import com.hazelcast.jet.pipeline.SinkStage;
 import com.hazelcast.jet.pipeline.Sink;
+import com.hazelcast.jet.pipeline.SinkStage;
 import com.hazelcast.jet.pipeline.Stage;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 class SinkStageImpl extends AbstractStage implements SinkStage {
 
     SinkStageImpl(Stage upstream, Sink transform, PipelineImpl pipeline) {
-        super(singletonList(upstream), transform, pipeline);
+        super(singletonList(upstream), emptyList(), transform, pipeline);
     }
 }


### PR DESCRIPTION
TopologicalSorter now demands a fully populated map: every vertex appearing in some value must appear as a key as well.

PipelineImpl now makes a safe copy of its adjacency map.