### PR TITLE
StreamKafkaP interrupt fix and ProcessorSupplier.complete null check

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
@@ -55,6 +55,9 @@ public interface ProcessorSupplier extends Serializable {
      * or not. Execution can also be <em>aborted</em>, for example if a topology
      * change is detected in the cluster. In such a case this method will be
      * called immediately, without waiting for completion on other members.
+     * <p>
+     * Note: this method can be called before {@link ProcessorSupplier#get(int)}
+     * is called in case the job fails before we manage to call it
      *
      * @param error the exception (if any) that caused the job to fail;
      *              {@code null} in the case of successful job completion

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
@@ -231,7 +231,9 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
 
         @Override
         public void complete(Throwable error) {
-            client.shutdown();
+            if (client != null) {
+                client.shutdown();
+            }
         }
 
         @Override @Nonnull

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
@@ -30,6 +30,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InterruptException;
 
 import javax.annotation.Nonnull;
 import java.io.Closeable;
@@ -154,7 +155,12 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
         assert !currentAssignment.isEmpty() : "No topic partitions assigned to this processor.";
 
         if (traverser == null) {
-            ConsumerRecords<Object, Object> records = consumer.poll(POLL_TIMEOUT_MS);
+            ConsumerRecords<Object, Object> records;
+            try {
+                records = consumer.poll(POLL_TIMEOUT_MS);
+            } catch (InterruptException e) {
+                return true;
+            }
             if (records.isEmpty()) {
                 return false;
             }

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
@@ -105,7 +105,9 @@ public final class WriteKafkaP<T, K, V> extends AbstractProcessor {
 
         @Override
         public void complete(Throwable error) {
-            producer.close();
+            if (producer != null) {
+                producer.close();
+            }
         }
     }
 }


### PR DESCRIPTION
add try/catch block for kafka consumer poll to catch the InterruptException while cancelling the job.

add null check to complete method of ProcessorSupplier for WriteHdfsP, WriteKafkaP and ReadWithPartitionIteratorP

Fixes https://github.com/hazelcast/hazelcast-jet/issues/567