### PR TITLE
Make sure that all whenComplete calls wrap the callback in “withTryCatch”

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobImpl.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.idToString;
 
 public abstract class AbstractJobImpl implements Job {
@@ -68,11 +69,11 @@ public abstract class AbstractJobImpl implements Job {
         ICompletableFuture<Void> invocationFuture = sendJoinRequest(masterAddress);
         JobCallback callback = new JobCallback(invocationFuture);
         invocationFuture.andThen(callback);
-        future.whenComplete((aVoid, throwable) -> {
+        future.whenComplete(withTryCatch(logger, (aVoid, throwable) -> {
             if (throwable instanceof CancellationException) {
                 callback.cancel();
             }
-        });
+        }));
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -73,7 +73,7 @@ import static com.hazelcast.jet.impl.execution.SnapshotContext.NO_SNAPSHOT;
 import static com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject.deserializeWithCustomClassLoader;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isTopologicalFailure;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.safeWhenComplete;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static java.util.Collections.emptyList;
@@ -519,7 +519,7 @@ public class MasterContext {
         invokeOnParticipants(futures, doneFuture, operationCtor);
 
         // once all invocations return, notify the completion callback
-        doneFuture.whenComplete(safeWhenComplete(logger, (aVoid, throwable) -> {
+        doneFuture.whenComplete(withTryCatch(logger, (aVoid, throwable) -> {
             Map<MemberInfo, Object> responses = new HashMap<>();
             for (Entry<MemberInfo, InternalCompletableFuture<Object>> entry : futures.entrySet()) {
                 Object val;
@@ -541,7 +541,7 @@ public class MasterContext {
         // if cancelOnFailure is true, we should cancel invocations when the future is cancelled, or any invocation fail
 
         if (cancelOnFailure) {
-            cancellationFuture.whenComplete(safeWhenComplete(logger, (r, e) -> {
+            cancellationFuture.whenComplete(withTryCatch(logger, (r, e) -> {
                 if (e instanceof CancellationException) {
                     futures.values().forEach(f -> f.cancel(true));
                 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.safeWhenComplete;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
@@ -99,12 +99,12 @@ public class ExecutionContext {
     public CompletionStage<Void> execute(Consumer<CompletionStage<Void>> doneCallback) {
         synchronized (executionLock) {
             if (jobFuture != null) {
-                jobFuture.whenComplete(safeWhenComplete(logger, (r, e) -> doneCallback.accept(jobFuture)));
+                jobFuture.whenComplete(withTryCatch(logger, (r, e) -> doneCallback.accept(jobFuture)));
             } else {
                 JetService service = nodeEngine.getService(JetService.SERVICE_NAME);
                 ClassLoader cl = service.getClassLoader(jobId);
                 jobFuture = execService.execute(tasklets, doneCallback, cl);
-                jobFuture.whenComplete(safeWhenComplete(logger, (r, e) -> tasklets.clear()));
+                jobFuture.whenComplete(withTryCatch(logger, (r, e) -> tasklets.clear()));
             }
 
             return jobFuture;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
@@ -34,7 +34,7 @@ import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.DONE;
 import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.DRAIN;
 import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.FLUSH;
 import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.REACHED_BARRIER;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.safeWhenComplete;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class StoreSnapshotTasklet implements Tasklet {
 
@@ -104,7 +104,7 @@ public class StoreSnapshotTasklet implements Tasklet {
             case FLUSH:
                 progTracker.notDone();
                 CompletableFuture<Void> future = new CompletableFuture<>();
-                future.whenComplete(safeWhenComplete(logger, (r, t) -> {
+                future.whenComplete(withTryCatch(logger, (r, t) -> {
                     // this callback may be called from a non-tasklet thread
                     if (t != null) {
                         logger.severe("Error writing to snapshot map '" + currMapName() + "'", t);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class JoinSubmittedJobOperation extends AsyncExecutionOperation implements IdentifiedDataSerializable {
 
@@ -43,7 +44,7 @@ public class JoinSubmittedJobOperation extends AsyncExecutionOperation implement
     protected void doRun() {
         JetService service = getService();
         executionFuture = service.joinSubmittedJob(jobId);
-        executionFuture.whenComplete((r, t) -> doSendResponse(peel(t)));
+        executionFuture.whenComplete(withTryCatch(getLogger(), (r, t) -> doSendResponse(peel(t))));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class SubmitJobOperation extends AsyncExecutionOperation implements IdentifiedDataSerializable {
 
@@ -48,7 +49,7 @@ public class SubmitJobOperation extends AsyncExecutionOperation implements Ident
     protected void doRun() {
         JetService service = getService();
         executionFuture = service.submitJob(jobId, dag, config);
-        executionFuture.whenComplete((r, t) -> doSendResponse(peel(t)));
+        executionFuture.whenComplete(withTryCatch(getLogger(), (r, t) -> doSendResponse(peel(t))));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -106,24 +106,25 @@ public final class ExceptionUtil {
         }
     }
 
-
     /**
      * Utility to make sure exceptions inside
      * {@link java.util.concurrent.CompletionStage#whenComplete(BiConsumer)} are not swallowed.
+     * Exceptions will be caught and logged using the supplied logger.
      */
     @Nonnull
-    public static <T> BiConsumer<T, ? super Throwable> safeWhenComplete(
+    public static <T> BiConsumer<T, ? super Throwable> withTryCatch(
             @Nonnull ILogger logger, @Nonnull BiConsumer<T, ? super Throwable> consumer
     ) {
-        return safeWhenComplete(logger, "Exception during callback", consumer);
+        return withTryCatch(logger, "Exception during callback", consumer);
     }
 
     /**
      * Utility to make sure exceptions inside
      * {@link java.util.concurrent.CompletionStage#whenComplete(BiConsumer)} are not swallowed.
+     * Exceptions will be caught and logged using the supplied logger and message.
      */
     @Nonnull
-    public static <T> BiConsumer<T, ? super Throwable> safeWhenComplete(
+    public static <T> BiConsumer<T, ? super Throwable> withTryCatch(
             @Nonnull ILogger logger, @Nonnull String message, @Nonnull BiConsumer<T, ? super Throwable> consumer
     ) {
         return (r, t) -> {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
@@ -40,7 +40,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 import static com.hazelcast.jet.impl.util.AsyncMapWriter.MAX_PARALLEL_ASYNC_OPS;
 import static org.junit.Assert.assertEquals;
@@ -245,13 +244,9 @@ public class AsyncMapWriterTest extends JetTestSupport {
         // Then
         assertTrue("tryFlush() returned false", flushed);
 
-        final Throwable[] actual = new Exception[1];
-        future.whenComplete((r, e) -> actual[0] = e);
-        try {
-            future.join();
-        } catch (CompletionException ignored) {
-        }
-        assertNotNull("No exception was thrown", actual[0]);
+        Throwable actual = future.handle((r, e) -> e).join();
+        assertNotNull("No exception was thrown", actual);
+        assertEquals("Always failing store", actual.getMessage());
     }
 
     @Test


### PR DESCRIPTION
This ensures that any exception which may occur during a whenComplete 
call is handled.