### PR TITLE
Add null check before trying to transmit flow control packet

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
@@ -102,9 +102,11 @@ public class Networking {
                     return;
                 }
                 Connection conn = getMemberConnection(nodeEngine, member);
-                conn.write(new Packet(packetBuf)
-                        .setPacketType(Packet.Type.JET)
-                        .raiseFlags(FLAG_URGENT | FLAG_JET_FLOW_CONTROL));
+                if (conn != null) {
+                    conn.write(new Packet(packetBuf)
+                            .setPacketType(Packet.Type.JET)
+                            .raiseFlags(FLAG_URGENT | FLAG_JET_FLOW_CONTROL));
+                }
             }));
         } catch (Throwable t) {
             logger.severe("Flow-control packet broadcast failed", t);


### PR DESCRIPTION
Otherwise we will get NullPointerExceptions if the member was just shutdown, for example.