### PR TITLE
Fail when outbox.offer() called again without returning

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperationBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperationBuilder.java
@@ -58,10 +58,9 @@ public final class AggregateOperationBuilder<A> {
      * This method is synonymous with {@link #andAccumulate0(
      * DistributedBiConsumer)}, but makes more sense when defining a
      * simple, arity-1 aggregate operation.
-     * <p>
-     * Parameters of the {@code accumulateFn} are {@code (accumulator, item)}.
      *
-     * @param accumulateFn the {@code accumulate} primitive
+     * @param accumulateFn the {@code accumulate} primitive, parameters are
+     *              {@code (accumulator, item)}
      * @param <T> the expected type of input item
      * @return a new builder object that captures the {@code T0} type parameter
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
@@ -766,5 +766,4 @@ public final class AggregateOperations {
                         : null)
                 .andFinish(MutableReference::get);
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
@@ -303,9 +303,9 @@ public abstract class AbstractProcessor implements Processor {
     /**
      * Offers the item to the outbox bucket at the supplied ordinal.
      * <p>
-     * Emitted items should not be subsequently mutated because the
-     * same instance might be used by a downstream processor in different
-     * thread, causing concurrent access.
+     * Emitted items should not be subsequently mutated because the same
+     * instance might be used by a downstream processor in a different thread,
+     * causing concurrent access.
      *
      * @return {@code true}, if the item was accepted. If {@code false} is
      * returned, the call must be retried later with the same (or equal) item.
@@ -318,9 +318,9 @@ public abstract class AbstractProcessor implements Processor {
     /**
      * Offers the item to all the outbox buckets (except the snapshot outbox).
      * <p>
-     * Emitted items should not be subsequently mutated because the
-     * same instance might be used by a downstream processor in different
-     * thread, causing concurrent access.
+     * Emitted items should not be subsequently mutated because the same
+     * instance might be used by a downstream processor in a different thread,
+     * causing concurrent access.
      *
      * @return {@code true}, if the item was accepted. If {@code false} is
      * returned, the call must be retried later with the same (or equal) item.
@@ -333,9 +333,9 @@ public abstract class AbstractProcessor implements Processor {
     /**
      * Offers the item to the outbox buckets identified in the supplied array.
      * <p>
-     * Emitted items should not be subsequently mutated because the
-     * same instance might be used by a downstream processor in different
-     * thread, causing concurrent access.
+     * Emitted items should not be subsequently mutated because the same
+     * instance might be used by a downstream processor in a different thread,
+     * causing concurrent access.
      *
      * @return {@code true}, if the item was accepted. If {@code false} is
      * returned, the call must be retried later with the same (or equal) item.
@@ -351,9 +351,9 @@ public abstract class AbstractProcessor implements Processor {
      * supplied) for each emitted item. If the outbox refuses an item, it backs
      * off and returns {@code false}.
      * <p>
-     * Emitted items should not be subsequently mutated because the
-     * same instance might be used by a downstream processor in different
-     * thread, causing concurrent access.
+     * Emitted items should not be subsequently mutated because the same
+     * instance might be used by a downstream processor in a different thread,
+     * causing concurrent access.
      * <p>
      * If this method returns {@code false}, then the caller must retain the
      * traverser and pass it again in the subsequent invocation of this method,
@@ -396,9 +396,9 @@ public abstract class AbstractProcessor implements Processor {
      * supplied) for each emitted item. If the outbox refuses an item, it backs
      * off and returns {@code false}.
      * <p>
-     * Emitted items should not be subsequently mutated because the
-     * same instance might be used by a downstream processor in different
-     * thread, causing concurrent access.
+     * Emitted items should not be subsequently mutated because the same
+     * instance might be used by a downstream processor in a different thread,
+     * causing concurrent access.
      * <p>
      * If this method returns {@code false}, then the caller must retain the
      * traverser and pass it again in the subsequent invocation of this method,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/AbstractProcessor.java
@@ -302,6 +302,10 @@ public abstract class AbstractProcessor implements Processor {
 
     /**
      * Offers the item to the outbox bucket at the supplied ordinal.
+     * <p>
+     * Emitted items should not be subsequently mutated because the
+     * same instance might be used by a downstream processor in different
+     * thread, causing concurrent access.
      *
      * @return {@code true}, if the item was accepted. If {@code false} is
      * returned, the call must be retried later with the same (or equal) item.
@@ -313,6 +317,10 @@ public abstract class AbstractProcessor implements Processor {
 
     /**
      * Offers the item to all the outbox buckets (except the snapshot outbox).
+     * <p>
+     * Emitted items should not be subsequently mutated because the
+     * same instance might be used by a downstream processor in different
+     * thread, causing concurrent access.
      *
      * @return {@code true}, if the item was accepted. If {@code false} is
      * returned, the call must be retried later with the same (or equal) item.
@@ -324,6 +332,10 @@ public abstract class AbstractProcessor implements Processor {
 
     /**
      * Offers the item to the outbox buckets identified in the supplied array.
+     * <p>
+     * Emitted items should not be subsequently mutated because the
+     * same instance might be used by a downstream processor in different
+     * thread, causing concurrent access.
      *
      * @return {@code true}, if the item was accepted. If {@code false} is
      * returned, the call must be retried later with the same (or equal) item.
@@ -338,6 +350,10 @@ public abstract class AbstractProcessor implements Processor {
      * identified in the supplied array. Calls the {@code onEmit} callback (if
      * supplied) for each emitted item. If the outbox refuses an item, it backs
      * off and returns {@code false}.
+     * <p>
+     * Emitted items should not be subsequently mutated because the
+     * same instance might be used by a downstream processor in different
+     * thread, causing concurrent access.
      * <p>
      * If this method returns {@code false}, then the caller must retain the
      * traverser and pass it again in the subsequent invocation of this method,
@@ -379,6 +395,10 @@ public abstract class AbstractProcessor implements Processor {
      * identified in the supplied array. Calls the {@code onEmit} callback (if
      * supplied) for each emitted item. If the outbox refuses an item, it backs
      * off and returns {@code false}.
+     * <p>
+     * Emitted items should not be subsequently mutated because the
+     * same instance might be used by a downstream processor in different
+     * thread, causing concurrent access.
      * <p>
      * If this method returns {@code false}, then the caller must retain the
      * traverser and pass it again in the subsequent invocation of this method,
@@ -455,6 +475,9 @@ public abstract class AbstractProcessor implements Processor {
      * BroadcastKey}, the entry will be restored to all processor instances.
      * Otherwise, the key will be distributed according to default partitioning
      * and only a single processor instance will receive the key.
+     * <p>
+     * Keys and values offered to snapshot are serialized and can be further
+     * mutated as soon as this method returns.
      *
      * @return {@code true}, if the item was accepted. If {@code false} is
      * returned, the call must be retried later with the same (or equal) key
@@ -470,6 +493,9 @@ public abstract class AbstractProcessor implements Processor {
      * of the outbox. Each item is a {@code Map.Entry} and its key and value
      * are passed as the two arguments of {@link #tryEmitToSnapshot(Object, Object)}.
      * If the outbox refuses an item, it backs off and returns {@code false}.
+     * <p>
+     * Keys and values offered to snapshot are serialized and can be further
+     * mutated as soon as this method returns.
      * <p>
      * If this method returns {@code false}, then the caller must retain the
      * traverser and pass it again in the subsequent invocation of this method,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Outbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Outbox.java
@@ -45,14 +45,13 @@ public interface Outbox {
     int bucketCount();
 
     /**
-     * Offers the supplied item to the bucket with the supplied ordinal. If
-     * {@code ordinal == -1}, offers the supplied item to all buckets (behaves
-     * the same as {@link #offer(Object)}).
+     * Offers the supplied item to the bucket with the supplied ordinal.
      * <p>
      * Items offered to outbox should not be subsequently mutated because the
      * same instance might be used by a downstream processor in different
      * thread, causing concurrent access.
      *
+     * @param ordinal output ordinal number of -1 to offer to all ordinals
      * @return {@code true} if the outbox accepted the item
      */
     @CheckReturnValue

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Outbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Outbox.java
@@ -51,7 +51,7 @@ public interface Outbox {
      * same instance might be used by a downstream processor in different
      * thread, causing concurrent access.
      *
-     * @param ordinal output ordinal number of -1 to offer to all ordinals
+     * @param ordinal output ordinal number or -1 to offer to all ordinals
      * @return {@code true} if the outbox accepted the item
      */
     @CheckReturnValue

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/JetAssert.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/JetAssert.java
@@ -32,10 +32,21 @@ final class JetAssert {
         }
     }
 
+    static void assertSame(String message, Object expected, Object actual) {
+        if (expected == actual) {
+            return;
+        }
+        throwNotEqual(message, expected, actual);
+    }
+
     static void assertEquals(String message, Object expected, Object actual) {
         if (Objects.equals(expected, actual)) {
             return;
         }
+        throwNotEqual(message, expected, actual);
+    }
+
+    private static void throwNotEqual(String message, Object expected, Object actual) {
         if (message != null && !message.equals("")) {
             message = message + " ";
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestInbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestInbox.java
@@ -21,7 +21,7 @@ import com.hazelcast.jet.core.Inbox;
 import java.util.ArrayDeque;
 
 /**
- * Extends {@link ArrayDeque} to implement {@link Inbox}.
+ * {@link Inbox} implementation suitable to be used in tests.
  */
 public final class TestInbox extends ArrayDeque<Object> implements Inbox {
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
@@ -26,16 +26,21 @@ import com.hazelcast.jet.impl.util.ProgressTracker;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import java.time.LocalTime;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map.Entry;
 import java.util.Queue;
+import java.util.stream.IntStream;
 
+import static com.hazelcast.jet.core.test.JetAssert.assertSame;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
 
 /**
- * Implements {@code Outbox} with an array of {@link ArrayDeque}s.
+ * {@code Outbox} implementation suitable to be used in tests.
  */
 public final class TestOutbox implements Outbox {
 
@@ -44,6 +49,15 @@ public final class TestOutbox implements Outbox {
     private final Queue<Object>[] buckets;
     private final Queue<Entry<MockData, MockData>> snapshotQueue = new ArrayDeque<>();
     private final OutboxImpl outbox;
+
+    /** Items that were rejected for each output ordinal */
+    private final Object[] rejectedItems;
+    /** Rejected snapshot key */
+    private Object rejectedSnapshotKey;
+    /** Rejected snapshot value */
+    private Object rejectedSnapshotValue;
+
+    private final int[] allOrdinals;
 
     /**
      * @param capacities Capacities of individual buckets. Number of buckets
@@ -66,6 +80,9 @@ public final class TestOutbox implements Outbox {
         buckets = new Queue[edgeCapacities.length];
         Arrays.setAll(buckets, i -> new ArrayDeque());
 
+        rejectedItems = new Object[edgeCapacities.length];
+        allOrdinals = IntStream.range(0, edgeCapacities.length).toArray();
+
         OutboundCollector[] outstreams = new OutboundCollector[edgeCapacities.length + (snapshotCapacity > 0 ? 1 : 0)];
         Arrays.setAll(outstreams, i ->
                 i < edgeCapacities.length
@@ -74,7 +91,7 @@ public final class TestOutbox implements Outbox {
 
         outbox = new OutboxImpl(outstreams, snapshotCapacity > 0, new ProgressTracker(), IDENTITY_SERIALIZER,
                 Integer.MAX_VALUE);
-        outbox.resetBatch();
+        outbox.reset();
     }
 
     private static <E> ProgressState addToQueue(Queue<? super E> queue, int capacity, E o) {
@@ -93,34 +110,44 @@ public final class TestOutbox implements Outbox {
 
     @Override
     public boolean offer(int ordinal, @Nonnull Object item) {
-        return outbox.offer(ordinal, item);
-    }
-
-    @Override
-    public boolean offer(int[] ordinals, @Nonnull Object item) {
-        return outbox.offer(ordinals, item);
+        return offer(ordinal == -1 ? allOrdinals : new int[]{ordinal}, item);
     }
 
     @Override
     public boolean offer(@Nonnull Object item) {
-        return outbox.offer(item);
+        return offer(allOrdinals, item);
     }
 
     @Override
-    public String toString() {
-        return Arrays.toString(buckets);
+    public boolean offer(int[] ordinals, @Nonnull Object item) {
+        boolean offerResult = outbox.offer(ordinals, item);
+        for (int ordinal : ordinals) {
+            rejectedItems[ordinal] = check(item, rejectedItems[ordinal], offerResult);
+        }
+        return offerResult;
     }
 
     @Override
-    public boolean offerToSnapshot(Object key, Object value) {
-        return outbox.offerToSnapshot(key, value);
+    public boolean offerToSnapshot(@Nonnull Object key, @Nonnull Object value) {
+        boolean offerResult = outbox.offerToSnapshot(key, value);
+        rejectedSnapshotKey = check(key, rejectedSnapshotKey, offerResult);
+        rejectedSnapshotValue = check(value, rejectedSnapshotValue, offerResult);
+        return offerResult;
+    }
+
+    @CheckReturnValue
+    private Object check(Object item, Object rejectedItem, boolean offerResult) {
+        if (rejectedItem != null) {
+            assertSame("Different item provided after offer() was rejected", rejectedItem, item);
+        }
+        return offerResult ? null : item;
     }
 
     /**
-     * Exposes individual buckets to the testing code.
+     * Exposes individual output queues to the testing code.
      * @param ordinal ordinal of the bucket
      */
-    public Queue<Object> queueWithOrdinal(int ordinal) {
+    public Queue<Object> queue(int ordinal) {
         return buckets[ordinal];
     }
 
@@ -131,6 +158,52 @@ public final class TestOutbox implements Outbox {
         return snapshotQueue;
     }
 
+    /**
+     * Move all items from the queue to the {@code target} collection and make
+     * the outbox available to accept more items. If you have limited capacity
+     * outbox, you need to call this regularly.
+     *
+     * @param queueOrdinal the queue from Outbox to drain
+     * @param target target list
+     * @param logItems whether to log drained items to {@code System.out}
+     */
+    public <T> void drainQueue(int queueOrdinal, Collection<T> target, boolean logItems) {
+        drainInternal(queue(queueOrdinal), target, logItems);
+    }
+
+    /**
+     * Move all items from the snapshot queue to the {@code target} collection
+     * and make the outbox available to accept more items. If you have limited
+     * capacity outbox, you need to call this regularly.
+     *
+     * @param target target list
+     * @param logItems whether to log drained items to {@code System.out}
+     */
+    public <T> void drainSnapshotQueue(Collection<T> target, boolean logItems) {
+        drainInternal(snapshotQueue(), target, logItems);
+    }
+
+    private <T> void drainInternal(Queue<?> q, Collection<T> target, boolean logItems) {
+        for (Object o; (o = q.poll()) != null; ) {
+            target.add((T) o);
+            if (logItems) {
+                System.out.println(LocalTime.now() + " Output: " + o);
+            }
+        }
+    }
+
+    /**
+     * Call this method after any of the {@code offer()} methods returned
+     * {@code false} to be able to offer again.
+     */
+    public void resetBatch() {
+        outbox.reset();
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.toString(buckets);
+    }
 
     /**
      * Javadoc pending

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
@@ -161,7 +161,7 @@ public final class TestOutbox implements Outbox {
     /**
      * Move all items from the queue to the {@code target} collection and make
      * the outbox available to accept more items. Also calls {@link
-     * #resetBatch()}. If you have limited capacity outbox, you need to call
+     * #reset()}. If you have a limited capacity outbox, you need to call
      * this regularly.
      *
      * @param queueOrdinal the queue from Outbox to drain
@@ -175,7 +175,7 @@ public final class TestOutbox implements Outbox {
     /**
      * Move all items from the snapshot queue to the {@code target} collection
      * and make the outbox available to accept more items. Also calls {@link
-     * #resetBatch()}. If you have limited capacity outbox, you need to call
+     * #reset()}. If you have a limited capacity outbox, you need to call
      * this regularly.
      *
      * @param target target list
@@ -192,7 +192,7 @@ public final class TestOutbox implements Outbox {
                 System.out.println(LocalTime.now() + " Output: " + o);
             }
         }
-        resetBatch();
+        reset();
     }
 
     /**
@@ -201,7 +201,7 @@ public final class TestOutbox implements Outbox {
      * from {@link #drainQueueAndReset} and {@link #drainSnapshotQueueAndReset}
      * methods.
      */
-    public void resetBatch() {
+    public void reset() {
         outbox.reset();
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestOutbox.java
@@ -160,26 +160,28 @@ public final class TestOutbox implements Outbox {
 
     /**
      * Move all items from the queue to the {@code target} collection and make
-     * the outbox available to accept more items. If you have limited capacity
-     * outbox, you need to call this regularly.
+     * the outbox available to accept more items. Also calls {@link
+     * #resetBatch()}. If you have limited capacity outbox, you need to call
+     * this regularly.
      *
      * @param queueOrdinal the queue from Outbox to drain
      * @param target target list
      * @param logItems whether to log drained items to {@code System.out}
      */
-    public <T> void drainQueue(int queueOrdinal, Collection<T> target, boolean logItems) {
+    public <T> void drainQueueAndReset(int queueOrdinal, Collection<T> target, boolean logItems) {
         drainInternal(queue(queueOrdinal), target, logItems);
     }
 
     /**
      * Move all items from the snapshot queue to the {@code target} collection
-     * and make the outbox available to accept more items. If you have limited
-     * capacity outbox, you need to call this regularly.
+     * and make the outbox available to accept more items. Also calls {@link
+     * #resetBatch()}. If you have limited capacity outbox, you need to call
+     * this regularly.
      *
      * @param target target list
      * @param logItems whether to log drained items to {@code System.out}
      */
-    public <T> void drainSnapshotQueue(Collection<T> target, boolean logItems) {
+    public <T> void drainSnapshotQueueAndReset(Collection<T> target, boolean logItems) {
         drainInternal(snapshotQueue(), target, logItems);
     }
 
@@ -190,11 +192,14 @@ public final class TestOutbox implements Outbox {
                 System.out.println(LocalTime.now() + " Output: " + o);
             }
         }
+        resetBatch();
     }
 
     /**
      * Call this method after any of the {@code offer()} methods returned
-     * {@code false} to be able to offer again.
+     * {@code false} to be able to offer again. Method is called automatically
+     * from {@link #drainQueueAndReset} and {@link #drainSnapshotQueueAndReset}
+     * methods.
      */
     public void resetBatch() {
         outbox.reset();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
@@ -25,7 +25,7 @@ import com.hazelcast.logging.Logger;
 import javax.annotation.Nonnull;
 
 /**
- * Simple implementation of {@link Processor.Context}.
+ * {@link Processor.Context} implementation suitable to be used in tests.
  */
 public class TestProcessorContext implements Processor.Context {
     private JetInstance jetInstance;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
@@ -25,7 +25,8 @@ import javax.annotation.Nonnull;
 import static com.hazelcast.jet.core.test.TestSupport.getLogger;
 
 /**
- * Simple implementation of {@link ProcessorMetaSupplier.Context}.
+ * {@link ProcessorMetaSupplier.Context} implementation suitable to be used
+ * in tests.
  */
 public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.Context {
     private JetInstance jetInstance;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnull;
 import static com.hazelcast.jet.core.test.TestSupport.getLogger;
 
 /**
- * Simple implementation of {@link ProcessorSupplier.Context}.
+ * {@link ProcessorSupplier.Context} implementation suitable to be used in tests.
  */
 public class TestProcessorSupplierContext implements ProcessorSupplier.Context {
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -441,7 +441,7 @@ public final class TestSupport {
                 // if the outbox is full, call the process() method again. Cooperative
                 // processor must be able to cope with this situation and not try to put
                 // more items to the outbox.
-                outbox.resetBatch();
+                outbox.reset();
                 processInbox(inbox, isCooperative, processor, wmToProcess);
             }
             outbox.drainQueueAndReset(0, actualOutput, logInputOutput);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -42,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
@@ -436,16 +435,17 @@ public final class TestSupport {
             } else {
                 methodName = processInbox(inbox, isCooperative, processor, wmToProcess);
             }
-            boolean madeProgress = inbox.isEmpty() || !outbox.queueWithOrdinal(0).isEmpty();
+            boolean madeProgress = inbox.isEmpty() || !outbox.queue(0).isEmpty();
             assertTrue(methodName + "() call without progress", !assertProgress || madeProgress);
             idleCount = idle(idler, idleCount, madeProgress);
-            if (outbox.queueWithOrdinal(0).size() == 1 && !inbox.isEmpty()) {
+            if (outbox.queue(0).size() == 1 && !inbox.isEmpty()) {
                 // if the outbox is full, call the process() method again. Cooperative
                 // processor must be able to cope with this situation and not try to put
                 // more items to the outbox.
+                outbox.resetBatch();
                 processInbox(inbox, isCooperative, processor, wmToProcess);
             }
-            drainOutbox(outbox.queueWithOrdinal(0), actualOutput, logInputOutput);
+            drainOutboxAndReset(outbox, actualOutput, logInputOutput);
             if (inbox.isEmpty() && wmToProcess[0] == null) {
                 snapshotAndRestore(processor, outbox, actualOutput, doSnapshots, doRestoreEvery, restoreCount);
             }
@@ -458,9 +458,9 @@ public final class TestSupport {
             double elapsed;
             do {
                 checkTime("complete", isCooperative, () -> done[0] = processor[0].complete());
-                boolean madeProgress = done[0] || !outbox.queueWithOrdinal(0).isEmpty();
+                boolean madeProgress = done[0] || !outbox.queue(0).isEmpty();
                 assertTrue("complete() call without progress", !assertProgress || madeProgress);
-                drainOutbox(outbox.queueWithOrdinal(0), actualOutput, logInputOutput);
+                drainOutboxAndReset(outbox, actualOutput, logInputOutput);
                 snapshotAndRestore(processor, outbox, actualOutput, madeProgress && doSnapshots && !done[0],
                         doRestoreEvery, restoreCount);
                 idleCount = idle(idler, idleCount, madeProgress);
@@ -532,8 +532,8 @@ public final class TestSupport {
             }
             assertTrue("saveToSnapshot() call without progress",
                     !assertProgress || done[0] || !outbox.snapshotQueue().isEmpty()
-                            || !outbox.queueWithOrdinal(0).isEmpty());
-            drainOutbox(outbox.queueWithOrdinal(0), actualOutput, logInputOutput);
+                            || !outbox.queue(0).isEmpty());
+            drainOutboxAndReset(outbox, actualOutput, logInputOutput);
             outbox.snapshotQueue().clear();
         } while (!done[0]);
 
@@ -554,16 +554,16 @@ public final class TestSupport {
             assertTrue("restoreFromSnapshot() call without progress",
                     !assertProgress
                             || lastInboxSize > snapshotInbox.size()
-                            || !outbox.queueWithOrdinal(0).isEmpty());
-            drainOutbox(outbox.queueWithOrdinal(0), actualOutput, logInputOutput);
+                            || !outbox.queue(0).isEmpty());
+            drainOutboxAndReset(outbox, actualOutput, logInputOutput);
             lastInboxSize = snapshotInbox.size();
         }
         do {
             checkTime("finishSnapshotRestore", isCooperative,
                     () -> done[0] = processor[0].finishSnapshotRestore());
             assertTrue("finishSnapshotRestore() call without progress",
-                    !assertProgress || done[0] || !outbox.queueWithOrdinal(0).isEmpty());
-            drainOutbox(outbox.queueWithOrdinal(0), actualOutput, logInputOutput);
+                    !assertProgress || done[0] || !outbox.queue(0).isEmpty());
+            drainOutboxAndReset(outbox, actualOutput, logInputOutput);
         } while (!done[0]);
     }
 
@@ -601,21 +601,9 @@ public final class TestSupport {
         return nanos / (double) MILLISECONDS.toNanos(1);
     }
 
-    /**
-     * Move all items from the outbox to the {@code target} list and make the
-     * outbox available to accept more items.
-     *
-     * @param outboxBucket the queue from Outbox to drain
-     * @param target       target list
-     * @param logItems     whether to log drained items to {@code System.out}
-     */
-    public static <T> void drainOutbox(Queue<T> outboxBucket, Collection<? super T> target, boolean logItems) {
-        for (T o; (o = outboxBucket.poll()) != null; ) {
-            target.add(o);
-            if (logItems) {
-                System.out.println(LocalTime.now() + " Output: " + o);
-            }
-        }
+    private void drainOutboxAndReset(TestOutbox outbox, Collection target, boolean logItems) {
+        outbox.drainQueue(0, target, logItems);
+        outbox.resetBatch();
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadIListP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadIListP.java
@@ -41,7 +41,7 @@ import static java.util.stream.IntStream.rangeClosed;
 
 public final class ReadIListP extends AbstractProcessor {
 
-    private static final int FETCH_SIZE = 16384;
+    static final int FETCH_SIZE = 16384;
 
     private final Traverser<Object> traverser;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
@@ -91,7 +91,7 @@ public class OutboxImpl implements Outbox {
     @Override
     public final boolean offer(int[] ordinals, @Nonnull Object item) {
         assert numRemainingInBatch != -1 : "Outbox.offer() called again after it returned false, without a " +
-                "call to resetBatch(). You probably didn't return from Processor method after Outbox.offer() " +
+                "call to reset(). You probably didn't return from Processor method after Outbox.offer() " +
                 "or AbstractProcessor.tryEmit() returned false";
         numRemainingInBatch--;
         if (numRemainingInBatch == -1) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
@@ -52,7 +52,7 @@ public class OutboxImpl implements Outbox {
      * @param progTracker Tracker to track progress. Only madeProgress will be called,
      *                    done status won't be ever changed
      * @param batchSize Maximum number of items that will be allowed to offer until
-     *                  {@link #resetBatch()} is called.
+     *                  {@link #reset()} is called.
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")
     public OutboxImpl(OutboundCollector[] outstreams, boolean hasSnapshot, ProgressTracker progTracker,
@@ -90,11 +90,11 @@ public class OutboxImpl implements Outbox {
 
     @Override
     public final boolean offer(int[] ordinals, @Nonnull Object item) {
-        if (numRemainingInBatch == 0) {
+        assert numRemainingInBatch != -1 : "offer() called again after it returned false without a call to resetBatch()";
+        numRemainingInBatch--;
+        if (numRemainingInBatch == -1) {
             return false;
         }
-        assert numRemainingInBatch > 0 : "numRemainingInBatch=" + numRemainingInBatch;
-        numRemainingInBatch--;
         boolean done = true;
         for (int i = 0; i < ordinals.length; i++) {
             if (broadcastTracker.get(i)) {
@@ -112,6 +112,8 @@ public class OutboxImpl implements Outbox {
         }
         if (done) {
             broadcastTracker.clear();
+        } else {
+            numRemainingInBatch = -1;
         }
         return done;
     }
@@ -143,7 +145,12 @@ public class OutboxImpl implements Outbox {
         return success;
     }
 
-    public void resetBatch() {
+    /**
+     * Resets the outbox so that it is available to receive another batch of
+     * items after any {@code offer()} method previously returned {@code
+     * false}.
+     */
+    public void reset() {
         numRemainingInBatch = batchSize;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
@@ -90,7 +90,9 @@ public class OutboxImpl implements Outbox {
 
     @Override
     public final boolean offer(int[] ordinals, @Nonnull Object item) {
-        assert numRemainingInBatch != -1 : "offer() called again after it returned false without a call to resetBatch()";
+        assert numRemainingInBatch != -1 : "Outbox.offer() called again after it returned false, without a " +
+                "call to resetBatch(). You probably didn't return from Processor method after Outbox.offer() " +
+                "or AbstractProcessor.tryEmit() returned false";
         numRemainingInBatch--;
         if (numRemainingInBatch == -1) {
             return false;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -137,7 +137,7 @@ public class ProcessorTasklet implements Tasklet {
     // package-visible for testing
     ProgressState call(long now) {
         progTracker.reset();
-        outbox.resetBatch();
+        outbox.reset();
         stateMachineStep(now);
         return progTracker.toProgressState();
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
@@ -242,7 +242,6 @@ public final class PeekWrappedP<T> implements Processor {
         public boolean offer(int[] ordinals, @Nonnull Object item) {
             // use broadcast logic to be able to report accurately
             // which queue was pushed to when.
-            boolean done = true;
             for (int i = 0; i < ordinals.length; i++) {
                 if (broadcastTracker.get(i)) {
                     continue;
@@ -250,13 +249,11 @@ public final class PeekWrappedP<T> implements Processor {
                 if (offer(i, item)) {
                     broadcastTracker.set(i);
                 } else {
-                    done = false;
+                    return false;
                 }
             }
-            if (done) {
-                broadcastTracker.clear();
-            }
-            return done;
+            broadcastTracker.clear();
+            return true;
         }
 
         @Override

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
@@ -365,7 +365,7 @@ public class AbstractProcessorTest {
 
     private void validateReceptionAtOrdinals(Object item, int... ordinals) {
         for (int i : range(0, OUTBOX_BUCKET_COUNT).toArray()) {
-            Queue<Object> q = outbox.queueWithOrdinal(i);
+            Queue<Object> q = outbox.queue(i);
             if (Arrays.stream(ordinals).anyMatch(ord -> ord == i)) {
                 assertEquals(item, q.poll());
             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.core.AbstractProcessor.FlatMapper;
 import com.hazelcast.jet.core.TestProcessors.ProcessorThatFailsInInit;
 import com.hazelcast.jet.core.test.TestInbox;
 import com.hazelcast.jet.core.test.TestOutbox;
+import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Before;
@@ -364,13 +365,14 @@ public class AbstractProcessorTest {
     }
 
     private void validateReceptionAtOrdinals(Object item, int... ordinals) {
-        for (int i : range(0, OUTBOX_BUCKET_COUNT).toArray()) {
+        for (int i = 0; i < OUTBOX_BUCKET_COUNT; i++) {
             Queue<Object> q = outbox.queue(i);
-            if (Arrays.stream(ordinals).anyMatch(ord -> ord == i)) {
+            if (Util.arrayIndexOf(i, ordinals) >= 0) {
                 assertEquals(item, q.poll());
             }
             assertNull(q.poll());
         }
+        outbox.resetBatch();
     }
 
     private static class RegisteringMethodCallsP extends AbstractProcessor {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
@@ -372,7 +372,7 @@ public class AbstractProcessorTest {
             }
             assertNull(q.poll());
         }
-        outbox.resetBatch();
+        outbox.reset();
     }
 
     private static class RegisteringMethodCallsP extends AbstractProcessor {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
@@ -33,7 +33,6 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
@@ -43,6 +42,7 @@ import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekOutputP;
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekSnapshotP;
 import static com.hazelcast.jet.core.test.TestSupport.supplierFrom;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -56,35 +56,38 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 public class PeekingWrapperTest {
 
     @Parameter
-    public DistributedFunction<Object, String> toStringFn;
+    public String mode;
 
-    @Parameter(1)
-    public DistributedPredicate<Object> shouldLogFn;
+    private DistributedFunction<Object, String> toStringFn;
+    private DistributedPredicate<Object> shouldLogFn;
 
     private TestProcessorContext context;
     private ILogger logger;
     private Processor peekP;
 
-    private final DistributedFunction<Entry<Integer, Integer>, String> snapshotToStringFn = e ->
-            toStringFn.apply(e.getKey()) + '=' + toStringFn.apply(e.getValue());
-    private final DistributedPredicate<Entry<Integer, Integer>> snapshotShouldLogFn = e ->
-            shouldLogFn.test(e.getKey());
+    private DistributedFunction<Entry<Integer, Integer>, String> snapshotToStringFn;
+    private DistributedPredicate<Entry<Integer, Integer>> snapshotShouldLogFn;
 
     @Parameters(name = "toStringFn={0}, shouldLogFn={1}")
-    public static Collection<Object[]> parameters() {
-        return Arrays.asList(
-                new Object[]{null, null},
-                new Object[]{
-                        (DistributedFunction<Object, String>) o -> "a" + o,
-                        (DistributedPredicate<Object>) o -> !(o instanceof Integer) || ((Integer) o) % 2 == 0,
-                }
-        );
+    public static Collection<Object> parameters() {
+        return asList("defaultFunctions", "customFunctions");
     }
 
     @Before
     public void before() {
         logger = mock(ILogger.class);
         context = new TestProcessorContext().setLogger(logger);
+        if (mode.equals("customFunctions")) {
+            toStringFn = (DistributedFunction<Object, String>) o -> "a" + o;
+            snapshotToStringFn = e -> toStringFn.apply(e.getKey()) + '=' + toStringFn.apply(e.getValue());
+            shouldLogFn = (DistributedPredicate<Object>) o -> !(o instanceof Integer) || ((Integer) o) % 2 == 0;
+            snapshotShouldLogFn = e -> shouldLogFn.test(e.getKey());
+        } else {
+            toStringFn = null;
+            snapshotToStringFn = null;
+            shouldLogFn = null;
+            snapshotShouldLogFn = null;
+        }
     }
 
     @Test
@@ -261,6 +264,7 @@ public class PeekingWrapperTest {
 
         outbox.queue(0).clear();
         outbox.queue(1).clear();
+        outbox.resetBatch();
 
         // only one queue has available space, call complete() again to emit another object
         peekP.complete();
@@ -270,6 +274,7 @@ public class PeekingWrapperTest {
         }
         outbox.queue(0).clear();
         outbox.queue(1).clear();
+        outbox.resetBatch();
         verifyZeroInteractions(logger);
 
         peekP.complete();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
@@ -259,8 +259,8 @@ public class PeekingWrapperTest {
         verify(logger).info("Output to 0: " + format(0));
         verify(logger).info("Output to 1: " + format(0));
 
-        outbox.queueWithOrdinal(0).clear();
-        outbox.queueWithOrdinal(1).clear();
+        outbox.queue(0).clear();
+        outbox.queue(1).clear();
 
         // only one queue has available space, call complete() again to emit another object
         peekP.complete();
@@ -268,8 +268,8 @@ public class PeekingWrapperTest {
             verify(logger).info("Output to 1: " + format(1));
             verify(logger).info("Output to 0: " + format(1));
         }
-        outbox.queueWithOrdinal(0).clear();
-        outbox.queueWithOrdinal(1).clear();
+        outbox.queue(0).clear();
+        outbox.queue(1).clear();
         verifyZeroInteractions(logger);
 
         peekP.complete();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
@@ -264,7 +264,7 @@ public class PeekingWrapperTest {
 
         outbox.queue(0).clear();
         outbox.queue(1).clear();
-        outbox.resetBatch();
+        outbox.reset();
 
         // only one queue has available space, call complete() again to emit another object
         peekP.complete();
@@ -274,7 +274,7 @@ public class PeekingWrapperTest {
         }
         outbox.queue(0).clear();
         outbox.queue(1).clear();
-        outbox.resetBatch();
+        outbox.reset();
         verifyZeroInteractions(logger);
 
         peekP.complete();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -58,7 +58,7 @@ public class ProcessorsTest {
         inbox = new TestInbox();
         outbox = new TestOutbox(1);
         context = mock(Context.class);
-        bucket = outbox.queueWithOrdinal(0);
+        bucket = outbox.queue(0);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -18,261 +18,134 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.aggregate.AggregateOperation;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
-import com.hazelcast.jet.core.Processor.Context;
 import com.hazelcast.jet.core.processor.Processors;
-import com.hazelcast.jet.core.test.TestInbox;
-import com.hazelcast.jet.core.test.TestOutbox;
+import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map.Entry;
-import java.util.Queue;
-import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.function.DistributedFunctions.alwaysTrue;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class ProcessorsTest {
-    private TestInbox inbox;
-    private TestOutbox outbox;
-    private Queue<Object> bucket;
-    private Context context;
-
-    @Before
-    public void before() {
-        inbox = new TestInbox();
-        outbox = new TestOutbox(1);
-        context = mock(Context.class);
-        bucket = outbox.queue(0);
-    }
 
     @Test
     public void map() {
-        // Given
-        final Processor p = processorFrom(Processors.mapP(Object::toString));
-        inbox.add(1);
-
-        // When
-        p.process(0, inbox);
-
-        // Then
-        assertEquals("1", bucket.remove());
+        TestSupport
+                .verifyProcessor(Processors.mapP(Object::toString))
+                .input(singletonList(1))
+                .expectOutput(singletonList("1"));
     }
 
     @Test
     public void filteringWithMap() {
-        // Given
-        final Processor p = processorFrom(Processors.mapP((Integer i) -> i > 1 ? i : null));
-        inbox.add(1);
-        inbox.add(2);
-
-        // When
-        p.process(0, inbox);
-
-        // Then
-        assertEquals(2, bucket.remove());
-        assertNull(bucket.poll());
+        TestSupport
+                .verifyProcessor(Processors.mapP((Integer i) -> i > 1 ? i : null))
+                .input(asList(1, 2))
+                .expectOutput(singletonList(2));
     }
 
     @Test
     public void filter() {
-        // Given
-        final Processor p = processorFrom(Processors.filterP(o -> o.equals(1)));
-        inbox.add(1);
-        inbox.add(2);
-        inbox.add(1);
-        inbox.add(2);
-
-        // When
-        p.process(0, inbox);
-        // Then
-        assertEquals(1, bucket.remove());
-
-        // When
-        p.process(0, inbox);
-        // Then
-        assertTrue(inbox.isEmpty());
-        assertEquals(1, bucket.remove());
+        TestSupport
+                .verifyProcessor(Processors.filterP(o -> o.equals(1)))
+                .input(asList(1, 2, 1, 2))
+                .expectOutput(asList(1, 1));
     }
 
     @Test
     public void flatMap() {
-        // Given
-        final Processor p = processorFrom(Processors.flatMapP(o -> traverseIterable(asList(o + "a", o + "b"))));
-        inbox.add(1);
-
-        // When
-        p.process(0, inbox);
-        // Then
-        assertEquals("1a", bucket.remove());
-
-        // When
-        p.process(0, inbox);
-        // Then
-        assertTrue(inbox.isEmpty());
-        assertEquals("1b", bucket.remove());
+        TestSupport
+                .verifyProcessor(Processors.flatMapP(o -> traverseIterable(asList(o + "a", o + "b"))))
+                .input(singletonList(1))
+                .expectOutput(asList("1a", "1b"));
     }
 
     @Test
     public void aggregateByKey() {
-        final Processor p = processorFrom(Processors.aggregateByKeyP(Object::toString, aggregateToListAndString()));
-        // Given
-        inbox.add(1);
-        inbox.add(1);
-        inbox.add(2);
-        inbox.add(2);
-        p.process(0, inbox);
-
-        // When
-        boolean done = p.complete();
-        // Then
-        assertFalse(done);
-        final Entry<String, String> result1 = (Entry<String, String>) bucket.remove();
-
-        // When
-        done = p.complete();
-        // Then
-        assertTrue(done);
-        final Entry<String, String> result2 = (Entry<String, String>) bucket.remove();
-
-        // Finally
-        assertEquals(
-                new HashSet<>(asList(
-                    entry("1", "[1, 1]"),
-                    entry("2", "[2, 2]")
-                )),
-                new HashSet<>(asList(result1, result2)));
+        TestSupport
+                .verifyProcessor(Processors.aggregateByKeyP(Object::toString, aggregateToListAndString()))
+                .disableSnapshots()
+                .outputChecker(TestSupport.SAME_ITEMS_ANY_ORDER)
+                .input(asList(1, 1, 2, 2))
+                .expectOutput(asList(
+                        entry("1", "[1, 1]"),
+                        entry("2", "[2, 2]")
+                ));
     }
 
     @Test
     public void accumulateByKey() {
-        final Processor p = processorFrom(Processors.accumulateByKeyP(Object::toString, aggregateToListAndString()));
-        // Given
-        inbox.add(1);
-        inbox.add(1);
-        inbox.add(2);
-        inbox.add(2);
-        p.process(0, inbox);
-
-        // When
-        boolean done = p.complete();
-        // Then
-        assertFalse(done);
-        final Entry<String, List<Integer>> result1 = (Entry<String, List<Integer>>) bucket.remove();
-
-        // When
-        done = p.complete();
-        // Then
-        assertTrue(done);
-        final Entry<String, List<Integer>> result2 = (Entry<String, List<Integer>>) bucket.remove();
-
-        // Finally
-        assertEquals(
-                new HashSet<>(asList(
+        TestSupport
+                .verifyProcessor(Processors.accumulateByKeyP(Object::toString, aggregateToListAndString()))
+                .disableSnapshots()
+                .input(asList(1, 1, 2, 2))
+                .outputChecker(TestSupport.SAME_ITEMS_ANY_ORDER)
+                .expectOutput(asList(
                         entry("1", asList(1, 1)),
                         entry("2", asList(2, 2))
-                )),
-                new HashSet<>(asList(result1, result2)));
+                ));
     }
 
     @Test
     public void combineByKey() {
-        final Processor p = processorFrom(Processors.combineByKeyP(aggregateToListAndString()));
-        // Given
-        inbox.add(entry("1", asList(1, 2)));
-        inbox.add(entry("1", asList(3, 4)));
-        inbox.add(entry("2", asList(5, 6)));
-        inbox.add(entry("2", asList(7, 8)));
-        p.process(0, inbox);
-
-        // When
-        boolean done = p.complete();
-        // Then
-        assertFalse(done);
-        final Entry<String, String> result1 = (Entry<String, String>) bucket.remove();
-
-        // When
-        done = p.complete();
-        // Then
-        assertTrue(done);
-        final Entry<String, String> result2 = (Entry<String, String>) bucket.remove();
-
-        // Finally
-        assertEquals(
-                new HashSet<>(asList(
+        TestSupport
+                .verifyProcessor(Processors.combineByKeyP(aggregateToListAndString()))
+                .disableSnapshots()
+                .outputChecker(TestSupport.SAME_ITEMS_ANY_ORDER)
+                .input(asList(
+                        entry("1", asList(1, 2)),
+                        entry("1", asList(3, 4)),
+                        entry("2", asList(5, 6)),
+                        entry("2", asList(7, 8))
+                ))
+                .expectOutput(asList(
                         entry("1", "[1, 2, 3, 4]"),
                         entry("2", "[5, 6, 7, 8]")
-                )),
-                new HashSet<>(asList(result1, result2)));
+                ));
     }
 
     @Test
     public void aggregate() {
-        final Processor p = processorFrom(Processors.aggregateP(aggregateToListAndString()));
-        // Given
-        inbox.add(1);
-        inbox.add(2);
-        p.process(0, inbox);
-
-        // When
-        boolean done = p.complete();
-        // Then
-        assertTrue(done);
-        final String result = (String) bucket.remove();
-
-        // Finally
-        assertEquals("[1, 2]", result);
+        TestSupport
+                .verifyProcessor(Processors.aggregateP(aggregateToListAndString()))
+                .disableSnapshots()
+                .input(asList(1, 2))
+                .expectOutput(singletonList("[1, 2]"));
     }
 
     @Test
     public void accumulate() {
-        final Processor p = processorFrom(Processors.accumulateP(aggregateToListAndString()));
-        // Given
-        inbox.add(1);
-        inbox.add(2);
-        p.process(0, inbox);
-
-        // When
-        boolean done = p.complete();
-        // Then
-        assertTrue(done);
-        final List<Integer> result = (List<Integer>) bucket.remove();
-
-        // Finally
-        assertEquals(asList(1, 2), result);
+        TestSupport
+                .verifyProcessor(Processors.accumulateP(aggregateToListAndString()))
+                .disableSnapshots()
+                .input(asList(1, 2))
+                .expectOutput(singletonList(asList(1, 2)));
     }
 
     @Test
     public void combine() {
-        final Processor p = processorFrom(Processors.combineP(aggregateToListAndString()));
-        // Given
-        inbox.add(singletonList(1));
-        inbox.add(singletonList(2));
-        p.process(0, inbox);
-
-        // When
-        boolean done = p.complete();
-        // Then
-        assertTrue(done);
-        final String result = (String) bucket.remove();
-
-        // Finally
-        assertEquals("[1, 2]", result);
+        TestSupport
+                .verifyProcessor(Processors.combineP(aggregateToListAndString()))
+                .disableSnapshots()
+                .input(asList(
+                        singletonList(1),
+                        singletonList(2)
+                ))
+                .expectOutput(singletonList("[1, 2]"));
     }
 
     @Test
@@ -293,19 +166,10 @@ public class ProcessorsTest {
 
     @Test
     public void noop() {
-        Processor p = processorFrom(Processors.noopP());
-        for (int i = 0; i < 100; i++) {
-            inbox.add("a");
-        }
-        p.process(0, inbox);
-        assertEquals(0, inbox.size());
-        assertEquals(0, bucket.size());
-    }
-
-    private Processor processorFrom(Supplier<Processor> supplier) {
-        Processor p = supplier.get();
-        p.init(outbox, context);
-        return p;
+        TestSupport
+                .verifyProcessor(Processors.noopP())
+                .input(Stream.generate(() -> "a").limit(100).collect(toList()))
+                .expectOutput(emptyList());
     }
 
     private static <T> AggregateOperation1<T, List<T>, String> aggregateToListAndString() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core.test;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestOutboxTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void when_differentObjectAfterFalse_then_rejected() {
+        TestOutbox outbox = new TestOutbox(1);
+        assertTrue(outbox.offer(1));
+        assertFalse(outbox.offer(2));
+        outbox.drainQueue(0, new ArrayList<>(), false);
+        outbox.resetBatch();
+
+        // Then
+        exception.expectMessage("Different");
+        // When
+        assertFalse(outbox.offer(3));
+    }
+
+    @Test
+    public void when_differentObjectToSnapshotAfterFalse_then_rejected() {
+        TestOutbox outbox = new TestOutbox(new int[]{1}, 1);
+        assertTrue(outbox.offerToSnapshot("k1", "v1"));
+        assertFalse(outbox.offerToSnapshot("k2", "v2"));
+        outbox.drainSnapshotQueue(new ArrayList<>(), false);
+        outbox.resetBatch();
+
+        // Then
+        exception.expectMessage("Different");
+        // When
+        assertFalse(outbox.offerToSnapshot("k3", "v3"));
+    }
+
+    @Test
+    public void when_resetBatchCalled_then_offerSucceeds() {
+        TestOutbox outbox = new TestOutbox(1);
+        assertTrue(outbox.offer(1));
+        assertFalse(outbox.offer(2));
+
+        // When
+        outbox.resetBatch();
+        // Then - this would fail if resetBatch() was required
+        assertFalse(outbox.offer(2));
+    }
+
+    @Test
+    public void when_resetBatchNotCalled_then_offerFails() {
+        TestOutbox outbox = new TestOutbox(1);
+        // When
+        assertTrue(outbox.offer(1));
+        assertFalse(outbox.offer(2));
+
+        // Then
+        exception.expectMessage("offer() called again");
+        assertFalse(outbox.offer(2));
+    }
+
+    @Test
+    public void when_offeredToMinusOne_then_offeredToAll() {
+        TestOutbox outbox = new TestOutbox(2);
+        assertTrue(outbox.offer(-1, "foo"));
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
@@ -57,19 +57,19 @@ public class TestOutboxTest {
     }
 
     @Test
-    public void when_resetBatchCalled_then_offerSucceeds() {
+    public void when_resetCalled_then_offerSucceeds() {
         TestOutbox outbox = new TestOutbox(1);
         assertTrue(outbox.offer(1));
         assertFalse(outbox.offer(2));
 
         // When
-        outbox.resetBatch();
-        // Then - this would fail if resetBatch() was required
+        outbox.reset();
+        // Then - this would fail if reset() was required
         assertFalse(outbox.offer(2));
     }
 
     @Test
-    public void when_resetBatchNotCalled_then_offerFails() {
+    public void when_resetNotCalled_then_offerFails() {
         TestOutbox outbox = new TestOutbox(1);
         // When
         assertTrue(outbox.offer(1));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/test/TestOutboxTest.java
@@ -35,8 +35,7 @@ public class TestOutboxTest {
         TestOutbox outbox = new TestOutbox(1);
         assertTrue(outbox.offer(1));
         assertFalse(outbox.offer(2));
-        outbox.drainQueue(0, new ArrayList<>(), false);
-        outbox.resetBatch();
+        outbox.drainQueueAndReset(0, new ArrayList<>(), false);
 
         // Then
         exception.expectMessage("Different");
@@ -49,8 +48,7 @@ public class TestOutboxTest {
         TestOutbox outbox = new TestOutbox(new int[]{1}, 1);
         assertTrue(outbox.offerToSnapshot("k1", "v1"));
         assertFalse(outbox.offerToSnapshot("k2", "v2"));
-        outbox.drainSnapshotQueue(new ArrayList<>(), false);
-        outbox.resetBatch();
+        outbox.drainSnapshotQueueAndReset(new ArrayList<>(), false);
 
         // Then
         exception.expectMessage("Different");

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
@@ -16,55 +16,35 @@
 
 package com.hazelcast.jet.impl.connector;
 
-import com.hazelcast.jet.core.Processor;
-import com.hazelcast.jet.core.test.TestOutbox;
+import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
-import java.util.Queue;
+import java.util.List;
+import java.util.stream.IntStream;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static java.util.stream.Collectors.toList;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class ReadIListPTest {
 
     @Test
     public void when_sizeLessThanFetchSize_then_readAll() {
-        testReader(13);
+        testReader(ReadIListP.FETCH_SIZE / 2);
     }
 
     @Test
     public void when_sizeMoreThanFetchSize_then_readAll() {
-        testReader(3);
+        testReader(ReadIListP.FETCH_SIZE * 3 / 2);
     }
 
-    private static void testReader(int fetchSize) {
-        final TestOutbox outbox = new TestOutbox(2);
-        final Queue<Object> bucket = outbox.queue(0);
-        final ReadIListP r = new ReadIListP(asList(1, 2, 3, 4));
-        r.init(outbox, Mockito.mock(Processor.Context.class));
-
-        // When
-        assertFalse(r.complete());
-
-        // Then
-        assertEquals(1, bucket.poll());
-        assertEquals(2, bucket.poll());
-        assertNull(bucket.poll());
-
-        // When
-        assertTrue(r.complete());
-
-        // Then
-        assertEquals(3, bucket.poll());
-        assertEquals(4, bucket.poll());
-        assertNull(bucket.poll());
+    private static void testReader(int listLength) {
+        List<Object> data = IntStream.range(0, listLength).boxed().collect(toList());
+        TestSupport
+                .verifyProcessor(new ReadIListP(data))
+                .disableSnapshots()
+                .disableLogging()
+                .expectOutput(data);
     }
-
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
@@ -46,7 +46,7 @@ public class ReadIListPTest {
 
     private static void testReader(int fetchSize) {
         final TestOutbox outbox = new TestOutbox(2);
-        final Queue<Object> bucket = outbox.queueWithOrdinal(0);
+        final Queue<Object> bucket = outbox.queue(0);
         final ReadIListP r = new ReadIListP(asList(1, 2, 3, 4));
         r.init(outbox, Mockito.mock(Processor.Context.class));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorPTest.java
@@ -51,7 +51,7 @@ public class ReadWithPartitionIteratorPTest {
         ReadWithPartitionIteratorP<Entry<Integer, Integer>> r =
                 new ReadWithPartitionIteratorP<>(p -> content[p], partitions);
         TestOutbox outbox = new TestOutbox(3);
-        Queue<Object> bucket = outbox.queueWithOrdinal(0);
+        Queue<Object> bucket = outbox.queue(0);
         r.init(outbox, mock(Processor.Context.class));
 
         // When

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorPTest.java
@@ -60,7 +60,7 @@ public class ReadWithPartitionIteratorPTest {
         assertEquals(entry(51), bucket.poll());
         assertEquals(entry(71), bucket.poll());
         assertEquals(entry(52), bucket.poll());
-        outbox.resetBatch();
+        outbox.reset();
 
         // When
         assertTrue(r.complete());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorPTest.java
@@ -41,7 +41,6 @@ public class ReadWithPartitionIteratorPTest {
     @Test
     @SuppressWarnings("unchecked")
     public void when_readFromTwoPartitions_then_emitRoundRobin() {
-
         // Given
         final List<Integer> partitions = asList(0, 1);
         final Iterator<Entry<Integer, Integer>>[] content = new Iterator[]{
@@ -61,6 +60,7 @@ public class ReadWithPartitionIteratorPTest {
         assertEquals(entry(51), bucket.poll());
         assertEquals(entry(71), bucket.poll());
         assertEquals(entry(52), bucket.poll());
+        outbox.resetBatch();
 
         // When
         assertTrue(r.complete());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
-import java.util.Queue;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -48,7 +47,6 @@ import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.WatermarkGenerationParams.wmGenParams;
 import static com.hazelcast.jet.core.WatermarkPolicies.withFixedLag;
 import static com.hazelcast.jet.core.test.TestSupport.SAME_ITEMS_ANY_ORDER;
-import static com.hazelcast.jet.core.test.TestSupport.drainOutbox;
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
@@ -106,7 +104,6 @@ public class StreamEventJournalPTest extends JetTestSupport {
     @Test
     public void when_newData() {
         TestOutbox outbox = new TestOutbox(new int[]{16}, 16);
-        Queue<Object> queue = outbox.queueWithOrdinal(0);
         List<Object> actual = new ArrayList<>();
         Processor p = supplier.get();
 
@@ -122,7 +119,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
         // consume
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            drainOutbox(queue, actual, true);
+            outbox.drainQueue(0, actual, true);
             assertEquals("consumed more items than expected", batchSize, actual.size());
             assertEquals(IntStream.range(0, batchSize).boxed().collect(Collectors.toSet()), new HashSet<>(actual));
         }, 3);
@@ -134,7 +131,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
         // consume again
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            drainOutbox(queue, actual, true);
+            outbox.drainQueue(0, actual, true);
             assertEquals("consumed more items than expected", JOURNAL_CAPACITY + 2, actual.size());
             assertEquals(IntStream.range(0, batchSize * 2).boxed().collect(Collectors.toSet()), new HashSet<>(actual));
         }, 3);
@@ -143,7 +140,6 @@ public class StreamEventJournalPTest extends JetTestSupport {
     @Test
     public void when_staleSequence() {
         TestOutbox outbox = new TestOutbox(new int[]{16}, 16);
-        Queue<Object> queue = outbox.queueWithOrdinal(0);
         Processor p = supplier.get();
         p.init(outbox, new TestProcessorContext());
 
@@ -156,7 +152,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
         List<Object> actual = new ArrayList<>();
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            drainOutbox(queue, actual, true);
+            outbox.drainQueue(0, actual, true);
             assertTrue("consumed less items than expected", actual.size() >= JOURNAL_CAPACITY);
         }, 3);
 
@@ -174,7 +170,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
 
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            drainOutbox(outbox.queueWithOrdinal(0), output, true);
+            outbox.drainQueue(0, output, true);
             assertTrue("consumed more items than expected", output.size() == 0);
         }, 3);
 
@@ -209,7 +205,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
 
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            drainOutbox(newOutbox.queueWithOrdinal(0), output, true);
+            newOutbox.drainQueue(0, output, true);
             assertEquals("consumed different number of items than expected", JOURNAL_CAPACITY, output.size());
         }, 3);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
@@ -119,7 +119,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
         // consume
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            outbox.drainQueue(0, actual, true);
+            outbox.drainQueueAndReset(0, actual, true);
             assertEquals("consumed more items than expected", batchSize, actual.size());
             assertEquals(IntStream.range(0, batchSize).boxed().collect(Collectors.toSet()), new HashSet<>(actual));
         }, 3);
@@ -131,7 +131,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
         // consume again
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            outbox.drainQueue(0, actual, true);
+            outbox.drainQueueAndReset(0, actual, true);
             assertEquals("consumed more items than expected", JOURNAL_CAPACITY + 2, actual.size());
             assertEquals(IntStream.range(0, batchSize * 2).boxed().collect(Collectors.toSet()), new HashSet<>(actual));
         }, 3);
@@ -152,7 +152,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
         List<Object> actual = new ArrayList<>();
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            outbox.drainQueue(0, actual, true);
+            outbox.drainQueueAndReset(0, actual, true);
             assertTrue("consumed less items than expected", actual.size() >= JOURNAL_CAPACITY);
         }, 3);
 
@@ -170,7 +170,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
 
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            outbox.drainQueue(0, output, true);
+            outbox.drainQueueAndReset(0, output, true);
             assertTrue("consumed more items than expected", output.size() == 0);
         }, 3);
 
@@ -205,7 +205,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
 
         assertTrueEventually(() -> {
             assertFalse("Processor should never complete", p.complete());
-            newOutbox.drainQueue(0, output, true);
+            newOutbox.drainQueueAndReset(0, output, true);
             assertEquals("consumed different number of items than expected", JOURNAL_CAPACITY, output.size());
         }, 3);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -276,10 +276,7 @@ public class StreamFilesPTest extends JetTestSupport {
         try {
             while (!completedNormally && !interrupted()) {
                 completedNormally = processor.complete();
-                // drain the outbox
-                for (Object o; (o = outbox.queue(0).poll()) != null; ) {
-                    outboxLines.add((String) o);
-                }
+                outbox.drainQueueAndReset(0, outboxLines, false);
                 updateFileOffsetsSize();
             }
         } catch (Throwable e) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -277,7 +277,7 @@ public class StreamFilesPTest extends JetTestSupport {
             while (!completedNormally && !interrupted()) {
                 completedNormally = processor.complete();
                 // drain the outbox
-                for (Object o; (o = outbox.queueWithOrdinal(0).poll()) != null; ) {
+                for (Object o; (o = outbox.queue(0).poll()) != null; ) {
                     outboxLines.add((String) o);
                 }
                 updateFileOffsetsSize();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
@@ -81,7 +81,7 @@ public class StreamSocketPTest extends JetTestSupport {
     public void before() {
         outbox = new TestOutbox(10);
         context = new TestProcessorContext();
-        bucket = outbox.queueWithOrdinal(0);
+        bucket = outbox.queue(0);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/OutboxImplTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/OutboxImplTest.java
@@ -19,23 +19,30 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.jet.impl.util.ProgressTracker;
 import com.hazelcast.spi.serialization.SerializationService;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.function.Predicate;
 
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
+import static com.hazelcast.jet.impl.util.ProgressState.NO_PROGRESS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
 public class OutboxImplTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     private OutboxImpl outbox = new OutboxImpl(new OutboundCollector[] {e -> DONE, e -> DONE},
             true, new ProgressTracker(), mock(SerializationService.class), 3);
 
     @Before
     public void before() {
-        outbox.resetBatch();
+        outbox.reset();
     }
 
     @Test
@@ -50,7 +57,7 @@ public class OutboxImplTest {
 
     @Test
     public void when_offer3_then_rateLimited() {
-        do_when_offer_then_rateLimited(e -> outbox.offerToSnapshot("key", "value"));
+        do_when_offer_then_rateLimited(e -> outbox.offerToSnapshot(e, e));
     }
 
     @Test
@@ -63,11 +70,52 @@ public class OutboxImplTest {
         do_when_offer_then_rateLimited(e -> outbox.offerToEdgesAndSnapshot(e));
     }
 
+    @Test
+    public void when_queueFullAndOfferReturnedFalse_then_subsequentCallFails() {
+        // See https://github.com/hazelcast/hazelcast-jet/issues/622
+        outbox = new OutboxImpl(new OutboundCollector[] {e -> DONE, e -> NO_PROGRESS},
+                true, new ProgressTracker(), mock(SerializationService.class), 128);
+
+        // we succeed offering to one queue, but not to the other, thus false
+        assertFalse(outbox.offer(4));
+
+        // Then
+        exception.expectMessage("offer() called again");
+        outbox.offer(4);
+    }
+
+    @Test
+    public void when_batchSizeReachedAndOfferReturnedFalse_then_subsequentCallFails() {
+        // See https://github.com/hazelcast/hazelcast-jet/issues/622
+        assertTrue(outbox.offer(1));
+        assertTrue(outbox.offer(2));
+        assertTrue(outbox.offer(3));
+        assertFalse(outbox.offer(4));
+
+        // Then
+        try {
+            outbox.offer(4);
+            fail("expected exception not thrown");
+        } catch (AssertionError e) {
+            assertTrue(e.getMessage().contains("offer() called again"));
+        }
+
+        // let's reset the outbox, we should be able to offer now
+        outbox.reset();
+        assertTrue(outbox.offer(4));
+    }
+
+    @Test
+    public void when_sameItemOfferedTwice_then_success() {
+        String item = "foo";
+        assertTrue(outbox.offer(item));
+        assertTrue(outbox.offer(item));
+    }
+
     private void do_when_offer_then_rateLimited(Predicate<Object> offerF) {
         assertTrue(offerF.test(1));
         assertTrue(offerF.test(2));
         assertTrue(offerF.test(3));
         assertFalse(offerF.test(4));
     }
-
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.core.WatermarkEmissionPolicy.emitByFrame;
 import static com.hazelcast.jet.core.WatermarkEmissionPolicy.emitByMinStep;
+import static com.hazelcast.jet.core.WatermarkEmissionPolicy.suppressDuplicates;
 import static com.hazelcast.jet.core.WatermarkGenerationParams.wmGenParams;
 import static com.hazelcast.jet.core.WatermarkPolicies.withFixedLag;
 import static com.hazelcast.jet.core.WindowDefinition.tumblingWindowDef;
@@ -70,8 +71,7 @@ public class InsertWatermarksPTest {
     private List<Object> resultToCheck = new ArrayList<>();
     private Context context;
     private DistributedSupplier<WatermarkPolicy> wmPolicy = withFixedLag(LAG);
-    private WatermarkEmissionPolicy wmEmissionPolicy = (WatermarkEmissionPolicy) (currentWm, lastEmittedWm) ->
-            currentWm > lastEmittedWm;
+    private WatermarkEmissionPolicy wmEmissionPolicy = suppressDuplicates();
 
     @Parameters(name = "outboxCapacity={0}")
     public static Collection<Object> parameters() {
@@ -215,7 +215,25 @@ public class InsertWatermarksPTest {
                         item(14)
                 )
         );
+    }
 
+    @Test
+    public void emitByFrame_when_eventsNotAtTheVergeOfFrame_then_wmEmittedCorrectly() {
+        wmEmissionPolicy = emitByFrame(tumblingWindowDef(10));
+        doTest(
+                asList(
+                        item(14),
+                        item(15),
+                        item(24)
+                ),
+                asList(
+                        wm(11),
+                        item(14),
+                        item(15),
+                        wm(21),
+                        item(24)
+                )
+        );
     }
 
     @Test
@@ -291,7 +309,7 @@ public class InsertWatermarksPTest {
         do {
             assertTrue(p.tryProcess());
             elapsedMs = NANOSECONDS.toMillis(System.nanoTime() - start);
-            drainOutbox();
+            outbox.drainQueue(0, resultToCheck, false);
             if (elapsedMs < 99) {
                 assertTrue("outbox should be empty, elapsedMs=" + elapsedMs, resultToCheck.isEmpty());
             } else if (!resultToCheck.isEmpty()) {
@@ -332,14 +350,9 @@ public class InsertWatermarksPTest {
         int count = 0;
         do {
             done = action.getAsBoolean();
-            drainOutbox();
+            outbox.drainQueue(0, resultToCheck, false);
             assertTrue("action not done in " + count + " attempts", ++count < 10);
         } while (!done);
-    }
-
-    private void drainOutbox() {
-        resultToCheck.addAll(outbox.queueWithOrdinal(0));
-        outbox.queueWithOrdinal(0).clear();
     }
 
     private String myToString(Object o) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
@@ -309,7 +309,7 @@ public class InsertWatermarksPTest {
         do {
             assertTrue(p.tryProcess());
             elapsedMs = NANOSECONDS.toMillis(System.nanoTime() - start);
-            outbox.drainQueue(0, resultToCheck, false);
+            outbox.drainQueueAndReset(0, resultToCheck, false);
             if (elapsedMs < 99) {
                 assertTrue("outbox should be empty, elapsedMs=" + elapsedMs, resultToCheck.isEmpty());
             } else if (!resultToCheck.isEmpty()) {
@@ -350,7 +350,7 @@ public class InsertWatermarksPTest {
         int count = 0;
         do {
             done = action.getAsBoolean();
-            outbox.drainQueue(0, resultToCheck, false);
+            outbox.drainQueueAndReset(0, resultToCheck, false);
             assertTrue("action not done in " + count + " attempts", ++count < 10);
         } while (!done);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksP_IntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.core.TestProcessors.ListSource;
+import com.hazelcast.jet.core.TestProcessors.MapWatermarksToString;
+import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.core.processor.Processors;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static com.hazelcast.jet.core.Edge.between;
+import static com.hazelcast.jet.core.WatermarkEmissionPolicy.emitByFrame;
+import static com.hazelcast.jet.core.WatermarkGenerationParams.wmGenParams;
+import static com.hazelcast.jet.core.WatermarkPolicies.withFixedLag;
+import static com.hazelcast.jet.core.WindowDefinition.tumblingWindowDef;
+import static com.hazelcast.jet.core.processor.SinkProcessors.writeListP;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertArrayEquals;
+
+public class InsertWatermarksP_IntegrationTest extends JetTestSupport {
+
+    private JetInstance instance;
+
+    @Before
+    public void before() {
+        instance = super.createJetMember();
+    }
+
+    @Test
+    public void test() {
+        DAG dag = new DAG();
+        Vertex source = dag.newVertex("source", ListSource.supplier(asList(111L, 222L, 333L)));
+        Vertex iwm = dag.newVertex("iwm", Processors.insertWatermarksP(wmGenParams(
+                (Long x) -> x, withFixedLag(100), emitByFrame(tumblingWindowDef(100)), -1)))
+                .localParallelism(1);
+        Vertex mapWmToStr = dag.newVertex("mapWmToStr", MapWatermarksToString::new)
+                .localParallelism(1);
+        Vertex sink = dag.newVertex("sink", writeListP("list"));
+
+        dag.edge(between(source, iwm))
+           .edge(between(iwm, mapWmToStr))
+           .edge(between(mapWmToStr, sink));
+
+        instance.newJob(dag).join();
+
+        Object[] actual = instance.getList("list").toArray();
+        assertArrayEquals(Arrays.toString(actual), new Object[]{"wm(11)", 111L, "wm(122)", 222L, "wm(233)", 333L}, actual);
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SessionWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SessionWindowPTest.java
@@ -176,11 +176,11 @@ public class SessionWindowPTest {
                 long wm = timestampBase - wmLag;
                 int winCount = 0;
                 while (!lastSuppliedProcessor.tryProcessWatermark(new Watermark(wm))) {
-                    while (outbox.queueWithOrdinal(0).poll() != null) {
+                    while (outbox.queue(0).poll() != null) {
                         winCount++;
                     }
                 }
-                while (outbox.queueWithOrdinal(0).poll() != null) {
+                while (outbox.queue(0).poll() != null) {
                     winCount++;
                 }
             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
@@ -123,7 +123,7 @@ public class SlidingWindowP_twoStageSnapshotTest {
         // process some events in the 1st stage
         assertTrue(stage1p1.tryProcess(0, entry(1L, 1L))); // entry key is time
         assertTrue(stage1p2.tryProcess(0, entry(2L, 2L)));
-        assertTrue(stage1p1Outbox.queueWithOrdinal(0).isEmpty() && stage2Outbox.queueWithOrdinal(0).isEmpty());
+        assertTrue(stage1p1Outbox.queue(0).isEmpty() && stage2Outbox.queue(0).isEmpty());
 
         // save state in stage1
         assertTrue(stage1p1.saveToSnapshot());
@@ -165,14 +165,14 @@ public class SlidingWindowP_twoStageSnapshotTest {
                         outboxFrame(7, 7),
                         outboxFrame(8, 4)
                 )),
-                collectionToString(stage2Outbox.queueWithOrdinal(0)));
+                collectionToString(stage2Outbox.queue(0)));
     }
 
     private void processStage2(SlidingWindowP p, TestOutbox stage1p1Outbox, TestOutbox stage1p2Outbox, TestInbox inbox) {
-        inbox.addAll(stage1p1Outbox.queueWithOrdinal(0));
-        inbox.addAll(stage1p2Outbox.queueWithOrdinal(0));
-        stage1p1Outbox.queueWithOrdinal(0).clear();
-        stage1p2Outbox.queueWithOrdinal(0).clear();
+        inbox.addAll(stage1p1Outbox.queue(0));
+        inbox.addAll(stage1p2Outbox.queue(0));
+        stage1p1Outbox.queue(0).clear();
+        stage1p2Outbox.queue(0).clear();
         p.process(0, inbox);
         assertTrue(inbox.isEmpty());
     }

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.jet.core.test.TestInbox;
 import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestOutbox.MockData;
 import com.hazelcast.jet.core.test.TestProcessorContext;
-import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.impl.SnapshotRepository;
 import com.hazelcast.jet.impl.execution.SnapshotRecord;
@@ -356,7 +355,7 @@ public class StreamKafkaPTest extends KafkaTestSupport {
         processor.init(outbox, context);
         processor.complete();
 
-        assertEquals(IDLE_MESSAGE, outbox.queueWithOrdinal(0).poll());
+        assertEquals(IDLE_MESSAGE, outbox.queue(0).poll());
     }
 
     @Test
@@ -384,24 +383,24 @@ public class StreamKafkaPTest extends KafkaTestSupport {
         // Then
         assertTrueEventually(() -> {
             assertFalse(processor.complete());
-            assertFalse("no item in outbox", outbox.queueWithOrdinal(0).isEmpty());
+            assertFalse("no item in outbox", outbox.queue(0).isEmpty());
         }, 3);
-        assertEquals("1", outbox.queueWithOrdinal(0).poll());
-        assertNull(outbox.queueWithOrdinal(0).poll());
+        assertEquals("1", outbox.queue(0).poll());
+        assertNull(outbox.queue(0).poll());
     }
 
     private <T> T consumeEventually(Processor processor, TestOutbox outbox) {
         assertTrueEventually(() -> {
             assertFalse(processor.complete());
-            assertFalse("no item in outbox", outbox.queueWithOrdinal(0).isEmpty());
+            assertFalse("no item in outbox", outbox.queue(0).isEmpty());
         }, 12);
-        return (T) outbox.queueWithOrdinal(0).poll();
+        return (T) outbox.queue(0).poll();
     }
 
     private void assertNoMoreItems(StreamKafkaP processor, TestOutbox outbox) throws InterruptedException {
         Thread.sleep(1000);
         assertFalse(processor.complete());
-        assertTrue("unexpected items in outbox: " + outbox.queueWithOrdinal(0), outbox.queueWithOrdinal(0).isEmpty());
+        assertTrue("unexpected items in outbox: " + outbox.queue(0), outbox.queue(0).isEmpty());
     }
 
     private Set<Entry<TopicPartition, String>> unwrapBroadcastKey(Collection c) {
@@ -417,7 +416,7 @@ public class StreamKafkaPTest extends KafkaTestSupport {
     private TestInbox saveSnapshot(StreamKafkaP streamKafkaP, TestOutbox outbox) {
         TestInbox snapshot = new TestInbox();
         assertTrue(streamKafkaP.saveToSnapshot());
-        TestSupport.drainOutbox(outbox.snapshotQueue(), snapshot, false);
+        outbox.drainSnapshotQueue(snapshot, false);
         snapshot = snapshot.stream().map(e -> (Entry<MockData, MockData>) e)
                            .map(e -> entry(e.getKey().getObject(), e.getValue().getObject()))
                            .collect(toCollection(TestInbox::new));

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaPTest.java
@@ -416,7 +416,7 @@ public class StreamKafkaPTest extends KafkaTestSupport {
     private TestInbox saveSnapshot(StreamKafkaP streamKafkaP, TestOutbox outbox) {
         TestInbox snapshot = new TestInbox();
         assertTrue(streamKafkaP.saveToSnapshot());
-        outbox.drainSnapshotQueue(snapshot, false);
+        outbox.drainSnapshotQueueAndReset(snapshot, false);
         snapshot = snapshot.stream().map(e -> (Entry<MockData, MockData>) e)
                            .map(e -> entry(e.getKey().getObject(), e.getValue().getObject()))
                            .collect(toCollection(TestInbox::new));


### PR DESCRIPTION
Check outbox.offer not called without returning

Another changes:
- check, if the object passed to offer is the same in TestOutbox
- move the method to drain an outbox from TestSupport to TestOutbox
