### PR TITLE
Modify allOf to use TupleN or ItemsByTag

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperationBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperationBuilder.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.impl.aggregate.AggregateOperationImpl;
 import com.hazelcast.jet.datamodel.Tag;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -57,6 +58,8 @@ public final class AggregateOperationBuilder<A> {
      * This method is synonymous with {@link #andAccumulate0(
      * DistributedBiConsumer)}, but makes more sense when defining a
      * simple, arity-1 aggregate operation.
+     * <p>
+     * Parameters of the {@code accumulateFn} are {@code (accumulator, item)}.
      *
      * @param accumulateFn the {@code accumulate} primitive
      * @param <T> the expected type of input item
@@ -135,7 +138,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code combine} primitive.
          */
         @Nonnull
-        public Arity1<T0, A> andCombine(DistributedBiConsumer<? super A, ? super A> combineFn) {
+        public Arity1<T0, A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
             this.combineFn = combineFn;
             return this;
         }
@@ -144,7 +147,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code deduct} primitive.
          */
         @Nonnull
-        public Arity1<T0, A> andDeduct(DistributedBiConsumer<? super A, ? super A> deductFn) {
+        public Arity1<T0, A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
             this.deductFn = deductFn;
             return this;
         }
@@ -212,7 +215,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code combine} primitive.
          */
         @Nonnull
-        public Arity2<T0, T1, A> andCombine(DistributedBiConsumer<? super A, ? super A> combineFn) {
+        public Arity2<T0, T1, A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
             this.combineFn = combineFn;
             return this;
         }
@@ -221,7 +224,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code deduct} primitive.
          */
         @Nonnull
-        public Arity2<T0, T1, A> andDeduct(DistributedBiConsumer<? super A, ? super A> deductFn) {
+        public Arity2<T0, T1, A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
             this.deductFn = deductFn;
             return this;
         }
@@ -283,7 +286,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code combine} primitive.
          */
         @Nonnull
-        public Arity3<T0, T1, T2, A> andCombine(DistributedBiConsumer<? super A, ? super A> combineFn) {
+        public Arity3<T0, T1, T2, A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
             this.combineFn = combineFn;
             return this;
         }
@@ -292,7 +295,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code deduct} primitive.
          */
         @Nonnull
-        public Arity3<T0, T1, T2, A> andDeduct(DistributedBiConsumer<? super A, ? super A> deductFn) {
+        public Arity3<T0, T1, T2, A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
             this.deductFn = deductFn;
             return this;
         }
@@ -360,9 +363,9 @@ public final class AggregateOperationBuilder<A> {
         public <T> VarArity<A> andAccumulate(
                 @Nonnull Tag<T> tag, @Nonnull DistributedBiConsumer<? super A, T> accumulateFn
         ) {
-            accumulateFnsByTag.merge(tag.index(), accumulateFn, (x, y) -> {
+            if (accumulateFnsByTag.putIfAbsent(tag.index(), accumulateFn) != null) {
                 throw new IllegalArgumentException("Tag with index " + tag.index() + " already registered");
-            });
+            }
             return this;
         }
 
@@ -370,7 +373,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code combine} primitive.
          */
         @Nonnull
-        public VarArity<A> andCombine(DistributedBiConsumer<? super A, ? super A> combineFn) {
+        public VarArity<A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
             this.combineFn = combineFn;
             return this;
         }
