### PR TITLE
Drop partially late events in SliWP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/accumulator/DoubleAccumulator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/accumulator/DoubleAccumulator.java
@@ -70,7 +70,7 @@ public class DoubleAccumulator {
     }
 
     /**
-     * Adds the value of to this objects' value.
+     * Adds the value to this objects' value.
      */
     public  DoubleAccumulator add(double v) {
         value += v;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
@@ -224,14 +224,18 @@ public interface ProcessorMetaSupplier extends Serializable {
         JetInstance jetInstance();
 
         /**
-         * Returns the total number of {@code Processor}s that will be
-         * created across the cluster.
+         * Returns the total number of {@code Processor}s that will be created
+         * across the cluster. This number remains stable for entire job
+         * execution.
          */
         int totalParallelism();
 
         /**
          * Returns the number of processors that each {@code ProcessorSupplier}
-         * will be asked to create once deserialized on each member.
+         * will be asked to create once deserialized on each member. All
+         * members have equal local parallelism; dividing {@link
+         * #totalParallelism} by local parallelism gives you the participating
+         * member count. The count doesn't change unless the job restarts.
          */
         int localParallelism();
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java
@@ -117,9 +117,11 @@ public class SlidingWindowP<T, A, R> extends AbstractProcessor {
         final long frameTs = getFrameTsFn.applyAsLong(t);
         assert frameTs == wDef.floorFrameTs(frameTs) : "getFrameTsFn returned an invalid frame timestamp";
 
-        // check if the event is late. We allow "partially late" events: events, which should be aggregated
-        // to some windows that are already emitted, but for which there are still windows that are not emitted.
-        if (frameTs + wDef.windowLength() <= nextWinToEmit) {
+        // check if the event is late. We don't allow "partially late" events: events, which should be aggregated
+        // to some windows that are already emitted, even though we still have the frame it would go to.
+        // Problem with this is that such frames were already added to `slidingWindow` and we can't modify
+        // the value, because different value would be deducted.
+        if (frameTs < nextWinToEmit) {
             if (getLogger().isInfoEnabled()) {
                 getLogger().info("Dropped late event: " + item);
             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
@@ -287,12 +287,19 @@ public class SlidingWindowPTest {
                         wm(10),
                         // this one is late
                         event(7L, 1L),
-                        // this one is "partially late" - it will miss some target windows, but we still can incorporate
-                        // it to window 11 that is due
-                        event(8L, 1L)
+                        // following events are "partially late" - it's still should be dropped, even though we still have
+                        // frame8, where we could accumulate it
+                        event(8L, 1L),
+                        event(9L, 1L),
+                        event(10L, 1L),
+                        // this event is the first one not late
+                        event(11L, 123L)
                 )).expectOutput(asList(
                         wm(10),
-                        outboxFrame(11, 1)
+                        outboxFrame(11L, 123L),
+                        outboxFrame(12L, 123L),
+                        outboxFrame(13L, 123L),
+                        outboxFrame(14L, 123L)
                 ));
     }
 


### PR DESCRIPTION
Partially late events caused that one value was combined to
`slidingWindow` and modified value will be deducted, causing computation
errors.