### PR TITLE
Fix Kafka writer issues

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -110,9 +110,12 @@ public interface Processor {
     }
 
     /**
-     * Called when there is no pending data in the inbox. Allows the processor
-     * to produce output in the absence of input. If it returns {@code false},
-     * it will be called again before proceeding to call any other method.
+     * This method will be called periodically and only when the current batch
+     * of items in the inbox has been exhausted. It can be used to produce
+     * output in the absence of input or to do general maintenance work.
+     * <p>
+     * If the call returns {@code false}, it will be called again before proceeding
+     * to call any other method. Default implementation returns {@code true}.
      */
     default boolean tryProcess() {
         return true;

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
@@ -39,14 +39,17 @@ public final class KafkaSinks {
      * supplied mapping function.
      * <p>
      * The source creates a single {@code KafkaProducer} per cluster
-     * member using the supplied properties.
+     * member using the supplied {@code properties}.
      * <p>
-     * Behavior on job restart: the processor is stateless. If the job is
-     * restarted, duplicate events can occur. If you need exactly-once
-     * behavior, you must ensure idempotence on the application level.
+     * Behavior on job restart: the processor is stateless. On snapshot we only
+     * make sure that all async operations are done. If the job is restarted,
+     * duplicate events can occur. If you need exactly-once behavior, you must
+     * ensure idempotence on the application level.
      * <p>
-     * IO failures are generally handled by Kafka producer and generally do not
-     * cause the processor to fail. Refer to Kafka documentation for details.
+     * IO failures are generally handled by Kafka producer and do not cause the
+     * processor to fail. Refer to Kafka documentation for details.
+     * <p>
+     * The
      *
      * @param properties     producer properties which should contain broker
      *                       address and key/value serializers

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
@@ -48,8 +48,6 @@ public final class KafkaSinks {
      * <p>
      * IO failures are generally handled by Kafka producer and do not cause the
      * processor to fail. Refer to Kafka documentation for details.
-     * <p>
-     * The
      *
      * @param properties     producer properties which should contain broker
      *                       address and key/value serializers

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
@@ -63,6 +63,12 @@ public final class WriteKafkaP<T, K, V> implements Processor {
     }
 
     @Override
+    public boolean tryProcess() {
+        checkError();
+        return true;
+    }
+
+    @Override
     public void process(int ordinal, @Nonnull Inbox inbox) {
         checkError();
         inbox.drain((T item) -> {

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
@@ -48,7 +48,7 @@ public final class WriteKafkaP<T, K, V> implements Processor {
     private final AtomicReference<Throwable> lastError = new AtomicReference<>();
 
     private final Callback callback = (metadata, exception) -> {
-        // Note: this method is called on different thread.
+        // Note: this method may be called on different thread.
         numPendingAsyncCalls.decrementAndGet();
         if (exception != null) {
             lastError.compareAndSet(null, exception);


### PR DESCRIPTION
KafkaProducer.send() call is async. This scenario was possible:
- send a record
- do a successful snapshot
- member fails before the async record is sent
- after restart, the record is lost and the at-least-once guarantee broken.

This was resolved that the processor ensures that all async calls are
done at the time of snapshot.

Another fixes:
- calling `producer.flush()` after each batch of items
- checking for errors from async calls

Fixes #605