### PR TITLE
Add id field to BroadcastKey

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/BroadcastKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/BroadcastKey.java
@@ -18,6 +18,10 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.impl.execution.BroadcastKeyReference;
 
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.jet.impl.util.Util.secureRandomNextLong;
+
 /**
  * Marker interface for a key in the snapshot state that indicates the
  * corresponding entry should be broadcast to all processors
@@ -30,13 +34,19 @@ public interface BroadcastKey<K> {
     /**
      * Returns the underlying key
      */
+    @Nonnull
     K key();
 
     /**
-     * Returns a given key as a broadcast key
+     * Returns a given key as a broadcast key.
+     * <p>
+     * Note: Several processor instances can use the returned {@code BroadcastKey}
+     * with the same {@code key} to store unique values and the values will not
+     * overwrite each other. Upon a snapshot restore, each processor
+     * will receive multiple key-value pairs with the given BroadcastKey
      */
-    static <K> BroadcastKey<K> broadcastKey(K key) {
-        return new BroadcastKeyReference<>(key);
+    @Nonnull
+    static <K> BroadcastKey<K> broadcastKey(@Nonnull K key) {
+        return new BroadcastKeyReference<>(secureRandomNextLong(), key);
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -126,7 +126,7 @@ public interface Processor {
      * <p>
      * Non-cooperative processors are required to return from this method from
      * time to time to give the system a chance to check for snapshot requests
-     * job cancellation. The time the processor spends in this method affects
+     * and job cancellation. The time the processor spends in this method affects
      * the latency of snapshots and job cancellations.
      *
      * @return {@code true} if the completing step is now done, {@code false}
@@ -172,11 +172,6 @@ public interface Processor {
      * exhausted, it may also be called between {@link #complete()} calls. Once
      * {@code complete()} returns {@code true}, this method won't be called
      * anymore.
-     * <p>
-     * Processors must ensure they give a chance to the system to call this
-     * method. Especially, non-cooperative source processors must make sure not
-     * to spend too much time per invocation of {@code complete()}, as this
-     * will prolong the snapshotting phase and impede overall progress.
      * <p>
      * The default implementation takes no action and returns {@code true}.
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/SnapshotOutbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/SnapshotOutbox.java
@@ -18,8 +18,6 @@ package com.hazelcast.jet.core;
 
 import javax.annotation.CheckReturnValue;
 
-import static com.hazelcast.jet.core.BroadcastKey.broadcastKey;
-
 /**
  * An {@link Outbox} which is used for offering items to processor's state snapshot.
  * <p>
@@ -35,24 +33,15 @@ public interface SnapshotOutbox {
 
     /**
      * Offers the specified key and value pair to the processor's snapshot storage.
-     * State stored this way, once restored, will be distributed among all
-     * processor instances using default partitioning.
+     *
+     * During a snapshot restore the type of key offered determines which processors
+     * receive the key and value pair. If the key is of type {@link BroadcastKey},
+     * the entry will be restored to all processor instances.
+     * Otherwise, the key will be distributed according to default partitioning and
+     * only a single processor instance will receive the key.
      *
      * @return whether the outbox fully accepted the item
      */
     @CheckReturnValue
     boolean offer(Object key, Object value);
-
-    /**
-     * Offers the specified key and value pair to the processor's snapshot storage.
-     * State stored this way, once restored, will be broadcast to all
-     * processor instances, meaning all processor instances will receive
-     * all key and value pairs which were broadcast using this method.
-     *
-     * @return whether the outbox fully accepted the item
-     */
-    @CheckReturnValue
-    default boolean offerBroadcast(Object key, Object value) {
-        return offer(broadcastKey(key), value);
-    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/BroadcastKeyReference.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/BroadcastKeyReference.java
@@ -18,16 +18,26 @@ package com.hazelcast.jet.impl.execution;
 
 import com.hazelcast.jet.core.BroadcastKey;
 
+import javax.annotation.Nonnull;
+
 public class BroadcastKeyReference<K> implements BroadcastKey<K> {
+
+    private final long id;
     private final K key;
 
-    public BroadcastKeyReference(K key) {
+    public BroadcastKeyReference(long id, K key) {
+        this.id = id;
         this.key = key;
     }
 
+    @Nonnull
     @Override
     public K key() {
         return key;
+    }
+
+    public long id() {
+        return id;
     }
 
     @Override
@@ -40,16 +50,25 @@ public class BroadcastKeyReference<K> implements BroadcastKey<K> {
         }
 
         BroadcastKeyReference<?> that = (BroadcastKeyReference<?>) o;
-        return key.equals(that.key);
+
+        if (id != that.id) {
+            return false;
+        }
+        return key != null ? key.equals(that.key) : that.key == null;
     }
 
     @Override
     public int hashCode() {
-        return key.hashCode();
+        int result = (int) (id ^ (id >>> 32));
+        result = 31 * result + (key != null ? key.hashCode() : 0);
+        return result;
     }
 
     @Override
     public String toString() {
-        return key.toString();
+        return "BroadcastKey{" +
+                "id=" + id +
+                ", key=" + key +
+                '}';
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionSerializerHooks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionSerializerHooks.java
@@ -128,12 +128,13 @@ public class ExecutionSerializerHooks {
 
                 @Override
                 public void write(ObjectDataOutput out, BroadcastKeyReference object) throws IOException {
+                    out.writeLong(object.id());
                     out.writeObject(object.key());
                 }
 
                 @Override
                 public BroadcastKeyReference read(ObjectDataInput in) throws IOException {
-                    return new BroadcastKeyReference(in.readObject());
+                    return new BroadcastKeyReference(in.readLong(), in.readObject());
                 }
             };
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/serialization/SerializerHookConstants.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/serialization/SerializerHookConstants.java
@@ -28,27 +28,26 @@ public final class SerializerHookConstants {
     public static final int JET_RESERVED_SPACE_START = SerializationConstants.JET_SERIALIZER_FIRST;
 
     public static final int MAP_ENTRY = -300;
-    public static final int ARRAY_LIST = -301;
-    public static final int CUSTOM_CLASS_LOADED_OBJECT = -302;
-    public static final int OBJECT_ARRAY = -303;
-    public static final int TIMESTAMPED_ENTRY = -304;
-    public static final int LONG_ACC = -305;
-    public static final int DOUBLE_ACC = -306;
-    public static final int MUTABLE_REFERENCE = -307;
-    public static final int LIN_TREND_ACC = -308;
-    public static final int LONG_LONG_ACC = -309;
-    public static final int LONG_DOUBLE_ACC = -310;
-    public static final int TUPLE2 = -311;
-    public static final int TUPLE3 = -312;
-    public static final int TWO_BAGS = -313;
-    public static final int THREE_BAGS = -314;
-    public static final int TAG = -315;
-    public static final int ITEMS_BY_TAG = -316;
-    public static final int BAGS_BY_TAG = -317;
-    public static final int WATERMARK = -318;
-    public static final int SNAPSHOT_BARRIER = -319;
-    public static final int BROADCAST_ENTRY = -320;
-    public static final int BROADCAST_KEY_REFERENCE = -321;
+    public static final int CUSTOM_CLASS_LOADED_OBJECT = -301;
+    public static final int OBJECT_ARRAY = -302;
+    public static final int TIMESTAMPED_ENTRY = -303;
+    public static final int LONG_ACC = -304;
+    public static final int DOUBLE_ACC = -305;
+    public static final int MUTABLE_REFERENCE = -306;
+    public static final int LIN_TREND_ACC = -307;
+    public static final int LONG_LONG_ACC = -308;
+    public static final int LONG_DOUBLE_ACC = -309;
+    public static final int TUPLE2 = -310;
+    public static final int TUPLE3 = -311;
+    public static final int TWO_BAGS = -312;
+    public static final int THREE_BAGS = -313;
+    public static final int TAG = -314;
+    public static final int ITEMS_BY_TAG = -315;
+    public static final int BAGS_BY_TAG = -316;
+    public static final int WATERMARK = -317;
+    public static final int SNAPSHOT_BARRIER = -318;
+    public static final int BROADCAST_ENTRY = -319;
+    public static final int BROADCAST_KEY_REFERENCE = -320;
 
 
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ExecutionSerializerHooksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ExecutionSerializerHooksTest.java
@@ -51,7 +51,7 @@ public class ExecutionSerializerHooksTest {
         return Arrays.asList(
                 new SnapshotBarrier(17L),
                 new BroadcastEntry<>("key", "value"),
-                new BroadcastKeyReference<>("broadcast-key")
+                new BroadcastKeyReference<>(17L, "broadcast-key")
         );
     }
 


### PR DESCRIPTION
SlidingWindowP instances should save unique ‘nextWmToEmit’ values and
 validate they are all same on snapshot restore.