### PR TITLE
Fix Java Serialization issue on mapWithUpdating

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetDataSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetDataSerializerHook.java
@@ -18,11 +18,13 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.jet.impl.SerializationConstants;
+import com.hazelcast.jet.impl.connector.HazelcastWriters.ApplyFnEntryProcessor;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import static com.hazelcast.jet.impl.SerializationConstants.DAG;
 import static com.hazelcast.jet.impl.SerializationConstants.EDGE;
+import static com.hazelcast.jet.impl.SerializationConstants.APPLY_FN_ENTRY_PROCESSOR;
 import static com.hazelcast.jet.impl.SerializationConstants.VERTEX;
 
 /**
@@ -51,6 +53,8 @@ public final class JetDataSerializerHook implements DataSerializerHook {
                     return new Edge();
                 case VERTEX:
                     return new Vertex();
+                case APPLY_FN_ENTRY_PROCESSOR:
+                    return new ApplyFnEntryProcessor();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SerializationConstants.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SerializationConstants.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.jet.core.Edge;
 import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.impl.connector.HazelcastWriters.ApplyFnEntryProcessor;
 
 /**
  * Constants used for Hazelcast's {@link com.hazelcast.nio.serialization.IdentifiedDataSerializable}
@@ -37,6 +38,8 @@ public final class SerializationConstants {
     public static final int VERTEX = 1;
     /** Serialization ID of the {@link Edge} class. */
     public static final int EDGE = 2;
