### PR TITLE
Log if current cluster quorum value passes quorum value of a jet job

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -217,6 +217,7 @@ public class JetService
 
     @Override
     public void memberAdded(MembershipServiceEvent event) {
+        jobCoordinationService.checkQuorumValues();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -127,6 +127,19 @@ public class JobCoordinationService {
         return masterContext.completionFuture();
     }
 
+    void checkQuorumValues() {
+        int currentQuorumSize = getQuorumSize();
+        for (JobRecord jobRecord : jobRepository.getJobRecords()) {
+            if (jobRecord.getConfig().isSplitBrainProtectionEnabled()) {
+                if (currentQuorumSize > jobRecord.getQuorumSize()) {
+                    logger.warning("Current quorum size: " + currentQuorumSize
+                            + " of cluster is larger than quorum size: " + jobRecord.getQuorumSize() + " of job "
+                            + idToString(jobRecord.getJobId()));
+                }
+            }
+        }
+    }
+
     /**
      * Starts the job if it is not already started or completed. Returns a future which represents result of the job.
      */

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -104,7 +104,8 @@ public class ExecutionLifecycleTest extends JetTestSupport {
                 Integer.toString(TIMEOUT_MILLIS));
         config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
         instance = factory.newMember(config);
-        factory.newMember(config);
+        JetInstance instance2 = factory.newMember(config);
+        warmUpPartitions(instance.getHazelcastInstance(), instance2.getHazelcastInstance());
     }
 
     @After

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
@@ -128,6 +128,11 @@ public abstract class JetSplitBrainTestSupport extends JetTestSupport {
             JetInstance hz = createJetMember(config);
             instances[i] = hz;
         }
+
+        for (JetInstance instance : instances) {
+            warmUpPartitions(instance.getHazelcastInstance());
+        }
+
         return instances;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -81,6 +81,8 @@ public class JobTest extends JetTestSupport {
         config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
         instance1 = factory.newMember(config);
         instance2 = factory.newMember(config);
+
+        warmUpPartitions(instance1.getHazelcastInstance(), instance2.getHazelcastInstance());
     }
 
     @After

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -140,6 +140,10 @@ public class TopologyChangeTest extends JetTestSupport {
 
             instances[i] = factory.newMember(config);
         }
+
+        for (JetInstance instance : instances) {
+            warmUpPartitions(instance.getHazelcastInstance());
+        }
     }
 
     @After


### PR DESCRIPTION
If a job enables split brain protection, JobCoordinationService prints a log when the current quorum value of the cluster becomes bigger than quorum value of the job. The log is printed because the job loses its split brain protection feature in this case. If the cluster splits into partitions, the job can be successfully restarted on both sides.