### PR TITLE
Delay job start if cluster is not safe

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobImpl.java
@@ -106,16 +106,17 @@ public abstract class AbstractJobImpl implements Job {
             long jobId = getJobId();
             if (isSplitBrainMerge(t)) {
                 String msg = "Job " + idToString(jobId) + " failed because the cluster is performing split-brain merge";
-                logger.fine(msg);
+                logger.fine(msg, t);
                 future.completeExceptionally(new CancellationException(msg));
             } else if (isRestartable(t)) {
                 try {
                     Address masterAddress = getMasterAddress();
                     if (masterAddress == null) {
                         // job data will be cleaned up eventually by coordinator
-                        String msg = "Job " + idToString(jobId) + " failed because cannot talk to the coordinator node";
-                        logger.fine(msg);
-                        future.completeExceptionally(new IllegalStateException(msg));
+                        String msg = "Job " + idToString(jobId) + " failed because the cluster is performing "
+                                + " split-brain merge and coordinator is not known";
+                        logger.fine(msg, t);
+                        future.completeExceptionally(new CancellationException(msg));
                         return;
                     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -258,8 +258,7 @@ public class MasterContext {
             return false;
         }
 
-        logger.fine("Rescheduling job " + idToString(jobId) + " restart since quorum size " + quorumSize
-                + " is not met");
+        logger.fine("Rescheduling restart of job " + idToString(jobId) + ": quorum size " + quorumSize + " is not met");
         scheduleRestart();
         return true;
     }
@@ -269,7 +268,7 @@ public class MasterContext {
             return false;
         }
 
-        logger.fine("Rescheduling job " + idToString(jobId) + " restart cluster is not safe");
+        logger.fine("Rescheduling restart of job " + idToString(jobId) + ": cluster is not safe");
         scheduleRestart();
         return true;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
@@ -18,16 +18,16 @@ package com.hazelcast.jet.benchmark;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
-import com.hazelcast.jet.core.AbstractProcessor;
-import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.Traverser;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.core.AbstractProcessor;
+import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
-import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.core.Vertex;
-import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -43,14 +43,13 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.Traversers.lazy;
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.jet.Util.entry;
-import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
+import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.processor.Processors.noop;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeMap;
-import static java.util.Arrays.asList;
+import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.assertEquals;
@@ -77,8 +76,6 @@ public class BackpressureTest extends JetTestSupport {
         factory = new JetTestInstanceFactory();
         jet1 = factory.newMember(config);
         jet2 = factory.newMember(config);
-        warmUpPartitions(asList(jet1.getHazelcastInstance(), jet2.getHazelcastInstance()));
-        assertEquals(2, jet1.getCluster().getMembers().size());
     }
 
     @After

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -104,9 +104,7 @@ public class ExecutionLifecycleTest extends JetTestSupport {
                 Integer.toString(TIMEOUT_MILLIS));
         config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
         instance = factory.newMember(config);
-        JetInstance instance2 = factory.newMember(config);
-        warmUpPartitions(instance.getHazelcastInstance(), instance2.getHazelcastInstance());
-        waitClusterForSafeState(instance.getHazelcastInstance());
+        factory.newMember(config);
     }
 
     @After

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
@@ -128,13 +128,6 @@ public abstract class JetSplitBrainTestSupport extends JetTestSupport {
             JetInstance hz = createJetMember(config);
             instances[i] = hz;
         }
-
-        for (JetInstance instance : instances) {
-            warmUpPartitions(instance.getHazelcastInstance());
-        }
-
-        waitClusterForSafeState(instances[0].getHazelcastInstance());
-
         return instances;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -92,8 +92,6 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         JetInstance[] instances = factory.newMembers(config, 2);
         instance1 = instances[0];
         instance2 = instances[1];
-        warmUpPartitions(instance1.getHazelcastInstance(), instance2.getHazelcastInstance());
-        waitClusterForSafeState(instance1.getHazelcastInstance());
     }
 
     @After

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -81,9 +81,6 @@ public class JobTest extends JetTestSupport {
         config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
         instance1 = factory.newMember(config);
         instance2 = factory.newMember(config);
-
-        warmUpPartitions(instance1.getHazelcastInstance(), instance2.getHazelcastInstance());
-        waitClusterForSafeState(instance1.getHazelcastInstance());
     }
 
     @After

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -140,12 +140,6 @@ public class TopologyChangeTest extends JetTestSupport {
 
             instances[i] = factory.newMember(config);
         }
-
-        for (JetInstance instance : instances) {
-            warmUpPartitions(instance.getHazelcastInstance());
-        }
-
-        waitClusterForSafeState(instances[0].getHazelcastInstance());
     }
 
     @After
@@ -384,6 +378,7 @@ public class TopologyChangeTest extends JetTestSupport {
             @Override
             public void run() throws Exception {
                 assertEquals(STARTING, masterContext.jobStatus());
+                assertNotEquals(0, masterContext.getExecutionId());
             }
         });
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
@@ -95,8 +95,6 @@ public class AsyncMapWriterTest extends JetTestSupport {
         writer = new AsyncMapWriter(nodeEngine);
         map = instance1.getMap("testMap");
         writer.setMapName(map.getName());
-
-        warmUpPartitions(instance1.getHazelcastInstance(), instance2.getHazelcastInstance());
     }
 
     @After


### PR DESCRIPTION
If the cluster is not safe when a job is submitted, it could happen that the job could be started before partition re-distribution is completed. To prevent such non-optimal runs, we delay starting execution of a job if the cluster is not safe at job submission time.

Recent `warmUpPartitions()` changes in the test classes are also reverted.