### PR TITLE
Introduce manual job restart

### DIFF
--- a/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
+++ b/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
@@ -47,4 +47,7 @@ public interface JetCodecTemplate {
 
     @Request(id = 8, retryable = false, response = ResponseMessageConst.DATA)
     Object getJobConfig(long jobId);
+
+    @Request(id = 9, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    boolean restartJob(long jobId);
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
@@ -95,4 +95,14 @@ public interface Job {
         Util.uncheckRun(() -> getFuture().get());
     }
 
+    /**
+     * Cancels the current execution if the job is currently running and
+     * schedules a new execution with the current member list of the Jet cluster
+     *
+     * @throws IllegalStateException if the job has been already completed
+     *
+     * @return true if the current execution of the job is cancelled
+     */
+    boolean restart();
+
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.codec.JetGetJobConfigCodec;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobStatusCodec;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobSubmissionTimeCodec;
 import com.hazelcast.client.impl.protocol.codec.JetJoinSubmittedJobCodec;
+import com.hazelcast.client.impl.protocol.codec.JetRestartJobCodec;
 import com.hazelcast.client.impl.protocol.codec.JetSubmitJobCodec;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.core.ExecutionCallback;
@@ -43,6 +44,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static com.hazelcast.jet.impl.util.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 
@@ -67,6 +69,17 @@ public class ClientJobProxy extends AbstractJobProxy<HazelcastClientInstanceImpl
             Data statusData = JetGetJobStatusCodec.decodeResponse(response).response;
             return serializationService().toObject(statusData);
         });
