### PR TITLE
Simplify the names of sources and sinks

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/JoinClause.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/JoinClause.java
@@ -36,7 +36,7 @@ import java.util.Map.Entry;
  *     to the item that will be in the result of the join operation.
  * </li></ol>
  *  The primary use case for the projection function is enrichment from a
- *  map source, such as {@link Sources#readMap}.
+ *  map source, such as {@link Sources#map}.
  *  The enriching stream consists of map entries, but the result should
  *  contain just the vaules. In this case the projection function should be
  *  {@code Entry::getValue}. There is direct support for this case with the

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Sinks.java
@@ -79,7 +79,7 @@ public final class Sinks {
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
      */
-    public static <E extends Map.Entry> Sink<E> writeMap(String mapName) {
+    public static <E extends Map.Entry> Sink<E> map(String mapName) {
         return fromProcessor("writeMap(" + mapName + ')', writeMapP(mapName));
     }
 
@@ -93,7 +93,7 @@ public final class Sinks {
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
      */
-    public static <E extends Map.Entry> Sink<E> writeRemoteMap(String mapName, ClientConfig clientConfig) {
+    public static <E extends Map.Entry> Sink<E> remoteMap(String mapName, ClientConfig clientConfig) {
         return fromProcessor("writeRemoteMap(" + mapName + ')', writeRemoteMapP(mapName, clientConfig));
     }
 
@@ -106,7 +106,7 @@ public final class Sinks {
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
      */
-    public static <E extends Map.Entry> Sink<E> writeCache(String cacheName) {
+    public static <E extends Map.Entry> Sink<E> cache(String cacheName) {
         return fromProcessor("writeCache(" + cacheName + ')', writeCacheP(cacheName));
     }
 
@@ -120,7 +120,7 @@ public final class Sinks {
      * but overwritten. After the job is restarted from snapshot, duplicate
      * items will not change the state in the target map.
      */
-    public static <E extends Map.Entry> Sink<E> writeRemoteCache(String cacheName, ClientConfig clientConfig) {
+    public static <E extends Map.Entry> Sink<E> remoteCache(String cacheName, ClientConfig clientConfig) {
         return fromProcessor("writeRemoteCache(" + cacheName + ')', writeRemoteCacheP(cacheName, clientConfig));
     }
 
@@ -132,7 +132,7 @@ public final class Sinks {
      * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      */
-    public static <E> Sink<E> writeList(String listName) {
+    public static <E> Sink<E> list(String listName) {
         return fromProcessor("writeList(" + listName + ')', writeListP(listName));
     }
 
@@ -145,7 +145,7 @@ public final class Sinks {
      * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      */
-    public static <E> Sink<E> writeRemoteList(String listName, ClientConfig clientConfig) {
+    public static <E> Sink<E> remoteList(String listName, ClientConfig clientConfig) {
         return fromProcessor("writeRemoteList(" + listName + ')', writeRemoteListP(listName, clientConfig));
     }
 
@@ -160,7 +160,7 @@ public final class Sinks {
      * the items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      */
-    public static <E> Sink<E> writeSocket(
+    public static <E> Sink<E> socket(
             @Nonnull String host,
             int port,
             @Nonnull DistributedFunction<E, String> toStringFn,
@@ -170,10 +170,10 @@ public final class Sinks {
     }
 
     /**
-     * Convenience for {@link #writeSocket(String, int, DistributedFunction,
+     * Convenience for {@link #socket(String, int, DistributedFunction,
      * Charset)} with UTF-8 as the charset.
      */
-    public static <E> Sink<E> writeSocket(
+    public static <E> Sink<E> socket(
             @Nonnull String host,
             int port,
             @Nonnull DistributedFunction<E, String> toStringFn
@@ -182,11 +182,11 @@ public final class Sinks {
     }
 
     /**
-     * Convenience for {@link #writeSocket(String, int, DistributedFunction,
+     * Convenience for {@link #socket(String, int, DistributedFunction,
      * Charset)} with {@code Object.toString} as the conversion function and
      * UTF-8 as the charset.
      */
-    public static <E> Sink<E> writeSocket(@Nonnull String host, int port) {
+    public static <E> Sink<E> socket(@Nonnull String host, int port) {
         return fromProcessor("writeSocket(" + host + ':' + port + ')',
                 writeSocketP(host, port, Object::toString, UTF_8));
     }
@@ -215,7 +215,7 @@ public final class Sinks {
      *               an existing file
      */
     @Nonnull
-    public static <E> Sink<E> writeFile(
+    public static <E> Sink<E> file(
             @Nonnull String directoryName,
             @Nonnull DistributedFunction<E, String> toStringFn,
             @Nonnull Charset charset,
@@ -226,23 +226,23 @@ public final class Sinks {
     }
 
     /**
-     * Convenience for {@link #writeFile(String, DistributedFunction, Charset,
+     * Convenience for {@link #file(String, DistributedFunction, Charset,
      * boolean)} with the UTF-8 charset and with overwriting of existing files.
      */
     @Nonnull
-    public static <E> Sink<E> writeFile(
+    public static <E> Sink<E> file(
             @Nonnull String directoryName, @Nonnull DistributedFunction<E, String> toStringFn
     ) {
-        return writeFile(directoryName, toStringFn, UTF_8, false);
+        return file(directoryName, toStringFn, UTF_8, false);
     }
 
     /**
-     * Convenience for {@link #writeFile(String, DistributedFunction, Charset,
+     * Convenience for {@link #file(String, DistributedFunction, Charset,
      * boolean)} with the UTF-8 charset and with overwriting of existing files.
      */
     @Nonnull
-    public static <E> Sink<E> writeFile(@Nonnull String directoryName) {
-        return writeFile(directoryName, Object::toString, UTF_8, false);
+    public static <E> Sink<E> file(@Nonnull String directoryName) {
+        return file(directoryName, Object::toString, UTF_8, false);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Sources.java
@@ -121,7 +121,7 @@ public final class Sources {
      * cluster topology change (triggering data migration), the source may
      * miss and/or duplicate some entries.
      */
-    public static <K, V> Source<Map.Entry<K, V>> readMap(@Nonnull String mapName) {
+    public static <K, V> Source<Map.Entry<K, V>> map(@Nonnull String mapName) {
         return fromProcessor("readMap(" + mapName + ')', readMapP(mapName));
     }
 
@@ -152,7 +152,7 @@ public final class Sources {
      * cluster topology change (triggering data migration), the source may
      * miss and/or duplicate some entries.
      */
-    public static <K, V, T> Source<T> readMap(
+    public static <K, V, T> Source<T> map(
             @Nonnull String mapName,
             @Nonnull Predicate<K, V> predicate,
             @Nonnull Projection<Entry<K, V>, T> projection
@@ -161,10 +161,10 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #readMap(String, Predicate, Projection)}
+     * Convenience for {@link #map(String, Predicate, Projection)}
      * which uses a {@link DistributedFunction} as the projection function.
      */
-    public static <K, V, T> Source<T> readMap(
+    public static <K, V, T> Source<T> map(
             @Nonnull String mapName,
             @Nonnull Predicate<K, V> predicate,
             @Nonnull DistributedFunction<Map.Entry<K, V>, T> projectionFn
@@ -213,7 +213,7 @@ public final class Sources {
      * @param <T> type of emitted item
      */
     @Nonnull
-    public static <K, V, T> Source<T> streamMap(
+    public static <K, V, T> Source<T> mapJournal(
             @Nonnull String mapName,
             @Nullable DistributedPredicate<EventJournalMapEvent<K, V>> predicate,
             @Nullable DistributedFunction<EventJournalMapEvent<K, V>, T> projection,
@@ -224,12 +224,12 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #streamMap(String, DistributedPredicate,
+     * Convenience for {@link #mapJournal(String, DistributedPredicate,
      * DistributedFunction, boolean)} with no projection or filtering. It
      * emits {@link EventJournalMapEvent}s.
      */
     @Nonnull
-    public static <K, V> Source<EventJournalMapEvent<K, V>> streamMap(
+    public static <K, V> Source<EventJournalMapEvent<K, V>> mapJournal(
             @Nonnull String mapName,
             boolean startFromLatestSequence
     ) {
@@ -249,7 +249,7 @@ public final class Sources {
      * miss and/or duplicate some entries.
      */
     @Nonnull
-    public static <K, V> Source<Map.Entry<K, V>> readRemoteMap(
+    public static <K, V> Source<Map.Entry<K, V>> remoteMap(
             @Nonnull String mapName,
             @Nonnull ClientConfig clientConfig
     ) {
@@ -280,7 +280,7 @@ public final class Sources {
      * cluster topology change (triggering data migration), the source may
      * miss and/or duplicate some entries.
      */
-    public static <K, V, T> Source<T> readRemoteMap(
+    public static <K, V, T> Source<T> remoteMap(
             @Nonnull String mapName,
             @Nonnull ClientConfig clientConfig,
             @Nonnull Predicate<K, V> predicate,
@@ -291,10 +291,10 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #readRemoteMap(String, ClientConfig, Predicate, Projection)}
+     * Convenience for {@link #remoteMap(String, ClientConfig, Predicate, Projection)}
      * which use a {@link DistributedFunction} as the projection function.
      */
-    public static <K, V, T> Source<T> readRemoteMap(
+    public static <K, V, T> Source<T> remoteMap(
             @Nonnull String mapName,
             @Nonnull ClientConfig clientConfig,
             @Nonnull Predicate<K, V> predicate,
@@ -332,7 +332,7 @@ public final class Sources {
      * @param <T> type of emitted item
      */
     @Nonnull
-    public static <K, V, T> Source<T> streamRemoteMap(
+    public static <K, V, T> Source<T> remoteMapJournal(
             @Nonnull String mapName,
             @Nonnull ClientConfig clientConfig,
             @Nullable DistributedPredicate<EventJournalMapEvent<K, V>> predicate,
@@ -344,12 +344,12 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #streamRemoteMap(String, ClientConfig,
+     * Convenience for {@link #remoteMapJournal(String, ClientConfig,
      * DistributedPredicate, DistributedFunction, boolean)} with no projection
      * or filtering. It emits {@link EventJournalMapEvent}s.
      */
     @Nonnull
-    public static <K, V> Source<EventJournalMapEvent<K, V>> streamRemoteMap(
+    public static <K, V> Source<EventJournalMapEvent<K, V>> remoteMapJournal(
             @Nonnull String mapName,
             @Nonnull ClientConfig clientConfig,
             boolean startFromLatestSequence
@@ -373,7 +373,7 @@ public final class Sources {
      * miss and/or duplicate some entries.
      */
     @Nonnull
-    public static <K, V> Source<Map.Entry<K, V>> readCache(@Nonnull String cacheName) {
+    public static <K, V> Source<Map.Entry<K, V>> cache(@Nonnull String cacheName) {
         return fromProcessor("readCache(" + cacheName + ')', readCacheP(cacheName));
     }
 
@@ -406,7 +406,7 @@ public final class Sources {
      * @param <T>                     type of emitted item
      */
     @Nonnull
-    public static <K, V, T> Source<T> streamCache(
+    public static <K, V, T> Source<T> cacheJournal(
             @Nonnull String cacheName,
             @Nullable DistributedPredicate<EventJournalCacheEvent<K, V>> predicate,
             @Nullable DistributedFunction<EventJournalCacheEvent<K, V>, T> projection,
@@ -418,11 +418,11 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #streamCache(String, DistributedPredicate,
+     * Convenience for {@link #cacheJournal(String, DistributedPredicate,
      * DistributedFunction, boolean)} with no projection or filtering.
      */
     @Nonnull
-    public static <K, V> Source<EventJournalCacheEvent<K, V>> streamCache(
+    public static <K, V> Source<EventJournalCacheEvent<K, V>> cacheJournal(
             @Nonnull String cacheName,
             boolean startFromLatestSequence
     ) {
@@ -442,7 +442,7 @@ public final class Sources {
      * miss and/or duplicate some entries.
      */
     @Nonnull
-    public static <K, V> Source<Map.Entry<K, V>> readRemoteCache(
+    public static <K, V> Source<Map.Entry<K, V>> remoteCache(
             @Nonnull String cacheName,
             @Nonnull ClientConfig clientConfig
     ) {
@@ -476,7 +476,7 @@ public final class Sources {
      * @param <T>                     type of emitted item
      */
     @Nonnull
-    public static <K, V, T> Source<T> streamRemoteCache(
+    public static <K, V, T> Source<T> remoteCacheJournal(
             @Nonnull String cacheName,
             @Nonnull ClientConfig clientConfig,
             @Nullable DistributedPredicate<EventJournalCacheEvent<K, V>> predicate,
@@ -488,12 +488,12 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #streamRemoteCache(String, ClientConfig,
+     * Convenience for {@link #remoteCacheJournal(String, ClientConfig,
      * DistributedPredicate, DistributedFunction, boolean)} with no projection
      * or filtering. It emits {@link EventJournalCacheEvent}s.
      */
     @Nonnull
-    public static <K, V> Source<EventJournalCacheEvent<K, V>> streamRemoteCache(
+    public static <K, V> Source<EventJournalCacheEvent<K, V>> remoteCacheJournal(
             @Nonnull String cacheName,
             @Nonnull ClientConfig clientConfig,
             boolean startFromLatestSequence
@@ -511,7 +511,7 @@ public final class Sources {
      * it will re-emit all entries.
      */
     @Nonnull
-    public static <E> Source<E> readList(@Nonnull String listName) {
+    public static <E> Source<E> list(@Nonnull String listName) {
         return fromProcessor("readList(" + listName + ')', readListP(listName));
     }
 
@@ -524,7 +524,7 @@ public final class Sources {
      * it will re-emit all entries.
      */
     @Nonnull
-    public static <E> Source<E> readRemoteList(@Nonnull String listName, @Nonnull ClientConfig clientConfig) {
+    public static <E> Source<E> remoteList(@Nonnull String listName, @Nonnull ClientConfig clientConfig) {
         return fromProcessor("readRemoteList(" + listName + ')', readRemoteListP(listName, clientConfig));
     }
 
@@ -544,7 +544,7 @@ public final class Sources {
      * non-blocking API, the processor is cooperative.
      */
     @Nonnull
-    public static Source<String> streamSocket(
+    public static Source<String> socket(
             @Nonnull String host, int port, @Nonnull Charset charset
     ) {
         return fromProcessor("streamSocket(" + host + ':' + port + ')', streamSocketP(host, port, charset));
@@ -571,17 +571,17 @@ public final class Sources {
      *             Use {@code "*"} for all files.
      */
     @Nonnull
-    public static Source<String> readFiles(
+    public static Source<String> files(
             @Nonnull String directory, @Nonnull Charset charset, @Nonnull String glob
     ) {
         return fromProcessor("readFiles(" + directory + '/' + glob + ')', readFilesP(directory, charset, glob));
     }
 
     /**
-     * Convenience for {@link #readFiles(String, Charset, String) readFiles(directory, UTF_8, "*")}.
+     * Convenience for {@link #files(String, Charset, String) readFiles(directory, UTF_8, "*")}.
      */
-    public static Source<String> readFiles(@Nonnull String directory) {
-        return readFiles(directory, UTF_8, GLOB_WILDCARD);
+    public static Source<String> files(@Nonnull String directory) {
+        return files(directory, UTF_8, GLOB_WILDCARD);
     }
 
     /**
@@ -630,7 +630,7 @@ public final class Sources {
      *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
      *             Use {@code "*"} for all files.
      */
-    public static Source<String> streamFiles(
+    public static Source<String> fileWatcher(
             @Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob
     ) {
         return fromProcessor("streamFiles(" + watchedDirectory + '/' + glob + ')',
@@ -639,10 +639,10 @@ public final class Sources {
     }
 
     /**
-     * Convenience for {@link #streamFiles(String, Charset, String)
+     * Convenience for {@link #fileWatcher(String, Charset, String)
      * streamFiles(watchedDirectory, UTF_8, "*")}.
      */
-    public static Source<String> streamFiles(@Nonnull String watchedDirectory) {
-        return streamFiles(watchedDirectory, UTF_8, GLOB_WILDCARD);
+    public static Source<String> fileWatcher(@Nonnull String watchedDirectory) {
+        return fileWatcher(watchedDirectory, UTF_8, GLOB_WILDCARD);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -52,7 +52,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeMap(String)}.
+     * {@link com.hazelcast.jet.Sinks#map(String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier writeMapP(@Nonnull String mapName) {
@@ -61,7 +61,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeRemoteMap(String, ClientConfig)}.
+     * {@link com.hazelcast.jet.Sinks#remoteMap(String, ClientConfig)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier writeRemoteMapP(@Nonnull String mapName, @Nonnull ClientConfig clientConfig) {
@@ -70,7 +70,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeCache(String)}.
+     * {@link com.hazelcast.jet.Sinks#cache(String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier writeCacheP(@Nonnull String cacheName) {
@@ -79,7 +79,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeRemoteCache(String, ClientConfig)}.
+     * {@link com.hazelcast.jet.Sinks#remoteCache(String, ClientConfig)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier writeRemoteCacheP(
@@ -90,7 +90,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeList(String)}.
+     * {@link com.hazelcast.jet.Sinks#list(String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier writeListP(@Nonnull String listName) {
@@ -99,7 +99,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeRemoteList(String, ClientConfig)}.
+     * {@link com.hazelcast.jet.Sinks#remoteList(String, ClientConfig)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier writeRemoteListP(@Nonnull String listName, @Nonnull ClientConfig clientConfig) {
@@ -108,7 +108,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeSocket(String, int)}.
+     * {@link com.hazelcast.jet.Sinks#socket(String, int)}.
      */
     public static <T> ProcessorMetaSupplier writeSocketP(
             @Nonnull String host,
@@ -136,7 +136,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeFile(String, DistributedFunction, Charset, boolean)}.
+     * {@link com.hazelcast.jet.Sinks#file(String, DistributedFunction, Charset, boolean)}.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeFileP(
@@ -150,7 +150,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeFile(String, DistributedFunction)}.
+     * {@link com.hazelcast.jet.Sinks#file(String, DistributedFunction)}.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeFileP(
@@ -161,7 +161,7 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sinks#writeFile(String)}.
+     * {@link com.hazelcast.jet.Sinks#file(String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier writeFileP(@Nonnull String directoryName) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -48,7 +48,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readMap(String)}.
+     * {@link com.hazelcast.jet.Sources#map(String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier readMapP(@Nonnull String mapName) {
@@ -57,7 +57,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readMap(String, Predicate, Projection)}}.
+     * {@link com.hazelcast.jet.Sources#map(String, Predicate, Projection)}}.
      */
     @Nonnull
     public static <K, V, T> ProcessorMetaSupplier readMapP(
@@ -70,7 +70,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readMap(String, Predicate, DistributedFunction)}}.
+     * {@link com.hazelcast.jet.Sources#map(String, Predicate, DistributedFunction)}}.
      */
     @Nonnull
     public static <K, V, T> ProcessorMetaSupplier readMapP(
@@ -84,7 +84,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamMap(String, boolean)}.
+     * {@link com.hazelcast.jet.Sources#mapJournal(String, boolean)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier streamMapP(@Nonnull String mapName, boolean startFromLatestSequence) {
@@ -93,7 +93,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamMap(String, DistributedPredicate, DistributedFunction, boolean)}.
+     * {@link com.hazelcast.jet.Sources#mapJournal(String, DistributedPredicate, DistributedFunction, boolean)}.
      */
     @Nonnull
     public static <K, V, T> ProcessorMetaSupplier streamMapP(
@@ -107,7 +107,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readRemoteMap(String, ClientConfig)}.
+     * {@link com.hazelcast.jet.Sources#remoteMap(String, ClientConfig)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier readRemoteMapP(@Nonnull String mapName, @Nonnull ClientConfig clientConfig) {
@@ -116,7 +116,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readRemoteMap(String, ClientConfig, Predicate, Projection)}.
+     * {@link com.hazelcast.jet.Sources#remoteMap(String, ClientConfig, Predicate, Projection)}.
      */
     @Nonnull
     public static <K, V, T> ProcessorMetaSupplier readRemoteMapP(
@@ -130,7 +130,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readRemoteMap(String, ClientConfig, Predicate, DistributedFunction)}.
+     * {@link com.hazelcast.jet.Sources#remoteMap(String, ClientConfig, Predicate, DistributedFunction)}.
      */
     @Nonnull
     public static <K, V, T> ProcessorMetaSupplier readRemoteMapP(
@@ -147,7 +147,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamRemoteMap(String, ClientConfig, boolean)}.
+     * {@link com.hazelcast.jet.Sources#remoteMapJournal(String, ClientConfig, boolean)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier streamRemoteMapP(
@@ -157,7 +157,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for {@link
-     * com.hazelcast.jet.Sources#streamRemoteMap(
+     * com.hazelcast.jet.Sources#remoteMapJournal(
      * String, ClientConfig, DistributedPredicate, DistributedFunction, boolean
      * )}.
      */
@@ -174,7 +174,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readCache(String)}.
+     * {@link com.hazelcast.jet.Sources#cache(String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier readCacheP(@Nonnull String cacheName) {
@@ -183,7 +183,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamCache(String, boolean)}.
+     * {@link com.hazelcast.jet.Sources#cacheJournal(String, boolean)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier streamCacheP(@Nonnull String cacheName, boolean startFromLatestSequence) {
@@ -192,7 +192,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamCache(String, DistributedPredicate, DistributedFunction, boolean)}.
+     * {@link com.hazelcast.jet.Sources#cacheJournal(String, DistributedPredicate, DistributedFunction, boolean)}.
      */
     @Nonnull
     public static <K, V, T> ProcessorMetaSupplier streamCacheP(
@@ -206,7 +206,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readRemoteCache(String, ClientConfig)}.
+     * {@link com.hazelcast.jet.Sources#remoteCache(String, ClientConfig)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier readRemoteCacheP(@Nonnull String cacheName, @Nonnull ClientConfig clientConfig) {
@@ -215,7 +215,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamRemoteCache(String, ClientConfig, boolean)}.
+     * {@link com.hazelcast.jet.Sources#remoteCacheJournal(String, ClientConfig, boolean)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier streamRemoteCacheP(
@@ -226,7 +226,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for {@link
-     * com.hazelcast.jet.Sources#streamRemoteCache(
+     * com.hazelcast.jet.Sources#remoteCacheJournal(
      * String, ClientConfig, DistributedPredicate, DistributedFunction, boolean
      * )}.
      */
@@ -244,7 +244,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readList(String)}.
+     * {@link com.hazelcast.jet.Sources#list(String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier readListP(@Nonnull String listName) {
@@ -253,7 +253,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readRemoteList(String, ClientConfig)}.
+     * {@link com.hazelcast.jet.Sources#remoteList(String, ClientConfig)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier readRemoteListP(@Nonnull String listName, @Nonnull ClientConfig clientConfig) {
@@ -262,7 +262,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamSocket(String, int, Charset)}.
+     * {@link com.hazelcast.jet.Sources#socket(String, int, Charset)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier streamSocketP(
@@ -273,7 +273,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#readFiles(String, Charset, String)}.
+     * {@link com.hazelcast.jet.Sources#files(String, Charset, String)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier readFilesP(
@@ -284,7 +284,7 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.Sources#streamFiles(String, Charset, String)}.
+     * {@link com.hazelcast.jet.Sources#fileWatcher(String, Charset, String)}.
      */
     public static ProcessorMetaSupplier streamFilesP(
             @Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ComputeStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/ComputeStageTest.java
@@ -71,7 +71,7 @@ public class ComputeStageTest extends TestInClusterSupport {
         srcMap = jet().getMap(srcName);
 
         String sinkName = randomName();
-        sink = Sinks.writeList(sinkName);
+        sink = Sinks.list(sinkName);
         sinkList = jet().getList(sinkName);
     }
 
@@ -87,7 +87,7 @@ public class ComputeStageTest extends TestInClusterSupport {
 
     @Test
     public void when_minimalPipeline_then_validDag() {
-        srcStage.drainTo(Sinks.writeList("out"));
+        srcStage.drainTo(Sinks.list("out"));
         assertTrue(pipeline.toDag().iterator().hasNext());
     }
 
@@ -169,7 +169,7 @@ public class ComputeStageTest extends TestInClusterSupport {
     public void hashJoinTwo() {
         // Given
         String enrichingName = randomName();
-        ComputeStage<Entry<Integer, String>> enrichingStage = pipeline.drawFrom(Sources.readMap(enrichingName));
+        ComputeStage<Entry<Integer, String>> enrichingStage = pipeline.drawFrom(Sources.map(enrichingName));
 
         ComputeStage<Tuple2<Integer, String>> joined = srcStage.hashJoin(enrichingStage, joinMapEntries(wholeItem()));
         joined.drainTo(sink);
@@ -193,8 +193,8 @@ public class ComputeStageTest extends TestInClusterSupport {
         // Given
         String enriching1Name = randomName();
         String enriching2Name = randomName();
-        ComputeStage<Entry<Integer, String>> enrichingStage1 = pipeline.drawFrom(Sources.readMap(enriching1Name));
-        ComputeStage<Entry<Integer, String>> enrichingStage2 = pipeline.drawFrom(Sources.readMap(enriching2Name));
+        ComputeStage<Entry<Integer, String>> enrichingStage1 = pipeline.drawFrom(Sources.map(enriching1Name));
+        ComputeStage<Entry<Integer, String>> enrichingStage2 = pipeline.drawFrom(Sources.map(enriching2Name));
         ComputeStage<Tuple3<Integer, String, String>> joined = srcStage.hashJoin(
                 enrichingStage1, joinMapEntries(wholeItem()),
                 enrichingStage2, joinMapEntries(wholeItem())
@@ -222,8 +222,8 @@ public class ComputeStageTest extends TestInClusterSupport {
         // Given
         String enriching1Name = randomName();
         String enriching2Name = randomName();
-        ComputeStage<Entry<Integer, String>> enrichingStage1 = pipeline.drawFrom(Sources.readMap(enriching1Name));
-        ComputeStage<Entry<Integer, String>> enrichingStage2 = pipeline.drawFrom(Sources.readMap(enriching2Name));
+        ComputeStage<Entry<Integer, String>> enrichingStage1 = pipeline.drawFrom(Sources.map(enriching1Name));
+        ComputeStage<Entry<Integer, String>> enrichingStage2 = pipeline.drawFrom(Sources.map(enriching2Name));
         HashJoinBuilder<Integer> b = srcStage.hashJoinBuilder();
         Tag<String> tagA = b.add(enrichingStage1, joinMapEntries(wholeItem()));
         Tag<String> tagB = b.add(enrichingStage2, joinMapEntries(wholeItem()));
@@ -403,7 +403,7 @@ public class ComputeStageTest extends TestInClusterSupport {
     }
 
     private static Source<Integer> readMapValues(String srcName) {
-        return Sources.readMap(srcName, truePredicate(),
+        return Sources.map(srcName, truePredicate(),
                 (DistributedFunction<Entry<Integer, Integer>, Integer>) Entry::getValue);
     }
 

--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/HdfsSinks.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/HdfsSinks.java
@@ -58,7 +58,7 @@ public final class HdfsSinks {
      * @param <V> type of value to write to HDFS
      */
     @Nonnull
-    public static <E, K, V> Sink<E> writeHdfs(
+    public static <E, K, V> Sink<E> hdfs(
             @Nonnull JobConf jobConf,
             @Nonnull DistributedFunction<? super E, K> extractKeyF,
             @Nonnull DistributedFunction<? super E, V> extractValueF
@@ -67,13 +67,13 @@ public final class HdfsSinks {
     }
 
     /**
-     * Convenience for {@link #writeHdfs(JobConf, DistributedFunction,
+     * Convenience for {@link #hdfs(JobConf, DistributedFunction,
      * DistributedFunction)} which expects {@code Map.Entry<K, V>} as
      * input and extracts its key and value parts to be written to HDFS.
      */
     @Nonnull
-    public static <K, V> Sink<Entry<K, V>> writeHdfs(@Nonnull JobConf jobConf) {
-        return writeHdfs(jobConf, Entry::getKey, Entry::getValue);
+    public static <K, V> Sink<Entry<K, V>> hdfs(@Nonnull JobConf jobConf) {
+        return hdfs(jobConf, Entry::getKey, Entry::getValue);
     }
 
 }

--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/HdfsSources.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/HdfsSources.java
@@ -55,18 +55,18 @@ public final class HdfsSources {
      * @param mapper  mapper which can be used to map the key and value to another value
      */
     @Nonnull
-    public static <K, V, E> Source<E> readHdfs(
+    public static <K, V, E> Source<E> hdfs(
             @Nonnull JobConf jobConf, @Nonnull DistributedBiFunction<K, V, E> mapper
     ) {
         return Sources.fromProcessor("readHdfs", new MetaSupplier<>(asSerializable(jobConf), mapper));
     }
 
     /**
-     * Convenience for {@link #readHdfs(JobConf, DistributedBiFunction)}
+     * Convenience for {@link #hdfs(JobConf, DistributedBiFunction)}
      * with {@link java.util.Map.Entry} as its output type.
      */
     @Nonnull
-    public static <K, V> Source<Entry<K, V>> readHdfs(@Nonnull JobConf jobConf) {
-        return readHdfs(jobConf, (DistributedBiFunction<K, V, Entry<K, V>>) Util::entry);
+    public static <K, V> Source<Entry<K, V>> hdfs(@Nonnull JobConf jobConf) {
+        return hdfs(jobConf, (DistributedBiFunction<K, V, Entry<K, V>>) Util::entry);
     }
 }

--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/core/processor/HdfsProcessors.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/core/processor/HdfsProcessors.java
@@ -38,7 +38,7 @@ public final class HdfsProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.HdfsSources#readHdfs(JobConf, DistributedBiFunction)}.
+     * {@link com.hazelcast.jet.HdfsSources#hdfs(JobConf, DistributedBiFunction)}.
      */
     @Nonnull
     public static <K, V, R> ReadHdfsP.MetaSupplier<K, V, R> readHdfsP(
@@ -49,7 +49,7 @@ public final class HdfsProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.HdfsSinks#writeHdfs(JobConf, DistributedFunction, DistributedFunction)}.
+     * {@link com.hazelcast.jet.HdfsSinks#hdfs(JobConf, DistributedFunction, DistributedFunction)}.
      */
     @Nonnull
     public static <E, K, V> ProcessorMetaSupplier writeHdfsP(

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
@@ -56,7 +56,7 @@ public final class KafkaSinks {
      * @param <K> type of the key published to Kafka
      * @param <V> type of the value published to Kafka
      */
-    public static <E, K, V> Sink<E> writeKafka(
+    public static <E, K, V> Sink<E> kafka(
             @Nonnull String topic,
             @Nonnull Properties properties,
             @Nonnull DistributedFunction<? super E, K> extractKeyFn,
@@ -67,7 +67,7 @@ public final class KafkaSinks {
     }
 
     /**
-     * Convenience for {@link #writeKafka(String, Properties,
+     * Convenience for {@link #kafka(String, Properties,
      * DistributedFunction, DistributedFunction)} which expects {@code
      * Map.Entry<K, V>} as input and extracts its key and value parts to be
      * published to Kafka.
@@ -79,7 +79,7 @@ public final class KafkaSinks {
      * @param <K> type of the key published to Kafka
      * @param <V> type of the value published to Kafka
      */
-    public static <K, V> Sink<Entry<K, V>> writeKafka(@Nonnull String topic, @Nonnull Properties properties) {
-        return writeKafka(topic, properties, Entry::getKey, Entry::getValue);
+    public static <K, V> Sink<Entry<K, V>> kafka(@Nonnull String topic, @Nonnull Properties properties) {
+        return kafka(topic, properties, Entry::getKey, Entry::getValue);
     }
 }

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSources.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSources.java
@@ -32,10 +32,10 @@ public final class KafkaSources {
     }
 
     /**
-     * Convenience for {@link #streamKafka(Properties, DistributedBiFunction,
+     * Convenience for {@link #kafka(Properties, DistributedBiFunction,
      * String...)} wrapping the output in {@code Map.Entry}.
      */
-    public static <K, V> Source<Entry<K, V>> streamKafka(@Nonnull Properties properties, @Nonnull String... topics) {
+    public static <K, V> Source<Entry<K, V>> kafka(@Nonnull Properties properties, @Nonnull String... topics) {
         return Sources.fromProcessor("streamKafka", KafkaProcessors.streamKafkaP(properties, topics));
     }
 
@@ -83,8 +83,11 @@ public final class KafkaSources {
      * @param projectionFn function to create output objects from key and value
      * @param topics     the list of topics
      */
-    public static <K, V, T> Source<T> streamKafka(@Nonnull Properties properties,
-                @Nonnull DistributedBiFunction<K, V, T> projectionFn, @Nonnull String... topics) {
+    public static <K, V, T> Source<T> kafka(
+            @Nonnull Properties properties,
+            @Nonnull DistributedBiFunction<K, V, T> projectionFn,
+            @Nonnull String... topics
+    ) {
         return Sources.fromProcessor("streamKafka", KafkaProcessors.streamKafkaP(properties, projectionFn, topics));
     }
 }

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/core/processor/KafkaProcessors.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/core/processor/KafkaProcessors.java
@@ -39,7 +39,7 @@ public final class KafkaProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.KafkaSources#streamKafka(Properties, DistributedBiFunction, String...)}.
+     * {@link com.hazelcast.jet.KafkaSources#kafka(Properties, DistributedBiFunction, String...)}.
      */
     public static <K, V, T> ProcessorMetaSupplier streamKafkaP(
             @Nonnull Properties properties,
@@ -53,7 +53,7 @@ public final class KafkaProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.KafkaSources#streamKafka(Properties, String...)}.
+     * {@link com.hazelcast.jet.KafkaSources#kafka(Properties, String...)}.
      */
     public static ProcessorMetaSupplier streamKafkaP(@Nonnull Properties properties, @Nonnull String... topics) {
         return streamKafkaP(properties, Util::entry, topics);
@@ -61,7 +61,7 @@ public final class KafkaProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link com.hazelcast.jet.KafkaSinks#writeKafka(String, Properties, DistributedFunction, DistributedFunction)}.
+     * {@link com.hazelcast.jet.KafkaSinks#kafka(String, Properties, DistributedFunction, DistributedFunction)}.
      */
     public static <T, K, V> ProcessorMetaSupplier writeKafkaP(
             @Nonnull String topic,


### PR DESCRIPTION
Current names were taken over from the underlying Core API vertex names.
This PR adapts them to better fit the Pipeline API.