### PR TITLE
Fix for when_snapshotStartedBeforeExecution test

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -142,7 +142,7 @@ public class JobConfig implements Serializable {
      * Default value is set to 10 seconds.
      */
     public JobConfig setSnapshotIntervalMillis(long snapshotInterval) {
-        Preconditions.checkPositive(snapshotInterval, "snapshotInterval must be positive");
+        Preconditions.checkNotNegative(snapshotInterval, "snapshotInterval can't be negative");
         this.snapshotIntervalMillis = snapshotInterval;
         return this;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.JobRestartWithSnapshotTest.SequencesInPartitionsMetaSupplier;
 import com.hazelcast.jet.impl.SnapshotRepository;
 import com.hazelcast.jet.impl.execution.SnapshotRecord;
+import com.hazelcast.jet.impl.execution.SnapshotRecord.SnapshotStatus;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -41,17 +42,16 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
 
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekOutputP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeMapP;
+import static com.hazelcast.jet.impl.SnapshotRepository.snapshotsMapName;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @Category(QuickTest.class)
@@ -92,7 +92,7 @@ public class SnapshotFailureTest extends JetTestSupport {
     }
 
     @Test
-    public void when_snapshotFails_then_jobShouldNotFail() throws InterruptedException {
+    public void when_snapshotFails_then_jobShouldNotFail() throws Exception {
         int numPartitions = 2;
         int numElements = 10;
         IStreamMap<Object, Object> results = instance1.getMap("results");
@@ -106,30 +106,32 @@ public class SnapshotFailureTest extends JetTestSupport {
 
         JobConfig config = new JobConfig();
         config.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
-        config.setSnapshotIntervalMillis(1200);
+        config.setSnapshotIntervalMillis(100);
+
         Job job = instance1.newJob(dag, config);
 
-        // Successful snapshot cannot happen in this test
-        AtomicInteger jobFinishedLatch = new AtomicInteger(1);
-        AtomicReference<SnapshotRecord> successfulRecord = new AtomicReference<>();
-        new Thread(() -> {
-            IMap<Object, Object> snapshotsMap = instance1.getMap(SnapshotRepository.snapshotsMapName(job.getJobId()));
-            while (jobFinishedLatch.get() != 0) {
-                snapshotsMap.values().stream()
-                            .filter(r -> r instanceof SnapshotRecord && ((SnapshotRecord) r).isSuccessful())
-                            .findFirst()
-                            .ifPresent(r -> successfulRecord.compareAndSet(null, (SnapshotRecord) r));
-                LockSupport.parkNanos(MILLISECONDS.toNanos(1));
-            }
-        }).start();
+        IMap<Object, Object> snapshotsMap = instance1.getMap(snapshotsMapName(job.getJobId()));
+
+        SnapshotRecord[] failedRecord = new SnapshotRecord[1];
+        while (failedRecord[0] == null && !job.getFuture().isDone()) {
+            // find a failed record in snapshots map
+            snapshotsMap
+                    .values().stream()
+                    .filter(r -> r instanceof SnapshotRecord)
+                    .map(r -> (SnapshotRecord) r)
+                    .filter(r -> r.status() == SnapshotStatus.FAILED)
+                    .findFirst()
+                    .ifPresent(r -> failedRecord[0] = r);
+            LockSupport.parkNanos(MILLISECONDS.toNanos(1));
+        }
+
         job.join();
-        jobFinishedLatch.decrementAndGet();
 
         assertEquals("numPartitions", numPartitions, results.size());
         assertEquals("offset partition 0", numElements - 1, results.get(0));
         assertEquals("offset partition 1", numElements - 1, results.get(1));
         assertTrue("no failure occurred in store", storeFailed);
-        assertNull("successful snapshot appeared in snapshotsMap", successfulRecord.get());
+        assertNotNull("no failed snapshot appeared in snapshotsMap", failedRecord[0]);
     }
 
     public static class FailingMapStore extends AMapStore implements Serializable {


### PR DESCRIPTION
* Increase timeout
* Prevent further snapshots from being completed to prevent
  snapshot record being deleted.

Fixes #641