### PR TITLE
[Backport] Avoid race between job cancellation and job completion (#604)

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/CloseableProcessorSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/CloseableProcessorSupplier.java
@@ -29,8 +29,12 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static java.util.stream.Collectors.toList;
 
 /**
- * A {@link ProcessorSupplier} which closes created processor instances
- * when the job is complete.
+ * A {@link ProcessorSupplier} which closes created processor instances when
+ * the job is complete. Class is useful to close external resources such as
+ * connections or files.
+ * <p>
+ * The {@code close()} method is called after all other calls on any local
+ * processor have returned.
  *
  * @param <E> Processor type
  */
@@ -45,7 +49,6 @@ public class CloseableProcessorSupplier<E extends Processor & Closeable> impleme
 
     /**
      * @param simpleSupplier Supplier to create processor instances.
-     *                       Parameter is the local processor index.
      */
     public CloseableProcessorSupplier(DistributedSupplier<E> simpleSupplier) {
         this(count -> IntStream.range(0, count)
@@ -55,6 +58,7 @@ public class CloseableProcessorSupplier<E extends Processor & Closeable> impleme
 
     /**
      * @param supplier Supplier to create processor instances.
+     *                 Parameter is the number of processors that should be in the collection.
      */
     public CloseableProcessorSupplier(DistributedIntFunction<Collection<E>>  supplier) {
         this.supplier = supplier;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -23,10 +23,10 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.JetBuildInfo;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.core.JobStatus;
-import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.impl.execution.TaskletExecutionService;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlan;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
@@ -50,8 +50,6 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Consumer;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class JetService
@@ -149,17 +147,6 @@ public class JetService
         jobExecutionService.initExecution(
                 jobId, executionId, coordinator, coordinatorMemberListVersion, participants, plan
         );
-    }
-
-    public CompletionStage<Void> execute(
-            Address coordinator, long jobId, long executionId,
-            Consumer<CompletionStage<Void>> doneCallback
-    ) {
-        return jobExecutionService.execute(coordinator, jobId, executionId, doneCallback);
-    }
-
-    public void completeExecution(long executionId, Throwable error) {
-        jobExecutionService.completeExecution(executionId, error);
     }
 
     public JobStatus getJobStatus(long jobId) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -81,6 +81,10 @@ import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
 
+/**
+ * Data pertaining to single job on master member. There's one instance per job,
+ * shared between multiple executions.
+ */
 public class MasterContext {
 
     public static final int SNAPSHOT_RESTORE_EDGE_PRIORITY = Integer.MIN_VALUE;
@@ -562,8 +566,8 @@ public class MasterContext {
 
         boolean cancelOnFailure = (cancellationFuture != null);
 
-        // if cancelOnFailure is true, we should cancel invocations when the future is cancelled, or any invocation fail
-
+        // if cancelOnFailure is true, we should cancel invocations when the future is cancelled or any
+        // of the invocations fails
         if (cancelOnFailure) {
             cancellationFuture.whenComplete(withTryCatch(logger, (r, e) -> {
                 if (e instanceof CancellationException) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
@@ -119,7 +119,7 @@ public class Networking {
         Map<Long, ExecutionContext> executionContexts = jobExecutionService.getExecutionContexts();
         out.writeInt(executionContexts.size());
         executionContexts.forEach((execId, exeCtx) -> uncheckRun(() -> {
-            if (!exeCtx.isParticipating(member)) {
+            if (!exeCtx.hasParticipant(member)) {
                 return;
             }
             out.writeLong(execId);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -35,7 +35,6 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.TreeMap;
-import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.execution.ProcessorState.COMPLETE;
@@ -114,7 +113,7 @@ public class ProcessorTasklet implements Tasklet {
     }
 
     @Override
-    public void init(CompletableFuture<Void> jobFuture) {
+    public void init() {
         processor.init(outbox, context);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -147,7 +147,7 @@ public class SnapshotContext {
             // member is already done with the job and master didn't know it yet - we are immediately done.
             return completedVoidFuture();
         }
-        CompletableFuture res = future = new CompletableFuture<>();
+        CompletableFuture<Void> res = future = new CompletableFuture<>();
         if (newNumRemainingTasklets == 0) {
             handleSnapshotDone();
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
@@ -20,11 +20,10 @@ import com.hazelcast.jet.impl.util.ProgressState;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 
 public interface Tasklet extends Callable<ProgressState> {
 
-    default void init(CompletableFuture<Void> jobFuture) {
+    default void init() {
     }
 
     @Override @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteOperation.java
@@ -60,7 +60,7 @@ public class CompleteOperation extends Operation implements IdentifiedDataSerial
                     + idToString(executionId) + " because it is not master. Master is: " + masterAddress);
         }
 
-        service.completeExecution(executionId, error);
+        service.getJobExecutionService().completeExecution(executionId, error);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/InitOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/InitOperation.java
@@ -68,7 +68,9 @@ public class InitOperation extends Operation implements IdentifiedDataSerializab
         Address caller = getCallerAddress();
         logger.fine("Initializing execution plan for " + jobAndExecutionId(jobId, executionId) + " from " + caller);
         ExecutionPlan plan = planSupplier.get();
-        service.initExecution(jobId, executionId, caller, coordinatorMemberListVersion, participants, plan);
+        service.getJobExecutionService().initExecution(
+                jobId, executionId, caller, coordinatorMemberListVersion, participants, plan
+        );
     }
 
     @Override

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -16,15 +16,19 @@
 
 package com.hazelcast.jet.core;
 
+import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.stream.IStreamCache;
 import com.hazelcast.jet.stream.IStreamList;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
@@ -91,30 +95,48 @@ public class JetTestSupport extends HazelcastTestSupport {
     }
 
     public static void assertTrueEventually(UncheckedRunnable runnable) {
-        HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                runnable.run();
-            }
-        });
+        HazelcastTestSupport.assertTrueEventually(assertTask(runnable));
     }
 
     public static void assertTrueEventually(UncheckedRunnable runnable, long timeoutSeconds) {
-        HazelcastTestSupport.assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                runnable.run();
-            }
-        }, timeoutSeconds);
+        HazelcastTestSupport.assertTrueEventually(assertTask(runnable), timeoutSeconds);
     }
 
     public static void assertTrueAllTheTime(UncheckedRunnable runnable, long durationSeconds) {
-        HazelcastTestSupport.assertTrueAllTheTime(new AssertTask() {
+        HazelcastTestSupport.assertTrueAllTheTime(assertTask(runnable), durationSeconds);
+    }
+
+    public static void assertTrueFiveSeconds(UncheckedRunnable runnable) {
+        HazelcastTestSupport.assertTrueFiveSeconds(assertTask(runnable));
+    }
+
+    public static JetService getJetService(JetInstance jetInstance) {
+        return getNodeEngineImpl(jetInstance).getService(JetService.SERVICE_NAME);
+    }
+
+    public static HazelcastInstance hz(JetInstance instance) {
+        return instance.getHazelcastInstance();
+    }
+
+    public static Address getAddress(JetInstance instance) {
+        return getAddress(hz(instance));
+    }
+
+    public static Node getNode(JetInstance instance) {
+        return getNode(hz(instance));
+    }
+
+    public static NodeEngineImpl getNodeEngineImpl(JetInstance instance) {
+        return getNodeEngineImpl(hz(instance));
+    }
+
+    private static AssertTask assertTask(UncheckedRunnable runnable) {
+        return new AssertTask() {
             @Override
             public void run() throws Exception {
                 runnable.run();
             }
-        }, durationSeconds);
+        };
     }
 
     public Address nextAddress() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.core;
 
-import com.hazelcast.instance.HazelcastInstanceImpl;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
@@ -28,12 +26,10 @@ import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.config.ProcessingGuarantee;
-import com.hazelcast.jet.core.processor.DiagnosticProcessors;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.core.test.TestProcessorMetaSupplierContext;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.datamodel.TimestampedEntry;
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.impl.SnapshotRepository;
 import com.hazelcast.jet.impl.execution.ExecutionContext;
@@ -43,7 +39,6 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.PacketFiltersUtil;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -61,7 +56,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.CancellationException;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -78,8 +72,10 @@ import static com.hazelcast.jet.core.processor.Processors.combineToSlidingWindow
 import static com.hazelcast.jet.core.processor.Processors.insertWatermarksP;
 import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static com.hazelcast.jet.core.processor.Processors.noopP;
+import static com.hazelcast.jet.core.processor.SinkProcessors.writeListP;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
+import static com.hazelcast.test.PacketFiltersUtil.delayOperationsFrom;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
@@ -111,9 +107,8 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         JetConfig config = new JetConfig();
         config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
 
-        JetInstance[] instances = factory.newMembers(config, 2);
-        instance1 = instances[0];
-        instance2 = instances[1];
+        instance1 = factory.newMember(config);
+        instance2 = factory.newMember(config);
     }
 
     @After
@@ -283,53 +278,84 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         /*
         Design of this test
 
-        The DAG is "source -> sink". Source completes immediately on slave member and is infinite on master.
-        Edge between source and sink is distributed. This situation will cause that after the source completes on
-        slave, the sink on slave will only have remote source. This will allow that we can receive the
-        barrier from remote master before slave even starts the snapshot. This is the very purpose of this
-        test. To ensure that this happens, we postpone handling of SnapshotOperation on slave.
-         */
-        boolean i1IsMaster = ((ClusterServiceImpl) instance1.getHazelcastInstance().getCluster()).isMaster();
-        JetInstance masterInstance = i1IsMaster ? instance1 : instance2;
-        JetInstance slaveInstance = i1IsMaster ? instance2 : instance1;
+        The DAG is "source -> sink". Source completes immediately on  non-coordinator (worker)
+        and is infinite on coordinator. Edge between source and sink is distributed. This
+        situation will cause that after the source completes on member, the sink on worker
+        will only have the remote source. This will allow that we can receive the barrier
+        from remote coordinator before worker even starts the snapshot. This is the very
+        purpose of this test. To ensure that this happens, we postpone handling of SnapshotOperation
+        on the worker.
+        */
 
-        JetService jetService = ((HazelcastInstanceImpl) slaveInstance.getHazelcastInstance())
-                .node.nodeEngine.getService(JetService.SERVICE_NAME);
-        PacketFiltersUtil.delayOperationsFrom(masterInstance.getHazelcastInstance(),
-                JetInitDataSerializerHook.FACTORY_ID, singletonList(JetInitDataSerializerHook.SNAPSHOT_OP));
+        // instance1 is always coordinator
+        delayOperationsFrom(
+                hz(instance1), JetInitDataSerializerHook.FACTORY_ID, singletonList(JetInitDataSerializerHook.SNAPSHOT_OP)
+        );
 
         DAG dag = new DAG();
-        Vertex source = dag.newVertex("source", new NonBalancedSource(
-                slaveInstance.getHazelcastInstance().getCluster().getLocalMember().getAddress().toString()));
-        Vertex sink = dag.newVertex("sink", DiagnosticProcessors.writeLoggerP());
+        Vertex source = dag.newVertex("source", new NonBalancedSource(getAddress(instance2).toString()));
+        Vertex sink = dag.newVertex("sink", writeListP("sink"));
         dag.edge(between(source, sink).distributed());
 
         JobConfig config = new JobConfig();
         config.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
         config.setSnapshotIntervalMillis(500);
-        Job job = masterInstance.newJob(dag, config);
+        Job job = instance1.newJob(dag, config);
 
-        IStreamMap<Long, Long> randomIdsMap = masterInstance.getMap(JobRepository.RANDOM_IDS_MAP_NAME);
-        long executionId = randomIdsMap.entrySet().stream()
-                    .filter(e -> e.getValue().equals(job.getJobId()) && !e.getValue().equals(e.getKey()))
-                    .mapToLong(Entry::getKey)
-                    .findAny()
-                    .orElseThrow(() -> new AssertionError("ExecutionId not found"));
-        ExecutionContext executionContext = null;
-        // spin until the executionContext is available on the slave member
-        while (executionContext == null) {
-            executionContext = jetService.getJobExecutionService().getExecutionContext(executionId);
-        }
-        SnapshotContext ssContext = executionContext.getSnapshotContext();
+        SnapshotContext ssContext = getSnapshotContext(job);
         assertTrueEventually(() -> assertTrue("numRemainingTasklets was not negative, the tested scenario did not happen",
                 ssContext.getNumRemainingTasklets().get() < 0), 3);
+    }
 
-        Thread.sleep(3000);
-        job.cancel();
-        try {
-            job.getFuture().get();
-        } catch (CancellationException expected) {
+    @Test
+    public void when_snapshotStartedBeforeExecution_then_firstSnapshotIsSuccessful() throws Exception {
+        // instance1 is always coordinator
+        // delay ExecuteOperation so that snapshot is started before execution is started on the worker member
+        delayOperationsFrom(
+                hz(instance1), JetInitDataSerializerHook.FACTORY_ID, singletonList(JetInitDataSerializerHook.EXECUTE_OP)
+        );
+
+        DAG dag = new DAG();
+        SequencesInPartitionsMetaSupplier pms = new SequencesInPartitionsMetaSupplier(3, 100);
+
+        Vertex source = dag.newVertex("source", throttle(pms, 10)).localParallelism(1);
+        Vertex sink = dag.newVertex("sink", writeListP("sink"));
+
+        dag.edge(between(source, sink).distributed());
+
+        JobConfig config = new JobConfig();
+        config.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
+        config.setSnapshotIntervalMillis(250);
+        Job job = instance1.newJob(dag, config);
+
+        // the first snapshot should succeed
+        assertTrueEventually(() -> {
+            IStreamMap<Long, SnapshotRecord> records = getSnapshotsMap(job);
+            SnapshotRecord record = records.get(0L);
+            assertNotNull("no record found for snapshot 0", record);
+            assertTrue("snapshot was not successful", record.isSuccessful());
+        }, 5);
+    }
+
+    private IStreamMap<Long, SnapshotRecord> getSnapshotsMap(Job job) {
+        SnapshotRepository snapshotRepository = new SnapshotRepository(instance1);
+        return snapshotRepository.getSnapshotMap(job.getJobId());
+    }
+
+    private SnapshotContext getSnapshotContext(Job job) {
+        IStreamMap<Long, Long> randomIdsMap = instance1.getMap(JobRepository.RANDOM_IDS_MAP_NAME);
+        long executionId = randomIdsMap.entrySet().stream()
+                                       .filter(e -> e.getValue().equals(job.getJobId())
+                                               && !e.getValue().equals(e.getKey()))
+                                       .mapToLong(Entry::getKey)
+                                       .findAny()
+                                       .orElseThrow(() -> new AssertionError("ExecutionId not found"));
+        ExecutionContext executionContext = null;
+        // spin until the executionContext is available on the worker
+        while (executionContext == null) {
+            executionContext = getJetService(instance2).getJobExecutionService().getExecutionContext(executionId);
         }
+        return executionContext.snapshotContext();
     }
 
     private void waitForNextSnapshot(IStreamMap<Long, Object> snapshotsMap, int timeout) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -43,7 +43,6 @@ import java.util.function.Consumer;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RESTARTING;
 import static com.hazelcast.jet.core.JobStatus.STARTING;
-import static com.hazelcast.jet.core.TestUtil.getJetService;
 import static com.hazelcast.spi.partition.IPartition.MAX_BACKUP_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -77,11 +77,22 @@ public class TestProcessors {
         public static volatile CountDownLatch executionStarted;
         public static volatile CountDownLatch proceedLatch;
 
+        // how long time to wait during calls to complete()
+        private final long timeoutMillis;
+
+        public StuckProcessor() {
+            this(1);
+        }
+
+        public StuckProcessor(long timeoutMillis) {
+            this.timeoutMillis = timeoutMillis;
+        }
+
         @Override
         public boolean complete() {
             executionStarted.countDown();
             try {
-                return proceedLatch.await(1, TimeUnit.MILLISECONDS);
+                return proceedLatch.await(timeoutMillis, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 return false;
             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.jet.core;
 
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.function.DistributedSupplier;
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.util.ThrottleWrappedP;
 import com.hazelcast.jet.impl.util.WrappingProcessorMetaSupplier;
 
@@ -27,7 +25,6 @@ import javax.annotation.Nonnull;
 import java.util.Objects;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static org.junit.Assert.assertEquals;
 
 public final class TestUtil {
@@ -64,10 +61,6 @@ public final class TestUtil {
         if (!found) {
             assertEquals("expected exception not found in causes chain", expected, caught);
         }
-    }
-
-    public static JetService getJetService(JetInstance jetInstance) {
-        return getNodeEngineImpl(jetInstance.getHazelcastInstance()).getService(JetService.SERVICE_NAME);
     }
 
     public static final class DummyUncheckedTestException extends RuntimeException {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -60,7 +60,6 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMB
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.SHUTDOWN_REQUEST;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.STARTING;
-import static com.hazelcast.jet.core.TestUtil.getJetService;
 import static com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook.EXECUTE_OP;
 import static com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook.INIT_OP;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
@@ -256,7 +255,7 @@ public class ProcessorTaskletTest {
 
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 mock(SnapshotContext.class), new MockOutboundCollector(10));
-        t.init(new CompletableFuture<>());
+        t.init();
         return t;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
@@ -298,7 +298,7 @@ public class ProcessorTaskletTest_Blocking {
         }
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 mock(SnapshotContext.class), new MockOutboundCollector(10));
-        t.init(jobFuture);
+        t.init();
         return t;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -16,14 +16,14 @@
 
 package com.hazelcast.jet.impl.execution;
 
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
-import com.hazelcast.jet.config.ProcessingGuarantee;
-import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
-import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.jet.core.test.TestOutbox.MockData;
 import com.hazelcast.jet.core.test.TestOutbox.MockSerializationService;
+import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
+import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Queue;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -200,7 +199,7 @@ public class ProcessorTaskletTest_Snapshots {
         snapshotContext.initTaskletCount(1, 0);
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 snapshotContext, snapshotCollector);
-        t.init(new CompletableFuture<>());
+        t.init();
         return t;
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,14 +37,12 @@ import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.LockSupport;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.MADE_PROGRESS;
@@ -64,7 +63,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
     @Rule
     public final ExpectedException exceptionRule = ExpectedException.none();
 
-    private final Consumer<CompletionStage<Void>> doneCallback = noopConsumer();
+    private final CompletableFuture<Void> cancellationFuture = new CompletableFuture<>();
 
     private TaskletExecutionService es;
     private ClassLoader classLoaderMock;
@@ -81,13 +80,18 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         classLoaderMock = mock(ClassLoader.class);
     }
 
+    @After
+    public void after() {
+        es.shutdown();
+    }
+
     @Test
     public void when_blockingTask_then_executed() {
         // Given
         final MockTasklet t = new MockTasklet().blocking();
 
         // When
-        es.execute(singletonList(t), doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(singletonList(t));
 
         // Then
         t.assertDone();
@@ -99,7 +103,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         final MockTasklet t = new MockTasklet();
 
         // When
-        es.execute(singletonList(t), doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(singletonList(t));
 
         // Then
         t.assertDone();
@@ -111,7 +115,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         final MockTasklet t = new MockTasklet().initFails();
 
         // When
-        es.execute(singletonList(t), doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(singletonList(t));
 
         // Then
         t.assertDone();
@@ -123,7 +127,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         final MockTasklet t = new MockTasklet().blocking().initFails();
 
         // When - Then
-        es.execute(singletonList(t), doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(singletonList(t));
     }
 
     @Test(expected = CompletionException.class)
@@ -132,7 +136,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         final MockTasklet t = new MockTasklet().callFails();
 
         // When - Then
-        es.execute(singletonList(t), doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(singletonList(t));
     }
 
     @Test(expected = CompletionException.class)
@@ -141,21 +145,21 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         final MockTasklet t = new MockTasklet().blocking().callFails();
 
         // When - Then
-        es.execute(singletonList(t), doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(singletonList(t));
     }
 
     @Test
     public void when_shutdown_then_submitFails() {
         // Given
-        es.execute(singletonList(new MockTasklet()), doneCallback, classLoaderMock);
-        es.execute(singletonList(new MockTasklet()), doneCallback, classLoaderMock);
+        es.beginExecute(singletonList(new MockTasklet()), new CompletableFuture<>(), classLoaderMock);
+        es.beginExecute(singletonList(new MockTasklet()), new CompletableFuture<>(), classLoaderMock);
 
         // When
         es.shutdown();
 
         // Then
         exceptionRule.expect(IllegalStateException.class);
-        es.execute(singletonList(new MockTasklet()), doneCallback, classLoaderMock);
+        es.beginExecute(singletonList(new MockTasklet()), new CompletableFuture<>(), classLoaderMock);
     }
 
     @Test
@@ -166,7 +170,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                 new MockTasklet().callsBeforeDone(10));
 
         // When
-        es.execute(tasklets, doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(tasklets);
 
         // Then
         tasklets.forEach(MockTasklet::assertDone);
@@ -180,7 +184,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        es.execute(tasklets, doneCallback, classLoaderMock).toCompletableFuture().join();
+        executeAndJoin(tasklets);
 
         // Then
         tasklets.forEach(MockTasklet::assertDone);
@@ -194,14 +198,14 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        CompletableFuture<Void> future = es.execute(tasklets, doneCallback, classLoaderMock).toCompletableFuture();
-        future.cancel(true);
+        CompletableFuture<Void> f = es.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        cancellationFuture.cancel(true);
 
         // Then
         tasklets.forEach(MockTasklet::assertNotDone);
 
         exceptionRule.expect(CancellationException.class);
-        future.get();
+        f.get();
     }
 
     @Test
@@ -212,14 +216,14 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        CompletableFuture<Void> future = es.execute(tasklets, doneCallback, classLoaderMock).toCompletableFuture();
-        future.cancel(true);
+        CompletableFuture<Void> f = es.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        cancellationFuture.cancel(true);
 
         // Then
         tasklets.forEach(MockTasklet::assertNotDone);
 
         exceptionRule.expect(CancellationException.class);
-        future.get();
+        f.get();
     }
 
     @Test
@@ -230,13 +234,15 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                       .limit(100).collect(toList());
 
         // When
-        CompletableFuture<Void> future = es.execute(tasklets, doneCallback, classLoaderMock).toCompletableFuture();
-        future.cancel(true);
+        CompletableFuture<Void> f = es.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        cancellationFuture.cancel(true);
 
         // Then
         tasklets.forEach(MockTasklet::assertNotDone);
+        assertTrueEventually(f::isDone);
+
         exceptionRule.expect(CancellationException.class);
-        future.get();
+        cancellationFuture.get();
     }
 
     @Test
@@ -247,26 +253,22 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
                 Stream.generate(() -> new MockTasklet().waitOnLatch(proceedLatch).callsBeforeDone(Integer.MAX_VALUE))
                       .limit(100).collect(toList());
 
-        CompletableFuture<Void> doneFuture = new CompletableFuture<Void>();
-
         // When
-        CompletableFuture<Void> future = es.execute(tasklets, f -> doneFuture.complete(null), classLoaderMock)
-                                           .toCompletableFuture();
+        CompletableFuture<Void> f = es.beginExecute(tasklets, cancellationFuture, classLoaderMock);
 
-        future.cancel(true);
+        cancellationFuture.cancel(true);
 
         // Then
-        assertTrue("future returned from .execute() should be done", future.isDone());
-        assertFalse("doneFuture should not be completed until tasklets are completed.", doneFuture.isDone());
+        assertFalse("future should not be completed until tasklets are completed.", f.isDone());
 
         proceedLatch.countDown();
 
         assertTrueEventually(() -> {
-            assertTrue("doneFuture should be completed eventually", doneFuture.isDone());
+            assertTrue("future should be completed eventually", f.isDone());
         });
 
         exceptionRule.expect(CancellationException.class);
-        future.get();
+        cancellationFuture.get();
     }
 
     @Test
@@ -277,13 +279,68 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         assertTrue(t1.isCooperative());
 
         // When
-        CompletableFuture<Void> f1 = es.execute(singletonList(t1), doneCallback, classLoaderMock).toCompletableFuture();
-        CompletableFuture<Void> f2 = es.execute(singletonList(t2), doneCallback, classLoaderMock).toCompletableFuture();
+        CompletableFuture<Void> f1 = es.beginExecute(singletonList(t1), new CompletableFuture<>(), classLoaderMock);
+        CompletableFuture<Void> f2 = es.beginExecute(singletonList(t2), new CompletableFuture<>(), classLoaderMock);
         f1.join();
         f2.join();
 
         // Then
         // -- assertions are inside TaskletAssertingThreadLocal and will fail, if t1 and t2 are running on the same thread
+    }
+
+    @Test
+    public void when_tryCompleteOnReturnedFuture_then_fails() {
+        // Given
+        final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
+        CompletableFuture<Void> f = es.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+
+        // When - Then
+        exceptionRule.expect(UnsupportedOperationException.class);
+        f.complete(null);
+    }
+
+    @Test
+    public void when_tryCompleteExceptionallyOnReturnedFuture_then_fails() {
+        // Given
+        final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
+        CompletableFuture<Void> f = es.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+
+        // When - Then
+        exceptionRule.expect(UnsupportedOperationException.class);
+        f.completeExceptionally(new RuntimeException());
+    }
+
+    @Test
+    public void when_tryCancelOnReturnedFuture_then_fails() {
+        // Given
+        final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
+        CompletableFuture<Void> f = es.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+
+        // When - Then
+        exceptionRule.expect(UnsupportedOperationException.class);
+        f.cancel(true);
+    }
+
+    @Test
+    public void when_cancellationFutureCompleted_then_fails() throws Throwable {
+        // Given
+        final MockTasklet t = new MockTasklet().callsBeforeDone(Integer.MAX_VALUE);
+        CompletableFuture<Void> f = es.beginExecute(singletonList(t), cancellationFuture, classLoaderMock);
+
+        // When - Then
+        cancellationFuture.complete(null);
+
+        exceptionRule.expect(IllegalStateException.class);
+        try {
+            f.join();
+        } catch (CompletionException e) {
+            throw peel(e);
+        }
+    }
+
+    private void executeAndJoin(List<MockTasklet> tasklets) {
+        CompletableFuture<Void> f = es.beginExecute(tasklets, cancellationFuture, classLoaderMock);
+        f.join();
     }
 
     static class MockTasklet implements Tasklet {
@@ -329,7 +386,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         }
 
         @Override
-        public void init(CompletableFuture<Void> jobFuture) {
+        public void init() {
             if (initFails) {
                 throw new RuntimeException("mock init failure");
             }

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
@@ -161,7 +161,7 @@ public class StreamKafkaPTest extends KafkaTestSupport {
             }
 
             assertTrueEventually(() -> {
-                assertTrue(list.size() >= messageCount * 4);
+                assertTrue("Not all messages were received", list.size() >= messageCount * 4);
                 for (int i = 0; i < 2 * messageCount; i++) {
                     assertTrue(list.contains(createEntry(i)));
                     assertTrue(list.contains(createEntry(i - messageCount)));


### PR DESCRIPTION
Replace `doneCallback` in TaskletExecutionService and ExecutionContext
with a single `executionFuture` which signals tasklet completion to simplify
execution flow and avoid races between job cancellation and completion.
Cancellation is now done through a separate future which is only used for
signalling cancellation.