### PR TITLE
Hat-trick fix (backport of #594)

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -49,6 +49,7 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 import java.util.zip.DeflaterOutputStream;
 
+import static com.hazelcast.jet.Jet.INTERNAL_JET_OBJECTS_PREFIX;
 import static com.hazelcast.jet.impl.util.Util.idToString;
 import static java.util.concurrent.TimeUnit.HOURS;
 
@@ -57,22 +58,22 @@ public class JobRepository {
     /**
      * Name of internal IMap which stores job resources
      */
-    public static final String RESOURCES_MAP_NAME_PREFIX = "__jet.resources.";
+    public static final String RESOURCES_MAP_NAME_PREFIX = INTERNAL_JET_OBJECTS_PREFIX + "resources.";
 
     /**
      * Name of internal IMap which is used for unique id generation
      */
-    public static final String RANDOM_IDS_MAP_NAME = "__jet.ids";
+    public static final String RANDOM_IDS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "ids";
 
     /**
      * Name of internal IMap which stores job records
      */
-    public static final String JOB_RECORDS_MAP_NAME = "__jet.records";
+    public static final String JOB_RECORDS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "records";
 
     /**
      * Name of internal IMap which stores job results
      */
-    public static final String JOB_RESULTS_MAP_NAME = "__jet.results";
+    public static final String JOB_RESULTS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "results";
 
     private static final String RESOURCE_MARKER = "__jet.resourceMarker";
     private static final long JOB_EXPIRATION_DURATION_IN_MILLIS = HOURS.toMillis(2);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet;
+
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.core.JetTestSupport;
+import org.junit.Test;
+
+import static com.hazelcast.jet.Jet.INTERNAL_JET_OBJECTS_PREFIX;
+import static org.junit.Assert.assertEquals;
+
+public class JetTest extends JetTestSupport {
+
+    @Test
+    public void when_defaultMapConfig_then_notUsed() {
+        // When
+        JetConfig config = new JetConfig();
+        config.getHazelcastConfig().getMapConfig("default")
+                .setTimeToLiveSeconds(MapConfig.DEFAULT_TTL_SECONDS + 1);
+        JetInstance instance = createJetMember(config);
+
+        try {
+            // Then
+            int actualTTL = instance.getConfig().getHazelcastConfig().findMapConfig(INTERNAL_JET_OBJECTS_PREFIX + "fooMap")
+                                    .getTimeToLiveSeconds();
+            assertEquals(MapConfig.DEFAULT_TTL_SECONDS, actualTTL);
+        } finally {
+            shutdownFactory();
+        }
+    }
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -218,10 +218,9 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
 
         instance2.shutdown();
 
-        // now the job should detect member shutdown and restart from snapshot
-        Thread.sleep(2000);
-
-        waitForNextSnapshot(snapshotsMap, timeout);
+        // Now the job should detect member shutdown and restart from snapshot.
+        // Let's wait until the next snapshot appears.
+        waitForNextSnapshot(snapshotsMap, (int) (MILLISECONDS.toSeconds(config.getSnapshotIntervalMillis()) + 10));
         waitForNextSnapshot(snapshotsMap, timeout);
 
         job.join();
@@ -358,12 +357,12 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         return executionContext.snapshotContext();
     }
 
-    private void waitForNextSnapshot(IStreamMap<Long, Object> snapshotsMap, int timeout) {
+    private void waitForNextSnapshot(IStreamMap<Long, Object> snapshotsMap, int timeoutSeconds) {
         SnapshotRecord maxRecord = findMaxRecord(snapshotsMap);
         assertNotNull("no snapshot found", maxRecord);
         // wait until there is at least one more snapshot
         assertTrueEventually(() -> assertTrue("No more snapshots produced after restart",
-                findMaxRecord(snapshotsMap).snapshotId() > maxRecord.snapshotId()), timeout);
+                findMaxRecord(snapshotsMap).snapshotId() > maxRecord.snapshotId()), timeoutSeconds);
     }
 
     private SnapshotRecord findMaxRecord(IStreamMap<Long, Object> snapshotsMap) {


### PR DESCRIPTION
* Don't inherit default config for Jet maps
Fixes #592

* Fix JobRestartWithSnapshotTest on Enterprise HZ
Fixes #591

* Make the internal objects prefix public
Fixes #583