### PR TITLE
Allow snapshotDone before snapshotStarted

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -189,4 +189,7 @@ public class ExecutionContext {
         return coordinator.equals(member) || isParticipating(member);
     }
 
+    public SnapshotContext getSnapshotContext() {
+        return snapshotContext;
+    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
@@ -73,7 +73,7 @@ public class SlidingWindowP<T, A, R> extends AbstractProcessor {
     private Traverser<Entry> snapshotTraverser;
 
     // This field tracks the upper bounds for the keyset of
-    // tsToKeyToAcc. It serves as an optimization that avoids a linear search
+    // tsToKeyToAcc. It serves as an optimization that avoids a full scan
     // over the entire keyset.
     private long topTs = Long.MIN_VALUE;
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.core;
 
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
@@ -25,8 +26,12 @@ import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.core.processor.DiagnosticProcessors;
 import com.hazelcast.jet.core.processor.SinkProcessors;
+import com.hazelcast.jet.impl.JetService;
+import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.SnapshotRepository;
+import com.hazelcast.jet.impl.execution.SnapshotContext;
 import com.hazelcast.jet.impl.execution.SnapshotRecord;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.nio.Address;
@@ -46,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.CancellationException;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -225,6 +231,50 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         assertTrue("Snapshots map not empty after job finished", snapshotsMap.isEmpty());
     }
 
+    @Test
+    public void when_snapshotDoneBeforeStarted_then_snapshotSuccessful() throws Exception {
+        /*
+        Design of this test
+
+        The DAG is "source -> sink". Source completes immediately on member2 and is infinite on member1.
+        Edge between source and sink is distributed. This situation will cause that after the source completes on
+        member2, the sink on member2 will only have remote source. This will allow that we can receive the
+        barrier from remote member1 before member2 even starts the snapshot. This is the very purpose of this
+        test. To ensure that this happens, we postpone handling of SnapshotOperation on member2 by 1s.
+         */
+        JetService jetService = ((HazelcastInstanceImpl) instance2.getHazelcastInstance())
+                .node.nodeEngine.getService(JetService.SERVICE_NAME);
+        jetService.getJobExecutionService().setPostponeSnapshotOperationMs(1000);
+
+        DAG dag = new DAG();
+        Vertex source = dag.newVertex("source", new NonBalancedSource(
+                instance2.getHazelcastInstance().getCluster().getLocalMember().getAddress().toString()));
+        Vertex sink = dag.newVertex("sink", DiagnosticProcessors.writeLogger());
+        dag.edge(between(source, sink).distributed());
+
+        JobConfig config = new JobConfig();
+        config.setSnapshotIntervalMillis(500);
+        Job job = instance1.newJob(dag, config);
+
+        IStreamMap<Long, Long> randomIdsMap = instance1.getMap(JobRepository.RANDOM_IDS_MAP_NAME);
+        long executionId = randomIdsMap.entrySet().stream()
+                    .filter(e -> e.getValue().equals(job.getJobId()) && !e.getValue().equals(e.getKey()))
+                    .mapToLong(Entry::getKey)
+                    .findAny()
+                    .orElseThrow(() -> new AssertionError("ExecutionId not found"));
+        SnapshotContext ssContext = jetService.getJobExecutionService().getExecutionContext(executionId)
+                                              .getSnapshotContext();
+        assertTrueEventually(() -> assertTrue("numRemainingTasklets was not negative, the tested scenario did not happen",
+                ssContext.getNumRemainingTasklets().get() < 0), 3);
+
+        Thread.sleep(3000);
+        job.cancel();
+        try {
+            job.getFuture().get();
+        } catch (CancellationException expected) {
+        }
+    }
+
     private void waitForNextSnapshot(IStreamMap<Long, Object> snapshotsMap, int timeout) {
         SnapshotRecord maxRecord = findMaxRecord(snapshotsMap);
         assertNotNull("no snapshot found", maxRecord);
@@ -401,6 +451,44 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
             return IntStream.range(0, numPartitions)
                             .filter(i -> i % totalProcessors == processorIndex)
                             .toArray();
+        }
+    }
+
+    /**
+     * Supplier of processors that emit nothing and complete immediately
+     * on designated member and never on others.
+     */
+    private static final class NonBalancedSource implements ProcessorMetaSupplier {
+        private final String noOutputAddress;
+
+        private NonBalancedSource(String noOutputAddress) {
+            this.noOutputAddress = noOutputAddress;
+        }
+
+        @Nonnull
+        @Override
+        public Function<Address, ProcessorSupplier> get(@Nonnull List<Address> addresses) {
+            return address -> {
+                String sAddress = address.toString();
+                return ProcessorSupplier.of(() -> sAddress.equals(noOutputAddress)
+                        ? new BatchNoopSourceP() : new StreamingNoopSourceP());
+            };
+        }
+    }
+
+    /** A source processor that emits nothing and never completes */
+    private static final class StreamingNoopSourceP implements Processor {
+        @Override
+        public boolean complete() {
+            return false;
+        }
+    }
+
+    /** A source processor that emits nothing and completes immediately */
+    private static final class BatchNoopSourceP implements Processor {
+        @Override
+        public boolean complete() {
+            return true;
         }
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
@@ -18,37 +18,98 @@ package com.hazelcast.jet.impl.execution;
 
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.logging.ILogger;
-import org.junit.After;
-import org.junit.Before;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+@RunWith(Parameterized.class)
+@Category({QuickTest.class, ParallelTest.class})
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 public class SnapshotContextTest {
 
-    private SnapshotContext ssContext =
-            new SnapshotContext(mock(ILogger.class), 1, 1, 9, ProcessingGuarantee.EXACTLY_ONCE);
+    @Parameter
+    public SnapshotStarted snapshotStarted;
 
-    @Before
-    public void before() {
-        ssContext.initTaskletCount(1, 0);
-        ssContext.startNewSnapshot(10);
-    }
+    @Parameter(1)
+    public int taskletCount;
 
-    @After
-    public void after() {
-        assertEquals(0, ssContext.numRemainingTasklets.get());
+    @Parameter(2)
+    public TaskletDone taskletDone;
+
+    @Parameter(3)
+    public int numHigherPriority;
+
+    @Parameters(name = "snapshotStarted={0}, taskletCount={1}, taskletDone={2}, numHigherPriority={3}")
+    public static Collection<Object[]> parameters() {
+        List<Object[]> res = new ArrayList<>();
+        for (SnapshotStarted snapshotStarted : SnapshotStarted.values()) {
+            for (int taskletCount = 1; taskletCount <= 2; taskletCount++) {
+                for (TaskletDone taskletDone : TaskletDone.values()) {
+                    for (int numHigherPriority = 0; numHigherPriority <= 1; numHigherPriority++) {
+                        res.add(new Object[]{snapshotStarted, taskletCount, taskletDone, numHigherPriority});
+                    }
+                }
+            }
+        }
+        return res;
     }
 
     @Test
-    public void when_taskletDoneBeforeItDidCurrentSnapshot_then_countedAsSnapshotWasDone() {
-        ssContext.taskletDone(9, false);
+    public void test() {
+        SnapshotContext ssContext =
+                new SnapshotContext(mock(ILogger.class), 1, 1, 9, ProcessingGuarantee.EXACTLY_ONCE);
+
+        ssContext.initTaskletCount(taskletCount, numHigherPriority);
+        CompletableFuture<Void> future = null;
+        if (snapshotStarted == SnapshotStarted.BEFORE) {
+            future = ssContext.startNewSnapshot(10);
+            assertEquals("lastSnapshotId initially", numHigherPriority > 0 ? 9 : 10, ssContext.lastSnapshotId());
+        }
+
+        if (taskletDone == TaskletDone.NOT_DONE) {
+            ssContext.snapshotDoneForTasklet();
+        } else if (taskletDone == TaskletDone.DONE_AFTER_CURRENT_SNAPSHOT) {
+            ssContext.snapshotDoneForTasklet();
+            ssContext.taskletDone(10, numHigherPriority > 0);
+        } else if (taskletDone == TaskletDone.DONE_BEFORE_CURRENT_SNAPSHOT) {
+            ssContext.taskletDone(9, numHigherPriority > 0);
+        }
+
+        if (snapshotStarted == SnapshotStarted.AFTER) {
+            future = ssContext.startNewSnapshot(10);
+        }
+
+        assertNotNull("future == null", future);
+        assertTrue("future.isDone() == " + future.isDone(),
+                future.isDone() == (taskletCount == 1));
+        assertEquals("numRemainingTasklets", taskletCount - 1, ssContext.getNumRemainingTasklets().get());
+        assertEquals("lastSnapshotId at the end",
+                taskletDone == TaskletDone.NOT_DONE && numHigherPriority > 0 ? 9 : 10, ssContext.lastSnapshotId());
     }
 
-    @Test
-    public void when_taskletDoneAfterItDidCurrentSnapshot_then_countedAsSnapshotWasDone() {
-        ssContext.snapshotDoneForTasklet();
-        ssContext.taskletDone(10, false);
+    private enum SnapshotStarted {
+        BEFORE,
+        AFTER
+    }
+    private enum TaskletDone {
+        NOT_DONE,
+        DONE_BEFORE_CURRENT_SNAPSHOT,
+        DONE_AFTER_CURRENT_SNAPSHOT
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
@@ -71,7 +71,7 @@ public class SnapshotContextTest {
     }
 
     @Test
-    public void test() {
+    public void test_snapShortStartAndDone() {
         SnapshotContext ssContext =
                 new SnapshotContext(mock(ILogger.class), 1, 1, 9, ProcessingGuarantee.EXACTLY_ONCE);
 
@@ -84,11 +84,11 @@ public class SnapshotContextTest {
 
         if (taskletDone == TaskletDone.NOT_DONE) {
             ssContext.snapshotDoneForTasklet();
+        } else if (taskletDone == TaskletDone.DONE_BEFORE_CURRENT_SNAPSHOT) {
+            ssContext.taskletDone(9, numHigherPriority > 0);
         } else if (taskletDone == TaskletDone.DONE_AFTER_CURRENT_SNAPSHOT) {
             ssContext.snapshotDoneForTasklet();
             ssContext.taskletDone(10, numHigherPriority > 0);
-        } else if (taskletDone == TaskletDone.DONE_BEFORE_CURRENT_SNAPSHOT) {
-            ssContext.taskletDone(9, numHigherPriority > 0);
         }
 
         if (snapshotStarted == SnapshotStarted.AFTER) {


### PR DESCRIPTION
The `SnapshotContext.startNewSnapshot()` method can be called _after_ `taskletDone()` or `snapshotDoneForTasklet()` is called. This can happen in a situation when a processor only has input queues from remote members and the remote members happen to process `SnapshotOperation` and send barriers to such processor before the `SnapshotOperation` is called on this member.