+    }
+
+    @Override
+    public boolean restart() {
+        try {
+            ClientMessage request = JetRestartJobCodec.encodeRequest(getId());
+            ClientMessage response = invocation(request, masterAddress()).invoke().get();
+            return JetRestartJobCodec.decodeResponse(response).response;
+        } catch (ExecutionException | InterruptedException e) {
+            throw rethrow(e);
+        }
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobProxy.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.impl.operation.GetJobStatusOperation;
 import com.hazelcast.jet.impl.operation.GetJobSubmissionTimeOperation;
 import com.hazelcast.jet.impl.operation.JoinSubmittedJobOperation;
 import com.hazelcast.jet.impl.operation.SubmitJobOperation;
+import com.hazelcast.jet.impl.operation.RestartJobOperation;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
@@ -34,7 +35,9 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.ExecutionException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 
 /**
@@ -57,6 +60,15 @@ public class JobProxy extends AbstractJobProxy<NodeEngineImpl> {
                         new GetJobStatusOperation(getId())
                 ).get()
         );
+    }
+
+    @Override
+    public boolean restart() {
+        try {
+            return this.<Boolean>invokeOp(new RestartJobOperation(getId())).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw rethrow(e);
+        }
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetMessageTaskFactoryProvider.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetMessageTaskFactoryProvider.java
@@ -26,6 +26,7 @@ import com.hazelcast.client.impl.protocol.codec.JetGetJobIdsCodec;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobStatusCodec;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobSubmissionTimeCodec;
 import com.hazelcast.client.impl.protocol.codec.JetJoinSubmittedJobCodec;
+import com.hazelcast.client.impl.protocol.codec.JetRestartJobCodec;
 import com.hazelcast.client.impl.protocol.codec.JetSubmitJobCodec;
 import com.hazelcast.client.impl.protocol.task.MessageTask;
 import com.hazelcast.instance.Node;
@@ -52,6 +53,7 @@ public class JetMessageTaskFactoryProvider implements MessageTaskFactoryProvider
         factories[JetGetJobSubmissionTimeCodec.RequestParameters.TYPE.id()] =
                 toFactory(JetGetJobSubmissionTimeMessageTask::new);
         factories[JetGetJobConfigCodec.REQUEST_TYPE.id()] = toFactory(JetGetJobConfigMessageTask::new);
+        factories[JetRestartJobCodec.REQUEST_TYPE.id()] = toFactory(JetRestartJobMessageTask::new);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetRestartJobMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetRestartJobMessageTask.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.client;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.JetRestartJobCodec;
+import com.hazelcast.client.impl.protocol.codec.JetRestartJobCodec.RequestParameters;
+import com.hazelcast.instance.Node;
+import com.hazelcast.jet.impl.operation.RestartJobOperation;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.Operation;
+
+public class JetRestartJobMessageTask extends AbstractJetMessageTask<RequestParameters> {
+    protected JetRestartJobMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection, JetRestartJobCodec::decodeRequest,
+                o -> JetRestartJobCodec.encodeResponse((Boolean) o));
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        return new RestartJobOperation(parameters.jobId);
+    }
+
+    @Override
+    public String getMethodName() {
+        return "restartJob";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{};
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/exception/JobRestartRequestedException.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/exception/JobRestartRequestedException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.exception;
+
+import com.hazelcast.jet.JetException;
+
+/**
+ * The exception class thrown and handled internally when a job restart is requested
+ */
+public class JobRestartRequestedException extends JetException {
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.impl.operation.CompleteExecutionOperation;
 import com.hazelcast.jet.impl.operation.GetJobConfigOperation;
 import com.hazelcast.jet.impl.operation.GetJobIdsByNameOperation;
 import com.hazelcast.jet.impl.operation.GetJobSubmissionTimeOperation;
+import com.hazelcast.jet.impl.operation.RestartJobOperation;
 import com.hazelcast.jet.impl.operation.StartExecutionOperation;
 import com.hazelcast.jet.impl.operation.GetJobIdsOperation;
 import com.hazelcast.jet.impl.operation.GetJobStatusOperation;
@@ -77,6 +78,7 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
     public static final int GET_JOB_IDS_BY_NAME_OP = 24;
     public static final int GET_JOB_SUBMISSION_TIME_OP = 25;
     public static final int GET_JOB_CONFIG_OP = 26;
+    public static final int RESTART_JOB_OP = 27;
 
     public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(JET_IMPL_DS_FACTORY, JET_IMPL_DS_FACTORY_ID);
 
@@ -150,6 +152,8 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
                     return new GetJobSubmissionTimeOperation();
                 case GET_JOB_CONFIG_OP:
                     return new GetJobConfigOperation();
+                case RESTART_JOB_OP:
+                    return new RestartJobOperation();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
@@ -17,13 +17,12 @@
 package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ExceptionAction;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isTopologicalFailure;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 
-public abstract class AsyncOperation extends AbstractJobOperation implements IdentifiedDataSerializable {
+public abstract class AsyncOperation extends AbstractJobOperation {
 
     protected AsyncOperation() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CancelJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CancelJobOperation.java
@@ -19,13 +19,12 @@ package com.hazelcast.jet.impl.operation;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 /**
  * Operation sent from user to master member to cancel the job. Master then sends
  * {@link CancelExecutionOperation} to other members.
  */
-public class CancelJobOperation extends AbstractJobOperation implements IdentifiedDataSerializable {
+public class CancelJobOperation extends AbstractJobOperation {
 
     public CancelJobOperation() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobConfigOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobConfigOperation.java
@@ -19,9 +19,8 @@ package com.hazelcast.jet.impl.operation;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class GetJobConfigOperation extends AbstractJobOperation implements IdentifiedDataSerializable {
+public class GetJobConfigOperation extends AbstractJobOperation {
 
     private JobConfig response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -19,9 +19,8 @@ package com.hazelcast.jet.impl.operation;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class GetJobStatusOperation extends AbstractJobOperation implements IdentifiedDataSerializable {
+public class GetJobStatusOperation extends AbstractJobOperation {
 
     private JobStatus response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -18,9 +18,8 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-public class GetJobSubmissionTimeOperation extends AbstractJobOperation implements IdentifiedDataSerializable {
+public class GetJobSubmissionTimeOperation extends AbstractJobOperation {
 
     private long response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/RestartJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/RestartJobOperation.java
@@ -17,35 +17,35 @@
 package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
-import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-import java.util.concurrent.CompletableFuture;
+/**
+ * Cancels the current execution of the job and restarts it
+ */
+public class RestartJobOperation extends AbstractJobOperation implements IdentifiedDataSerializable {
+    private boolean response;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
-
-public class JoinSubmittedJobOperation extends AsyncOperation {
-
-    public JoinSubmittedJobOperation() {
+    public RestartJobOperation() {
     }
 
-    public JoinSubmittedJobOperation(long jobId) {
+    public RestartJobOperation(long jobId) {
         super(jobId);
-
     }
 
     @Override
-    protected void doRun() {
+    public void run() throws Exception {
         JetService service = getService();
-        JobCoordinationService coordinationService = service.getJobCoordinationService();
-        CompletableFuture<Void> executionFuture = coordinationService.joinSubmittedJob(jobId());
-        executionFuture.whenComplete(withTryCatch(getLogger(), (r, t) -> doSendResponse(peel(t))));
+        response = service.getJobCoordinationService().restartJobExecution(jobId());
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
     }
 
     @Override
     public int getId() {
-        return JetInitDataSerializerHook.JOIN_SUBMITTED_JOB;
+        return JetInitDataSerializerHook.RESTART_JOB_OP;
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/CompletionToken.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/CompletionToken.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.logging.ILogger;
+
+import java.util.concurrent.CompletableFuture;
+
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+
+/**
+ * Wraps a CompletableFuture that is expected to be completed
+ * only in a single way and provides methods for ease of use
+ */
+public class CompletionToken {
+    private final CompletableFuture<Void> future = new CompletableFuture<>();
+    private final ILogger logger;
+
+    public CompletionToken(ILogger logger) {
+        this.logger = logger;
+    }
+
+    public boolean complete() {
+        return future.complete(null);
+    }
+
+    public boolean isCompleted() {
+        return future.isDone();
+    }
+
+    public void whenCompleted(Runnable runnable) {
+        future.whenComplete(withTryCatch(logger, (result, throwable) -> runnable.run()));
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.core.TestProcessors.MockPS;
+import com.hazelcast.jet.core.TestProcessors.StuckForeverSourceP;
+import com.hazelcast.jet.core.TestProcessors.StuckProcessor;
+import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
+import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class ManualRestartTest extends JetTestSupport {
+    private static final int NODE_COUNT = 2;
+    private static final int LOCAL_PARALLELISM = 1;
+
+
+    private JetTestInstanceFactory factory;
+    private DAG dag;
+    private JetInstance[] instances;
+
+    @Before
+    public void setup() {
+        MockPS.completeCount.set(0);
+        MockPS.initCount.set(0);
+        MockPS.completeErrors.clear();
+
+        StuckProcessor.proceedLatch = new CountDownLatch(1);
+        StuckProcessor.executionStarted = new CountDownLatch(NODE_COUNT * LOCAL_PARALLELISM);
+
+        factory = new JetTestInstanceFactory();
+        dag = new DAG().vertex(new Vertex("test", new MockPS(StuckForeverSourceP::new, NODE_COUNT)));
+
+        instances = factory.newMembers(new JetConfig(), NODE_COUNT);
+    }
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void when_jobIsRunning_then_itRestarts() {
+        testJobRestartWhenJobIsRunning(true);
+    }
+
+    @Test
+    public void when_autoRestartOnMemberFailureDisabled_then_jobRestarts() {
+        testJobRestartWhenJobIsRunning(false);
+    }
+
+    private void testJobRestartWhenJobIsRunning(boolean autoRestartOnMemberFailureEnabled) {
+        // Given that the job is running
+        JetInstance client = factory.newClient();
+        Job job = client.newJob(dag, new JobConfig().setAutoRestartOnMemberFailure(autoRestartOnMemberFailureEnabled));
+
+        assertTrueEventually(() -> {
+            assertEquals(NODE_COUNT, MockPS.initCount.get());
+        });
+
+        // When the job is restarted after new members join to the cluster
+        int newMemberCount = 2;
+        for (int i = 0; i < newMemberCount; i++) {
+            factory.newMember();
+        }
+
+        job.restart();
+
+        // Then, the job restarts
+        int initCount = NODE_COUNT * 2 + newMemberCount;
+        assertTrueEventually(() -> {
+            assertEquals(initCount, MockPS.initCount.get());
+        });
+    }
+
+    @Test
+    public void when_jobIsNotBeingExecuted_then_itCannotBeRestarted() {
+        // Given that the job execution has not started
+        dropOperationsBetween(instances[0].getHazelcastInstance(), instances[1].getHazelcastInstance(),
+                JetInitDataSerializerHook.FACTORY_ID, singletonList(JetInitDataSerializerHook.INIT_EXECUTION_OP));
+
+        JetInstance client = factory.newClient();
+        Job job = client.newJob(dag);
+
+        assertTrueEventually(() -> assertTrue(job.getStatus() == JobStatus.STARTING));
+
+        // Then, the job cannot restart
+        assertFalse(job.restart());
+
+        resetPacketFiltersFrom(instances[0].getHazelcastInstance());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void when_jobIsCompleted_then_isCannotBeRestarted() {
+        // Given that the job is completed
+        JetInstance client = factory.newClient();
+        Job job = client.newJob(dag);
+
+        job.cancel();
+
+        try {
+            job.join();
+            fail();
+        } catch (CancellationException ignored) {
+        }
+
+        // Then, the job cannot restart
+        job.restart();
+    }
+}


### PR DESCRIPTION
A new method is added to the Job interface. If the user calls job.restart() while a job is running, the job is restarted on the current member list of the cluster from the last successful snapshot. The new method can be used as a non-graceful way of achieving elasticity.