+    /** Serialization ID of the {@link ApplyFnEntryProcessor} class. */
+    public static final int APPLY_FN_ENTRY_PROCESSOR = 3;
 
     private SerializationConstants() {
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -34,8 +34,13 @@ import com.hazelcast.jet.function.DistributedBinaryOperator;
 import com.hazelcast.jet.function.DistributedConsumer;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedIntFunction;
-import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.jet.impl.SerializationConstants;
+import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.ArrayList;
@@ -102,16 +107,7 @@ public final class HazelcastWriters {
                 instance -> {
                     IMap map = instance.getMap(name);
                     Map<K, T> tmpMap = new HashMap<>();
-                    AbstractEntryProcessor<K, V> entryProcessor = new AbstractEntryProcessor<K, V>() {
-                        @Override
-                        public Object process(Entry<K, V> entry) {
-                            V oldValue = entry.getValue();
-                            T item = tmpMap.get(entry.getKey());
-                            V newValue = updateFn.apply(oldValue, item);
-                            entry.setValue(newValue);
-                            return null;
-                        }
-                    };
+                    ApplyFnEntryProcessor<K, V, T> entryProcessor = new ApplyFnEntryProcessor<>(tmpMap, updateFn);
 
                     return buffer -> {
                         try {
@@ -487,4 +483,64 @@ public final class HazelcastWriters {
                          .limit(count).collect(toList());
         }
     }
+
+    public static class ApplyFnEntryProcessor<K, V, T> implements EntryProcessor<K, V>, EntryBackupProcessor,
+            IdentifiedDataSerializable {
+        private Map<K, T> tmpMap;
+        private DistributedBiFunction<V, T, V> updateFn;
+
+        public ApplyFnEntryProcessor() {
+        }
+
+        public ApplyFnEntryProcessor(Map<K, T> tmpMap, DistributedBiFunction<V, T, V> updateFn) {
+            this.tmpMap = tmpMap;
+            this.updateFn = updateFn;
+        }
+
+        @Override
+        public Object process(Entry<K, V> entry) {
+            V oldValue = entry.getValue();
+            T item = tmpMap.get(entry.getKey());
+            V newValue = updateFn.apply(oldValue, item);
+            entry.setValue(newValue);
+            return null;
+        }
+
+        @Override public EntryBackupProcessor<K, V> getBackupProcessor() {
+            return this;
+        }
+
+        @Override public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeInt(tmpMap.size());
+            for (Entry<K, T> entry : tmpMap.entrySet()) {
+                out.writeObject(entry.getKey());
+                out.writeObject(entry.getValue());
+            }
+            out.writeObject(updateFn);
+        }
+
+        @Override public void readData(ObjectDataInput in) throws IOException {
+            int size = in.readInt();
+            tmpMap = new HashMap<>(size);
+            for (int i = 0; i < size; i++) {
+                K key = in.readObject();
+                T value = in.readObject();
+                tmpMap.put(key, value);
+            }
+            updateFn = in.readObject();
+        }
+
+        @Override public void processBackup(Entry entry) {
+            process(entry);
+        }
+
+        @Override public int getFactoryId() {
+            return SerializationConstants.FACTORY_ID;
+        }
+
+        @Override public int getId() {
+            return SerializationConstants.APPLY_FN_ENTRY_PROCESSOR;
+        }
+    }
+
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SinksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SinksTest.java
@@ -273,10 +273,10 @@ public class SinksTest extends PipelineTestSupport {
         execute();
 
         // Then
-        List<Entry<String, DataSerializableObject>> expected = input.stream()
-                                                                    .map(i -> entry(String.valueOf(i),
-                                                                            new DataSerializableObject(i * 2)))
-                                                                    .collect(toList());
+        List<Entry<String, DataSerializableObject>> expected = input
+                .stream()
+                .map(i -> entry(String.valueOf(i), new DataSerializableObject(i * 2)))
+                .collect(toList());
         Set<Entry<Object, Object>> actual = jet().getMap(srcName).entrySet();
         assertEquals(expected.size(), actual.size());
         expected.forEach(entry -> assertTrue(actual.contains(entry)));
@@ -353,10 +353,10 @@ public class SinksTest extends PipelineTestSupport {
         execute();
 
         // Then
-        List<Entry<String, DataSerializableObject>> expected = input.stream()
-                                                                    .map(i -> entry(String.valueOf(i),
-                                                                            new DataSerializableObject(i * 2)))
-                                                                    .collect(toList());
+        List<Entry<String, DataSerializableObject>> expected = input
+                .stream()
+                .map(i -> entry(String.valueOf(i), new DataSerializableObject(i * 2)))
+                .collect(toList());
         Set<Entry<Object, Object>> actual = hz.getMap(srcName).entrySet();
         assertEquals(expected.size(), actual.size());
         expected.forEach(entry -> assertTrue(actual.contains(entry)));
@@ -452,15 +452,18 @@ public class SinksTest extends PipelineTestSupport {
             this.value = value;
         }
 
-        @Override public void writeData(ObjectDataOutput out) throws IOException {
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(value);
         }
 
-        @Override public void readData(ObjectDataInput in) throws IOException {
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
             value = in.readInt();
         }
 
-        @Override public boolean equals(Object o) {
+        @Override
+        public boolean equals(Object o) {
             if (this == o) {
                 return true;
             }
@@ -473,7 +476,8 @@ public class SinksTest extends PipelineTestSupport {
             return value == that.value;
         }
 
-        @Override public int hashCode() {
+        @Override
+        public int hashCode() {
             return value;
         }
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SinksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SinksTest.java
@@ -19,9 +19,14 @@ package com.hazelcast.jet;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.map.AbstractEntryProcessor;
 import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -254,6 +259,30 @@ public class SinksTest extends PipelineTestSupport {
     }
 
     @Test
+    public void mapWithUpdating_when_itemDataSerializable_then_exceptionShouldNotThrown() {
+        // Given
+        IStreamMap<Object, Object> sourceMap = jet().getMap(srcName);
+        List<Integer> input = sequence(ITEM_COUNT);
+        input.forEach(i -> sourceMap.put(String.valueOf(i), new DataSerializableObject(i)));
+
+        // When
+        pipeline.drawFrom(Sources.<String, DataSerializableObject>map(srcName))
+                .drainTo(Sinks.mapWithUpdating(srcName,
+                        (DataSerializableObject value, Entry<String, DataSerializableObject> item) ->
+                                new DataSerializableObject(value.value + item.getValue().value)));
+        execute();
+
+        // Then
+        List<Entry<String, DataSerializableObject>> expected = input.stream()
+                                                                    .map(i -> entry(String.valueOf(i),
+                                                                            new DataSerializableObject(i * 2)))
+                                                                    .collect(toList());
+        Set<Entry<Object, Object>> actual = jet().getMap(srcName).entrySet();
+        assertEquals(expected.size(), actual.size());
+        expected.forEach(entry -> assertTrue(actual.contains(entry)));
+    }
+
+    @Test
     public void mapWithUpdating_when_entryIsLocked_then_entryIsUpdatedRegardlessTheLock() {
         // Given
         srcMap.put("key", 1);
@@ -308,6 +337,31 @@ public class SinksTest extends PipelineTestSupport {
         Set<Entry<Object, Object>> actual = hz.getMap(srcName).entrySet();
         assertEquals(0, actual.size());
     }
+
+    @Test
+    public void remoteMapWithUpdating_when_itemDataSerializable_then_exceptionShouldNotThrown() {
+        // Given
+        IMap<Object, Object> sourceMap = hz.getMap(srcName);
+        List<Integer> input = sequence(ITEM_COUNT);
+        input.forEach(i -> sourceMap.put(String.valueOf(i), new DataSerializableObject(i)));
+
+        // When
+        pipeline.drawFrom(Sources.<String, DataSerializableObject>remoteMap(srcName, clientConfig))
+                .drainTo(Sinks.remoteMapWithUpdating(srcName, clientConfig,
+                        (DataSerializableObject value, Entry<String, DataSerializableObject> item) ->
+                                new DataSerializableObject(value.value + item.getValue().value)));
+        execute();
+
+        // Then
+        List<Entry<String, DataSerializableObject>> expected = input.stream()
+                                                                    .map(i -> entry(String.valueOf(i),
+                                                                            new DataSerializableObject(i * 2)))
+                                                                    .collect(toList());
+        Set<Entry<Object, Object>> actual = hz.getMap(srcName).entrySet();
+        assertEquals(expected.size(), actual.size());
+        expected.forEach(entry -> assertTrue(actual.contains(entry)));
+    }
+
 
     @Test
     public void mapWithEntryProcessor() {
@@ -385,6 +439,42 @@ public class SinksTest extends PipelineTestSupport {
         public Object process(Entry<K, Integer> entry) {
             entry.setValue(entry.getValue() == null ? value : entry.getValue() + value);
             return null;
+        }
+    }
+
+    private static class DataSerializableObject implements DataSerializable {
+        int value;
+
+        DataSerializableObject() {
+        }
+
+        DataSerializableObject(int value) {
+            this.value = value;
+        }
+
+        @Override public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeInt(value);
+        }
+
+        @Override public void readData(ObjectDataInput in) throws IOException {
+            value = in.readInt();
+        }
+
+        @Override public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            DataSerializableObject that = (DataSerializableObject) o;
+
+            return value == that.value;
+        }
+
+        @Override public int hashCode() {
+            return value;
         }
     }
 


### PR DESCRIPTION
Replace internally used AbstractEntryProcessor inside updatingMap with a counterpart which implements IdentifiedDataSerializable to prevent Java Serialization.

Fixes #671 