### PR TITLE
Pass classloader while instantiating class

### DIFF
--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/impl/connector/hadoop/ReadHdfsP.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/impl/connector/hadoop/ReadHdfsP.java
@@ -388,7 +388,7 @@ public final class ReadHdfsP<K, V, R> extends AbstractProcessor {
 
         private void readObject(ObjectInputStream in) throws Exception {
             index = in.readInt();
-            split = ClassLoaderUtil.newInstance(null, in.readUTF());
+            split = ClassLoaderUtil.newInstance(Thread.currentThread().getContextClassLoader(), in.readUTF());
             split.readFields(in);
         }
 

--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/impl/connector/hadoop/WritableSerializerHooks.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/impl/connector/hadoop/WritableSerializerHooks.java
@@ -145,7 +145,7 @@ final class WritableSerializerHooks {
             }
             String className = in.readUTF();
             try {
-                Writable instance = ClassLoaderUtil.newInstance(null, className);
+                Writable instance = ClassLoaderUtil.newInstance(Thread.currentThread().getContextClassLoader(), className);
                 instance.readFields(in);
                 return instance;
             } catch (Exception e) {


### PR DESCRIPTION
While instantiating any class, we must pass the context classloader (which is job classloader)