### PR TITLE
Make parallelism available to ProcessorSupplier.Context and Processor.Context

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetException;
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.logging.ILogger;
 
@@ -234,13 +233,7 @@ public interface Processor {
      * Context passed to the processor in the
      * {@link #init(Outbox, Context) init()} call.
      */
-    interface Context {
-
-        /**
-         * Returns the current Jet instance
-         */
-        @Nonnull
-        JetInstance jetInstance();
+    interface Context extends ProcessorSupplier.Context {
 
         /**
          *  Return a logger for the processor
@@ -253,12 +246,6 @@ public interface Processor {
          * this vertex on all nodes: its unique cluster-wide index.
          */
         int globalProcessorIndex();
-
-        /***
-         * Returns the name of the vertex associated with this processor.
-         */
-        @Nonnull
-        String vertexName();
 
         /**
          * Returns true, if snapshots will be saved for this job.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -244,6 +244,8 @@ public interface Processor {
         /**
          * Returns the index of the processor among all the processors created for
          * this vertex on all nodes: its unique cluster-wide index.
+         * <p>
+         * The index values will be in the range of {@code [0...totalParallelism-1]}.
          */
         int globalProcessorIndex();
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
@@ -320,7 +320,13 @@ public interface ProcessorMetaSupplier extends Serializable {
         int localParallelism();
 
         /**
-         * Returns a logger for the associated {@code ProcessorSupplier}.
+         * Returns the name of the associated vertex.
+         */
+        @Nonnull
+        String vertexName();
+
+        /**
+         * Returns a logger for the associated {@code ProcessorMetaSupplier}.
          */
         @Nonnull
         ILogger logger();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.core;
 
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.logging.ILogger;
 
@@ -78,19 +77,7 @@ public interface ProcessorSupplier extends Serializable {
     /**
      * Context passed to the supplier in the {@link #init(Context) init()} call.
      */
-    interface Context {
-
-        /**
-         * Returns the current Jet instance
-         */
-        @Nonnull
-        JetInstance jetInstance();
-
-        /**
-         * Returns the number of processors that the associated {@code ProcessorSupplier}
-         * will be asked to create.
-         */
-        int localParallelism();
+    interface Context extends ProcessorMetaSupplier.Context {
 
         /**
          * Returns a logger for the associated {@code ProcessorSupplier}.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
@@ -20,17 +20,14 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 
 import javax.annotation.Nonnull;
 
 /**
  * {@link Processor.Context} implementation suitable to be used in tests.
  */
-public class TestProcessorContext implements Processor.Context {
-    private JetInstance jetInstance;
-    private ILogger logger;
-    private String vertexName = "testVertex";
+public class TestProcessorContext extends TestProcessorSupplierContext implements Processor.Context {
+
     private int globalProcessorIndex;
     private ProcessingGuarantee processingGuarantee = ProcessingGuarantee.NONE;
 
@@ -39,48 +36,6 @@ public class TestProcessorContext implements Processor.Context {
      */
     public TestProcessorContext() {
         globalProcessorIndex = 0;
-    }
-
-    @Nonnull @Override
-    public JetInstance jetInstance() {
-        return jetInstance;
-    }
-
-    /**
-     * Set the jet instance.
-     */
-    public TestProcessorContext setJetInstance(JetInstance jetInstance) {
-        this.jetInstance = jetInstance;
-        return this;
-    }
-
-    @Nonnull @Override
-    public ILogger logger() {
-        if (logger == null) {
-            logger = Logger.getLogger(vertexName + "#" + globalProcessorIndex);
-        }
-        return logger;
-    }
-
-    /**
-     * Set the logger.
-     */
-    public TestProcessorContext setLogger(@Nonnull ILogger logger) {
-        this.logger = logger;
-        return this;
-    }
-
-    @Nonnull @Override
-    public String vertexName() {
-        return vertexName;
-    }
-
-    /**
-     * Set the vertex name.
-     */
-    public TestProcessorContext setVertexName(@Nonnull String vertexName) {
-        this.vertexName = vertexName;
-        return this;
     }
 
     @Override
@@ -104,8 +59,39 @@ public class TestProcessorContext implements Processor.Context {
     /**
      * Sets the processing guarantee.
      */
+    @Nonnull
     public TestProcessorContext setProcessingGuarantee(ProcessingGuarantee processingGuarantee) {
         this.processingGuarantee = processingGuarantee;
         return this;
+    }
+
+    @Nonnull @Override
+    public TestProcessorContext setLogger(@Nonnull ILogger logger) {
+        return (TestProcessorContext) super.setLogger(logger);
+    }
+
+    @Nonnull @Override
+    public TestProcessorContext setJetInstance(@Nonnull JetInstance jetInstance) {
+        return (TestProcessorContext) super.setJetInstance(jetInstance);
+    }
+
+    @Nonnull @Override
+    public TestProcessorContext setTotalParallelism(int totalParallelism) {
+        return (TestProcessorContext) super.setTotalParallelism(totalParallelism);
+    }
+
+    @Nonnull @Override
+    public TestProcessorContext setLocalParallelism(int localParallelism) {
+        return (TestProcessorContext) super.setLocalParallelism(localParallelism);
+    }
+
+    @Nonnull @Override
+    public TestProcessorContext setVertexName(@Nonnull String vertexName) {
+        return (TestProcessorContext) super.setVertexName(vertexName);
+    }
+
+    @Override
+    protected String loggerName() {
+        return vertexName() + "#" + globalProcessorIndex;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
@@ -19,19 +19,22 @@ package com.hazelcast.jet.core.test;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 
 import javax.annotation.Nonnull;
-
-import static com.hazelcast.jet.core.test.TestSupport.getLogger;
 
 /**
  * {@link ProcessorMetaSupplier.Context} implementation suitable to be used
  * in tests.
  */
 public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.Context {
+
+    protected ILogger logger;
+
     private JetInstance jetInstance;
     private int totalParallelism = 1;
     private int localParallelism = 1;
+    private String vertexName = "testVertex";
 
     @Nonnull @Override
     public JetInstance jetInstance() {
@@ -41,7 +44,8 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     /**
      * Set the jet instance.
      */
-    public TestProcessorMetaSupplierContext setJetInstance(JetInstance jetInstance) {
+    @Nonnull
+    public TestProcessorMetaSupplierContext setJetInstance(@Nonnull JetInstance jetInstance) {
         this.jetInstance = jetInstance;
         return this;
     }
@@ -54,8 +58,25 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     /**
      * Set total parallelism.
      */
+    @Nonnull
     public TestProcessorMetaSupplierContext setTotalParallelism(int totalParallelism) {
         this.totalParallelism = totalParallelism;
+        return this;
+    }
+
+    @Nonnull @Override
+    public ILogger logger() {
+        if (logger == null) {
+            logger = Logger.getLogger(loggerName());
+        }
+        return logger;
+    }
+
+    /**
+     * Set the logger.
+     */
+    public TestProcessorMetaSupplierContext setLogger(@Nonnull ILogger logger) {
+        this.logger = logger;
         return this;
     }
 
@@ -64,16 +85,30 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
         return localParallelism;
     }
 
-    @Nonnull @Override
-    public ILogger logger() {
-        return getLogger(getClass());
-    }
-
     /**
      * Set local parallelism.
      */
+    @Nonnull
     public TestProcessorMetaSupplierContext setLocalParallelism(int localParallelism) {
         this.localParallelism = localParallelism;
         return this;
+    }
+
+    @Nonnull @Override
+    public String vertexName() {
+        return vertexName;
+    }
+
+    /**
+     * Set the vertex name.
+     */
+    @Nonnull
+    public TestProcessorMetaSupplierContext setVertexName(@Nonnull String vertexName) {
+        this.vertexName = vertexName;
+        return this;
+    }
+
+    protected String loggerName() {
+        return vertexName() + "#PMS";
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
@@ -22,44 +22,40 @@ import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
 
-import static com.hazelcast.jet.core.test.TestSupport.getLogger;
-
 /**
  * {@link ProcessorSupplier.Context} implementation suitable to be used in tests.
  */
-public class TestProcessorSupplierContext implements ProcessorSupplier.Context {
+public class TestProcessorSupplierContext
+        extends TestProcessorMetaSupplierContext
+        implements ProcessorSupplier.Context {
 
-    private JetInstance jetInstance;
-    private int localParallelism = 1;
-
-    @Override
-    public JetInstance jetInstance() {
-        return jetInstance;
-    }
-
-    /**
-     * Set the jet instance.
-     */
-    public TestProcessorSupplierContext setJetInstance(JetInstance jetInstance) {
-        this.jetInstance = jetInstance;
-        return this;
-    }
-
-    @Override
-    public int localParallelism() {
-        return localParallelism;
+    @Nonnull @Override
+    public TestProcessorSupplierContext setLogger(@Nonnull ILogger logger) {
+        return (TestProcessorContext) super.setLogger(logger);
     }
 
     @Nonnull @Override
-    public ILogger logger() {
-        return getLogger(getClass());
+    public TestProcessorSupplierContext setJetInstance(@Nonnull JetInstance jetInstance) {
+        return (TestProcessorSupplierContext) super.setJetInstance(jetInstance);
     }
 
-    /**
-     * Set local parallelism.
-     */
+    @Nonnull @Override
+    public TestProcessorSupplierContext setVertexName(@Nonnull String vertexName) {
+        return (TestProcessorSupplierContext) super.setVertexName(vertexName);
+    }
+
+    @Nonnull @Override
+    public TestProcessorSupplierContext setTotalParallelism(int totalParallelism) {
+        return (TestProcessorSupplierContext) super.setTotalParallelism(totalParallelism);
+    }
+
+    @Nonnull @Override
     public TestProcessorSupplierContext setLocalParallelism(int localParallelism) {
-        this.localParallelism = localParallelism;
-        return this;
+        return (TestProcessorSupplierContext) super.setLocalParallelism(localParallelism);
+    }
+
+    @Override
+    protected String loggerName() {
+        return vertexName() + "#PS";
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -127,38 +127,40 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
 
         this.ptionArrgmt = new PartitionArrangement(partitionOwners, nodeEngine.getThisAddress());
         JetInstance instance = getJetInstance(nodeEngine);
-        for (VertexDef srcVertex : vertices) {
-            Collection<? extends Processor> processors = createProcessors(srcVertex, srcVertex.parallelism());
+        for (VertexDef vertex : vertices) {
+            Collection<? extends Processor> processors = createProcessors(vertex, vertex.localParallelism());
 
             // create StoreSnapshotTasklet and the queues to it
-            QueuedPipe<Object>[] snapshotQueues = new QueuedPipe[srcVertex.parallelism()];
+            QueuedPipe<Object>[] snapshotQueues = new QueuedPipe[vertex.localParallelism()];
             Arrays.setAll(snapshotQueues, i -> new OneToOneConcurrentArrayQueue<>(SNAPSHOT_QUEUE_SIZE));
             ConcurrentConveyor<Object> ssConveyor = ConcurrentConveyor.concurrentConveyor(null, snapshotQueues);
             StoreSnapshotTasklet ssTasklet = new StoreSnapshotTasklet(snapshotContext, jobId,
                     new ConcurrentInboundEdgeStream(ssConveyor, 0, 0, lastSnapshotId, true, -1),
-                    nodeEngine, srcVertex.name(), srcVertex.isHigherPriorityUpstream());
+                    nodeEngine, vertex.name(), vertex.isHigherPriorityUpstream());
             tasklets.add(ssTasklet);
 
             int localProcessorIdx = 0;
             for (Processor p : processors) {
-                int globalProcessorIndex = srcVertex.getProcIdxOffset() + localProcessorIdx;
-                String loggerName = createLoggerName(p.getClass().getName(), srcVertex.name(), globalProcessorIndex);
+                int globalProcessorIndex = vertex.getProcIdxOffset() + localProcessorIdx;
+                String loggerName = createLoggerName(p.getClass().getName(), vertex.name(), globalProcessorIndex);
                 ProcCtx context = new ProcCtx(
                         instance,
                         nodeEngine.getSerializationService(),
                         nodeEngine.getLogger(loggerName),
-                        srcVertex.name(),
+                        vertex.name(),
                         globalProcessorIndex,
-                        jobConfig.getProcessingGuarantee());
+                        jobConfig.getProcessingGuarantee(),
+                        vertex.localParallelism(), vertex.totalParallelism()
+                );
 
-                 String probePrefix = String.format("jet.job.%s.%s#%d", idToString(executionId), srcVertex.name(),
+                 String probePrefix = String.format("jet.job.%s.%s#%d", idToString(executionId), vertex.name(),
                          localProcessorIdx);
                  ((NodeEngineImpl) nodeEngine).getMetricsRegistry().scanAndRegister(p, probePrefix);
 
                 // createOutboundEdgeStreams() populates localConveyorMap and edgeSenderConveyorMap.
                 // Also populates instance fields: senderMap, receiverMap, tasklets.
-                List<OutboundEdgeStream> outboundStreams = createOutboundEdgeStreams(srcVertex, localProcessorIdx);
-                List<InboundEdgeStream> inboundStreams = createInboundEdgeStreams(srcVertex, localProcessorIdx);
+                List<OutboundEdgeStream> outboundStreams = createOutboundEdgeStreams(vertex, localProcessorIdx);
+                List<InboundEdgeStream> inboundStreams = createInboundEdgeStreams(vertex, localProcessorIdx);
 
                 OutboundCollector snapshotCollector = new ConveyorCollector(ssConveyor, localProcessorIdx, null);
 
@@ -249,7 +251,12 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             ProcessorSupplier supplier = vertex.processorSupplier();
             ILogger logger = nodeEngine.getLogger(supplier.getClass().getName() + '.'
                     + vertex.name() + "#ProcessorSupplier");
-            supplier.init(new ProcSupplierCtx(service.getJetInstance(), logger, vertex.parallelism()));
+            supplier.init(new ProcSupplierCtx(
+                    service.getJetInstance(),
+                    logger,
+                    vertex.name(),
+                    vertex.localParallelism(), vertex.totalParallelism()
+            ));
         }
     }
 
@@ -304,7 +311,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             final Map<Address, ConcurrentConveyor<Object>> addrToConveyor = new HashMap<>();
             for (Address destAddr : remoteMembers.get()) {
                 final ConcurrentConveyor<Object> conveyor = createConveyorArray(
-                        1, edge.sourceVertex().parallelism(), edge.getConfig().getQueueSize())[0];
+                        1, edge.sourceVertex().localParallelism(), edge.getConfig().getQueueSize())[0];
                 final ConcurrentInboundEdgeStream inboundEdgeStream = newEdgeStream(edge, conveyor);
                 final int destVertexId = edge.destVertex().vertexId();
                 final SenderTasklet t = new SenderTasklet(inboundEdgeStream, nodeEngine,
@@ -342,8 +349,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
     private OutboundCollector[] createOutboundCollectors(
             EdgeDef edge, int processorIndex, Map<Address, ConcurrentConveyor<Object>> senderConveyorMap
     ) {
-        final int upstreamParallelism = edge.sourceVertex().parallelism();
-        final int downstreamParallelism = edge.destVertex().parallelism();
+        final int upstreamParallelism = edge.sourceVertex().localParallelism();
+        final int downstreamParallelism = edge.destVertex().localParallelism();
         final int numRemoteMembers = ptionArrgmt.remotePartitionAssignment.get().size();
         final int queueSize = edge.getConfig().getQueueSize();
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -82,7 +82,8 @@ public final class ExecutionPlanBuilder {
                     e -> vertexIdMap.get(e.getDestName()), isJobDistributed);
             final ILogger logger = nodeEngine.getLogger(String.format("%s.%s#ProcessorMetaSupplier",
                     metaSupplier.getClass().getName(), vertex.getName()));
-            metaSupplier.init(new MetaSupplierCtx(instance, logger, totalParallelism, localParallelism));
+            metaSupplier.init(new MetaSupplierCtx(instance, logger, vertex.getName(),
+                    localParallelism, totalParallelism));
 
             Function<Address, ProcessorSupplier> procSupplierFn = metaSupplier.get(addresses);
             int procIdxOffset = 0;
@@ -90,7 +91,8 @@ public final class ExecutionPlanBuilder {
                 final ProcessorSupplier processorSupplier = procSupplierFn.apply(e.getKey().getAddress());
                 checkSerializable(processorSupplier, "ProcessorSupplier in vertex '" + vertex.getName() + '\'');
                 final VertexDef vertexDef = new VertexDef(
-                        vertexId, vertex.getName(), processorSupplier, procIdxOffset, localParallelism);
+                        vertexId, vertex.getName(), processorSupplier, procIdxOffset, localParallelism, totalParallelism
+                );
                 vertexDef.addInboundEdges(inbound);
                 vertexDef.addOutboundEdges(outbound);
                 e.getValue().addVertex(vertexDef);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/VertexDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/VertexDef.java
@@ -37,26 +37,34 @@ public class VertexDef implements IdentifiedDataSerializable {
     private String name;
     private ProcessorSupplier processorSupplier;
     private int procIdxOffset;
-    private int parallelism;
+    private int localParallelism;
+    private int totalParallelism;
 
     VertexDef() {
     }
 
-    VertexDef(int id, String name, ProcessorSupplier processorSupplier,
-              int procIdxOffset, int parallelism) {
+    VertexDef(
+            int id, String name, ProcessorSupplier processorSupplier, int procIdxOffset,
+            int localParallelism, int totalParallelism
+    ) {
         this.id = id;
         this.name = name;
         this.processorSupplier = processorSupplier;
         this.procIdxOffset = procIdxOffset;
-        this.parallelism = parallelism;
+        this.localParallelism = localParallelism;
+        this.totalParallelism = totalParallelism;
     }
 
     String name() {
         return name;
     }
 
-    int parallelism() {
-        return parallelism;
+    int localParallelism() {
+        return localParallelism;
+    }
+
+    int totalParallelism() {
+        return totalParallelism;
     }
 
     int vertexId() {
@@ -140,7 +148,8 @@ public class VertexDef implements IdentifiedDataSerializable {
         writeList(out, outboundEdges);
         CustomClassLoadedObject.write(out, processorSupplier);
         out.writeInt(procIdxOffset);
-        out.writeInt(parallelism);
+        out.writeInt(localParallelism);
+        out.writeInt(totalParallelism);
     }
 
     @Override
@@ -151,6 +160,7 @@ public class VertexDef implements IdentifiedDataSerializable {
         outboundEdges = readList(in);
         processorSupplier = CustomClassLoadedObject.read(in);
         procIdxOffset = in.readInt();
-        parallelism = in.readInt();
+        localParallelism = in.readInt();
+        totalParallelism = in.readInt();
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
@@ -80,7 +80,7 @@ public final class PeekWrappedP<T> extends ProcessorWrapper {
             ILogger newLogger = nodeEngine.getLogger(
                     createLoggerName(wrapped.getClass().getName(), c.vertexName(), c.globalProcessorIndex()));
             context = new ProcCtx(c.jetInstance(), c.getSerializationService(), newLogger, c.vertexName(),
-                    c.globalProcessorIndex(), c.processingGuarantee());
+                    c.globalProcessorIndex(), c.processingGuarantee(), c.localParallelism(), c.globalProcessorIndex());
         }
         super.init(outbox, context);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
@@ -64,7 +64,10 @@ public class ProcessorTaskletTest {
     public void setUp() {
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.processor = new PassThroughProcessor();
-        this.context = new ProcCtx(null, new DefaultSerializationServiceBuilder().build(), null, null, 0, NONE);
+        this.context = new ProcCtx(
+                null, new DefaultSerializationServiceBuilder().build(), null,
+                null, 0, NONE, 1, 1
+        );
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
@@ -62,7 +62,10 @@ public class ProcessorTaskletTest_Blocking {
     @Before
     public void setUp() {
         this.processor = new PassThroughProcessor();
-        this.context = new ProcCtx(null, new DefaultSerializationServiceBuilder().build(), null, null, 0, NONE);
+        this.context = new ProcCtx(
+                null, new DefaultSerializationServiceBuilder().build(), null,
+                null, 0, NONE, 1, 1
+        );
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -72,8 +72,10 @@ public class ProcessorTaskletTest_Snapshots {
     public void setUp() {
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.processor = new SnapshottableProcessor();
-        this.context = new ProcCtx(null, new DefaultSerializationServiceBuilder().build(), null, null, 0,
-                EXACTLY_ONCE);
+        this.context = new ProcCtx(
+                null, new DefaultSerializationServiceBuilder().build(), null, null, 0,
+                EXACTLY_ONCE, 1, 1
+        );
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
         this.snapshotCollector = new MockOutboundCollector(1024);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
@@ -59,8 +59,10 @@ public class ProcessorTaskletTest_Watermarks {
     @Before
     public void setUp() {
         this.processor = new ProcessorWithWatermarks();
-        this.context = new ProcCtx(null, new DefaultSerializationServiceBuilder().build(), null, null, 0,
-                EXACTLY_ONCE);
+        this.context = new ProcCtx(
+                null, new DefaultSerializationServiceBuilder().build(), null, null, 0,
+                EXACTLY_ONCE, 1, 1
+        );
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
         this.snapshotCollector = new MockOutboundCollector(0);

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/core/processor/KafkaProcessors.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/core/processor/KafkaProcessors.java
@@ -52,7 +52,10 @@ public final class KafkaProcessors {
     ) {
         Preconditions.checkPositive(topics.length, "At least one topic must be supplied");
         properties.put("enable.auto.commit", false);
-        return new StreamKafkaP.MetaSupplier<>(properties, Arrays.asList(topics), projectionFn, wmGenParams);
+        return ProcessorMetaSupplier.of(
+                StreamKafkaP.processorSupplier(properties, Arrays.asList(topics), projectionFn, wmGenParams),
+                2
+        );
     }
 
     /**

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
@@ -273,7 +273,7 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
             @Nonnull DistributedFunction<ConsumerRecord<K, V>, T> projectionFn,
             @Nonnull WatermarkGenerationParams<T> wmGenParams
     ) {
-        return new CloseableProcessorSupplier<StreamKafkaP>(() -> new StreamKafkaP<>(
+        return new CloseableProcessorSupplier<>(() -> new StreamKafkaP<>(
                 properties, topics, projectionFn, wmGenParams
         ));
     }

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
@@ -21,13 +21,11 @@ import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.BroadcastKey;
 import com.hazelcast.jet.core.CloseableProcessorSupplier;
-import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.WatermarkGenerationParams;
 import com.hazelcast.jet.core.WatermarkSourceUtil;
 import com.hazelcast.jet.function.DistributedFunction;
-import com.hazelcast.nio.Address;
 import com.hazelcast.util.Preconditions;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -45,7 +43,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -70,11 +67,11 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
     private final Properties properties;
     private final List<String> topics;
     private final DistributedFunction<ConsumerRecord<K, V>, T> projectionFn;
-    private final int globalParallelism;
     private final WatermarkSourceUtil<T> watermarkSourceUtil;
+    private int totalParallelism;
     private boolean snapshottingEnabled;
-    private KafkaConsumer<K, V> consumer;
 
+    private KafkaConsumer<K, V> consumer;
     private final int[] partitionCounts;
     private long nextMetadataCheck = Long.MIN_VALUE;
 
@@ -93,14 +90,11 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
             @Nonnull Properties properties,
             @Nonnull List<String> topics,
             @Nonnull DistributedFunction<ConsumerRecord<K, V>, T> projectionFn,
-            int globalParallelism,
             @Nonnull WatermarkGenerationParams<? super T> wmGenParams
     ) {
         this.properties = properties;
         this.topics = topics;
         this.projectionFn = projectionFn;
-        this.globalParallelism = globalParallelism;
-
         watermarkSourceUtil = new WatermarkSourceUtil<>(wmGenParams);
         partitionCounts = new int[topics.size()];
     }
@@ -108,6 +102,7 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
     @Override
     protected void init(@Nonnull Context context) {
         processorIndex = context.globalProcessorIndex();
+        totalParallelism = context.totalParallelism();
         snapshottingEnabled = context.snapshottingEnabled();
         consumer = new KafkaConsumer<>(properties);
         assignPartitions(false);
@@ -127,7 +122,7 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
             return;
         }
 
-        KafkaPartitionAssigner assigner = new KafkaPartitionAssigner(topics, partitionCounts, globalParallelism);
+        KafkaPartitionAssigner assigner = new KafkaPartitionAssigner(topics, partitionCounts, totalParallelism);
         Set<TopicPartition> newAssignments = assigner.topicPartitionsFor(processorIndex);
         logFinest(getLogger(), "Currently assigned partitions: %s", newAssignments);
 
@@ -271,43 +266,16 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
         }
     }
 
-    public static class MetaSupplier<K, V, T> implements ProcessorMetaSupplier {
-
-        private final Properties properties;
-        private final List<String> topics;
-        private final DistributedFunction<ConsumerRecord<K, V>, T> projectionFn;
-        private final WatermarkGenerationParams<? super T> wmGenParams;
-        private int totalParallelism;
-
-        public MetaSupplier(
-                @Nonnull Properties properties,
-                @Nonnull List<String> topics,
-                @Nonnull DistributedFunction<ConsumerRecord<K, V>, T> projectionFn,
-                @Nonnull WatermarkGenerationParams<? super T> wmGenParams) {
-            this.properties = new Properties();
-            this.properties.putAll(properties);
-            this.topics = topics;
-            this.projectionFn = projectionFn;
-            this.wmGenParams = wmGenParams;
-        }
-
-        @Override
-        public int preferredLocalParallelism() {
-            return 2;
-        }
-
-        @Override
-        public void init(@Nonnull Context context) {
-            totalParallelism = context.totalParallelism();
-        }
-
-        @Nonnull
-        @Override
-        public Function<Address, ProcessorSupplier> get(@Nonnull List<Address> addresses) {
-            return address -> new CloseableProcessorSupplier<>(
-                    () -> new StreamKafkaP<>(properties, topics, projectionFn, totalParallelism, wmGenParams)
-            );
-        }
+    @Nonnull
+    public static <K, V, T> ProcessorSupplier processorSupplier(
+            @Nonnull Properties properties,
+            @Nonnull List<String> topics,
+            @Nonnull DistributedFunction<ConsumerRecord<K, V>, T> projectionFn,
+            @Nonnull WatermarkGenerationParams<T> wmGenParams
+    ) {
+        return new CloseableProcessorSupplier<StreamKafkaP>(() -> new StreamKafkaP<>(
+                properties, topics, projectionFn, wmGenParams
+        ));
     }
 
     /**


### PR DESCRIPTION
New additional fields of `localParallelism` and `totalParallelism` are now available in `Processor `and `ProcessorSupplier` level. 

Also made them extend the upstream interfaces, so that gradually more information is available in each context as you drill down.