### PR TITLE
StreamKafkaP should throw when there are not enough partitions

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -115,7 +115,8 @@ public class JobConfig implements Serializable {
      * Set the {@link ProcessingGuarantee processing guarantee} for the job.
      * When the processing guarantee is set to <i>at-least-once</i> or
      * <i>exactly-once</i>, the snapshot interval can be configured via
-     * {@link #setSnapshotIntervalMillis(long)}.
+     * {@link #setSnapshotIntervalMillis(long)}, otherwise it will default to
+     * 10 seconds.
      * <p>
      * The default value is {@link ProcessingGuarantee#NONE}.
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -72,7 +72,7 @@ public final class HazelcastWriters {
                         try {
                             map.putAll(buffer);
                         } catch (HazelcastInstanceNotActiveException e) {
-                            handleInstaceNotActive(instance, e, isLocal);
+                            handleInstanceNotActive(instance, e, isLocal);
                         }
                         buffer.clear();
                     };
@@ -112,7 +112,7 @@ public final class HazelcastWriters {
                     try {
                         cache.putAll(buffer);
                     } catch (HazelcastInstanceNotActiveException e) {
-                        handleInstaceNotActive(instance, e, isLocal);
+                        handleInstanceNotActive(instance, e, isLocal);
                     }
                     buffer.clear();
                 };
@@ -138,7 +138,7 @@ public final class HazelcastWriters {
                         try {
                             list.addAll(buffer);
                         } catch (HazelcastInstanceNotActiveException e) {
-                            handleInstaceNotActive(instance, e, isLocal);
+                            handleInstanceNotActive(instance, e, isLocal);
                         }
                         buffer.clear();
                     };
@@ -147,14 +147,15 @@ public final class HazelcastWriters {
         );
     }
 
-    private static void handleInstaceNotActive(
+    private static void handleInstanceNotActive(
             HazelcastInstance instance, HazelcastInstanceNotActiveException e, boolean isLocal
     ) {
         if (isLocal) {
             // if we are writing to a local instance, we can safely ignore this exception
             // as the job will eventually restart on its own.
-            instance.getLoggingService().getLogger(HazelcastWriters.class).warning(
-                    "Ignored HazelcastInstanceNotActiveException, we expect the job will be restarted", e);
+            instance.getLoggingService().getLogger(HazelcastWriters.class).fine(
+                    "Ignoring HazelcastInstanceNotActiveException from local cluster as the job will be" +
+                            " restarted automatically.", e);
             return;
         }
         throw e;

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
@@ -86,8 +86,10 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
     private Traverser<T> traverser;
     private ConsumerRecord<Object, Object> lastEmittedItem;
 
-    StreamKafkaP(Properties properties, List<String> topics, DistributedBiFunction<K, V, T> projectionFn,
-                 int globalParallelism, long metadataRefreshInterval) {
+    StreamKafkaP(@Nonnull Properties properties, @Nonnull List<String> topics,
+                 @Nonnull DistributedBiFunction<K, V, T> projectionFn, int globalParallelism,
+                 long metadataRefreshInterval
+    ) {
         this.properties = properties;
         this.topics = topics;
         this.projectionFn = projectionFn;
@@ -307,9 +309,9 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
             for (int i = 0; i < topics.size(); i++) {
                 topicToCount.put(topics.get(i), partitionCounts.get(i));
             }
-            throw new JetException("Total number of Kafka topic partitions is less than the global parallelism " +
-                    "for this vertex. Global parallelism=" + globalParallelism + ", total Kafka partition count=" +
-                    totalPartitionCount + ", number of Kafka partitions per topic=" + topicToCount);
+            throw new JetException("Total number of Kafka topic partitions (" + totalPartitionCount  + ")" +
+                    " is less than the global parallelism (" + globalParallelism + ") for this vertex. "
+                    + " The partition counts for individual Kafka topics are " + topicToCount);
         }
     }
 }

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/KafkaTestSupport.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/KafkaTestSupport.java
@@ -95,8 +95,8 @@ public class KafkaTestSupport extends JetTestSupport {
         return BROKER_HOST + ':' + brokerPort;
     }
 
-    void createTopic(String topicId) {
-        AdminUtils.createTopic(zkUtils, topicId, 1, 1, new Properties(), MODULE$);
+    void createTopic(String topicId, int partitionCount) {
+        AdminUtils.createTopic(zkUtils, topicId, partitionCount, 1, new Properties(), MODULE$);
     }
 
     void setPartitionCount(String topicId, int numPartitions) {

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/KafkaTestSupport.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/KafkaTestSupport.java
@@ -99,7 +99,8 @@ public class KafkaTestSupport extends JetTestSupport {
         AdminUtils.createTopic(zkUtils, topicId, 1, 1, new Properties(), MODULE$);
     }
 
-    void addPartitions(String topicId, int numPartitions) {
+    void setPartitionCount(String topicId, int numPartitions) {
+        // doesn't actually add the given number to existing partitions, just sets to it
         AdminUtils.addPartitions(zkUtils, topicId, numPartitions, "", true, null);
     }
 

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
@@ -75,6 +75,8 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 public class StreamKafkaPTest extends KafkaTestSupport {
 
+    private static final int INITIAL_PARTITION_COUNT = 4;
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
@@ -91,6 +93,8 @@ public class StreamKafkaPTest extends KafkaTestSupport {
         topic2Name = randomString();
         createTopic(topic1Name);
         createTopic(topic2Name);
+        setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT);
+        setPartitionCount(topic2Name, INITIAL_PARTITION_COUNT);
     }
 
     @Test
@@ -232,7 +236,7 @@ public class StreamKafkaPTest extends KafkaTestSupport {
         produce(topic1Name, 0, "0");
         assertEquals(entry(0, "0"), consumeEventually(processor, outbox));
 
-        addPartitions(topic1Name, 2);
+        setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT + 2);
         Thread.sleep(1000);
         resetProducer(); // this allows production to the added partition
 

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaPTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaPTest.java
@@ -50,7 +50,7 @@ public class WriteKafkaPTest extends KafkaTestSupport {
         String brokerConnectionString = createKafkaCluster();
 
         final String topic = randomName();
-        createTopic(topic);
+        createTopic(topic, 1);
         JetInstance instance = createJetMember();
 
         int messageCount = 20;


### PR DESCRIPTION
This can cause watermarks to lag behind indefinitely.