### PR TITLE
Return actual job status on job cancellation

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
@@ -52,7 +52,10 @@ public interface Job {
     JobStatus getJobStatus();
 
     /**
-     * Attempts to cancel execution of this job.
+     * Attempts to cancel execution of this job. Upon cancellation the job
+     * future will be completed immediately as per the contract of {@code Future.cancel()},
+     * however the job might still be running on the cluster. You can query
+     * the status via {@link #getJobStatus()} to check for actual completion.
      *
      * Shorthand for <code>job.getFuture().cancel()</code>
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobImpl.java
@@ -78,14 +78,16 @@ public abstract class AbstractJobImpl implements Job {
     @Nonnull
     @Override
     public final JobStatus getJobStatus() {
-        if (future.isCancelled()) {
-            return JobStatus.COMPLETED;
-        } else if (future.isCompletedExceptionally()) {
-            return JobStatus.FAILED;
-        } else if (future.isDone()) {
-            return JobStatus.COMPLETED;
+        if (!future.isCancelled()) {
+            // only check for the completion of the future is the job is cancelled
+            // - in which case the future doesn't indicate if the job is still running
+            // on the cluster or not
+            if (future.isCompletedExceptionally()) {
+                return JobStatus.FAILED;
+            } else if (future.isDone()) {
+                return JobStatus.COMPLETED;
+            }
         }
-
         return sendJobStatusRequest();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -117,7 +117,8 @@ public class JobTest extends JetTestSupport {
         job.cancel();
         joinAndExpectCancellation(job);
 
-        assertEquals(COMPLETED, job.getJobStatus());
+        StuckProcessor.proceedLatch.countDown();
+        assertCompletedEventually(job);
     }
 
     @Test
@@ -197,7 +198,8 @@ public class JobTest extends JetTestSupport {
         // Then
         joinAndExpectCancellation(trackedJob);
 
-        assertEquals(COMPLETED, trackedJob.getJobStatus());
+        StuckProcessor.proceedLatch.countDown();
+        assertCompletedEventually(trackedJob);
     }
 
     @Test
@@ -240,8 +242,10 @@ public class JobTest extends JetTestSupport {
         joinAndExpectCancellation(trackedJob);
         joinAndExpectCancellation(submittedJob);
 
-        assertEquals(COMPLETED, trackedJob.getJobStatus());
-        assertEquals(COMPLETED, submittedJob.getJobStatus());
+        StuckProcessor.proceedLatch.countDown();
+
+        assertCompletedEventually(trackedJob);
+        assertCompletedEventually(submittedJob);
     }
 
     @Test
@@ -273,6 +277,10 @@ public class JobTest extends JetTestSupport {
             fail();
         } catch (CancellationException ignored) {
         }
+    }
+
+    private void assertCompletedEventually(Job job) {
+        assertTrueEventually(() -> assertEquals(COMPLETED, job.getJobStatus()));
     }
 
 }


### PR DESCRIPTION
When a job is cancelled, instead of JobStatus.COMPLETED return
the actual status. Fixes #579.