### PR TITLE
Multiple fixes to snapshotting code

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
@@ -164,28 +164,6 @@ public interface Traverser<T> {
     }
 
     /**
-     * TODO
-     */
-    @Nonnull
-    default Traverser<T> prependTraverser(@Nonnull Traverser<? extends T> prepended) {
-        return new Traverser<T>() {
-            private boolean prependedFinished;
-            @Override
-            public T next() {
-                if (!prependedFinished) {
-                    T res = prepended.next();
-                    if (res == null) {
-                        prependedFinished = true;
-                    } else {
-                        return res;
-                    }
-                }
-                return Traverser.this.next();
-            }
-        };
-    }
-
-    /**
      * Adds a flat-mapping layer to this traverser. The returned traverser
      * will apply the given mapping function to each item retrieved from this
      * traverser, and will emit all the items from the resulting traverser(s).

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -169,9 +169,8 @@ public interface Processor {
      * snapshot" operation. The type of items in the inbox is {@code
      * Map.Entry}. May emit items to the outbox.
      * <p>
-     * If there is no snapshot to restore, this method won't be called at all,
-     * even if the processor is stateful and would otherwise be guaranteed to
-     * get at least one item in the inbox.
+     * If there is no data in the snapshot to restore, this method won't be
+     * called at all.
      * <p>
      * If the method returns with items still present in the inbox, it will be
      * called again before proceeding to call any other methods. There is at
@@ -186,11 +185,14 @@ public interface Processor {
 
     /**
      * Called after all keys have been restored using {@link
-     * #restoreFromSnapshot(Inbox)}. If it returns {@code false}, it will be called
-     * again before proceeding to call any other method.
+     * #restoreFromSnapshot(Inbox)}, and also in case when there were no keys
+     * to restore, but the job was started using a state snapshot. It's not
+     * called, if the job was not started using a state snapshot.
+     * <p>
+     * If it returns {@code false}, it will be
+     * called again before proceeding to call any other method.
      * <p>
      * The default implementation takes no action and returns {@code true}.
-     *
      */
     default boolean finishSnapshotRestore() {
         return true;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -18,7 +18,9 @@ package com.hazelcast.jet.core.test;
 
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.Processor.Context;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.test.TestOutbox.MockData;
@@ -58,7 +60,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * The test process does the following:
  * <ul>
  *     <li>initializes the processor by calling
- *     {@link Processor#init(com.hazelcast.jet.core.Outbox, Processor.Context) Processor.init()}
+ *     {@link Processor#init(Outbox, Context) Processor.init()}
  *
  *     <li>does snapshot+restore (optional, see below)
  *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -152,14 +152,12 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
     }
 
     private void observeBarrier(int queueIndex, long snapshotId) {
-        // TODO basri is this necessary? can't we just check monotonicity?
         if (snapshotId != pendingSnapshotId) {
             throw new JetException("Unexpected snapshot barrier "
                     + snapshotId + ", expected " + pendingSnapshotId);
         }
         receivedBarriers.set(queueIndex);
     }
-
 
     private void observeWm(int queueIndex, final long wmValue) {
         if (queueWms[queueIndex] >= wmValue) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -94,6 +94,7 @@ public class ProcessorTasklet implements Tasklet {
         this.ssContext = ssContext;
 
         instreamCursor = popInstreamGroup();
+        currInstream = instreamCursor != null ? instreamCursor.value() : null;
         outbox = createOutbox(ssCollector);
         receivedBarriers = new BitSet(instreams.size());
         state = initialProcessingState();
@@ -268,11 +269,6 @@ public class ProcessorTasklet implements Tasklet {
                        .map(CircularListCursor::new)
                        .orElse(null);
     }
-
-    protected OutboxImpl getOutbox() {
-        return outbox;
-    }
-
 
     @Override
     public String toString() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
@@ -160,7 +160,7 @@ public class SlidingWindowP<T, A, R> extends AbstractProcessor {
 
     @Override
     public boolean finishSnapshotRestore() {
-        logFine(getLogger(), "Restored snapshot to: %s", nextWinToEmit);
+        logFine(getLogger(), "Restored nextWinToEmit from snapshot to: %s", nextWinToEmit);
         return true;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
@@ -58,7 +58,6 @@ import static com.hazelcast.util.CollectionUtil.toIntArray;
  */
 public class AsyncMapWriter {
 
-    //TODO: What number to put here?
     public static final int MAX_PARALLEL_ASYNC_OPS = 1000;
 
     // These magic values are copied from com.hazelcast.spi.impl.operationservice.impl.InvokeOnPartitions


### PR DESCRIPTION
* Change contract of Processor.finishSnapshotRestore: now it is called
each time the processor state is restored from snapshot. Previously, it
was only called if there was at least one key in the state.

* Simplifications in StreamEventJournalP: we don't need two places to
check for stale offset. We restore whatever offset there is in the
snapshot, it will fail later when trying to read from it.

* Initialize currInstream in ProcessorTasklet: having it uninitialized
caused the `tryProcess` method to by called once before
restoreFromSnapshot.

* Remove unused method from Traverser and outstanding TODOs