### PR TITLE
Avoid race between job cancellation and job completion

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/CloseableProcessorSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/CloseableProcessorSupplier.java
@@ -29,8 +29,12 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static java.util.stream.Collectors.toList;
 
 /**
- * A {@link ProcessorSupplier} which closes created processor instances
- * when the job is complete.
+ * A {@link ProcessorSupplier} which closes created processor instances when
+ * the job is complete. Class is useful to close external resources such as
+ * connections or files.
+ * <p>
+ * The {@code close()} method is called after all other calls on any local
+ * processor have returned.
  *
  * @param <E> Processor type
  */
@@ -45,7 +49,6 @@ public class CloseableProcessorSupplier<E extends Processor & Closeable> impleme
 
     /**
      * @param simpleSupplier Supplier to create processor instances.
-     *                       Parameter is the local processor index.
      */
     public CloseableProcessorSupplier(DistributedSupplier<E> simpleSupplier) {
         this(count -> IntStream.range(0, count)
@@ -55,6 +58,7 @@ public class CloseableProcessorSupplier<E extends Processor & Closeable> impleme
 
     /**
      * @param supplier Supplier to create processor instances.
+     *                 Parameter is the number of processors that should be in the collection.
      */
     public CloseableProcessorSupplier(DistributedIntFunction<Collection<E>>  supplier) {
         this.supplier = supplier;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -23,10 +23,10 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.JetBuildInfo;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.core.JobStatus;
-import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.impl.execution.TaskletExecutionService;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlan;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
@@ -50,8 +50,6 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Consumer;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class JetService
@@ -149,17 +147,6 @@ public class JetService
         jobExecutionService.initExecution(
                 jobId, executionId, coordinator, coordinatorMemberListVersion, participants, plan
         );
-    }
-
-    public CompletionStage<Void> execute(
-            Address coordinator, long jobId, long executionId,
-            Consumer<CompletionStage<Void>> doneCallback
-    ) {
-        return jobExecutionService.execute(coordinator, jobId, executionId, doneCallback);
-    }
-
-    public void completeExecution(long executionId, Throwable error) {
-        jobExecutionService.completeExecution(executionId, error);
     }
 
     public JobStatus getJobStatus(long jobId) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -27,10 +27,9 @@ import com.hazelcast.jet.impl.execution.ExecutionContext;
 import com.hazelcast.jet.impl.execution.SenderTasklet;
 import com.hazelcast.jet.impl.execution.TaskletExecutionService;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlan;
-import com.hazelcast.jet.impl.operation.ExecuteOperation;
-import com.hazelcast.jet.impl.operation.SnapshotOperation;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -39,10 +38,8 @@ import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
@@ -97,7 +94,7 @@ public class JobExecutionService {
     public void reset(String reason, Supplier<RuntimeException> exceptionSupplier) {
         executionContexts.values().forEach(exeCtx -> {
             String message = String.format("Completing %s locally. Reason: %s",
-                    jobAndExecutionId(exeCtx.getJobId(), exeCtx.getExecutionId()),
+                    jobAndExecutionId(exeCtx.jobId(), exeCtx.executionId()),
                     reason);
             cancelAndComplete(exeCtx, message, exceptionSupplier.get());
         });
@@ -108,27 +105,31 @@ public class JobExecutionService {
      * job participant
      */
     void onMemberLeave(Address address) {
-        executionContexts.values()
-                         .stream()
-                         .filter(exeCtx -> exeCtx.isCoordinatorOrParticipating(address))
-                         .forEach(exeCtx -> {
-                             String message = String.format("Completing %s locally. Reason: %s left the cluster",
-                                     jobAndExecutionId(exeCtx.getJobId(), exeCtx.getExecutionId()),
-                                     address);
-                             cancelAndComplete(exeCtx, message, new TopologyChangedException("Topology has been changed"));
-                         });
+        executionContexts.values().stream()
+             .filter(exeCtx -> exeCtx.isCoordinator(address) || exeCtx.isParticipating(address))
+             .forEach(exeCtx -> {
+                 String message = String.format("Completing %s locally. Reason: Coordinator %s left the cluster",
+                         jobAndExecutionId(exeCtx.jobId(), exeCtx.executionId()),
+                         address);
+                 cancelAndComplete(exeCtx, message, new TopologyChangedException("Topology has been changed."));
+             });
     }
 
+    /**
+     * Cancel job execution and complete execution without waiting for coordinator
+     * to send CompleteOperation.
+     */
     private void cancelAndComplete(ExecutionContext exeCtx, String message, Throwable t) {
         try {
-            exeCtx.cancel().whenComplete(withTryCatch(logger, (r, e) -> {
-                long executionId = exeCtx.getExecutionId();
+            exeCtx.cancelExecution();
+            exeCtx.doneFuture().whenComplete(withTryCatch(logger, (r, e) -> {
+                long executionId = exeCtx.executionId();
                 logger.fine(message);
                 completeExecution(executionId, t);
             }));
         } catch (Throwable e) {
             logger.severe(String.format("Local cancellation of %s failed",
-                    jobAndExecutionId(exeCtx.getJobId(), exeCtx.getExecutionId())), e);
+                    jobAndExecutionId(exeCtx.jobId(), exeCtx.executionId())), e);
         }
     }
 
@@ -147,7 +148,7 @@ public class JobExecutionService {
      *     init execution is retried.
      * </li></ul>
      */
-    void initExecution(
+    public void initExecution(
             long jobId, long executionId, Address coordinator, int coordinatorMemberListVersion,
             Set<MemberInfo> participants, ExecutionPlan plan
     ) {
@@ -164,11 +165,11 @@ public class JobExecutionService {
             }
 
             executionContexts.values().stream()
-                             .filter(e -> e.getJobId() == jobId)
+                             .filter(e -> e.jobId() == jobId)
                              .forEach(e -> logger.fine(String.format(
                                      "Execution context for %s for coordinator %s already exists"
                                              + " with local execution %s for coordinator %s",
-                                     jobAndExecutionId(jobId, executionId), coordinator, idToString(e.getJobId()),
+                                     jobAndExecutionId(jobId, executionId), coordinator, idToString(e.jobId()),
                                      e.getCoordinator())));
 
             throw new RetryableHazelcastException();
@@ -244,29 +245,16 @@ public class JobExecutionService {
         }
     }
 
-    /**
-     * Starts execution of the job if the coordinator is verified
-     * as the accepted master and the correct initiator.
-     */
-    public CompletionStage<Void> execute(Address coordinator, long jobId, long executionId,
-                                         Consumer<CompletionStage<Void>> doneCallback) {
-        ExecutionContext executionContext = verifyAndGetExecutionContext(coordinator, jobId, executionId,
-                ExecuteOperation.class.getSimpleName());
-
-        logger.info("Start execution of " + jobAndExecutionId(jobId, executionId) + " from coordinator " + coordinator);
-
-        return executionContext.execute(doneCallback);
-    }
-
-    private ExecutionContext verifyAndGetExecutionContext(Address coordinator, long jobId, long executionId,
-                                                          String operationName) {
+    public ExecutionContext assertExecutionContext(Address coordinator, long jobId, long executionId,
+                                                   Operation callerOp) {
         Address masterAddress = nodeEngine.getMasterAddress();
         if (!coordinator.equals(masterAddress)) {
             failIfNotRunning();
 
             throw new IllegalStateException(String.format(
                     "Coordinator %s cannot do '%s' for %s: it is not the master, the master is %s",
-                    coordinator, operationName, jobAndExecutionId(jobId, executionId), masterAddress));
+                    coordinator, callerOp.getClass().getSimpleName(),
+                    jobAndExecutionId(jobId, executionId), masterAddress));
         }
 
         failIfNotRunning();
@@ -275,12 +263,12 @@ public class JobExecutionService {
         if (executionContext == null) {
             throw new TopologyChangedException(String.format(
                     "%s not found for coordinator %s for '%s'",
-                    jobAndExecutionId(jobId, executionId), coordinator, operationName));
+                    jobAndExecutionId(jobId, executionId), coordinator, callerOp.getClass().getSimpleName()));
         } else if (!executionContext.verify(coordinator, jobId)) {
             throw new IllegalStateException(String.format(
                     "%s, originally from coordinator %s, cannot do '%s' by coordinator %s and execution %s",
-                    jobAndExecutionId(jobId, executionContext.getExecutionId()), executionContext.getCoordinator(),
-                    operationName, coordinator, idToString(executionId)));
+                    jobAndExecutionId(jobId, executionContext.executionId()), executionContext.getCoordinator(),
+                    callerOp.getClass().getSimpleName(), coordinator, idToString(executionId)));
         }
 
         return executionContext;
@@ -289,25 +277,18 @@ public class JobExecutionService {
     /**
      * Completes and cleans up execution of the given job
      */
-    void completeExecution(long executionId, Throwable error) {
+    public void completeExecution(long executionId, Throwable error) {
         ExecutionContext executionContext = executionContexts.remove(executionId);
         if (executionContext != null) {
             try {
                 executionContext.complete(error);
             } finally {
-                classLoaders.remove(executionContext.getJobId());
-                executionContextJobIds.remove(executionContext.getJobId());
-                logger.fine("Completed execution of " + jobAndExecutionId(executionContext.getJobId(), executionId));
+                classLoaders.remove(executionContext.jobId());
+                executionContextJobIds.remove(executionContext.jobId());
+                logger.fine("Completed execution of " + jobAndExecutionId(executionContext.jobId(), executionId));
             }
         } else {
             logger.fine("Execution " + idToString(executionId) + " not found for completion");
         }
-    }
-
-    public CompletionStage<Void> beginSnapshot(Address coordinator, long jobId, long executionId, long snapshotId) {
-        ExecutionContext executionContext = verifyAndGetExecutionContext(coordinator, jobId, executionId,
-                SnapshotOperation.class.getSimpleName());
-
-        return executionContext.beginSnapshot(snapshotId);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -121,8 +121,7 @@ public class JobExecutionService {
      */
     private void cancelAndComplete(ExecutionContext exeCtx, String message, Throwable t) {
         try {
-            exeCtx.cancelExecution();
-            exeCtx.doneFuture().whenComplete(withTryCatch(logger, (r, e) -> {
+            exeCtx.cancelExecution().whenComplete(withTryCatch(logger, (r, e) -> {
                 long executionId = exeCtx.executionId();
                 logger.fine(message);
                 completeExecution(executionId, t);
@@ -281,7 +280,7 @@ public class JobExecutionService {
         ExecutionContext executionContext = executionContexts.remove(executionId);
         if (executionContext != null) {
             try {
-                executionContext.complete(error);
+                executionContext.completeExecution(error);
             } finally {
                 classLoaders.remove(executionContext.jobId());
                 executionContextJobIds.remove(executionContext.jobId());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -81,6 +81,10 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 
+/**
+ * Data pertaining to single job on master member. There's one instance per job,
+ * shared between multiple executions.
+ */
 public class MasterContext {
 
     public static final int SNAPSHOT_RESTORE_EDGE_PRIORITY = Integer.MIN_VALUE;
@@ -562,8 +566,8 @@ public class MasterContext {
 
         boolean cancelOnFailure = (cancellationFuture != null);
 
-        // if cancelOnFailure is true, we should cancel invocations when the future is cancelled, or any invocation fail
-
+        // if cancelOnFailure is true, we should cancel invocations when the future is cancelled or any
+        // of the invocations fails
         if (cancelOnFailure) {
             cancellationFuture.whenComplete(withTryCatch(logger, (r, e) -> {
                 if (e instanceof CancellationException) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
@@ -119,7 +119,7 @@ public class Networking {
         Map<Long, ExecutionContext> executionContexts = jobExecutionService.getExecutionContexts();
         out.writeInt(executionContexts.size());
         executionContexts.forEach((execId, exeCtx) -> uncheckRun(() -> {
-            if (!exeCtx.isParticipating(member)) {
+            if (!exeCtx.hasParticipant(member)) {
                 return;
             }
             out.writeLong(execId);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -167,7 +167,7 @@ public class ExecutionContext {
      */
     public CompletionStage<Void> beginSnapshot(long snapshotId) {
         synchronized (executionLock) {
-            if (cancellationFuture.isDone() || executionFuture.isDone()) {
+            if (cancellationFuture.isDone() || executionFuture != null && executionFuture.isDone()) {
                 throw new CancellationException();
             }
             return snapshotContext.startNewSnapshot(snapshotId);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -135,7 +135,6 @@ public class ExecutionContext {
         assert executionFuture == null || executionFuture.isDone()
                 : "If execution was begun, then completeExecution() should not be called before execution is done.";
 
-        ILogger logger = nodeEngine.getLogger(getClass());
         procSuppliers.forEach(s -> {
             try {
                 s.complete(error);
@@ -175,12 +174,27 @@ public class ExecutionContext {
         }
     }
 
+    public void handlePacket(int vertexId, int ordinal, Address sender, BufferObjectDataInput in) {
+        receiverMap.get(vertexId)
+                   .get(ordinal)
+                   .get(sender)
+                   .receiveStreamPacket(in);
+    }
+
+    public boolean hasParticipant(Address member) {
+        return participants.contains(member);
+    }
+
     public long jobId() {
         return jobId;
     }
 
     public long executionId() {
         return executionId;
+    }
+
+    public Address coordinator() {
+        return coordinator;
     }
 
     public Map<Integer, Map<Integer, Map<Address, SenderTasklet>>> senderMap() {
@@ -191,31 +205,8 @@ public class ExecutionContext {
         return receiverMap;
     }
 
-    public boolean verify(Address coordinator, long jobId) {
-        return this.coordinator.equals(coordinator) && this.jobId == jobId;
-    }
-
-
-    public void handlePacket(int vertexId, int ordinal, Address sender, BufferObjectDataInput in) {
-        receiverMap.get(vertexId)
-                   .get(ordinal)
-                   .get(sender)
-                   .receiveStreamPacket(in);
-    }
-
-    public boolean isParticipating(Address member) {
-        return participants.contains(member);
-    }
-
-    public Address getCoordinator() {
-        return coordinator;
-    }
-
-    public boolean isCoordinator(Address member) {
-        return coordinator.equals(member);
-    }
-
-    public SnapshotContext getSnapshotContext() {
+    // visible for testing only
+    public SnapshotContext snapshotContext() {
         return snapshotContext;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -165,6 +165,18 @@ public class ExecutionContext {
         }
     }
 
+    /**
+     * Starts a new snapshot by incrementing the current snapshot id
+     */
+    public CompletionStage<Void> beginSnapshot(long snapshotId) {
+        synchronized (executionLock) {
+            if (cancellationFuture.isDone()) {
+                throw new CancellationException();
+            }
+            return snapshotContext.startNewSnapshot(snapshotId);
+        }
+    }
+
     public long jobId() {
         return jobId;
     }
@@ -191,15 +203,6 @@ public class ExecutionContext {
                    .get(ordinal)
                    .get(sender)
                    .receiveStreamPacket(in);
-    }
-
-    public CompletionStage<Void> beginSnapshot(long snapshotId) {
-        synchronized (executionLock) {
-            if (cancellationFuture.isDone()) {
-                throw new CancellationException();
-            }
-            return snapshotContext.startNewSnapshot(snapshotId);
-        }
     }
 
     public boolean isParticipating(Address member) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -42,6 +42,11 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 
+/**
+ * Data pertaining to single job execution on all cluster members. There's one
+ * instance per job execution; if the job is restarted, another instance will
+ * be used.
+ */
 public class ExecutionContext {
 
     private final long jobId;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -35,7 +35,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.execution.ProcessorState.COMPLETE;
@@ -114,7 +113,7 @@ public class ProcessorTasklet implements Tasklet {
     }
 
     @Override
-    public void init(CompletableFuture<Void> jobFuture) {
+    public void init() {
         processor.init(outbox, context);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -147,7 +147,7 @@ public class SnapshotContext {
             // member is already done with the job and master didn't know it yet - we are immediately done.
             return completedVoidFuture();
         }
-        CompletableFuture res = future = new CompletableFuture<>();
+        CompletableFuture<Void> res = future = new CompletableFuture<>();
         if (newNumRemainingTasklets == 0) {
             handleSnapshotDone();
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
@@ -20,11 +20,10 @@ import com.hazelcast.jet.impl.util.ProgressState;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 
 public interface Tasklet extends Callable<ProgressState> {
 
-    default void init(CompletableFuture<Void> jobFuture) {
+    default void init() {
     }
 
     @Override @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -329,8 +329,8 @@ public class TaskletExecutionService {
 
             cancellationFuture.whenComplete(withTryCatch(logger, (r, e) -> {
                 if (!(e instanceof CancellationException)) {
-                    exception(new IllegalStateException("cancellationFuture was completed with an " +
-                            "exception other than CancellationException: " + e, e));
+                    exception(new IllegalStateException("cancellationFuture was completed with something " +
+                            "other than CancellationException:" + e, e));
                     return;
                 }
                 exception(e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -29,8 +29,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -38,8 +38,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
-import java.util.function.Consumer;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import static com.hazelcast.jet.impl.util.Util.completeVoidFuture;
 import static java.lang.Thread.currentThread;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -70,25 +71,31 @@ public class TaskletExecutionService {
     }
 
     /**
-     * @return instance of {@code java.util.concurrent.CompletableFuture}
+     *
+     * @param tasklets tasklets to run
+     * @param jobFuture future that will be completed when the job is done
+     *                  successfully, or upon the first exception
+     * @param doneFuture future that will be completed when all the tasklets are finished executing.
+     *                   Never completes with an exception even if the job fails.
+     * @param jobClassLoader classloader to use when running the tasklets
      */
-    public CompletionStage<Void> execute(
+    public void beginExecute(
             @Nonnull List<? extends Tasklet> tasklets,
-            @Nonnull Consumer<CompletionStage<Void>> doneCallback,
+            @Nonnull CompletableFuture<Void> jobFuture,
+            @Nonnull CompletableFuture<Void> doneFuture,
             @Nonnull ClassLoader jobClassLoader
     ) {
         ensureStillRunning();
-        final JobFuture jobFuture = new JobFuture(tasklets.size(), doneCallback);
+        final ExecutionTracker executionTracker = new ExecutionTracker(tasklets.size(), jobFuture, doneFuture);
         try {
             final Map<Boolean, List<Tasklet>> byCooperation =
                     tasklets.stream().collect(partitioningBy(Tasklet::isCooperative));
-            submitCooperativeTasklets(jobFuture, jobClassLoader, byCooperation.get(true));
-            submitBlockingTasklets(jobFuture, jobClassLoader, byCooperation.get(false));
+            submitCooperativeTasklets(executionTracker, jobClassLoader, byCooperation.get(true));
+            submitBlockingTasklets(executionTracker, jobClassLoader, byCooperation.get(false));
         } catch (Throwable t) {
-            jobFuture.completeExceptionally(t);
-            doneCallback.accept(jobFuture);
+            executionTracker.exception(t);
+            completeVoidFuture(doneFuture);
         }
-        return jobFuture;
     }
 
     public void shutdown() {
@@ -102,7 +109,7 @@ public class TaskletExecutionService {
         }
     }
 
-    private void submitBlockingTasklets(JobFuture jobFuture, ClassLoader jobClassLoader, List<Tasklet> tasklets) {
+    private void submitBlockingTasklets(ExecutionTracker jobFuture, ClassLoader jobClassLoader, List<Tasklet> tasklets) {
         jobFuture.blockingFutures = tasklets
                 .stream()
                 .map(t -> new BlockingWorker(new TaskletTracker(t, jobFuture, jobClassLoader)))
@@ -110,12 +117,14 @@ public class TaskletExecutionService {
                 .collect(toList());
     }
 
-    private void submitCooperativeTasklets(JobFuture jobFuture, ClassLoader jobClassLoader, List<Tasklet> tasklets) {
+    private void submitCooperativeTasklets(
+            ExecutionTracker jobFuture, ClassLoader jobClassLoader, List<Tasklet> tasklets
+    ) {
         ensureThreadsStarted();
         final List<TaskletTracker>[] trackersByThread = new List[cooperativeWorkers.length];
         Arrays.setAll(trackersByThread, i -> new ArrayList());
         for (Tasklet t : tasklets) {
-            t.init(jobFuture);
+            t.init();
             trackersByThread[cooperativeThreadIndex.getAndUpdate(i -> (i + 1) % trackersByThread.length)]
                     .add(new TaskletTracker(t, jobFuture, jobClassLoader));
         }
@@ -157,10 +166,10 @@ public class TaskletExecutionService {
             final Tasklet t = tracker.tasklet;
             currentThread().setContextClassLoader(tracker.jobClassLoader);
             try {
-                t.init(tracker.jobFuture);
+                t.init();
                 long idleCount = 0;
                 for (ProgressState result;
-                     !(result = t.call()).isDone() && !tracker.jobFuture.isDone() && !isShutdown;
+                     !(result = t.call()).isDone() && !tracker.executionTracker.executionCompleted() && !isShutdown;
                  ) {
                     if (result.isMadeProgress()) {
                         idleCount = 0;
@@ -170,10 +179,10 @@ public class TaskletExecutionService {
                 }
             } catch (Throwable e) {
                 logger.warning("Exception in " + t, e);
-                tracker.jobFuture.completeExceptionally(new JetException("Exception in " + t + ": " + e, e));
+                tracker.executionTracker.exception(new JetException("Exception in " + t + ": " + e, e));
             } finally {
                 currentThread().setContextClassLoader(clBackup);
-                tracker.jobFuture.taskletDone();
+                tracker.executionTracker.taskletDone();
             }
         }
     }
@@ -212,9 +221,9 @@ public class TaskletExecutionService {
                         }
                     } catch (Throwable e) {
                         logger.warning("Exception in " + t.tasklet, e);
-                        t.jobFuture.completeExceptionally(new JetException("Exception in " + t.tasklet + ": " + e, e));
+                        t.executionTracker.exception(new JetException("Exception in " + t.tasklet + ": " + e, e));
                     }
-                    if (t.jobFuture.isCompletedExceptionally()) {
+                    if (t.executionTracker.executionCompletedExceptionally()) {
                         dismissTasklet(t);
                     }
                 }
@@ -227,11 +236,12 @@ public class TaskletExecutionService {
             }
             // Best-effort attempt to release all tasklets. A tasklet can still be added
             // to a dead worker through work stealing.
+            trackers.forEach(t -> t.executionTracker.taskletDone());
             trackers.clear();
         }
 
         private void dismissTasklet(TaskletTracker t) {
-            t.jobFuture.taskletDone();
+            t.executionTracker.taskletDone();
             trackers.remove(t);
             stealWork();
         }
@@ -261,13 +271,13 @@ public class TaskletExecutionService {
 
     private static final class TaskletTracker {
         final Tasklet tasklet;
-        final JobFuture jobFuture;
+        final ExecutionTracker executionTracker;
         final ClassLoader jobClassLoader;
         final AtomicReference<CooperativeWorker> stealingWorker = new AtomicReference<>();
 
-        TaskletTracker(Tasklet tasklet, JobFuture jobFuture, ClassLoader jobClassLoader) {
+        TaskletTracker(Tasklet tasklet, ExecutionTracker executionTracker, ClassLoader jobClassLoader) {
             this.tasklet = tasklet;
-            this.jobFuture = jobFuture;
+            this.executionTracker = executionTracker;
             this.jobClassLoader = jobClassLoader;
         }
 
@@ -287,34 +297,47 @@ public class TaskletExecutionService {
         }
     }
 
-    private static final class JobFuture extends CompletableFuture<Void> {
+
+    /**
+     * Internal utility class to track the overall state of tasklet execution.
+     */
+    private final class ExecutionTracker {
 
         private final AtomicInteger completionLatch;
-        private final Consumer<CompletionStage<Void>> doneCallback;
+        private final CompletableFuture<Void> jobFuture;
+        private final CompletableFuture<Void> doneFuture;
         private List<Future> blockingFutures;
 
-        JobFuture(int taskletCount, Consumer<CompletionStage<Void>> doneCallback) {
-            this.doneCallback = doneCallback;
+        ExecutionTracker(int taskletCount, CompletableFuture<Void> jobFuture, CompletableFuture<Void> doneFuture) {
+            this.jobFuture = jobFuture;
+            this.doneFuture = doneFuture;
             this.completionLatch = new AtomicInteger(taskletCount);
+
+            jobFuture.whenComplete(withTryCatch(logger, (r, e) -> {
+               if (e instanceof CancellationException) {
+                   blockingFutures.forEach(f -> f.cancel(true)); // CompletableFuture.cancel ignores the flag
+               }
+            }));
         }
 
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            boolean cancelled = super.cancel(mayInterruptIfRunning);
-            if (cancelled) {
-                blockingFutures.forEach(f -> f.cancel(true)); // CompletableFuture.cancel ignores the flag
-            }
-            return cancelled;
+        void exception(Throwable t) {
+            jobFuture.completeExceptionally(t);
         }
 
         @SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "CompletableFuture<Void>")
-        private void taskletDone() {
+        void taskletDone() {
             if (completionLatch.decrementAndGet() == 0) {
-                complete(null);
-                if (doneCallback != null) {
-                    doneCallback.accept(this);
-                }
+                completeVoidFuture(jobFuture);
+                completeVoidFuture(doneFuture);
             }
+        }
+
+        boolean executionCompletedExceptionally() {
+            return jobFuture.isCompletedExceptionally();
+        }
+
+        boolean executionCompleted() {
+            return jobFuture.isDone();
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -73,7 +73,7 @@ public class TaskletExecutionService {
 
     /**
      * Submits the tasklets for execution and returns a future which is completed only
-     * when execution of all the tasklets are completed. If an exception occurred during
+     * when execution of all the tasklets has completed. If an exception occurred during
      * execution or execution was cancelled then the future will be completed exceptionally
      * but only after all tasklets are finished executing. The returned future does not
      * support cancellation, instead the supplied {@code cancellationFuture} should be used.
@@ -329,8 +329,8 @@ public class TaskletExecutionService {
 
             cancellationFuture.whenComplete(withTryCatch(logger, (r, e) -> {
                 if (!(e instanceof CancellationException)) {
-                    exception(new IllegalStateException("cancellationFuture was completed with another " +
-                            "exception than CancellationException"));
+                    exception(new IllegalStateException("cancellationFuture was completed with an " +
+                            "exception other than CancellationException: " + e, e));
                     return;
                 }
                 exception(e);
@@ -364,17 +364,17 @@ public class TaskletExecutionService {
     private static class ExecutionFuture extends CompletableFuture<Void> {
         @Override
         public boolean completeExceptionally(Throwable ex) {
-            throw new UnsupportedOperationException("This future can't be completed by outside caller");
+            throw new UnsupportedOperationException("This future can't be completed by an outside caller");
         }
 
         @Override
         public boolean complete(Void value) {
-            throw new UnsupportedOperationException("This future can't be completed by outside caller");
+            throw new UnsupportedOperationException("This future can't be completed by an outside caller");
         }
 
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
-            throw new UnsupportedOperationException("This future can't be cancelled by outside caller");
+            throw new UnsupportedOperationException("This future can't be cancelled by an outside caller");
         }
 
         @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -78,7 +78,7 @@ public class TaskletExecutionService {
      *                   Never completes with an exception even if the job fails.
      * @param jobClassLoader classloader to use when running the tasklets
      */
-    public void beginExecute(
+    void beginExecute(
             @Nonnull List<? extends Tasklet> tasklets,
             @Nonnull CompletableFuture<Void> jobFuture,
             @Nonnull CompletableFuture<Void> doneFuture,
@@ -108,7 +108,8 @@ public class TaskletExecutionService {
         }
     }
 
-    private void submitBlockingTasklets(ExecutionTracker executionTracker, ClassLoader jobClassLoader, List<Tasklet> tasklets) {
+    private void submitBlockingTasklets(ExecutionTracker executionTracker, ClassLoader jobClassLoader,
+                                        List<Tasklet> tasklets) {
         executionTracker.blockingFutures = tasklets
                 .stream()
                 .map(t -> new BlockingWorker(new TaskletTracker(t, executionTracker, jobClassLoader)))

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -330,7 +330,7 @@ public class TaskletExecutionService {
             cancellationFuture.whenComplete(withTryCatch(logger, (r, e) -> {
                 if (!(e instanceof CancellationException)) {
                     exception(new IllegalStateException("cancellationFuture was completed with something " +
-                            "other than CancellationException:" + e, e));
+                            "other than CancellationException: " + e, e));
                     return;
                 }
                 exception(e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteOperation.java
@@ -60,7 +60,7 @@ public class CompleteOperation extends Operation implements IdentifiedDataSerial
                     + idToString(executionId) + " because it is not master. Master is: " + masterAddress);
         }
 
-        service.completeExecution(executionId, error);
+        service.getJobExecutionService().completeExecution(executionId, error);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/InitOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/InitOperation.java
@@ -68,7 +68,9 @@ public class InitOperation extends Operation implements IdentifiedDataSerializab
         Address caller = getCallerAddress();
         logger.fine("Initializing execution plan for " + jobAndExecutionId(jobId, executionId) + " from " + caller);
         ExecutionPlan plan = planSupplier.get();
-        service.initExecution(jobId, executionId, caller, coordinatorMemberListVersion, participants, plan);
+        service.getJobExecutionService().initExecution(
+                jobId, executionId, caller, coordinatorMemberListVersion, participants, plan
+        );
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
@@ -57,7 +57,7 @@ public class SnapshotOperation extends AsyncExecutionOperation {
         }).exceptionally(e -> {
             getLogger().warning(String.format("Snapshot %d for job %s finished with error on member",
                     snapshotId, idToString(jobId)), e);
-            doSendResponse(new JetException("Exception during snapshot", e));
+            doSendResponse(new JetException("Exception during snapshot: " + e, e));
             return null;
         });
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.impl.JetService;
+import com.hazelcast.jet.impl.execution.ExecutionContext;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -45,20 +46,20 @@ public class SnapshotOperation extends AsyncExecutionOperation {
     @Override
     protected void doRun() throws Exception {
         JetService service = getService();
-        service.getJobExecutionService()
-               .beginSnapshot(getCallerAddress(), jobId, executionId, snapshotId)
-               .thenAccept(r -> {
-                   logFine(getLogger(),
-                           "Snapshot %s for job %s finished successfully on member",
-                           snapshotId, idToString(jobId));
-                   doSendResponse(null);
-               })
-               .exceptionally(e -> {
-                   getLogger().warning(String.format("Snapshot %d for job %s finished with error on member",
-                           snapshotId, idToString(jobId)), e);
-                   doSendResponse(new JetException("Exception during snapshot", e));
-                   return null;
-               });
+        ExecutionContext ctx = service.getJobExecutionService().assertExecutionContext(
+                getCallerAddress(), jobId, executionId, this
+        );
+        ctx.beginSnapshot(snapshotId).thenAccept(r -> {
+            logFine(getLogger(),
+                    "Snapshot %s for job %s finished successfully on member",
+                    snapshotId, idToString(jobId));
+            doSendResponse(null);
+        }).exceptionally(e -> {
+            getLogger().warning(String.format("Snapshot %d for job %s finished with error on member",
+                    snapshotId, idToString(jobId)), e);
+            doSendResponse(new JetException("Exception during snapshot", e));
+            return null;
+        });
 
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -57,7 +57,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.jet.core.TestUtil.assertExceptionInCauses;
-import static com.hazelcast.jet.core.TestUtil.getJetService;
 import static com.hazelcast.jet.impl.execution.SnapshotContext.NO_SNAPSHOT;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static org.junit.Assert.assertEquals;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -91,30 +91,28 @@ public class JetTestSupport extends HazelcastTestSupport {
     }
 
     public static void assertTrueEventually(UncheckedRunnable runnable) {
-        HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                runnable.run();
-            }
-        });
+        HazelcastTestSupport.assertTrueEventually(assertTask(runnable));
     }
 
     public static void assertTrueEventually(UncheckedRunnable runnable, long timeoutSeconds) {
-        HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                runnable.run();
-            }
-        }, timeoutSeconds);
+        HazelcastTestSupport.assertTrueEventually(assertTask(runnable), timeoutSeconds);
     }
 
     public static void assertTrueAllTheTime(UncheckedRunnable runnable, long durationSeconds) {
-        HazelcastTestSupport.assertTrueAllTheTime(new AssertTask() {
+        HazelcastTestSupport.assertTrueAllTheTime(assertTask(runnable), durationSeconds);
+    }
+
+    public static void assertTrueFiveSeconds(UncheckedRunnable runnable) {
+        HazelcastTestSupport.assertTrueFiveSeconds(assertTask(runnable));
+    }
+
+    private static AssertTask assertTask(UncheckedRunnable runnable) {
+        return new AssertTask() {
             @Override
             public void run() throws Exception {
                 runnable.run();
             }
-        }, durationSeconds);
+        };
     }
 
     public Address nextAddress() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -16,15 +16,19 @@
 
 package com.hazelcast.jet.core;
 
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.stream.IStreamCache;
 import com.hazelcast.jet.stream.IStreamList;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
@@ -104,6 +108,26 @@ public class JetTestSupport extends HazelcastTestSupport {
 
     public static void assertTrueFiveSeconds(UncheckedRunnable runnable) {
         HazelcastTestSupport.assertTrueFiveSeconds(assertTask(runnable));
+    }
+
+    public static JetService getJetService(JetInstance jetInstance) {
+        return getNodeEngineImpl(jetInstance).getService(JetService.SERVICE_NAME);
+    }
+
+    public static HazelcastInstance hz(JetInstance instance) {
+        return instance.getHazelcastInstance();
+    }
+
+    public static Address getAddress(JetInstance instance) {
+        return getAddress(hz(instance));
+    }
+
+    public static Node getNode(JetInstance instance) {
+        return getNode(hz(instance));
+    }
+
+    public static NodeEngineImpl getNodeEngineImpl(JetInstance instance) {
+        return getNodeEngineImpl(hz(instance));
     }
 
     private static AssertTask assertTask(UncheckedRunnable runnable) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.core;
 
-import com.hazelcast.instance.HazelcastInstanceImpl;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
@@ -28,12 +26,10 @@ import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.config.ProcessingGuarantee;
-import com.hazelcast.jet.core.processor.DiagnosticProcessors;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.core.test.TestProcessorMetaSupplierContext;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.datamodel.TimestampedEntry;
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.SnapshotRepository;
 import com.hazelcast.jet.impl.execution.ExecutionContext;
@@ -43,7 +39,6 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.PacketFiltersUtil;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -61,7 +56,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.CancellationException;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -78,8 +72,10 @@ import static com.hazelcast.jet.core.processor.Processors.combineToSlidingWindow
 import static com.hazelcast.jet.core.processor.Processors.insertWatermarksP;
 import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static com.hazelcast.jet.core.processor.Processors.noopP;
+import static com.hazelcast.jet.core.processor.SinkProcessors.writeListP;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
+import static com.hazelcast.test.PacketFiltersUtil.delayOperationsFrom;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
@@ -111,9 +107,8 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         JetConfig config = new JetConfig();
         config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
 
-        JetInstance[] instances = factory.newMembers(config, 2);
-        instance1 = instances[0];
-        instance2 = instances[1];
+        instance1 = factory.newMember(config);
+        instance2 = factory.newMember(config);
     }
 
     @After
@@ -282,53 +277,84 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         /*
         Design of this test
 
-        The DAG is "source -> sink". Source completes immediately on slave member and is infinite on master.
-        Edge between source and sink is distributed. This situation will cause that after the source completes on
-        slave, the sink on slave will only have remote source. This will allow that we can receive the
-        barrier from remote master before slave even starts the snapshot. This is the very purpose of this
-        test. To ensure that this happens, we postpone handling of SnapshotOperation on slave.
-         */
-        boolean i1IsMaster = ((ClusterServiceImpl) instance1.getHazelcastInstance().getCluster()).isMaster();
-        JetInstance masterInstance = i1IsMaster ? instance1 : instance2;
-        JetInstance slaveInstance = i1IsMaster ? instance2 : instance1;
+        The DAG is "source -> sink". Source completes immediately on  non-coordinator (worker)
+        and is infinite on coordinator. Edge between source and sink is distributed. This
+        situation will cause that after the source completes on member, the sink on worker
+        will only have the remote source. This will allow that we can receive the barrier
+        from remote coordinator before worker even starts the snapshot. This is the very
+        purpose of this test. To ensure that this happens, we postpone handling of SnapshotOperation
+        on the worker.
+        */
 
-        JetService jetService = ((HazelcastInstanceImpl) slaveInstance.getHazelcastInstance())
-                .node.nodeEngine.getService(JetService.SERVICE_NAME);
-        PacketFiltersUtil.delayOperationsFrom(masterInstance.getHazelcastInstance(),
-                JetInitDataSerializerHook.FACTORY_ID, singletonList(JetInitDataSerializerHook.SNAPSHOT_OP));
+        // instance1 is always coordinator
+        delayOperationsFrom(
+                hz(instance1), JetInitDataSerializerHook.FACTORY_ID, singletonList(JetInitDataSerializerHook.SNAPSHOT_OP)
+        );
 
         DAG dag = new DAG();
-        Vertex source = dag.newVertex("source", new NonBalancedSource(
-                slaveInstance.getHazelcastInstance().getCluster().getLocalMember().getAddress().toString()));
-        Vertex sink = dag.newVertex("sink", DiagnosticProcessors.writeLoggerP());
+        Vertex source = dag.newVertex("source", new NonBalancedSource(getAddress(instance2).toString()));
+        Vertex sink = dag.newVertex("sink", writeListP("sink"));
         dag.edge(between(source, sink).distributed());
 
         JobConfig config = new JobConfig();
         config.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
         config.setSnapshotIntervalMillis(500);
-        Job job = masterInstance.newJob(dag, config);
+        Job job = instance1.newJob(dag, config);
 
-        IStreamMap<Long, Long> randomIdsMap = masterInstance.getMap(JobRepository.RANDOM_IDS_MAP_NAME);
-        long executionId = randomIdsMap.entrySet().stream()
-                    .filter(e -> e.getValue().equals(job.getJobId()) && !e.getValue().equals(e.getKey()))
-                    .mapToLong(Entry::getKey)
-                    .findAny()
-                    .orElseThrow(() -> new AssertionError("ExecutionId not found"));
-        ExecutionContext executionContext = null;
-        // spin until the executionContext is available on the slave member
-        while (executionContext == null) {
-            executionContext = jetService.getJobExecutionService().getExecutionContext(executionId);
-        }
-        SnapshotContext ssContext = executionContext.snapshotContext();
+        SnapshotContext ssContext = getSnapshotContext(job);
         assertTrueEventually(() -> assertTrue("numRemainingTasklets was not negative, the tested scenario did not happen",
                 ssContext.getNumRemainingTasklets().get() < 0), 3);
+    }
 
-        Thread.sleep(3000);
-        job.cancel();
-        try {
-            job.getFuture().get();
-        } catch (CancellationException expected) {
+    @Test
+    public void when_snapshotStartedBeforeExecution_then_firstSnapshotIsSuccessful() throws Exception {
+        // instance1 is always coordinator
+        // delay ExecuteOperation so that snapshot is started before execution is started on the worker member
+        delayOperationsFrom(
+                hz(instance1), JetInitDataSerializerHook.FACTORY_ID, singletonList(JetInitDataSerializerHook.EXECUTE_OP)
+        );
+
+        DAG dag = new DAG();
+        SequencesInPartitionsMetaSupplier pms = new SequencesInPartitionsMetaSupplier(3, 100);
+
+        Vertex source = dag.newVertex("source", throttle(pms, 10)).localParallelism(1);
+        Vertex sink = dag.newVertex("sink", writeListP("sink"));
+
+        dag.edge(between(source, sink).distributed());
+
+        JobConfig config = new JobConfig();
+        config.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
+        config.setSnapshotIntervalMillis(250);
+        Job job = instance1.newJob(dag, config);
+
+        // the first snapshot should succeed
+        assertTrueEventually(() -> {
+            IStreamMap<Long, SnapshotRecord> records = getSnapshotsMap(job);
+            SnapshotRecord record = records.get(0L);
+            assertNotNull("no record found for snapshot 0", record);
+            assertTrue("snapshot was not successful", record.isSuccessful());
+        }, 5);
+    }
+
+    private IStreamMap<Long, SnapshotRecord> getSnapshotsMap(Job job) {
+        SnapshotRepository snapshotRepository = new SnapshotRepository(instance1);
+        return snapshotRepository.getSnapshotMap(job.getJobId());
+    }
+
+    private SnapshotContext getSnapshotContext(Job job) {
+        IStreamMap<Long, Long> randomIdsMap = instance1.getMap(JobRepository.RANDOM_IDS_MAP_NAME);
+        long executionId = randomIdsMap.entrySet().stream()
+                                       .filter(e -> e.getValue().equals(job.getJobId())
+                                               && !e.getValue().equals(e.getKey()))
+                                       .mapToLong(Entry::getKey)
+                                       .findAny()
+                                       .orElseThrow(() -> new AssertionError("ExecutionId not found"));
+        ExecutionContext executionContext = null;
+        // spin until the executionContext is available on the worker
+        while (executionContext == null) {
+            executionContext = getJetService(instance2).getJobExecutionService().getExecutionContext(executionId);
         }
+        return executionContext.snapshotContext();
     }
 
     private void waitForNextSnapshot(IStreamMap<Long, Object> snapshotsMap, int timeoutSeconds) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -319,7 +319,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         while (executionContext == null) {
             executionContext = jetService.getJobExecutionService().getExecutionContext(executionId);
         }
-        SnapshotContext ssContext = executionContext.getSnapshotContext();
+        SnapshotContext ssContext = executionContext.snapshotContext();
         assertTrueEventually(() -> assertTrue("numRemainingTasklets was not negative, the tested scenario did not happen",
                 ssContext.getNumRemainingTasklets().get() < 0), 3);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -43,7 +43,6 @@ import java.util.function.Consumer;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RESTARTING;
 import static com.hazelcast.jet.core.JobStatus.STARTING;
-import static com.hazelcast.jet.core.TestUtil.getJetService;
 import static com.hazelcast.spi.partition.IPartition.MAX_BACKUP_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -77,11 +77,22 @@ public class TestProcessors {
         public static volatile CountDownLatch executionStarted;
         public static volatile CountDownLatch proceedLatch;
 
+        // how long time to wait during calls to complete()
+        private final long timeoutMillis;
+
+        public StuckProcessor() {
+            this(1);
+        }
+
+        public StuckProcessor(long timeoutMillis) {
+            this.timeoutMillis = timeoutMillis;
+        }
+
         @Override
         public boolean complete() {
             executionStarted.countDown();
             try {
-                return proceedLatch.await(1, TimeUnit.MILLISECONDS);
+                return proceedLatch.await(timeoutMillis, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 return false;
             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.jet.core;
 
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.function.DistributedSupplier;
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.util.ThrottleWrappedP;
 import com.hazelcast.jet.impl.util.WrappingProcessorMetaSupplier;
 
@@ -27,7 +25,6 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static org.junit.Assert.assertEquals;
 
 public final class TestUtil {
@@ -64,10 +61,6 @@ public final class TestUtil {
         if (!found) {
             assertEquals("expected exception not found in causes chain", expected, caught);
         }
-    }
-
-    public static JetService getJetService(JetInstance jetInstance) {
-        return getNodeEngineImpl(jetInstance.getHazelcastInstance()).getService(JetService.SERVICE_NAME);
     }
 
     public static final class DummyUncheckedTestException extends RuntimeException {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -60,7 +60,6 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMB
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.SHUTDOWN_REQUEST;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.STARTING;
-import static com.hazelcast.jet.core.TestUtil.getJetService;
 import static com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook.EXECUTE_OP;
 import static com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook.INIT_OP;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
@@ -256,7 +255,7 @@ public class ProcessorTaskletTest {
 
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 mock(SnapshotContext.class), new MockOutboundCollector(10));
-        t.init(new CompletableFuture<>());
+        t.init();
         return t;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
@@ -298,7 +298,7 @@ public class ProcessorTaskletTest_Blocking {
         }
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 mock(SnapshotContext.class), new MockOutboundCollector(10));
-        t.init(jobFuture);
+        t.init();
         return t;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.jet.impl.execution;
 
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
-import com.hazelcast.jet.config.ProcessingGuarantee;
-import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
-import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.jet.core.test.TestOutbox.MockData;
 import com.hazelcast.jet.core.test.TestOutbox.MockSerializationService;
+import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
+import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -200,7 +199,7 @@ public class ProcessorTaskletTest_Snapshots {
         snapshotContext.initTaskletCount(1, 0);
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 snapshotContext, snapshotCollector);
-        t.init(new CompletableFuture<>());
+        t.init();
         return t;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -289,7 +289,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     }
 
     @Test
-    public void when_tryCompleteReturnedFuture_then_fails() {
+    public void when_tryCompleteOnReturnedFuture_then_fails() {
         // Given
         final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
         CompletableFuture<Void> f = es.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
@@ -300,7 +300,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     }
 
     @Test
-    public void when_tryCompleteExceptionallyReturnedFuture_then_fails() {
+    public void when_tryCompleteExceptionallyOnReturnedFuture_then_fails() {
         // Given
         final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
         CompletableFuture<Void> f = es.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
@@ -311,7 +311,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     }
 
     @Test
-    public void when_tryCancelReturnedFuture_then_fails() {
+    public void when_tryCancelOnReturnedFuture_then_fails() {
         // Given
         final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
         CompletableFuture<Void> f = es.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
@@ -161,7 +161,7 @@ public class StreamKafkaPTest extends KafkaTestSupport {
             }
 
             assertTrueEventually(() -> {
-                assertTrue(list.size() >= messageCount * 4);
+                assertTrue("Not all messages were received", list.size() >= messageCount * 4);
                 for (int i = 0; i < 2 * messageCount; i++) {
                     assertTrue(list.contains(createEntry(i)));
                     assertTrue(list.contains(createEntry(i - messageCount)));


### PR DESCRIPTION
This supports more flexible execution flow and avoids the
race between job cancellation and completion. Fixes #589