### PR TITLE
Fix Sonar Build Issues

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/annotation/IgnoredForCoverage.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/annotation/IgnoredForCoverage.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.annotation;
+
+/**
+ * Category marker for the tests which are excluded from test coverage profile.
+ */
+public interface IgnoredForCoverage {
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/AbstractDeploymentTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/AbstractDeploymentTest.java
@@ -17,13 +17,13 @@
 package com.hazelcast.jet.impl.deployment;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.annotation.IgnoredForCoverage;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.impl.deployment.LoadPersonIsolated.LoadPersonIsolatedMetaSupplier;
 import com.hazelcast.jet.stream.IStreamMap;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.util.FilteringClassLoader;
-import org.junit.Test;
-
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -31,6 +31,8 @@ import java.net.URLClassLoader;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.jet.core.TestUtil.executeAndPeel;
 import static com.hazelcast.jet.stream.DistributedCollectors.toList;
@@ -48,7 +50,7 @@ public abstract class AbstractDeploymentTest extends HazelcastTestSupport {
         createCluster();
 
         DAG dag = new DAG();
-        dag.newVertex("create and print person", LoadPersonIsolated::new);
+        dag.newVertex("create and print person", new LoadPersonIsolatedMetaSupplier());
 
 
         JetInstance jetInstance = getJetInstance();
@@ -60,7 +62,13 @@ public abstract class AbstractDeploymentTest extends HazelcastTestSupport {
         executeAndPeel(jetInstance.newJob(dag, jobConfig));
     }
 
+    /**
+     * The test is excluded from the test coverage since JaCoCo instrumentation messes up with the
+     * class internals which generates different serialVersionUid's for same classes.
+     * This leads test to fail with InvalidClassException
+     */
     @Test
+    @Category(IgnoredForCoverage.class)
     public void testStream() throws Throwable {
         createCluster();
 
@@ -82,7 +90,7 @@ public abstract class AbstractDeploymentTest extends HazelcastTestSupport {
         createCluster();
 
         DAG dag = new DAG();
-        dag.newVertex("create and print person", LoadPersonIsolated::new);
+        dag.newVertex("create and print person", new LoadPersonIsolatedMetaSupplier());
 
         JobConfig jobConfig = new JobConfig();
         URL classUrl = this.getClass().getResource("/cp1/");

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/LoadPersonIsolated.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/LoadPersonIsolated.java
@@ -17,7 +17,17 @@
 package com.hazelcast.jet.impl.deployment;
 
 import com.hazelcast.jet.core.AbstractProcessor;
+import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.ProcessorMetaSupplier;
+import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.nio.Address;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.fail;
 
 public class LoadPersonIsolated extends AbstractProcessor {
@@ -36,5 +46,27 @@ public class LoadPersonIsolated extends AbstractProcessor {
         } catch (ClassNotFoundException ignored) {
         }
         return true;
+    }
+
+    static class LoadPersonIsolatedSupplier implements ProcessorSupplier {
+
+        private static final long serialVersionUID = 9124364032142382663L;
+
+        @Nonnull
+        @Override
+        public Collection<? extends Processor> get(int count) {
+            return Stream.generate(LoadPersonIsolated::new).limit(count).collect(toList());
+        }
+    }
+
+    static class LoadPersonIsolatedMetaSupplier implements ProcessorMetaSupplier {
+
+        private static final long serialVersionUID = -2678527620814378262L;
+
+        @Nonnull
+        @Override
+        public Function<Address, ProcessorSupplier> get(@Nonnull List<Address> addresses) {
+            return (Address x) -> new LoadPersonIsolatedSupplier();
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -427,6 +427,7 @@
                         <configuration>
                             <testFailureIgnore>true</testFailureIgnore>
                             <argLine>@{argLine}</argLine>
+                            <excludedGroups>com.hazelcast.jet.annotation.IgnoredTest</excludedGroups>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Fixed the InvalidClassExceptions by using explicit Processor(Meta)Supplier implementations and ignored the j.u.s test which cannot be fixed that way in the sonar build.

Fixes #706 