@@ -379,7 +382,7 @@ public final class AggregateOperationBuilder<A> {
          * Registers the {@code deduct} primitive.
          */
         @Nonnull
-        public VarArity<A> andDeduct(DistributedBiConsumer<? super A, ? super A> deductFn) {
+        public VarArity<A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
             this.deductFn = deductFn;
             return this;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
@@ -256,7 +256,7 @@ public final class AggregateOperations {
      *
      * @param op1 1st operation
      * @param op2 2nd operation
-     * @param finishFn a function combining 3 results into single target instance
+     * @param finishFn a function combining 2 results into single target instance
      *
      * @param <T> type of input items
      * @param <A1> 1st accumulator type
@@ -358,17 +358,15 @@ public final class AggregateOperations {
     }
 
     /**
-     * Returns a builder to create a composite aggregate operation, if the
-     * number of operations is 4 or more. It allows you to calculate multiple
-     * aggregations over the same items at once.
+     * Returns a builder to create a composite of multiple aggregate
+     * operations. It allows you to calculate multiple aggregations over the
+     * same items at once. The number of operations is unbounded. Results are
+     * stored in single {@link com.hazelcast.jet.datamodel.ItemsByTag} object.
      * <p>
-     * The aggregation results are always wrapped in {@link
-     * com.hazelcast.jet.datamodel.ItemsByTag}; you have to store the {@link
-     * com.hazelcast.jet.datamodel.Tag}s to be able to query the results. If
-     * you have 2 or 3 aggregate operations, you might prefer the
-     * tuple-producing versions ({@link #allOf(AggregateOperation1,
-     * AggregateOperation1) here} or {@link #allOf(AggregateOperation1,
-     * AggregateOperation1, AggregateOperation1) here}).
+     * If you have exactly 2 or 3 operations, you might prefer more type-safe
+     * versions ({@link #allOf(AggregateOperation1, AggregateOperation1) here}
+     * or {@link #allOf(AggregateOperation1, AggregateOperation1,
+     * AggregateOperation1) here}).
      * <p>
      * Example: to calculate sum and count at the same time, you can use:
      * <pre>{@code
@@ -378,8 +376,8 @@ public final class AggregateOperations {
      *     AggregateOperation1<Long, ?, ItemsByTag> op = builder.build();
      * }</pre>
      *
-     * When you receive the resulting {@link com.hazelcast.jet.datamodel.ItemsByTag},
-     * query individual values like this:
+     * When you receive the resulting {@link com.hazelcast.jet.datamodel.ItemsByTag}
+     * object, query individual values like this:
      * <pre>{@code
      *     ItemsByTag result = ...;
      *     Long sum = result.get(tagSum);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AllOfAggregationBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AllOfAggregationBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.aggregate;
+
+import com.hazelcast.jet.datamodel.ItemsByTag;
+import com.hazelcast.jet.datamodel.Tag;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.jet.datamodel.Tag.tag;
+
+/**
+ * TODO
+ *
+ * Use {@link AggregateOperations#allOfBuilder()} to create.
+ *
+ * @param <T>
+ */
+public final class AllOfAggregationBuilder<T> {
+
+    private List<Tag> tags = new ArrayList<>();
+    private List<AggregateOperation1> operations = new ArrayList<>();
+
+    AllOfAggregationBuilder() { }
+
+    public <R> Tag<R> add(AggregateOperation1<? super T, ?, R> operation) {
+        operations.add(operation);
+        Tag<R> tag = tag(tags.size());
+        tags.add(tag);
+        return tag;
+    }
+
+    public AggregateOperation1<T, Object[], ItemsByTag> build() {
+        return (AggregateOperation1<T, Object[], ItemsByTag>) AggregateOperation
+                .withCreate(() -> {
+                    Object[] acc = new Object[tags.size()];
+                    for (int i = 0; i < acc.length; i++) {
+                        acc[i] = operations.get(i).createFn().get();
+                    }
+                    return acc;
+                })
+                .andAccumulate((acc, item) -> {
+                    for (int i = 0; i < acc.length; i++) {
+                        operations.get(i).accumulateFn().accept(acc[i], item);
+                    }
+                })
+                .andCombine(operations.stream().anyMatch(o -> o.combineFn() == null) ? null :
+                        (acc1, acc2) -> {
+                            for (int i = 0; i < acc1.length; i++) {
+                                operations.get(i).combineFn().accept(acc1[i], acc2[i]);
+                            }
+                        }
+                )
+                .andDeduct(operations.stream().anyMatch(o -> o.deductFn() == null) ? null :
+                        (acc1, acc2) -> {
+                            for (int i = 0; i < acc1.length; i++) {
+                                operations.get(i).deductFn().accept(acc1[i], acc2[i]);
+                            }
+                        }
+                )
+                .andFinish(acc -> {
+                    ItemsByTag result = new ItemsByTag();
+                    for (int i = 0; i < tags.size(); i++) {
+                        Object finishedVal = operations.get(i).finishFn().apply(acc[i]);
+                        result.put(tags.get(i), finishedVal);
+                    }
+                    return result;
+                });
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/WatermarkGenerationParams.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/WatermarkGenerationParams.java
@@ -72,7 +72,8 @@ public final class WatermarkGenerationParams<T> implements Serializable {
      * @param newWmPolicyF watermark policy factory
      * @param wmEmitPolicy watermark emission policy
      * @param idleTimeoutMillis a timeout after which the source partition will
-     *      be marked as <em>idle</em>
+     *      be marked as <em>idle</em>. If <=0, partitions will never be marked
+     *      as idle.
      */
     public static <T> WatermarkGenerationParams<T> wmGenParams(
             @Nonnull DistributedToLongFunction<T> getTimestampF,
@@ -94,7 +95,7 @@ public final class WatermarkGenerationParams<T> implements Serializable {
     /**
      * A timeout after which the {@link
      * com.hazelcast.jet.impl.execution.WatermarkCoalescer#IDLE_MESSAGE} will
-     * be sent.
+     * be sent. If <=0, partitions will never be marked as idle.
      */
     public long idleTimeoutMillis() {
         return idleTimeoutMillis;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * A 2-tuple (pair) of statically typed fields. Also implements
+ * An immutable 2-tuple (pair) of statically typed fields. Also implements
  * {@link Map.Entry}.
  *
  * @param <E0> the type of the field 0
@@ -76,8 +76,6 @@ public final class Tuple2<E0, E1> implements Map.Entry<E0, E1> {
     public E1 setValue(E1 value) {
         throw new UnsupportedOperationException("Tuple2 is immutable");
     }
-
-
 
     @Override
     public boolean equals(Object obj) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
@@ -19,7 +19,7 @@ package com.hazelcast.jet.datamodel;
 import java.util.Objects;
 
 /**
- * A 3-tuple (triple) of statically typed fields.
+ * An immutable 3-tuple (triple) of statically typed fields.
  *
  * @param <E0> the type of the field 0
  * @param <E1> the type of the field 1

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedTriFunction.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedTriFunction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.function;
+
+import java.io.Serializable;
+
+/**
+ * Represents a three-arity function that accepts three arguments and produces a result.
+ **/
+@FunctionalInterface
+public interface DistributedTriFunction<T, U, V, R> extends Serializable {
+
+    /**
+     * Applies this function to the given arguments.
+     *
+     * @param t the first argument
+     * @param u the second argument
+     * @param v the third argument
+     * @return the function result
+     */
+    R apply(T t, U u, V v);
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
@@ -22,6 +22,9 @@ import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.accumulator.LongDoubleAccumulator;
 import com.hazelcast.jet.accumulator.LongLongAccumulator;
 import com.hazelcast.jet.accumulator.MutableReference;
+import com.hazelcast.jet.datamodel.ItemsByTag;
+import com.hazelcast.jet.datamodel.Tag;
+import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.function.DistributedFunctions;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Rule;
@@ -32,7 +35,6 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
@@ -42,6 +44,7 @@ import java.util.function.Supplier;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.aggregate.AggregateOperations.allOf;
+import static com.hazelcast.jet.aggregate.AggregateOperations.allOfBuilder;
 import static com.hazelcast.jet.aggregate.AggregateOperations.averagingDouble;
 import static com.hazelcast.jet.aggregate.AggregateOperations.averagingLong;
 import static com.hazelcast.jet.aggregate.AggregateOperations.concatenating;
@@ -57,6 +60,8 @@ import static com.hazelcast.jet.aggregate.AggregateOperations.summingLong;
 import static com.hazelcast.jet.aggregate.AggregateOperations.toList;
 import static com.hazelcast.jet.aggregate.AggregateOperations.toMap;
 import static com.hazelcast.jet.aggregate.AggregateOperations.toSet;
+import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
+import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
 import static com.hazelcast.jet.function.DistributedComparator.naturalOrder;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryValue;
@@ -65,6 +70,7 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.function.Function.identity;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -146,26 +152,52 @@ public class AggregateOperationsTest {
         validateOp(
                 allOf(counting(), summingLong(Long::longValue)),
                 identity(), 10L, 11L,
-                asList(longAcc(1), longAcc(10)),
-                asList(longAcc(2), longAcc(21)),
-                asList(2L, 21L)
+                tuple2(longAcc(1), longAcc(10)),
+                tuple2(longAcc(2), longAcc(21)),
+                tuple2(2L, 21L)
         );
     }
 
     @Test
     public void when_allOfWithoutDeduct_then_noDeduct() {
         validateOpWithoutDeduct(
-                allOf(counting(), maxBy(naturalOrder())),
+                allOf(counting(), AggregateOperations.<Long>maxBy(naturalOrder())),
                 identity(), 10L, 11L,
-                asList(longAcc(1), new MutableReference<>(10L)),
-                asList(longAcc(2), new MutableReference<>(11L)),
-                asList(2L, 11L)
+                tuple2(longAcc(1), new MutableReference<>(10L)),
+                tuple2(longAcc(2), new MutableReference<>(11L)),
+                tuple2(2L, 11L)
+        );
+    }
+
+    @Test
+    public void when_allOf3() {
+        validateOp(
+                allOf(counting(), summingLong(Long::longValue), averagingLong(Long::longValue)),
+                identity(), 10L, 11L,
+                tuple3(longAcc(1), longAcc(10), longLongAcc(1, 10)),
+                tuple3(longAcc(2), longAcc(21), longLongAcc(2, 21)),
+                tuple3(2L, 21L, 10.5)
+        );
+    }
+
+    @Test
+    public void when_allOfN() {
+        AllOfAggregationBuilder<Long> builder = allOfBuilder();
+        Tag<Long> tagSum = builder.add(summingLong(Long::longValue));
+        Tag<Long> tagCount = builder.add(counting());
+        AggregateOperationsTest.validateOp(
+                builder.build(),
+                identity(),
+                10L, 11L,
+                new Object[]{longAcc(10L), longAcc(1L)},
+                new Object[]{longAcc(21L), longAcc(2L)},
+                ItemsByTag.itemsByTag(tagCount, 2L, tagSum, 21L)
         );
     }
 
     @Test
     public void when_allOfWithoutCombine_then_noCombine() {
-        AggregateOperation1<Long, List<Object>, List<Object>> composite =
+        AggregateOperation1<Long, ?, Tuple2<Long, Long>> composite =
                 allOf(AggregateOperation
                                 .withCreate(LongAccumulator::new)
                                 .<Long>andAccumulate(LongAccumulator::add)
@@ -442,7 +474,7 @@ public class AggregateOperationsTest {
     public void when_groupingBy_withDownstreamOperation() {
         Entry<String, Integer> entryA = entry("a", 1);
         validateOpWithoutDeduct(
-                groupingBy(entryKey(), AggregateOperations.counting()),
+                groupingBy(entryKey(), counting()),
                 identity(),
                 entryA,
                 entryA,
@@ -457,7 +489,7 @@ public class AggregateOperationsTest {
         Entry<String, Integer> entryA = entry("a", 1);
         Entry<String, Integer> entryB = entry("b", 1);
         validateOpWithoutDeduct(
-                groupingBy(entryKey(), TreeMap::new, AggregateOperations.counting()),
+                groupingBy(entryKey(), TreeMap::new, counting()),
                 a -> {
                     assertThat(a, instanceOf(TreeMap.class));
                     return a;
@@ -495,29 +527,37 @@ public class AggregateOperationsTest {
         // are allowed to be destructive ops
 
         // Then
-        assertEquals("accumulated", expectAcced1, getAccValFn.apply(acc1));
+        assertEqualsOrArrayEquals("accumulated", expectAcced1, getAccValFn.apply(acc1));
 
         // When
         op.combineFn().accept(acc1, acc2);
         // Then
-        assertEquals("combined", expectCombined, getAccValFn.apply(acc1));
+        assertEqualsOrArrayEquals("combined", expectCombined, getAccValFn.apply(acc1));
 
         // When
         R finished = op.finishFn().apply(acc1);
         // Then
-        assertEquals("finished", expectFinished, finished);
+        assertEqualsOrArrayEquals("finished", expectFinished, finished);
 
         // When
         deductAccFn.accept(acc1, acc2);
         // Then
-        assertEquals("deducted", expectAcced1, getAccValFn.apply(acc1));
+        assertEqualsOrArrayEquals("deducted", expectAcced1, getAccValFn.apply(acc1));
 
         // When - accumulate both items into single accumulator
         acc1 = op.createFn().get();
         op.accumulateFn().accept(acc1, item1);
         op.accumulateFn().accept(acc1, item2);
         // Then
-        assertEquals("accumulated", expectCombined, getAccValFn.apply(acc1));
+        assertEqualsOrArrayEquals("accumulated", expectCombined, getAccValFn.apply(acc1));
+    }
+
+    private static void assertEqualsOrArrayEquals(String msg, Object expected, Object actual) {
+        if (expected instanceof Object[]) {
+            assertArrayEquals(msg, (Object[]) expected, (Object[]) actual);
+        } else {
+            assertEquals(msg, expected, actual);
+        }
     }
 
     private static <T, A, X, R> void validateOpWithoutDeduct(
@@ -575,4 +615,7 @@ public class AggregateOperationsTest {
         return new LongAccumulator(val);
     }
 
+    private static LongLongAccumulator longLongAcc(long val1, long val2) {
+        return new LongLongAccumulator(val1, val2);
+    }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
@@ -148,7 +148,7 @@ public class AggregateOperationsTest {
     }
 
     @Test
-    public void when_allOf() {
+    public void when_allOf2() {
         validateOp(
                 allOf(counting(), summingLong(Long::longValue)),
                 identity(), 10L, 11L,

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkSourceUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkSourceUtilTest.java
@@ -50,7 +50,7 @@ public class WatermarkSourceUtilTest {
     }
 
     @Test
-    public void smokeTest_disabledTimeout() {
+    public void smokeTest_disabledIdleTimeout() {
         WatermarkSourceUtil<Long> wsu = new WatermarkSourceUtil<>(wmGenParams(Long::longValue, withFixedLag(LAG),
                 suppressDuplicates(), -1));
         wsu.increasePartitionCount(2);

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSources.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/KafkaSources.java
@@ -53,7 +53,8 @@ public final class KafkaSources {
      * com.hazelcast.jet.core.Processor processor} instance using the supplied
      * {@code properties}. It assigns a subset of Kafka partitions to each of
      * them using manual partition assignment (it ignores the {@code group.id}
-     * property).
+     * property). Default local parallelism for this processor is 2 (or less
+     * if less CPUs are available).
      * <p>
      * If snapshotting is enabled, partition offsets are saved to the snapshot.
      * After restart, the source emits the events from the same offset.


### PR DESCRIPTION
Before, `AggregateOperations.allOf` wrapped the result to a 
`List<Object>`, which is type-unsafe. This commit replaces it with 
a special versions that uses either `Tuple2`, `Tuple3` or `ItemsByTag` 
in the general case.