### PR TITLE
Attempt to fix test failure

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
@@ -227,7 +227,7 @@ public class HazelcastConnectorTest extends JetTestSupport {
         IStreamMap<Integer, Entry<Integer, String>> sourceMap = jetInstance.getMap(streamSourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, entry(i, i % 2 == 0 ? null : String.valueOf(i))));
 
-        assertTrueEventually(() -> checkContents_projectedToNull(streamSinkName), 3);
+        assertTrueEventually(() -> checkContents_projectedToNull(streamSinkName), 10);
         job.cancel();
     }
 
@@ -350,7 +350,7 @@ public class HazelcastConnectorTest extends JetTestSupport {
             e = sinkList.get(1);
             assertEquals(Integer.valueOf(1), e.getKey());
             assertEquals(Integer.valueOf(2), e.getValue());
-        }, 3);
+        }, 10);
 
         job.cancel();
     }
@@ -382,7 +382,7 @@ public class HazelcastConnectorTest extends JetTestSupport {
             e = sinkList.get(1);
             assertEquals(Integer.valueOf(1), e.getKey());
             assertEquals(Integer.valueOf(2), e.getValue());
-        }, 3);
+        }, 10);
 
         job.cancel();
     }


### PR DESCRIPTION
Fixes #735

```
java.lang.AssertionError: expected:<2> but was:<1>
	at com.hazelcast.jet.impl.connector.HazelcastConnectorTest.lambda$test_defaultFilter_mapJournal$12(HazelcastConnectorTest.java:344)
	at com.hazelcast.jet.impl.connector.HazelcastConnectorTest.test_defaultFilter_mapJournal(HazelcastConnectorTest.java:343)
```