### PR TITLE
Fix failure in SliWP for at-least-once jobs & docs

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Sinks.java
@@ -66,7 +66,7 @@ public final class Sinks {
      * Returns a sink that puts {@code Map.Entry}s it receives into a Hazelcast
      * {@code IMap} with the specified name.
      * <p>
-     * This sink provides the exactly once guarantee thanks to <i>idempotent
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
      * updates</i>. It means that the value with the same key is not appended,
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
@@ -80,7 +80,7 @@ public final class Sinks {
      * {@code IMap} with the specified name in a remote cluster identified by
      * the supplied {@code ClientConfig}.
      * <p>
-     * This sink provides the exactly once guarantee thanks to <i>idempotent
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
      * updates</i>. It means that the value with the same key is not appended,
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
@@ -95,7 +95,7 @@ public final class Sinks {
      * Returns a sink that puts {@code Map.Entry}s it receives into a Hazelcast
      * {@code ICache} with the specified name.
      * <p>
-     * This sink provides the exactly once guarantee thanks to <i>idempotent
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
      * updates</i>. It means that the value with the same key is not appended,
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
@@ -109,7 +109,7 @@ public final class Sinks {
      * {@code ICache} with the specified name in a remote cluster identified by
      * the supplied {@code ClientConfig}.
      * <p>
-     * This sink provides the exactly once guarantee thanks to <i>idempotent
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
      * updates</i>. It means that the value with the same key is not appended,
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
@@ -124,7 +124,7 @@ public final class Sinks {
      * IList} with the specified name.
      * <p>
      * No state is saved to snapshot for this sink. After the job is restarted,
-     * the items will likely be duplicated, providing an <i>at least once</i>
+     * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      */
     public static <E> Sink<E> writeList(String listName) {
@@ -137,7 +137,7 @@ public final class Sinks {
      * supplied {@code ClientConfig}.
      * <p>
      * No state is saved to snapshot for this sink. After the job is restarted,
-     * the items will likely be duplicated, providing an <i>at least once</i>
+     * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      */
     public static <E> Sink<E> writeRemoteList(String listName, ClientConfig clientConfig) {
@@ -153,7 +153,7 @@ public final class Sinks {
      * follows each item with a newline character.
      * <p>
      * No state is saved to snapshot for this sink. After the job is restarted,
-     * the items will likely be duplicated, providing an <i>at least once</i>
+     * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      */
     public static <E> Sink<E> writeSocket(
@@ -202,7 +202,7 @@ public final class Sinks {
      * line separator.
      * <p>
      * No state is saved to snapshot for this sink. After the job is restarted,
-     * the items will likely be duplicated, providing an <i>at least once</i>
+     * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      *
      * @param directoryName directory to create the files in. Will be created

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/ProcessingGuarantee.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/ProcessingGuarantee.java
@@ -35,7 +35,7 @@ package com.hazelcast.jet.config;
  * process any more items from inputs from which the barrier was already
  * received. If the stream is skewed (due to partition imbalance, long GC pause
  * on some member or a network hiccup), processing has to be halted until the
- * situation recovers. At least once mode allows processing of further items
+ * situation recovers. At-least-once mode allows processing of further items
  * during this alignment period.
  */
 public enum ProcessingGuarantee {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
@@ -272,6 +272,14 @@ public abstract class AbstractProcessor implements Processor {
      * The default implementation just emits the watermark downstream
      * to all ordinals.
      * <p>
+     * <i>Caution for jobs with at-least-once guarantee</i><br>
+     * In snapshotted jobs with <i>at least once</i> processing guarantee it
+     * can happen that the watermarks break the monotonicity requirement when
+     * the job is restarted. This is caused by the fact that watermark, like any
+     * other stream item, can be delivered duplicately after restart. This
+     * means that after a restart, a processor can be asked to process a
+     * watermark older than it already processed.
+     * <p>
      * <strong>NOTE:</strong> unless the processor doesn't differentiate between
      * its inbound edges, the first choice should be leaving this method alone
      * and instead overriding the specific {@code tryProcessN()} methods for

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
@@ -273,7 +273,7 @@ public abstract class AbstractProcessor implements Processor {
      * to all ordinals.
      * <p>
      * <i>Caution for jobs with at-least-once guarantee</i><br>
-     * In snapshotted jobs with <i>at least once</i> processing guarantee it
+     * In snapshotted jobs with <i>at-least-once</i> processing guarantee it
      * can happen that the watermarks break the monotonicity requirement when
      * the job is restarted. This is caused by the fact that watermark, like any
      * other stream item, can be delivered duplicately after restart. This
@@ -282,7 +282,7 @@ public abstract class AbstractProcessor implements Processor {
      * <p>
      * <strong>NOTE:</strong> unless the processor doesn't differentiate between
      * its inbound edges, the first choice should be leaving this method alone
-     * and instead overriding the specific {@code tryProcessN()} methods for
+     * and instead overriding the specific {@code tryProcessWmN()} methods for
      * each ordinal the processor expects.
      *
      * @param ordinal ordinal of the edge that delivered the watermark

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
@@ -232,5 +233,10 @@ public interface Processor {
          * Returns true, if snapshots will be saved for this job.
          */
         boolean snapshottingEnabled();
+
+        /**
+         * Returns the guarantee for current job.
+         */
+        ProcessingGuarantee processingGuarantee();
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -201,6 +201,9 @@ public final class Processors {
      * and performs the provided aggregate operation on each group. After
      * exhausting all its input it emits one {@code Map.Entry<K, R>} per
      * distinct key.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param getKeyFn computes the key from the entry
      * @param aggrOp the aggregate operation to perform
@@ -226,6 +229,9 @@ public final class Processors {
      * applies the {@link AggregateOperation1#accumulateFn()} accumulate}
      * primitive to each group. After exhausting all its input it emits one
      * {@code Map.Entry<K, A>} per observed key.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param getKeyFn computes the key from the entry
      * @param aggrOp the aggregate operation to perform
@@ -251,6 +257,9 @@ public final class Processors {
      * items may be different on each edge. For each edge a separate key
      * extracting function must be supplied and the aggregate operation must
      * contain a separate accumulation function for each edge.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param getKeyFs functions that compute the grouping key
      * @param aggrOp the aggregate operation
@@ -278,6 +287,9 @@ public final class Processors {
      * items may be different on each edge. For each edge a separate key
      * extracting function must be supplied and the aggregate operation must
      * contain a separate accumulation function for each edge.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param getKeyFs functions that compute the grouping key
      * @param aggrOp the aggregate operation to perform
@@ -303,6 +315,9 @@ public final class Processors {
      * <p>
      * Since the input to this vertex must be bounded, its primary use case
      * are batch jobs.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param aggrOp the aggregate operation to perform
      * @param <A> type of accumulator returned from {@code aggrOp.createAccumulatorFn()}
@@ -324,6 +339,9 @@ public final class Processors {
      * <p>
      * Since the input to this vertex must be bounded, its primary use case are
      * batch jobs.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param aggrOp the aggregate operation to perform
      * @param <T> type of received item
@@ -347,6 +365,9 @@ public final class Processors {
      * <p>
      * Since the input to this vertex must be bounded, its primary use case are
      * batch jobs.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param aggrOp the aggregate operation to perform
      * @param <T> type of received item
@@ -370,6 +391,9 @@ public final class Processors {
      * <p>
      * Since the input to this vertex must be bounded, its primary use case are
      * batch jobs.
+     * <p>
+     * This processor has state, but does not save it to snapshot. On job
+     * restart, the state will be lost.
      *
      * @param aggrOp the aggregate operation to perform
      * @param <T> type of received item
@@ -403,6 +427,16 @@ public final class Processors {
      * it deletes from storage all the frames that trail behind the emitted
      * windows. The type of emitted items is {@link TimestampedEntry
      * TimestampedEntry&lt;K, A>} so there is one item per key per window position.
+     * <p>
+     * <i>Behavior on job restart</i><br>
+     * This processor saves its state to snapshot. After restart, it can
+     * continue accumulating where it left off.
+     * <p>
+     * In at-least-once mode, the watermarks are allowed to resume at lower
+     * value than what was already processed after restart. Or simply,
+     * watermark can go back in time. This processor evicts state based on
+     * watermarks it received. If it receives duplicate watermark, it might
+     * emit windows with missing events, because they were already evicted.
      */
     @Nonnull
     public static <T, K, A, R> DistributedSupplier<Processor> aggregateToSlidingWindowP(
@@ -436,6 +470,9 @@ public final class Processors {
      * timestamp <= wmVal} and deletes these frames from its storage.
      * The type of emitted items is {@link TimestampedEntry
      * TimestampedEntry&lt;K, A>} so there is one item per key per frame.
+     * <p>
+     * When a state snapshot is requested, the state is flushed to second-stage
+     * processor and nothing is saved to snapshot.
      *
      * @param <T> input item type
      * @param <K> type of key returned from {@code getKeyFn}
@@ -477,6 +514,16 @@ public final class Processors {
      * it deletes from storage all the frames that trail behind the emitted
      * windows. The type of emitted items is {@link TimestampedEntry
      * TimestampedEntry&lt;K, A>} so there is one item per key per window position.
+     * <p>
+     * <i>Behavior on job restart</i><br>
+     * This processor saves its state to snapshot. After restart, it can
+     * continue accumulating where it left off.
+     * <p>
+     * In at-least-once mode, the watermarks are allowed to resume at lower
+     * value than what was already processed after restart. Or simply,
+     * watermark can go back in time. This processor evicts state based on
+     * watermarks it received. If it receives duplicate watermark, it might
+     * emit windows with missing events, because they were already evicted.
      *
      * @param <A> type of the accumulator
      * @param <R> type of the finished result returned from {@code aggrOp.
@@ -531,9 +578,10 @@ public final class Processors {
     }
 
     /**
-     * Returns a supplier of processors for a vetex that aggregates events into
+     * Returns a supplier of processors for a vertex that aggregates events into
      * session windows. Events and windows under different grouping keys are
-     * treated independently.
+     * treated independently. Outputs objects of type {@link
+     * com.hazelcast.jet.core.Session}.
      * <p>
      * The functioning of this vertex is easiest to explain in terms of the
      * <em>event interval</em>: the range {@code [timestamp, timestamp +
@@ -543,6 +591,18 @@ public final class Processors {
      * window is extended to cover the entire interval of the new event. The
      * event may happen to belong to two existing windows if its interval
      * bridges the gap between them; in that case they are combined into one.
+     * <p>
+     * <i>Behavior on job restart</i><br>
+     * This processor saves its state to snapshot. After restart, it can
+     * continue accumulating where it left off.
+     * <p>
+     * In at-least-once mode, the watermarks are allowed to resume at lower
+     * value than what was already processed after restart. Or simply,
+     * watermark can go back in time. The processor evicts state based on
+     * watermarks it received. If it receives duplicate watermark, it might
+     * emit sessions with missing events, because they were already evicted.
+     * The sessions before and after snapshot might overlap, which they
+     * normally don't.
      *
      * @param sessionTimeout maximum gap between consecutive events in the same session window
      * @param getTimestampFn function to extract the timestamp from the item
@@ -566,9 +626,23 @@ public final class Processors {
 
     /**
      * Returns a supplier of processors for a vertex that inserts {@link
-     * com.hazelcast.jet.core.Watermark watermark items} into a stream. The
+     * com.hazelcast.jet.core.Watermark watermark items} into the stream. The
      * value of the watermark is determined by the supplied {@link
      * WatermarkPolicy} instance.
+     * <p>
+     * This processor also drops late items. It never allows an event, which is
+     * late with regard to already emitted watermark to pass.
+     * <p>
+     * The processor saves value of the last emitted watermark to snapshot.
+     * Different instances of this processor can be at different watermark at
+     * snapshot time. After restart all instances will start at watermark of
+     * the most-behind instance before the restart.
+     * <p>
+     * This might sound as it could break the monotonicity requirement, but
+     * thanks to watermark coalescing, watermarks are only delivered for
+     * downstream processing after they have been received from <i>all</i>
+     * upstream processors. Another side effect of this is, that a late event,
+     * which was dropped before restart, is not considered late after restart.
      *
      * @param <T> the type of the stream item
      */
@@ -586,6 +660,8 @@ public final class Processors {
      * item, emits the result of applying the given mapping function to it. If
      * the result is {@code null}, it emits nothing. Therefore this vertex can
      * be used to implement filtering semantics as well.
+     * <p>
+     * This processor is stateless.
      *
      * @param mapper the mapping function
      * @param <T> type of received item
@@ -607,6 +683,8 @@ public final class Processors {
     /**
      * Returns a supplier of processors for a vertex that emits the same items
      * it receives, but only those that pass the given predicate.
+     * <p>
+     * This processor is stateless.
      *
      * @param predicate the predicate to test each received item against
      * @param <T> type of received item
@@ -626,6 +704,8 @@ public final class Processors {
      * Returns a supplier of processors for a vertex that applies the provided
      * item-to-traverser mapping function to each received item and emits all
      * the items from the resulting traverser.
+     * <p>
+     * This processor is stateless.
      *
      * @param mapper function that maps the received item to a traverser over output items
      * @param <T> received item type

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -432,11 +432,11 @@ public final class Processors {
      * This processor saves its state to snapshot. After restart, it can
      * continue accumulating where it left off.
      * <p>
-     * In at-least-once mode, the watermarks are allowed to resume at lower
-     * value than what was already processed after restart. Or simply,
-     * watermark can go back in time. This processor evicts state based on
-     * watermarks it received. If it receives duplicate watermark, it might
-     * emit windows with missing events, because they were already evicted.
+     * After a restart in at-least-once mode, watermarks are allowed to go back
+     * in time. If such a watermark is received, some windows that were emitted
+     * in previous execution, will be re-emitted. These windows might miss
+     * events as some of them had already been evicted before the snapshot was
+     * done in previous execution.
      */
     @Nonnull
     public static <T, K, A, R> DistributedSupplier<Processor> aggregateToSlidingWindowP(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -434,7 +434,7 @@ public final class Processors {
      * <p>
      * After a restart in at-least-once mode, watermarks are allowed to go back
      * in time. If such a watermark is received, some windows that were emitted
-     * in previous execution, will be re-emitted. These windows might miss
+     * in previous execution will be re-emitted. These windows might miss
      * events as some of them had already been evicted before the snapshot was
      * done in previous execution.
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -519,11 +519,11 @@ public final class Processors {
      * This processor saves its state to snapshot. After restart, it can
      * continue accumulating where it left off.
      * <p>
-     * In at-least-once mode, the watermarks are allowed to resume at lower
-     * value than what was already processed after restart. Or simply,
-     * watermark can go back in time. This processor evicts state based on
-     * watermarks it received. If it receives duplicate watermark, it might
-     * emit windows with missing events, because they were already evicted.
+     * After a restart in at-least-once mode, watermarks are allowed to go back
+     * in time. If such a watermark is received, some windows that were emitted
+     * in previous execution will be re-emitted. These windows might miss
+     * events as some of them had already been evicted before the snapshot was
+     * done in previous execution.
      *
      * @param <A> type of the accumulator
      * @param <R> type of the finished result returned from {@code aggrOp.
@@ -541,7 +541,7 @@ public final class Processors {
     }
 
     /**
-     * Returns a supplier of processors for a vertexs that performs a general
+     * Returns a supplier of processors for a vertex that performs a general
      * group-by-key-and-window operation and applies the provided aggregate
      * operation on groups.
      *
@@ -596,13 +596,11 @@ public final class Processors {
      * This processor saves its state to snapshot. After restart, it can
      * continue accumulating where it left off.
      * <p>
-     * In at-least-once mode, the watermarks are allowed to resume at lower
-     * value than what was already processed after restart. Or simply,
-     * watermark can go back in time. The processor evicts state based on
-     * watermarks it received. If it receives duplicate watermark, it might
-     * emit sessions with missing events, because they were already evicted.
-     * The sessions before and after snapshot might overlap, which they
-     * normally don't.
+     * After a restart in at-least-once mode, watermarks are allowed to go back
+     * in time. The processor evicts state based on watermarks it received. If
+     * it receives duplicate watermark, it might emit sessions with missing
+     * events, because they were already evicted. The sessions before and after
+     * snapshot might overlap, which they normally don't.
      *
      * @param sessionTimeout maximum gap between consecutive events in the same session window
      * @param getTimestampFn function to extract the timestamp from the item

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.core.test;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.logging.ILogger;
 
@@ -33,6 +34,7 @@ public class TestProcessorContext implements Processor.Context {
     private String vertexName = "testVertex";
     private int globalProcessorIndex;
     private boolean snapshottingEnabled;
+    private ProcessingGuarantee processingGuarantee = ProcessingGuarantee.EXACTLY_ONCE;
 
     /**
      * Constructor with default values.
@@ -104,6 +106,19 @@ public class TestProcessorContext implements Processor.Context {
      */
     public TestProcessorContext setSnapshottingEnabled(boolean snapshottingEnabled) {
         this.snapshottingEnabled = snapshottingEnabled;
+        return this;
+    }
+
+    @Override
+    public ProcessingGuarantee processingGuarantee() {
+        return processingGuarantee;
+    }
+
+    /**
+     * Sets the processing guarantee.
+     */
+    public TestProcessorContext setProcessingGuarantee(ProcessingGuarantee processingGuarantee) {
+        this.processingGuarantee = processingGuarantee;
         return this;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -55,8 +55,8 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
 
     /**
      * @param waitForSnapshot If true, queues won't be drained until the same
-     *                        barrier is received from all of them. This will enforce exactly once
-     *                        vs. at least once, if it is false.
+     *                        barrier is received from all of them. This will enforce exactly-once
+     *                        vs. at-least-once, if it is false.
      */
     public ConcurrentInboundEdgeStream(ConcurrentConveyor<Object> conveyor, int ordinal, int priority,
                                        long lastSnapshotId, boolean waitForSnapshot) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier.Context;
 import com.hazelcast.jet.core.ProcessorSupplier;
@@ -38,15 +39,17 @@ public final class Contexts {
         private final int index;
         private final SerializationService serService;
         private final boolean snapshottingEnabled;
+        private final ProcessingGuarantee processingGuarantee;
 
-        public ProcCtx(JetInstance instance, SerializationService serService,
-                       ILogger logger, String vertexName, int index, boolean snapshottingEnabled) {
+        public ProcCtx(JetInstance instance, SerializationService serService, ILogger logger, String vertexName,
+                       int index, boolean snapshottingEnabled, ProcessingGuarantee processingGuarantee) {
             this.instance = instance;
             this.serService = serService;
             this.logger = logger;
             this.vertexName = vertexName;
             this.index = index;
             this.snapshottingEnabled = snapshottingEnabled;
+            this.processingGuarantee = processingGuarantee;
         }
 
         @Nonnull
@@ -75,6 +78,11 @@ public final class Contexts {
         @Override
         public boolean snapshottingEnabled() {
             return snapshottingEnabled;
+        }
+
+        @Override
+        public ProcessingGuarantee processingGuarantee() {
+            return processingGuarantee;
         }
 
         public SerializationService getSerializationService() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -149,8 +149,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                         logger,
                         srcVertex.name(),
                         processorIdx + srcVertex.getProcIdxOffset(),
-                        jobConfig.getSnapshotIntervalMillis() > 0
-                );
+                        jobConfig.getSnapshotIntervalMillis() > 0,
+                        jobConfig.getProcessingGuarantee());
 
                  String probePrefix = String.format("jet.job.%s.%s#%d", idToString(executionId), srcVertex.name(),
                          processorIdx);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/InsertWatermarksP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/InsertWatermarksP.java
@@ -50,7 +50,7 @@ public class InsertWatermarksP<T> extends AbstractProcessor {
     private long currWm = Long.MIN_VALUE;
     private long lastEmittedWm = Long.MIN_VALUE;
 
-    // value to be used during temporarily snapshot restore
+    // value to be used temporarily during snapshot restore
     private long minRestoredWm = Long.MAX_VALUE;
 
     /**

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
@@ -36,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.MADE_PROGRESS;
@@ -66,7 +67,7 @@ public class ProcessorTaskletTest {
     public void setUp() {
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.processor = new PassThroughProcessor();
-        this.context = new ProcCtx(null, null, null, null, 0, false);
+        this.context = new ProcCtx(null, null, null, null, 0, false, EXACTLY_ONCE);
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.MADE_PROGRESS;
@@ -65,7 +66,7 @@ public class ProcessorTaskletTest_Blocking {
     @Before
     public void setUp() {
         this.processor = new PassThroughProcessor();
-        this.context = new ProcCtx(null, null, null, null, 0, false);
+        this.context = new ProcCtx(null, null, null, null, 0, false, EXACTLY_ONCE);
         this.jobFuture = new CompletableFuture<>();
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.instreams = new ArrayList<>();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.NO_PROGRESS;
@@ -75,7 +76,7 @@ public class ProcessorTaskletTest_Snapshots {
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.processor = new SnapshottableProcessor();
         this.context = new ProcCtx(null, new MockSerializationService(), null, null, 0,
-                true);
+                true, EXACTLY_ONCE);
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
         this.snapshotCollector = new MockOutboundCollector(1024);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_failoverTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_failoverTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.accumulator.LongAccumulator;
+import com.hazelcast.jet.aggregate.AggregateOperation1;
+import com.hazelcast.jet.config.ProcessingGuarantee;
+import com.hazelcast.jet.core.BroadcastKey;
+import com.hazelcast.jet.core.Outbox;
+import com.hazelcast.jet.core.Processor.Context;
+import com.hazelcast.jet.core.WindowDefinition;
+import com.hazelcast.jet.core.test.TestOutbox;
+import com.hazelcast.jet.core.test.TestProcessorContext;
+import com.hazelcast.jet.impl.processor.SlidingWindowP.Keys;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Map.Entry;
+
+import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
+import static com.hazelcast.jet.config.ProcessingGuarantee.AT_LEAST_ONCE;
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
+import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SlidingWindowP_failoverTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private SlidingWindowP<Entry<String, Long>, LongAccumulator, Long> p;
+
+    private void init(ProcessingGuarantee guarantee) {
+        WindowDefinition wDef = WindowDefinition.tumblingWindowDef(1);
+        AggregateOperation1<Object, LongAccumulator, Long> aggrOp = counting();
+        p = new SlidingWindowP<>(entryKey(), Entry::getValue, wDef, aggrOp, true);
+
+        Outbox outbox = new TestOutbox(128);
+        Context context = new TestProcessorContext()
+                .setProcessingGuarantee(guarantee)
+                .setSnapshottingEnabled(true);
+        p.init(outbox, context);
+    }
+
+    @Test
+    public void when_differentWmExactlyOnce_then_fail() {
+        init(EXACTLY_ONCE);
+
+        p.restoreFromSnapshot(BroadcastKey.broadcastKey(Keys.NEXT_WIN_TO_EMIT), 1L);
+        exception.expect(AssertionError.class);
+        p.restoreFromSnapshot(BroadcastKey.broadcastKey(Keys.NEXT_WIN_TO_EMIT), 2L);
+    }
+
+    @Test
+    public void when_differentWmAtLeastOnce_then_useMin() {
+        init(AT_LEAST_ONCE);
+
+        p.restoreFromSnapshot(BroadcastKey.broadcastKey(Keys.NEXT_WIN_TO_EMIT), 2L);
+        p.restoreFromSnapshot(BroadcastKey.broadcastKey(Keys.NEXT_WIN_TO_EMIT), 1L);
+        p.finishSnapshotRestore();
+
+        assertEquals(1L, p.nextWinToEmit);
+    }
+
+    @Test
+    public void when_noSnapshotRestored_then_wmIsMin() {
+        init(AT_LEAST_ONCE);
+
+        assertEquals(Long.MIN_VALUE, p.nextWinToEmit);
+    }
+}

--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/HdfsSinks.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/HdfsSinks.java
@@ -46,7 +46,7 @@ public final class HdfsSinks {
      * a path.
      * <p>
      * No state is saved to snapshot for this sink. After the job is restarted,
-     * the items will likely be duplicated, providing an <i>at least once</i>
+     * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      *
      * @param jobConf     {@code JobConf} used for output format configuration

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
@@ -40,7 +40,7 @@ public final class KafkaSinks {
      * member using the supplied properties.
      * <p>
      * Behavior on job restart: the processor is stateless. If the job is
-     * restarted, duplicate events can occur. If you need exactly once
+     * restarted, duplicate events can occur. If you need exactly-once
      * behavior, you must ensure idempotence on the application level.
      * <p>
      * IO failures are generally handled by Kafka producer and generally do not


### PR DESCRIPTION
Document the possibility of watermarks going back after restart of a job with at-least-once guarantee. Fix the assert in SlidingWindowP to allow it.