### PR TITLE
Fix cooperative emission in StreamFilesP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/JetInstance.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/JetInstance.java
@@ -157,7 +157,7 @@ public interface JetInstance {
     JetCacheManager getCacheManager();
 
     /**
-     * Shutdowns the current instance.
+     * Shuts down the current instance.
      */
     void shutdown();
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
@@ -20,10 +20,9 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 
 import javax.annotation.Nonnull;
-
-import static com.hazelcast.jet.core.test.TestSupport.getLogger;
 
 /**
  * Simple implementation of {@link Processor.Context}.
@@ -40,7 +39,6 @@ public class TestProcessorContext implements Processor.Context {
      */
     public TestProcessorContext() {
         globalProcessorIndex = 0;
-        logger = getLogger(vertexName + "#" + globalProcessorIndex);
     }
 
     @Nonnull @Override
@@ -58,6 +56,9 @@ public class TestProcessorContext implements Processor.Context {
 
     @Nonnull @Override
     public ILogger logger() {
+        if (logger == null) {
+            logger = Logger.getLogger(vertexName + "#" + globalProcessorIndex);
+        }
         return logger;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
@@ -140,7 +140,7 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
             if (isClosed()) {
                 return;
             }
-            getLogger().info("Closing StreamFilesP");
+            getLogger().fine("Closing StreamFilesP");
             watcher.close();
         } catch (IOException e) {
             getLogger().severe("Failed to close StreamFilesP", e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -119,10 +120,12 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
 
     @Override
     protected void init(@Nonnull Context context) throws Exception {
-        for (Path file : Files.newDirectoryStream(watchedDirectory)) {
-            if (Files.isRegularFile(file)) {
-                // Negative offset means "initial offset", needed to skip the first line
-                fileOffsets.put(file, new FileOffset(-Files.size(file), ""));
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(watchedDirectory)) {
+            for (Path file : directoryStream) {
+                if (Files.isRegularFile(file)) {
+                    // Negative offset means "initial offset", needed to skip the first line
+                    fileOffsets.put(file, new FileOffset(-Files.size(file), ""));
+                }
             }
         }
         watcher = FileSystems.getDefault().newWatchService();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
@@ -83,8 +83,13 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
     private static final WatchEvent.Kind[] WATCH_EVENT_KINDS = {ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE};
     private static final WatchEvent.Modifier[] WATCH_EVENT_MODIFIERS = getHighSensitivityModifiers();
 
+    /**
+     * Map from file to offset. Initially we store (-fileSize): if the offset is negative when we
+     * receive the first watcher event, we skip up to the next newline to avoid partial reading
+     * of the first line.
+     */
     // exposed for testing
-    final Map<Path, Long> fileOffsets = new HashMap<>();
+    final Map<Path, FileOffset> fileOffsets = new HashMap<>();
 
     private final Path watchedDirectory;
     private final Charset charset;
@@ -96,6 +101,7 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
 
     private WatchService watcher;
     private StringBuilder lineBuilder = new StringBuilder();
+    private String pendingLine;
     private Path currentFile;
     private FileInputStream currentInputStream;
     private Reader currentReader;
@@ -116,7 +122,7 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
         for (Path file : Files.newDirectoryStream(watchedDirectory)) {
             if (Files.isRegularFile(file)) {
                 // Negative offset means "initial offset", needed to skip the first line
-                fileOffsets.put(file, -Files.size(file));
+                fileOffsets.put(file, new FileOffset(-Files.size(file), ""));
             }
         }
         watcher = FileSystems.getDefault().newWatchService();
@@ -131,7 +137,7 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
             if (isClosed()) {
                 return;
             }
-            getLogger().info("Closing StreamFilesP. Any pending watch events will be processed.");
+            getLogger().info("Closing StreamFilesP");
             watcher.close();
         } catch (IOException e) {
             getLogger().severe("Failed to close StreamFilesP", e);
@@ -142,12 +148,11 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
 
     @Override
     public boolean complete() {
+        if (isClosed()) {
+            return true;
+        }
         try {
-            if (!isClosed()) {
-                drainWatcherEvents();
-            } else if (eventQueue.isEmpty()) {
-                return true;
-            }
+            drainWatcherEvents();
             if (currentFile == null) {
                 currentFile = eventQueue.poll();
             }
@@ -208,13 +213,19 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
                 return;
             }
             for (int i = 0; i < LINES_IN_ONE_BATCH; i++) {
-                String line = readCompleteLine(currentReader);
-                if (line == null) {
-                    fileOffsets.put(currentFile, currentInputStream.getChannel().position());
+                if (pendingLine == null) {
+                    pendingLine = readCompleteLine(currentReader);
+                }
+                if (pendingLine == null) {
+                    fileOffsets.put(currentFile,
+                            new FileOffset(currentInputStream.getChannel().position(), lineBuilder.toString()));
+                    lineBuilder.setLength(0);
                     closeCurrentFile();
                     break;
                 }
-                if (!tryEmit(line)) {
+                if (tryEmit(pendingLine)) {
+                    pendingLine = null;
+                } else {
                     break;
                 }
             }
@@ -228,21 +239,19 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
         if (currentReader != null) {
             return true;
         }
-        long offset = fileOffsets.getOrDefault(currentFile, 0L);
-        logFinest(getLogger(), "Processing file %s, previous offset: %,d", currentFile, offset);
+        FileOffset offset = fileOffsets.getOrDefault(currentFile, FileOffset.ZERO);
+        logFine(getLogger(), "Processing file %s, previous offset: %s", currentFile, offset);
         try {
             FileInputStream fis = new FileInputStream(currentFile.toFile());
-            // Negative offset means we're reading the file for the first time.
-            // We recover the actual offset by negating, then we subtract one
-            // so as not to miss a preceding newline.
-            fis.getChannel().position(offset >= 0 ? offset : -offset - 1);
+            fis.getChannel().position(offset.positiveOffset());
             BufferedReader r = new BufferedReader(new InputStreamReader(fis, charset));
-            if (offset < 0 && !findNextLine(r, offset)) {
+            if (offset.offset < 0 && !findEndOfLine(r)) {
                 closeCurrentFile();
                 return false;
             }
             currentReader = r;
             currentInputStream = fis;
+            lineBuilder.append(offset.pendingLine);
             return true;
         } catch (FileNotFoundException ignored) {
             // This could be caused by ENTRY_MODIFY emitted on file deletion
@@ -252,12 +261,16 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
         }
     }
 
-    private boolean findNextLine(Reader in, long offset) throws IOException {
+    /**
+     * Reads the file until the end of line is found.
+     *
+     * @return whether it was found
+     */
+    private boolean findEndOfLine(Reader in) throws IOException {
         while (true) {
             int ch = in.read();
             if (ch < 0) {
                 // we've hit EOF before finding the end of current line
-                fileOffsets.put(currentFile, offset);
                 return false;
             }
             if (ch == '\n' || ch == '\r') {
@@ -278,9 +291,6 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
     String readCompleteLine(Reader reader) throws IOException {
         int ch;
         while ((ch = reader.read()) >= 0) {
-            if (ch < 0) {
-                break;
-            }
             if (ch == '\r' || ch == '\n') {
                 maybeSkipLF(reader, ch);
                 try {
@@ -352,5 +362,31 @@ public class StreamFilesP extends AbstractProcessor implements Closeable {
         }
         //bad luck, we did not find the modifier
         return new WatchEvent.Modifier[0];
+    }
+
+    private static final class FileOffset {
+        private static final FileOffset ZERO = new FileOffset(0, "");
+
+        private final long offset;
+        private final String pendingLine;
+
+        private FileOffset(long offset, @Nonnull String pendingLine) {
+            this.offset = offset;
+            this.pendingLine = pendingLine;
+        }
+
+        /**
+         * Negative offset means we're reading the file for the first time.
+         * We recover the actual offset by negating, then we subtract one
+         * so that we don't skip the first line if we started right after a newline.
+         */
+        private long positiveOffset() {
+            return offset >= 0 ? offset : -offset - 1;
+        }
+
+        @Override
+        public String toString() {
+            return "FileOffset{offset=" + offset + ", pendingLine='" + pendingLine + '\'' + '}';
+        }
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -17,11 +17,13 @@
 package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.jet.core.JetTestSupport;
-import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor.Context;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
-import com.hazelcast.logging.Log4jFactory;
+import com.hazelcast.jet.core.test.TestOutbox;
+import com.hazelcast.jet.core.test.TestProcessorContext;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -34,19 +36,24 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
+import java.io.Writer;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamFilesP;
 import static java.lang.Thread.interrupted;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class StreamFilesPTest extends JetTestSupport {
@@ -60,20 +67,24 @@ public class StreamFilesPTest extends JetTestSupport {
     private StreamFilesP processor;
 
     private Thread driverThread;
-    private long emittedCount;
+    private TestOutbox outbox;
+    private final List<String> outboxLines = Collections.synchronizedList(new ArrayList<>());
 
     private volatile int fileOffsetsSize;
     private volatile boolean completedNormally;
+    private volatile Throwable driverException;
 
     @Before
     public void before() throws Exception {
         workDir = Files.createTempDirectory("jet-test-streamFilesPTest").toFile();
-        driverThread = new Thread(this::driveProcessor,
-                "Driving StreamFileP (" + testName.getMethodName() + ')');
+        driverThread = new Thread(this::driveProcessor, "driver@" + testName.getMethodName());
     }
 
     @After
-    public void after() throws InterruptedException {
+    public void after() throws Throwable {
+        if (driverException != null) {
+            throw driverException;
+        }
         driverThread.interrupt();
         driverThread.join();
         IOUtil.delete(workDir);
@@ -193,7 +204,7 @@ public class StreamFilesPTest extends JetTestSupport {
         raf.write(0xFF);
         raf.close();
         Thread.sleep(5000);
-        assertEquals(0, emittedCount);
+        assertEquals(0, outboxLines.size());
     }
 
     @Test
@@ -218,7 +229,7 @@ public class StreamFilesPTest extends JetTestSupport {
     }
 
     @Test
-    public void when_watchedDirDeleted_then_complete() throws Exception {
+    public void when_watchedDirDeleted_then_complete() {
         // Given
         initializeProcessor(null);
         driverThread.start();
@@ -230,12 +241,50 @@ public class StreamFilesPTest extends JetTestSupport {
         assertTrueEventually(() -> assertTrue(completedNormally));
     }
 
-    private void driveProcessor() {
-        while (!completedNormally && !interrupted()) {
-            completedNormally = processor.complete();
-            updateFileOffsetsSize();
+    @Test
+    public void when_lineAddedInChunks_then_readAtOnce() throws Exception {
+        // Given
+        initializeProcessor(null);
+        driverThread.start();
+
+        ILogger logger = Logger.getLogger(this.getClass());
+
+        // When
+        Path file1 = workDir.toPath().resolve("a.txt");
+        Path file2 = workDir.toPath().resolve("b.txt");
+        writeToFile(file1, "incomplete1");
+        writeToFile(file2, "incomplete2");
+        Thread.sleep(2000);
+        logger.info("complete1");
+        writeToFile(file1, " complete1\n");
+        Thread.sleep(1000);
+        logger.info("complete2");
+        writeToFile(file2, " complete2\n");
+
+        // Then
+        List<String> expected = asList("incomplete1 complete1", "incomplete2 complete2");
+        assertTrueEventually(() -> assertEquals(expected, outboxLines), ASSERT_COUNT_TIMEOUT_SECONDS);
+    }
+
+    private void writeToFile(Path file, String text) throws IOException {
+        try (Writer wr = Files.newBufferedWriter(file, StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
+            wr.append(text);
         }
-        completedNormally = true;
+    }
+
+    private void driveProcessor() {
+        try {
+            while (!completedNormally && !interrupted()) {
+                completedNormally = processor.complete();
+                // drain the outbox
+                for (Object o; (o = outbox.queueWithOrdinal(0).poll()) != null; ) {
+                    outboxLines.add((String) o);
+                }
+                updateFileOffsetsSize();
+            }
+        } catch (Throwable e) {
+            driverException = e;
+        }
     }
 
     private void updateFileOffsetsSize() {
@@ -247,26 +296,22 @@ public class StreamFilesPTest extends JetTestSupport {
             glob = "*";
         }
         processor = new StreamFilesP(workDir.getAbsolutePath(), UTF_8, glob, 1, 0);
-        Outbox outbox = mock(Outbox.class);
-        when(outbox.offer(any())).thenAnswer(item -> {
-            emittedCount++;
-            return true;
-        });
-        Context ctx = mock(Context.class);
-        when(ctx.logger()).thenReturn(new Log4jFactory().getLogger("testing"));
+        outbox = new TestOutbox(1);
+        Context ctx = new TestProcessorContext()
+                .setLogger(Logger.getLogger(StreamFilesP.class));
         processor.init(outbox, ctx);
     }
 
     // Asserts the eventual stable state of the item counter as follows:
     // 1. Wait for the count to reach at least the expected value
-    // 2. Ensure the value is exactly as expceted
+    // 2. Ensure the value is exactly as expected
     // 3. Wait a bit more
     // 4. Ensure the value hasn't increased
     private void assertEmittedCountEventually(long expected) throws Exception {
-        assertTrueEventually(() -> assertTrue("emittedCount=" + emittedCount + ", expected=" + expected,
-                emittedCount >= expected), ASSERT_COUNT_TIMEOUT_SECONDS);
-        assertEquals(expected, emittedCount);
+        assertTrueEventually(() -> assertTrue("emittedCount=" + outboxLines.size() + ", expected=" + expected,
+                outboxLines.size() >= expected), ASSERT_COUNT_TIMEOUT_SECONDS);
+        assertEquals(expected, outboxLines.size());
         Thread.sleep(2000);
-        assertEquals(expected, emittedCount);
+        assertEquals(expected, outboxLines.size());
     }
 }


### PR DESCRIPTION
Other fixes:

- Fix the case when EOF is encountered mid-line and the reading of the
line resumes later

- The processor tried to finish watcher events after it was closed,
which is nonsense. It's only closed when the job is cancelled or the
watched directory was deleted. In neither case we should continue the
work.

- Updated the test to check cooperative emission.

- Fix TestProcessorContext.getLogger: the logger was created in
constructor even though the vertexName or globalProcessorIndex could be
changed later

Fixes #658