### PR TITLE
Obsolete JavaDoc updated

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ProgressTracker.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ProgressTracker.java
@@ -66,7 +66,7 @@ public class ProgressTracker {
     }
 
     /**
-     * Equivalent to {@code update(NO_PROGRESS)}, but more descriptive in certain usages.
+     * Equivalent to {@code mergeWith(NO_PROGRESS)}, but more descriptive in certain usages.
      */
     public void notDone() {
         isDone = false;


### PR DESCRIPTION
a trivial change. the JavaDoc should have been updated by https://github.com/jerrinot/hazelcast-jet/commit/8b5f25fdc65d5308161244327b3d05647c95292d#diff-bc7c1bd4228a368e23974518c7fd84cfR51 