### PR TITLE
Fix & improve resources cleanup

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -103,6 +103,9 @@ public class TestProcessors {
         }
     }
 
+    /**
+     * A processor that emits nothing and never completes.
+     */
     public static final class StuckForeverSourceP implements Processor {
         @Override
         public boolean complete() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastSerialClassRunner.class)
 public class JobRepositoryTest extends JetTestSupport {
 
-    private static final long JOB_EXPIRATION_TIME_IN_MILLIS = SECONDS.toMillis(1);
+    private static final long RESOURCES_EXPIRATION_TIME_MILLIS = SECONDS.toMillis(1);
     private static final long JOB_SCAN_PERIOD_IN_MILLIS = HOURS.toMillis(1);
     private static final int QUORUM_SIZE = 2;
 
@@ -67,7 +67,7 @@ public class JobRepositoryTest extends JetTestSupport {
 
         instance = factory.newMember(config);
         jobRepository = new JobRepository(instance, null);
-        jobRepository.setJobExpirationDurationInMillis(JOB_EXPIRATION_TIME_IN_MILLIS);
+        jobRepository.setResourcesExpirationMillis(RESOURCES_EXPIRATION_TIME_MILLIS);
 
         jobIds = instance.getMap(RANDOM_IDS_MAP_NAME);
     }
@@ -212,12 +212,8 @@ public class JobRepositoryTest extends JetTestSupport {
     }
 
     private void sleepUntilJobExpires() {
-        sleepAtLeastMillis(2 * JOB_EXPIRATION_TIME_IN_MILLIS);
+        sleepAtLeastMillis(2 * RESOURCES_EXPIRATION_TIME_MILLIS);
     }
 
-
-    static class DummyClass {
-
-    }
-
+    static class DummyClass { }
 }


### PR DESCRIPTION
- Fix 1: we relied on `EntryView.getCreationTime`, but we have
statistics disabled.

- Fix 2: we repeatedly tried to delete maps for completed jobs in a way
that created and destroyed the distributed object. Now we try only once.
Fixes #653