### PR TITLE
WIP: Read Sensitivity Modifiers via reflection

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ReflectionUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import java.lang.reflect.Field;
+
+public final class ReflectionUtils {
+    private ReflectionUtils() {
+
+    }
+
+    public static <T> T readStaticFieldOrNull(String classname, String fieldName) {
+        try {
+            Class<?> clazz = Class.forName(classname);
+            return readStaticField(clazz, fieldName);
+        } catch (ClassNotFoundException e) {
+            return null;
+        } catch (NoSuchFieldException e) {
+            return null;
+        } catch (IllegalAccessException e) {
+            return null;
+        } catch (SecurityException e) {
+            return null;
+        }
+    }
+
+    private static <T> T readStaticField(Class<?> clazz, String fieldName) throws NoSuchFieldException,
+            IllegalAccessException {
+        Field field = clazz.getDeclaredField(fieldName);
+        if (!field.isAccessible()) {
+            field.setAccessible(true);
+        }
+        return (T) field.get(null);
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ReflectionUtilsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class ReflectionUtilsTest {
+
+    @Test
+    public void readStaticFieldOrNull_whenClassDoesNotExist_thenReturnNull() {
+        Object field = ReflectionUtils.readStaticFieldOrNull("foo.bar.nonExistingClass", "field");
+        assertNull(field);
+    }
+
+    @Test
+    public void readStaticFieldOrNull_whenFieldDoesNotExist_thenReturnNull() {
+        Object field = ReflectionUtils.readStaticFieldOrNull(MyClass.class.getName(), "nonExistingField");
+        assertNull(field);
+    }
+
+    @Test
+    public void readStaticFieldOrNull_readFromPrivateField() {
+        String field = ReflectionUtils.readStaticFieldOrNull(MyClass.class.getName(), "staticPrivateField");
+        assertEquals("staticPrivateFieldContent", field);
+    }
+
+    @Test
+    public void readStaticFieldOrNull_readFromPublicField() {
+        String field = ReflectionUtils.readStaticFieldOrNull(MyClass.class.getName(), "staticPublicField");
+        assertEquals("staticPublicFieldContent", field);
+    }
+
+    public static final class MyClass {
+        public static String staticPublicField = "staticPublicFieldContent";
+        private static String staticPrivateField = "staticPrivateFieldContent";
+    }
+
+}


### PR DESCRIPTION
Java SE 7 does not specify any standard modifiers. Some implementations
use custom modifier, but we should not have a hard dependency on them.

This changeset will use the HIGH-sensitivity modifier whenever possible,
yet it will fallback to a default mode when the custom modifier is unavailable.