### PR TITLE
Improve signature of coGroup

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/ComputeStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/ComputeStage.java
@@ -77,16 +77,17 @@ public interface ComputeStage<E> extends Stage {
      * @param keyFn the function that extracts the grouping key from an item
      * @param aggrOp the aggregate operation to perform
      * @param <K> the type of key
+     * @param <A> the type of the accumulator
      * @param <R> the type of the aggregation result
      */
-    <K, R> ComputeStage<Entry<K, R>> groupBy(
-            DistributedFunction<? super E, ? extends K> keyFn, AggregateOperation1<E, ?, R> aggrOp
+    <K, A, R> ComputeStage<Entry<K, R>> groupBy(
+            DistributedFunction<? super E, ? extends K> keyFn, AggregateOperation1<? super E, A, R> aggrOp
     );
 
     /**
      * Attaches to both this and the supplied stage a hash-joining stage and
      * returns it. This stage plays the role of the <em>primary stage</em> in
-     * the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
+     * the hash-join. Please refer to the {@link com.hazelcast.jet
      * package Javadoc} for a detailed description of the hash-join transform.
      *
      * @param stage1     the stage to hash-join with this one
@@ -147,10 +148,10 @@ public interface ComputeStage<E> extends Stage {
      * @param <E1>      the type of {@code stage1} items
      * @param <R>       the result type of the aggregate operation
      */
-    <K, A, E1, R> ComputeStage<Tuple2<K, R>> coGroup(
+    <K, A, E1, R> ComputeStage<Entry<K, R>> coGroup(
             DistributedFunction<? super E, ? extends K> thisKeyFn,
             ComputeStage<E1> stage1, DistributedFunction<? super E1, ? extends K> key1Fn,
-            AggregateOperation2<E, E1, A, R> aggrOp
+            AggregateOperation2<? super E, ? super E1, A, R> aggrOp
     );
 
     /**
@@ -170,11 +171,11 @@ public interface ComputeStage<E> extends Stage {
      * @param <E2>      the type of {@code stage1} items
      * @param <R>       the result type of the aggregate operation
      */
-    <K, A, E1, E2, R> ComputeStage<Tuple2<K, R>> coGroup(
+    <K, A, E1, E2, R> ComputeStage<Entry<K, R>> coGroup(
             DistributedFunction<? super E, ? extends K> thisKeyFn,
             ComputeStage<E1> stage1, DistributedFunction<? super E1, ? extends K> key1Fn,
             ComputeStage<E2> stage2, DistributedFunction<? super E2, ? extends K> key2Fn,
-            AggregateOperation3<E, E1, E2, A, R> aggrOp
+            AggregateOperation3<? super E, ? super E1, ? super E2, A, R> aggrOp
     );
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ComputeStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ComputeStageImpl.java
@@ -84,8 +84,8 @@ public class ComputeStageImpl<E> extends AbstractStage implements ComputeStage<E
     }
 
     @Override
-    public <K, R> ComputeStage<Entry<K, R>> groupBy(
-            DistributedFunction<? super E, ? extends K> keyFn, AggregateOperation1<E, ?, R> aggrOp
+    public <K, A, R> ComputeStage<Entry<K, R>> groupBy(
+            DistributedFunction<? super E, ? extends K> keyFn, AggregateOperation1<? super E, A, R> aggrOp
     ) {
         return attach(new GroupByTransform<>(keyFn, aggrOp));
     }
@@ -109,21 +109,21 @@ public class ComputeStageImpl<E> extends AbstractStage implements ComputeStage<E
 
     @Override
     @SuppressWarnings("unchecked")
-    public <K, A, E1, R> ComputeStage<Tuple2<K, R>> coGroup(
+    public <K, A, E1, R> ComputeStage<Entry<K, R>> coGroup(
             DistributedFunction<? super E, ? extends K> thisKeyFn,
             ComputeStage<E1> stage1, DistributedFunction<? super E1, ? extends K> key1Fn,
-            AggregateOperation2<E, E1, A, R> aggrOp
+            AggregateOperation2<? super E, ? super E1, A, R> aggrOp
     ) {
         return attach(new CoGroupTransform<K, A, R>(asList(thisKeyFn, key1Fn), aggrOp), singletonList(stage1));
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    public <K, A, E1, E2, R> ComputeStage<Tuple2<K, R>> coGroup(
+    public <K, A, E1, E2, R> ComputeStage<Entry<K, R>> coGroup(
             DistributedFunction<? super E, ? extends K> thisKeyFn,
             ComputeStage<E1> stage1, DistributedFunction<? super E1, ? extends K> key1Fn,
             ComputeStage<E2> stage2, DistributedFunction<? super E2, ? extends K> key2Fn,
-            AggregateOperation3<E, E1, E2, A, R> aggrOp
+            AggregateOperation3<? super E, ? super E1, ? super E2, A, R> aggrOp
     ) {
         return attach(new CoGroupTransform<K, A, R>(asList(thisKeyFn, key1Fn, key2Fn), aggrOp), asList(stage1, stage2));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Planner.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Planner.java
@@ -139,7 +139,7 @@ class Planner {
         addEdges(stage, pv.v);
     }
 
-    private void handleGroupBy(AbstractStage stage, GroupByTransform<Object, Object, Object> groupBy) {
+    private void handleGroupBy(AbstractStage stage, GroupByTransform<Object, Object, Object, Object> groupBy) {
         String name = "groupByKey." + randomSuffix() + ".stage";
         Vertex v1 = dag.newVertex(name + '1',
                 Processors.accumulateByKey(groupBy.keyFn(), groupBy.aggregateOperation()));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/transform/GroupByTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/transform/GroupByTransform.java
@@ -21,11 +21,13 @@ import com.hazelcast.jet.function.DistributedFunction;
 
 import java.util.Map.Entry;
 
-public class GroupByTransform<E, K, R> implements UnaryTransform<E, Entry<K, R>> {
+public class GroupByTransform<E, K, A, R> implements UnaryTransform<E, Entry<K, R>> {
     private final DistributedFunction<? super E, ? extends K> keyFn;
-    private final AggregateOperation1<E, ?, R> aggrOp;
+    private final AggregateOperation1<? super E, A, R> aggrOp;
 
-    public GroupByTransform(DistributedFunction<? super E, ? extends K> keyFn, AggregateOperation1<E, ?, R> aggrOp) {
+    public GroupByTransform(DistributedFunction<? super E, ? extends K> keyFn,
+                            AggregateOperation1<? super E, A, R> aggrOp
+    ) {
         this.keyFn = keyFn;
         this.aggrOp = aggrOp;
     }
@@ -39,7 +41,7 @@ public class GroupByTransform<E, K, R> implements UnaryTransform<E, Entry<K, R>>
         return keyFn;
     }
 
-    public AggregateOperation1<E, ?, R> aggregateOperation() {
+    public AggregateOperation1<? super E, A, R> aggregateOperation() {
         return aggrOp;
     }
 }


### PR DESCRIPTION
- add variance to AggregateOperation arguments
- use `Map.Entry` instead of `Tuple2` for co-grouped results