### PR TITLE
Fix CIES to not reorder WM and barrier

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Traverser.java
@@ -164,28 +164,6 @@ public interface Traverser<T> {
     }
 
     /**
-     * TODO
-     */
-    @Nonnull
-    default Traverser<T> prependTraverser(@Nonnull Traverser<? extends T> prepended) {
-        return new Traverser<T>() {
-            private boolean prependedFinished;
-            @Override
-            public T next() {
-                if (!prependedFinished) {
-                    T res = prepended.next();
-                    if (res == null) {
-                        prependedFinished = true;
-                    } else {
-                        return res;
-                    }
-                }
-                return Traverser.this.next();
-            }
-        };
-    }
-
-    /**
      * Adds a flat-mapping layer to this traverser. The returned traverser
      * will apply the given mapping function to each item retrieved from this
      * traverser, and will emit all the items from the resulting traverser(s).

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -169,9 +169,8 @@ public interface Processor {
      * snapshot" operation. The type of items in the inbox is {@code
      * Map.Entry}. May emit items to the outbox.
      * <p>
-     * If there is no snapshot to restore, this method won't be called at all,
-     * even if the processor is stateful and would otherwise be guaranteed to
-     * get at least one item in the inbox.
+     * If there is no data in the snapshot to restore, this method won't be
+     * called at all.
      * <p>
      * If the method returns with items still present in the inbox, it will be
      * called again before proceeding to call any other methods. There is at
@@ -186,11 +185,14 @@ public interface Processor {
 
     /**
      * Called after all keys have been restored using {@link
-     * #restoreFromSnapshot(Inbox)}. If it returns {@code false}, it will be called
-     * again before proceeding to call any other method.
+     * #restoreFromSnapshot(Inbox)}, and also in case when there were no keys
+     * to restore, but the job was started using a state snapshot. It's not
+     * called, if the job was not started using a state snapshot.
+     * <p>
+     * If it returns {@code false}, it will be
+     * called again before proceeding to call any other method.
      * <p>
      * The default implementation takes no action and returns {@code true}.
-     *
      */
     default boolean finishSnapshotRestore() {
         return true;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -18,7 +18,9 @@ package com.hazelcast.jet.core.test;
 
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.Processor.Context;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.test.TestOutbox.MockData;
@@ -58,7 +60,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * The test process does the following:
  * <ul>
  *     <li>initializes the processor by calling
- *     {@link Processor#init(com.hazelcast.jet.core.Outbox, Processor.Context) Processor.init()}
+ *     {@link Processor#init(Outbox, Context) Processor.init()}
  *
  *     <li>does snapshot+restore (optional, see below)
  *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -152,14 +152,12 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
     }
 
     private void observeBarrier(int queueIndex, long snapshotId) {
-        // TODO basri is this necessary? can't we just check monotonicity?
         if (snapshotId != pendingSnapshotId) {
             throw new JetException("Unexpected snapshot barrier "
                     + snapshotId + ", expected " + pendingSnapshotId);
         }
         receivedBarriers.set(queueIndex);
     }
-
 
     private void observeWm(int queueIndex, final long wmValue) {
         if (queueWms[queueIndex] >= wmValue) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -102,6 +102,7 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
             if (itemDetector.item == DONE_ITEM) {
                 conveyor.removeQueue(queueIndex);
                 receivedBarriers.clear(queueIndex);
+                queueWms[queueIndex] = Long.MAX_VALUE;
                 numActiveQueues--;
             } else if (itemDetector.item instanceof Watermark) {
                 observeWm(queueIndex, ((Watermark) itemDetector.item).timestamp());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -200,8 +200,8 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
 
         @Override
         public boolean test(Object o) {
-            if (o instanceof BroadcastItem) {
-                assert item == null : "Received multiple BroadcastItem-s without a call to reset()";
+            if (o instanceof Watermark || o instanceof SnapshotBarrier || o == DONE_ITEM) {
+                assert item == null : "Received multiple BroadcastItem-s without a call to reset(): " + item;
                 item = (BroadcastItem) o;
                 return false;
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -201,7 +201,7 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
         @Override
         public boolean test(Object o) {
             if (o instanceof Watermark || o instanceof SnapshotBarrier || o == DONE_ITEM) {
-                assert item == null : "Received multiple BroadcastItem-s without a call to reset(): " + item;
+                assert item == null : "Received multiple special items without a call to reset(): " + item;
                 item = (BroadcastItem) o;
                 return false;
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -99,35 +99,39 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
 
             drainQueue(q, dest);
 
-            if (itemDetector.isDone) {
+            if (itemDetector.item == DONE_ITEM) {
                 conveyor.removeQueue(queueIndex);
                 receivedBarriers.clear(queueIndex);
                 numActiveQueues--;
-            } else if (itemDetector.wm != null) {
-                observeWm(queueIndex, itemDetector.wm.timestamp());
-            } else if (itemDetector.barrier != null) {
-                observeBarrier(queueIndex, itemDetector.barrier.snapshotId());
+            } else if (itemDetector.item instanceof Watermark) {
+                observeWm(queueIndex, ((Watermark) itemDetector.item).timestamp());
+            } else if (itemDetector.item instanceof SnapshotBarrier) {
+                observeBarrier(queueIndex, ((SnapshotBarrier) itemDetector.item).snapshotId());
+            }
+
+            if (numActiveQueues == 0) {
+                return tracker.toProgressState();
+            }
+
+            // coalesce WMs received and emit new WM if needed
+            long bottomWm = bottomObservedWm();
+            if (bottomWm > lastEmittedWm) {
+                lastEmittedWm = bottomWm;
+                dest.accept(new Watermark(bottomWm));
+                break;
+            }
+
+            // if we have received the current snapshot from all active queues, forward it
+            if (receivedBarriers.cardinality() == numActiveQueues) {
+                dest.accept(new SnapshotBarrier(pendingSnapshotId));
+                pendingSnapshotId++;
+                receivedBarriers.clear();
+                break;
             }
         }
 
-        if (numActiveQueues == 0) {
-            return tracker.toProgressState();
-        }
-
-        tracker.notDone();
-
-        // coalesce WMs received and emit new WM if needed
-        long bottomWm = bottomObservedWm();
-        if (bottomWm > lastEmittedWm) {
-            lastEmittedWm = bottomWm;
-            dest.accept(new Watermark(bottomWm));
-        }
-
-        // if we have received the current snapshot from all active queues, forward it
-        if (receivedBarriers.cardinality() == numActiveQueues) {
-            dest.accept(new SnapshotBarrier(pendingSnapshotId));
-            pendingSnapshotId++;
-            receivedBarriers.clear();
+        if (numActiveQueues > 0) {
+            tracker.notDone();
         }
         return tracker.toProgressState();
     }
@@ -146,7 +150,7 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
         itemDetector.reset(dest);
 
         int drainedCount = queue.drain(itemDetector);
-        tracker.mergeWith(ProgressState.valueOf(drainedCount > 0, itemDetector.isDone));
+        tracker.mergeWith(ProgressState.valueOf(drainedCount > 0, itemDetector.item == DONE_ITEM));
 
         itemDetector.dest = null;
     }
@@ -184,31 +188,18 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
      */
     private static final class ItemDetector implements Predicate<Object> {
         Consumer<Object> dest;
-        Watermark wm;
-        SnapshotBarrier barrier;
-        boolean isDone;
+        BroadcastItem item;
 
         void reset(Consumer<Object> newDest) {
             dest = newDest;
-            wm = null;
-            isDone = false;
-            barrier = null;
+            item = null;
         }
 
         @Override
         public boolean test(Object o) {
-            if (o instanceof Watermark) {
-                assert wm == null : "Received multiple Watermarks without a call to reset()";
-                wm = (Watermark) o;
-                return false;
-            }
-            if (o instanceof SnapshotBarrier) {
-                assert barrier == null : "Received multiple barriers without a call to reset()";
-                barrier = (SnapshotBarrier) o;
-                return false;
-            }
-            if (o == DONE_ITEM) {
-                isDone = true;
+            if (o instanceof BroadcastItem) {
+                assert item == null : "Received multiple BroadcastItem-s without a call to reset()";
+                item = (BroadcastItem) o;
                 return false;
             }
             dest.accept(o);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -94,6 +94,7 @@ public class ProcessorTasklet implements Tasklet {
         this.ssContext = ssContext;
 
         instreamCursor = popInstreamGroup();
+        currInstream = instreamCursor != null ? instreamCursor.value() : null;
         outbox = createOutbox(ssCollector);
         receivedBarriers = new BitSet(instreams.size());
         state = initialProcessingState();
@@ -268,11 +269,6 @@ public class ProcessorTasklet implements Tasklet {
                        .map(CircularListCursor::new)
                        .orElse(null);
     }
-
-    protected OutboxImpl getOutbox() {
-        return outbox;
-    }
-
 
     @Override
     public String toString() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
@@ -160,7 +160,7 @@ public class SlidingWindowP<T, A, R> extends AbstractProcessor {
 
     @Override
     public boolean finishSnapshotRestore() {
-        logFine(getLogger(), "Restored snapshot to: %s", nextWinToEmit);
+        logFine(getLogger(), "Restored nextWinToEmit from snapshot to: %s", nextWinToEmit);
         return true;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
@@ -58,7 +58,6 @@ import static com.hazelcast.util.CollectionUtil.toIntArray;
  */
 public class AsyncMapWriter {
 
-    //TODO: What number to put here?
     public static final int MAX_PARALLEL_ASYNC_OPS = 1000;
 
     // These magic values are copied from com.hazelcast.spi.impl.operationservice.impl.InvokeOnPartitions

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
@@ -194,6 +194,18 @@ public class ConcurrentInboundEdgeStreamTest {
         drainAndAssert(DONE);
     }
 
+    @Test
+    public void when_oneQueueDone_then_theOtherWorks() {
+        add(q1, DONE_ITEM);
+        drainAndAssert(MADE_PROGRESS);
+
+        add(q2, barrier(0));
+        drainAndAssert(MADE_PROGRESS, barrier(0));
+
+        add(q2, wm(0));
+        drainAndAssert(MADE_PROGRESS, wm(0));
+    }
+
     private void drainAndAssert(ProgressState expectedState, Object... expectedItems) {
         List<Object> list = new ArrayList<>();
         assertEquals("progressState", expectedState, stream.drainTo(list::add));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
@@ -117,6 +117,7 @@ public class ConcurrentInboundEdgeStreamTest {
 
         add(q1, wm(3));
         add(q2, wm(3));
+        drainAndAssert(MADE_PROGRESS, wm(2));
         drainAndAssert(MADE_PROGRESS, wm(3));
     }
 
@@ -167,6 +168,30 @@ public class ConcurrentInboundEdgeStreamTest {
 
         add(q2, barrier(0));
         drainAndAssert(MADE_PROGRESS, barrier(0));
+    }
+
+    @Test
+    public void when_barrierAndWmInQueues_then_notReordered() {
+        // When
+        add(q1, wm(1));
+        add(q2, barrier(0));
+        drainAndAssert(MADE_PROGRESS);
+
+        add(q1, barrier(0));
+        add(q2, wm(1));
+
+        // Then
+        drainAndAssert(MADE_PROGRESS, barrier(0));
+        drainAndAssert(MADE_PROGRESS, wm(1));
+    }
+
+    @Test
+    public void when_barrierAndDone_then_barrierEmitted() {
+        add(q1, barrier(0), DONE_ITEM);
+        add(q2, barrier(0), DONE_ITEM);
+
+        drainAndAssert(MADE_PROGRESS, barrier(0));
+        drainAndAssert(DONE);
     }
 
     private void drainAndAssert(ProgressState expectedState, Object... expectedItems) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
@@ -122,7 +122,7 @@ public class ConcurrentInboundEdgeStreamTest {
     }
 
     @Test
-    public void when_receivingSnapshots_then_coalesce() {
+    public void when_receivingBarriers_then_coalesce() {
         add(q1, barrier(0));
         add(q2, 1);
         drainAndAssert(MADE_PROGRESS, 1);
@@ -133,7 +133,7 @@ public class ConcurrentInboundEdgeStreamTest {
     }
 
     @Test
-    public void when_receivingSnapshots_then_waitForSnapshot() {
+    public void when_receivingBarriers_then_waitForBarrier() {
         stream = new ConcurrentInboundEdgeStream(conveyor, 0, 0, -1, true);
 
         add(q1, barrier(0));
@@ -149,7 +149,7 @@ public class ConcurrentInboundEdgeStreamTest {
     }
 
     @Test
-    public void when_receivingSnapshotsWhileDone_then_coalesce() {
+    public void when_receivingBarriersWhileDone_then_coalesce() {
         stream = new ConcurrentInboundEdgeStream(conveyor, 0, 0, -1, true);
 
         add(q1, 1, barrier(0));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
@@ -206,6 +206,16 @@ public class ConcurrentInboundEdgeStreamTest {
         drainAndAssert(MADE_PROGRESS, wm(0));
     }
 
+    @Test
+    public void when_nonSpecificBroadcastItem_then_drained() {
+        // When
+        BroadcastEntry<String, String> entry = new BroadcastEntry<>("k", "v");
+        add(q1, entry);
+
+        // Then
+        drainAndAssert(MADE_PROGRESS, entry);
+    }
+
     private void drainAndAssert(ProgressState expectedState, Object... expectedItems) {
         List<Object> list = new ArrayList<>();
         assertEquals("progressState", expectedState, stream.drainTo(list::add));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
@@ -207,13 +207,14 @@ public class ConcurrentInboundEdgeStreamTest {
     }
 
     @Test
-    public void when_nonSpecificBroadcastItem_then_drained() {
+    public void when_nonSpecificBroadcastItems_then_drainedInOneBatch() {
         // When
         BroadcastEntry<String, String> entry = new BroadcastEntry<>("k", "v");
         add(q1, entry);
+        add(q1, entry);
 
         // Then
-        drainAndAssert(MADE_PROGRESS, entry);
+        drainAndAssert(MADE_PROGRESS, entry, entry);
     }
 
     private void drainAndAssert(ProgressState expectedState, Object... expectedItems) {


### PR DESCRIPTION
It could happen that even in exactly once mode, the WM and barriers
could be reordered with respect to each other.

This was caused by the fact that we could stop at a barrier in one queue,
that would cause the barrier to be emitted, but we continued to another
queue which drained a watermark, which would also cause a WM to be
emitted. After iterating all queues, we first checked for WM to emit and
then for barrier to emit, effectively causing the reordering. It was
fixed by moving the emit check inside to the loop and breaking the
iteration if we emitted either WM or barrier.

ItemDetector was simplified too along the way.