### PR TITLE
[Backport of #611] Fix Kafka writer issues

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -110,9 +110,12 @@ public interface Processor {
     }
 
     /**
-     * Called when there is no pending data in the inbox. Allows the processor
-     * to produce output in the absence of input. If it returns {@code false},
-     * it will be called again before proceeding to call any other method.
+     * This method will be called periodically and only when the current batch
+     * of items in the inbox has been exhausted. It can be used to produce
+     * output in the absence of input or to do general maintenance work.
+     * <p>
+     * If the call returns {@code false}, it will be called again before proceeding
+     * to call any other method. Default implementation returns {@code true}.
      */
     default boolean tryProcess() {
         return true;

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSinks.java
@@ -39,14 +39,15 @@ public final class KafkaSinks {
      * supplied mapping function.
      * <p>
      * The source creates a single {@code KafkaProducer} per cluster
-     * member using the supplied properties.
+     * member using the supplied {@code properties}.
      * <p>
-     * Behavior on job restart: the processor is stateless. If the job is
-     * restarted, duplicate events can occur. If you need exactly-once
-     * behavior, you must ensure idempotence on the application level.
+     * Behavior on job restart: the processor is stateless. On snapshot we only
+     * make sure that all async operations are done. If the job is restarted,
+     * duplicate events can occur. If you need exactly-once behavior, you must
+     * ensure idempotence on the application level.
      * <p>
-     * IO failures are generally handled by Kafka producer and generally do not
-     * cause the processor to fail. Refer to Kafka documentation for details.
+     * IO failures are generally handled by Kafka producer and do not cause the
+     * processor to fail. Refer to Kafka documentation for details.
      *
      * @param properties     producer properties which should contain broker
      *                       address and key/value serializers

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/WriteKafkaP.java
@@ -16,18 +16,21 @@
 
 package com.hazelcast.jet.impl.connector.kafka;
 
-import com.hazelcast.jet.core.AbstractProcessor;
+import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
 import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -36,10 +39,18 @@ import static java.util.stream.Collectors.toList;
  * com.hazelcast.jet.function.DistributedFunction)
  * KafkaProcessors.writeKafka()}.
  */
-public final class WriteKafkaP<T, K, V> extends AbstractProcessor {
+public final class WriteKafkaP<T, K, V> implements Processor {
 
     private final KafkaProducer<K, V> producer;
     private final Function<T, ProducerRecord<K, V>> toRecordFn;
+    private final AtomicReference<Throwable> lastError = new AtomicReference<>();
+
+    private final Callback callback = (metadata, exception) -> {
+        // Note: this method may be called on different thread.
+        if (exception != null) {
+            lastError.compareAndSet(null, exception);
+        }
+    };
 
     WriteKafkaP(KafkaProducer<K, V> producer, Function<T, ProducerRecord<K, V>> toRecordFn) {
         this.producer = producer;
@@ -52,21 +63,50 @@ public final class WriteKafkaP<T, K, V> extends AbstractProcessor {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    protected boolean tryProcess(int ordinal, @Nonnull Object item) throws Exception {
-        producer.send(toRecordFn.apply((T) item));
+    public boolean tryProcess() {
+        checkError();
         return true;
     }
 
     @Override
+    public void process(int ordinal, @Nonnull Inbox inbox) {
+        checkError();
+        inbox.drain((T item) -> {
+            // Note: send() method can block even though it is declared to not. This is true for Kafka 1.0 and probably
+            // will stay so, unless they change API.
+            producer.send(toRecordFn.apply(item), callback);
+        });
+    }
+
+    @Override
     public boolean complete() {
-        producer.flush();
+        ensureAllWritten();
         return true;
+    }
+
+    @Override
+    public boolean saveToSnapshot() {
+        ensureAllWritten();
+        return true;
+    }
+
+    private void ensureAllWritten() {
+        checkError();
+        // flush() should ensure that all lingering records are sent and that all futures from
+        // producer.send() are done.
+        producer.flush();
+    }
+
+    private void checkError() {
+        Throwable t = lastError.get();
+        if (t != null) {
+            throw sneakyThrow(t);
+        }
     }
 
     public static class Supplier<T, K, V> implements ProcessorSupplier {
 
-        static final long serialVersionUID = 1L;
+        private static final long serialVersionUID = 1L;
 
         private final Properties properties;
         private final Function<? super T, ProducerRecord<K, V>> toRecordFn;


### PR DESCRIPTION
`KafkaProducer.send()` call is async. This scenario was possible:
- send a record
- do a successful snapshot
- member fails before the async record is sent
- after restart, the record is lost and the at-least-once guarantee broken.

This was resolved by calling `producer.flush()` in `saveToSnapshot()`.

Another fixes:
- checking for errors from async calls
- improve `Processor.tryProcess()` javadoc

Fixes #605