### PR TITLE
Add hazelcast jet spring module

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/EdgeConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/EdgeConfig.java
@@ -20,6 +20,8 @@ import com.hazelcast.jet.core.Edge;
 
 import java.io.Serializable;
 
+import static com.hazelcast.util.Preconditions.checkPositive;
+
 /**
  * A configuration object for a DAG {@link Edge} that holds fine-tuning
  * parameters that influence its performance characteristics.
@@ -65,9 +67,7 @@ public class EdgeConfig implements Serializable {
      * @return {@code this} instance for fluent API
      */
     public EdgeConfig setQueueSize(int queueSize) {
-        if (queueSize <= 0) {
-            throw new IllegalArgumentException("queueSize should be a positive number");
-        }
+        checkPositive(queueSize, "queueSize should be a positive number");
         this.queueSize = queueSize;
         return this;
     }
@@ -107,9 +107,7 @@ public class EdgeConfig implements Serializable {
      * @return {@code this} instance for fluent API
      */
     public EdgeConfig setReceiveWindowMultiplier(int receiveWindowMultiplier) {
-        if (receiveWindowMultiplier <= 0) {
-            throw new IllegalArgumentException("receiveWindowMultiplier should be a positive number");
-        }
+        checkPositive(receiveWindowMultiplier, "receiveWindowMultiplier should be a positive number");
         this.receiveWindowMultiplier = receiveWindowMultiplier;
         return this;
     }
@@ -137,9 +135,7 @@ public class EdgeConfig implements Serializable {
      * @return {@code this} instance for fluent API
      */
     public EdgeConfig setPacketSizeLimit(int packetSizeLimit) {
-        if (packetSizeLimit <= 0) {
-            throw new IllegalArgumentException("packetSizeLimit should be a positive number");
-        }
+        checkPositive(packetSizeLimit, "packetSizeLimit should be a positive number");
         this.packetSizeLimit = packetSizeLimit;
         return this;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/EdgeConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/EdgeConfig.java
@@ -65,6 +65,9 @@ public class EdgeConfig implements Serializable {
      * @return {@code this} instance for fluent API
      */
     public EdgeConfig setQueueSize(int queueSize) {
+        if (queueSize <= 0) {
+            throw new IllegalArgumentException("queueSize should be a positive number");
+        }
         this.queueSize = queueSize;
         return this;
     }
@@ -104,6 +107,9 @@ public class EdgeConfig implements Serializable {
      * @return {@code this} instance for fluent API
      */
     public EdgeConfig setReceiveWindowMultiplier(int receiveWindowMultiplier) {
+        if (receiveWindowMultiplier <= 0) {
+            throw new IllegalArgumentException("receiveWindowMultiplier should be a positive number");
+        }
         this.receiveWindowMultiplier = receiveWindowMultiplier;
         return this;
     }
@@ -131,6 +137,9 @@ public class EdgeConfig implements Serializable {
      * @return {@code this} instance for fluent API
      */
     public EdgeConfig setPacketSizeLimit(int packetSizeLimit) {
+        if (packetSizeLimit <= 0) {
+            throw new IllegalArgumentException("packetSizeLimit should be a positive number");
+        }
         this.packetSizeLimit = packetSizeLimit;
         return this;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
@@ -49,6 +49,9 @@ public class InstanceConfig {
      * processors; each <em>blocking</em> processor is assigned its own thread.
      */
     public InstanceConfig setCooperativeThreadCount(int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("cooperativeThreadCount should be a positive number");
+        }
         this.cooperativeThreadCount = size;
         return this;
     }
@@ -85,6 +88,9 @@ public class InstanceConfig {
      * (in milliseconds) of the interval between flow-control ("ack") packets.
      */
     public InstanceConfig setFlowControlPeriodMs(int flowControlPeriodMs) {
+        if (flowControlPeriodMs <= 0) {
+            throw new IllegalArgumentException("flowControlPeriodMs should be a positive number");
+        }
         this.flowControlPeriodMs = flowControlPeriodMs;
         return this;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/InstanceConfig.java
@@ -20,7 +20,8 @@ import com.hazelcast.config.MapConfig;
 
 import javax.annotation.Nonnull;
 
-import static com.hazelcast.spi.partition.IPartition.MAX_BACKUP_COUNT;
+import static com.hazelcast.util.Preconditions.checkBackupCount;
+import static com.hazelcast.util.Preconditions.checkPositive;
 
 /**
  * General configuration options pertaining to a Jet instance.
@@ -49,9 +50,7 @@ public class InstanceConfig {
      * processors; each <em>blocking</em> processor is assigned its own thread.
      */
     public InstanceConfig setCooperativeThreadCount(int size) {
-        if (size <= 0) {
-            throw new IllegalArgumentException("cooperativeThreadCount should be a positive number");
-        }
+        checkPositive(size, "cooperativeThreadCount should be a positive number");
         this.cooperativeThreadCount = size;
         return this;
     }
@@ -88,9 +87,7 @@ public class InstanceConfig {
      * (in milliseconds) of the interval between flow-control ("ack") packets.
      */
     public InstanceConfig setFlowControlPeriodMs(int flowControlPeriodMs) {
-        if (flowControlPeriodMs <= 0) {
-            throw new IllegalArgumentException("flowControlPeriodMs should be a positive number");
-        }
+        checkPositive(flowControlPeriodMs, "flowControlPeriodMs should be a positive number");
         this.flowControlPeriodMs = flowControlPeriodMs;
         return this;
     }
@@ -112,11 +109,7 @@ public class InstanceConfig {
      * and continued from latest snapshot.
      */
     public InstanceConfig setBackupCount(int newBackupCount) {
-        if (newBackupCount < 0) {
-            throw new IllegalArgumentException("backup count can't be smaller than 0");
-        } else if (newBackupCount > MAX_BACKUP_COUNT) {
-            throw new IllegalArgumentException("backup count can't be larger than than " + MAX_BACKUP_COUNT);
-        }
+        checkBackupCount(newBackupCount, 0);
         this.backupCount = newBackupCount;
         return this;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
@@ -102,7 +102,6 @@ public class JetConfig {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setMulticastPort(DEFAULT_JET_MULTICAST_PORT);
         config.getGroupConfig().setName("jet");
-        config.getGroupConfig().setPassword("jet-pass");
         return config;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/SerializableClientConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/SerializableClientConfig.java
@@ -29,21 +29,18 @@ import java.util.List;
 class SerializableClientConfig implements Serializable {
 
     private String groupName;
-    private String groupPass;
     private List<String> addresses;
 
     SerializableClientConfig(ClientConfig clientConfig) {
         GroupConfig groupConfig = clientConfig.getGroupConfig();
         List<String> addresses = clientConfig.getNetworkConfig().getAddresses();
         this.groupName = groupConfig.getName();
-        this.groupPass = groupConfig.getPassword();
         this.addresses = addresses;
     }
 
     ClientConfig asClientConfig() {
         ClientConfig config = new ClientConfig();
         config.getGroupConfig().setName(groupName);
-        config.getGroupConfig().setPassword(groupPass);
         config.getNetworkConfig().setAddresses(addresses);
         return config;
     }

--- a/hazelcast-jet-core/src/main/resources/hazelcast-jet-client-default.xml
+++ b/hazelcast-jet-core/src/main/resources/hazelcast-jet-client-default.xml
@@ -20,6 +20,5 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>
         <name>jet</name>
-        <password>jet-pass</password>
     </group>
 </hazelcast-client>

--- a/hazelcast-jet-core/src/main/resources/hazelcast-jet-config-0.6.xsd
+++ b/hazelcast-jet-core/src/main/resources/hazelcast-jet-config-0.6.xsd
@@ -30,7 +30,7 @@
                             <xs:element name="cooperative-thread-count" type="positive-int" minOccurs="0"/>
                             <xs:element name="temp-dir" type="xs:string" minOccurs="0"/>
                             <xs:element name="flow-control-period" type="positive-int" minOccurs="0"/>
-                            <xs:element name="backup-count" minOccurs="0" type="positive-int" />
+                            <xs:element name="backup-count" minOccurs="0" type="backup-count" />
                         </xs:all>
                     </xs:complexType>
                 </xs:element>
@@ -70,6 +70,12 @@
     <xs:simpleType name="positive-int">
         <xs:restriction base="xs:int">
             <xs:minInclusive value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="backup-count">
+        <xs:restriction base="xs:byte">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="6"/>
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="non-space-string">

--- a/hazelcast-jet-core/src/main/resources/hazelcast-jet-member-default.xml
+++ b/hazelcast-jet-core/src/main/resources/hazelcast-jet-member-default.xml
@@ -20,7 +20,6 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>
         <name>jet</name>
-        <password>jet-pass</password>
     </group>
     <network>
         <port auto-increment="true" port-count="100">5701</port>

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/config/XmlConfigTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/config/XmlConfigTest.java
@@ -44,7 +44,7 @@ public class XmlConfigTest {
     private static final String TEST_XML_1 = "hazelcast-jet-test.xml";
     private static final String TEST_XML_2 = "hazelcast-jet-member-test.xml";
     private static final String TEST_XML_2_GROUP_NAME = "imdg";
-    private static final String WORLDS_MOST_COMMON_PASSWORD = "123456";
+    private static final String INSTANCE_NAME = "my-instance";
 
     @Test
     public void when_noConfigSpecified_usesDefaultConfig() {
@@ -148,14 +148,14 @@ public class XmlConfigTest {
         Properties properties = new Properties();
         properties.put(XmlJetConfigLocator.HAZELCAST_MEMBER_CONFIG_PROPERTY, "classpath:${my.filename}");
         properties.put("my.filename", TEST_XML_2);
-        properties.put("imdg.pass", WORLDS_MOST_COMMON_PASSWORD);
+        properties.put("imdg.instance.name", INSTANCE_NAME);
 
         // When
         JetConfig jetConfig = XmlJetConfigBuilder.getConfig(properties);
 
         // Then
         assertXmlMemberConfig(jetConfig.getHazelcastConfig());
-        assertThat(jetConfig.getHazelcastConfig().getGroupConfig().getPassword(), equalTo(WORLDS_MOST_COMMON_PASSWORD));
+        assertThat(jetConfig.getHazelcastConfig().getInstanceName(), equalTo(INSTANCE_NAME));
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/resources/hazelcast-jet-member-test.xml
+++ b/hazelcast-jet-core/src/test/resources/hazelcast-jet-member-test.xml
@@ -20,6 +20,6 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>
         <name>imdg</name>
-        <password>${imdg.pass}</password>
     </group>
+    <instance-name>${imdg.instance.name}</instance-name>
 </hazelcast>

--- a/hazelcast-jet-distribution/src/main/resources/bin/cluster.sh
+++ b/hazelcast-jet-distribution/src/main/resources/bin/cluster.sh
@@ -7,7 +7,6 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
     echo "	-a, --address  	    : Defines which ip address hazelcast is running. Default value is '127.0.0.1'."
    	echo "	-p, --port  	    : Defines which port hazelcast is running. Default value is '5701'."
    	echo "	-g, --groupname     : Defines groupname of the cluster. Default value is 'dev'."
-   	echo "	-P, --password      : Defines password of the cluster. Default value is 'dev-pass'."
    	echo "	-v, --version       : Defines the cluster version to change to. To be used in conjunction with '-o change-cluster-version'."
    	exit 0
 fi
@@ -30,10 +29,6 @@ case "$key" in
     ;;
     -g|--groupname)
     GROUPNAME="$2"
-    shift # past argument
-    ;;
-    -P|--password)
-    PASSWORD="$2"
     shift # past argument
     ;;
      -a|--address)
@@ -64,11 +59,6 @@ if [ -z "$GROUPNAME" ]; then
     GROUPNAME="dev"
 fi
 
-if [ -z "$PASSWORD" ]; then
-    echo "No password is defined, running script with default password : 'dev-pass'."
-    PASSWORD="dev-pass"
-fi
-
 if [ -z "$ADDRESS" ]; then
     echo "No specific ip address is defined, running script with default ip : '127.0.0.1'."
     ADDRESS="127.0.0.1"
@@ -84,7 +74,7 @@ fi
 if [ "$OPERATION" = "get-state" ]; then
     echo "Getting cluster state on ip ${ADDRESS} on port ${PORT}"
 	request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/state"
- 	response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+ 	response=$(curl --data "${GROUPNAME}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
  	if [ "$STATUS" = "fail" ];then
         echo "An error occured while listing !";
@@ -117,7 +107,7 @@ if [ "$OPERATION" = "change-state" ]; then
 
     echo "Changing cluster state to ${STATE} on ip ${ADDRESS} on port ${PORT}"
     request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/changeState"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}&${STATE}" --silent "${request}");
+    response=$(curl --data "${GROUPNAME}&${STATE}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 
     if [ "$STATUS" = "fail" ];then
@@ -150,7 +140,7 @@ if [ "$OPERATION" = "force-start" ]; then
     echo "Starting cluster from member on ip ${ADDRESS} on port ${PORT}"
 
     request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/forceStart"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+    response=$(curl --data "${GROUPNAME}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 
     if [ "$STATUS" = "fail" ];then
@@ -177,7 +167,7 @@ if [ "$OPERATION" = "partial-start" ]; then
     echo "Starting cluster from member on ip ${ADDRESS} on port ${PORT}"
 
     request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/partialStart"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+    response=$(curl --data "${GROUPNAME}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 
     if [ "$STATUS" = "fail" ];then
@@ -205,7 +195,7 @@ if [ "$OPERATION" = "shutdown" ]; then
     echo "Shutting down from member on ip ${ADDRESS} on port ${PORT}"
 
     request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/clusterShutdown"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}" --silent "${request}");
+    response=$(curl --data "${GROUPNAME}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 
     if [ "$STATUS" = "fail" ];then
@@ -258,7 +248,7 @@ if [ "$OPERATION" = "change-cluster-version" ]; then
 
     echo "Changing cluster version to ${CLUSTER_VERSION} on ip ${ADDRESS} on port ${PORT}"
     request="http://${ADDRESS}:${PORT}/hazelcast/rest/management/cluster/version"
-    response=$(curl --data "${GROUPNAME}&${PASSWORD}&${CLUSTER_VERSION}" --silent "${request}");
+    response=$(curl --data "${GROUPNAME}&${CLUSTER_VERSION}" --silent "${request}");
     STATUS=$(echo "${response}" | sed -e 's/^.*"status"[ ]*:[ ]*"//' -e 's/".*//');
 
     if [ "$STATUS" = "fail" ];then

--- a/hazelcast-jet-spring/pom.xml
+++ b/hazelcast-jet-spring/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+    <name>hazelcast-jet-spring</name>
+    <description>Spring integration for Hazelcast Jet</description>
+    <url>http://www.hazelcast.com/</url>
+
+    <artifactId>hazelcast-jet-spring</artifactId>
+
+    <parent>
+        <artifactId>hazelcast-jet-root</artifactId>
+        <groupId>com.hazelcast.jet</groupId>
+        <version>0.6-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <spring.version>4.3.0.RELEASE</spring.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.hazelcast.jet.spring</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <createSourcesJar>true</createSourcesJar>
+                    <createDependencyReducedPom>true</createDependencyReducedPom>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                            <resource>META-INF/spring.handlers</resource>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                            <resource>META-INF/spring.schemas</resource>
+                        </transformer>
+                    </transformers>
+                    <artifactSet>
+                        <includes>
+                            <include>com.hazelcast:hazelcast-spring</include>
+                        </includes>
+                    </artifactSet>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast.jet</groupId>
+            <artifactId>hazelcast-jet</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-spring</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-spring</artifactId>
+            <version>${hazelcast.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetClientBeanDefinitionParser.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetClientBeanDefinitionParser.java
@@ -30,7 +30,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  * <b>Sample Spring XML for Hazelcast Jet Client:</b>
  * <pre>{@code
  *   <jet:client id="client">
- *      <jet:group name="jet" password="jet-pass"/>
+ *      <jet:group name="jet"/>
  *      <jet:network connection-attempt-limit="3"
  *          connection-attempt-period="3000"
  *          connection-timeout="1000"

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetClientBeanDefinitionParser.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetClientBeanDefinitionParser.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.spring;
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.spring.HazelcastClientBeanDefinitionParser;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
+
+/**
+ * BeanDefinitionParser for Hazelcast Jet Client Configuration.
+ * <p>
+ * <b>Sample Spring XML for Hazelcast Jet Client:</b>
+ * <pre>{@code
+ *   <jet:client id="client">
+ *      <jet:group name="jet" password="jet-pass"/>
+ *      <jet:network connection-attempt-limit="3"
+ *          connection-attempt-period="3000"
+ *          connection-timeout="1000"
+ *          redo-operation="true"
+ *          smart-routing="true">
+ *              <hz:member>10.10.1.2:5701</hz:member>
+ *              <hz:member>10.10.1.3:5701</hz:member>
+ *      </jet:network>
+ *   </jet:client>
+ * }</pre>
+ */
+public class JetClientBeanDefinitionParser extends HazelcastClientBeanDefinitionParser {
+    @Override
+    protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+        JetClientSpringXmlBuilder springXmlBuilder = new JetClientSpringXmlBuilder(parserContext);
+        return springXmlBuilder.handleClient(element);
+    }
+
+    private class JetClientSpringXmlBuilder extends HazelcastClientBeanDefinitionParser.SpringXmlBuilder {
+
+        JetClientSpringXmlBuilder(ParserContext parserContext) {
+            super(parserContext, rootBeanDefinition(Jet.class)
+                    .setFactoryMethod("newJetClient")
+                    .setDestroyMethodName("shutdown"));
+        }
+
+    }
+}

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetHazelcastBeanDefinitionParser.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetHazelcastBeanDefinitionParser.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.spring;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.spring.AbstractHazelcastBeanDefinitionParser;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
+
+/**
+ * BeanDefinitionParser for Hazelcast Instance created via Jet Instance.
+ * <p>
+ * <b>Sample Spring XML for Hazelcast Instance created via Jet Instance:</b>
+ * <pre>{@code
+ * <jet:hazelcast jet-instance-ref="jet-instance" id="hazelcast-instance"/>
+ * }</pre>
+ */
+public class JetHazelcastBeanDefinitionParser extends AbstractHazelcastBeanDefinitionParser {
+
+    @Override
+    protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+        return new SpringXmlBuilder(parserContext).handle(element);
+    }
+
+    private class SpringXmlBuilder extends SpringXmlBuilderHelper {
+
+        private final ParserContext parserContext;
+        private final BeanDefinitionBuilder builder;
+
+        SpringXmlBuilder(ParserContext parserContext) {
+            this.parserContext = parserContext;
+            this.builder = rootBeanDefinition(JetInstance.class).setFactoryMethod("getHazelcastInstance");
+        }
+
+        AbstractBeanDefinition handle(Element element) {
+            handleCommonBeanAttributes(element, builder, parserContext);
+            NamedNodeMap attributes = element.getAttributes();
+            if (attributes != null) {
+                Node jetInstanceRefNode = attributes.getNamedItem("jet-instance-ref");
+                if (jetInstanceRefNode != null) {
+                    String jetInstanceRef = getTextContent(jetInstanceRefNode);
+                    builder.getRawBeanDefinition().setFactoryBeanName(jetInstanceRef);
+                    return builder.addDependsOn(jetInstanceRef).getBeanDefinition();
+                }
+            }
+            throw new IllegalStateException("'jet-instance-ref' attribute is required for creating HazelcastInstance");
+        }
+
+    }
+}

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetInstanceBeanDefinitionParser.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetInstanceBeanDefinitionParser.java
@@ -38,7 +38,7 @@ import static org.springframework.beans.factory.support.BeanDefinitionBuilder.ro
  * <jet:instance id="jet-instance">
  *      <hz:config>
  *          <hz:spring-aware/>
- *          <hz:group name="jet" password="jet-pass"/>
+ *          <hz:group name="jet"/>
  *          <hz:network port="5701" port-auto-increment="false">
  *              <hz:join>
  *                  <hz:multicast enabled="false"/>

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetInstanceBeanDefinitionParser.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetInstanceBeanDefinitionParser.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.spring;
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.config.EdgeConfig;
+import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.spring.AbstractHazelcastBeanDefinitionParser;
+import com.hazelcast.spring.HazelcastConfigBeanDefinitionParser;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
+
+/**
+ * BeanDefinitionParser for Hazelcast Jet Instance Configuration.
+ * <p>
+ * <b>Sample Spring XML for Hazelcast Jet Instance:</b>
+ * <pre>{@code
+ * <jet:instance id="jet-instance">
+ *      <hz:config>
+ *          <hz:spring-aware/>
+ *          <hz:group name="jet" password="jet-pass"/>
+ *          <hz:network port="5701" port-auto-increment="false">
+ *              <hz:join>
+ *                  <hz:multicast enabled="false"/>
+ *                   <hz:tcp-ip enabled="true">
+ *                      <hz:members>10.10.1.2, 10.10.1.3</hz:members>
+ *                   </hz:tcp-ip>
+ *              </hz:join>
+ *          </hz:network>
+ *          <hz:map name="map" backup-count="2" max-size="0" eviction-percentage="30"
+ *              read-backup-data="true" eviction-policy="NONE"
+ *          merge-policy="com.hazelcast.map.merge.PassThroughMergePolicy"/>
+ *      </hz:config>
+ * </jet:instance>
+ * }</pre>
+ */
+public class JetInstanceBeanDefinitionParser extends AbstractHazelcastBeanDefinitionParser {
+
+    @Override
+    protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+        SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
+        return springXmlBuilder.handle(element);
+    }
+
+    private class SpringXmlBuilder extends SpringXmlBuilderHelper {
+
+        private final ParserContext parserContext;
+        private final BeanDefinitionBuilder builder;
+
+        SpringXmlBuilder(ParserContext parserContext) {
+            this.parserContext = parserContext;
+            this.builder = rootBeanDefinition(Jet.class)
+                    .setFactoryMethod("newJetInstance")
+                    .setDestroyMethodName("shutdown");
+        }
+
+        private AbstractBeanDefinition handle(Element element) {
+            handleCommonBeanAttributes(element, builder, parserContext);
+            configBuilder = rootBeanDefinition(JetConfig.class)
+                    .setScope(builder.getBeanDefinition().getScope())
+                    .setLazyInit(builder.getBeanDefinition().isLazyInit());
+
+            for (Node node : childElements(element)) {
+                String nodeName = cleanNodeName(node);
+                if ("config".equals(nodeName)) {
+                    configBuilder.addPropertyValue("hazelcastConfig", parseConfigBeanDefinition((Element) node));
+                } else if ("instance-config".equals(nodeName)) {
+                    createAndFillBeanBuilder(node, InstanceConfig.class, "instanceConfig", configBuilder);
+                } else if ("default-edge-config".equals(nodeName)) {
+                    createAndFillBeanBuilder(node, EdgeConfig.class, "defaultEdgeConfig", configBuilder);
+                } else if ("properties".equals(nodeName)) {
+                    handleProperties(node, configBuilder);
+                } else {
+                    throw new IllegalArgumentException("Unknown configuration for JetConfig nodeName: " + nodeName);
+                }
+            }
+
+            return builder.addConstructorArgValue(configBuilder.getBeanDefinition())
+                          .getBeanDefinition();
+        }
+
+        private AbstractBeanDefinition parseConfigBeanDefinition(Element config) {
+            if (config == null) {
+                return defaultConfigBeanDefinition();
+            }
+            HazelcastConfigBeanDefinitionParser configParser = new HazelcastConfigBeanDefinitionParser();
+            return configParser.parseInternal(config, parserContext);
+        }
+
+        private AbstractBeanDefinition defaultConfigBeanDefinition() {
+            return rootBeanDefinition(JetConfig.class)
+                    .setFactoryMethod("defaultHazelcastConfig").getBeanDefinition();
+        }
+    }
+}

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetNamespaceHandler.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetNamespaceHandler.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.spring;
+
+import com.hazelcast.spring.HazelcastTypeBeanDefinitionParser;
+import org.springframework.beans.factory.xml.NamespaceHandlerSupport;
+
+/**
+ * Hazelcast Jet Custom Namespace Definitions.
+ */
+public class JetNamespaceHandler extends NamespaceHandlerSupport {
+
+    @Override
+    public void init() {
+        registerBeanDefinitionParser("instance", new JetInstanceBeanDefinitionParser());
+        registerBeanDefinitionParser("client", new JetClientBeanDefinitionParser());
+        registerBeanDefinitionParser("hazelcast", new JetHazelcastBeanDefinitionParser());
+        registerBeanDefinitionParser("map", new HazelcastTypeBeanDefinitionParser("map"));
+        registerBeanDefinitionParser("list", new HazelcastTypeBeanDefinitionParser("list"));
+    }
+}

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/package-info.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Spring integration for Hazelcast Jet
+ */
+package com.hazelcast.jet.spring;

--- a/hazelcast-jet-spring/src/main/resources/META-INF/spring.handlers
+++ b/hazelcast-jet-spring/src/main/resources/META-INF/spring.handlers
@@ -1,0 +1,2 @@
+http\://www.hazelcast.com/schema/jet-spring=com.hazelcast.jet.spring.JetNamespaceHandler
+https\://www.hazelcast.com/schema/jet-spring=com.hazelcast.jet.spring.JetNamespaceHandler

--- a/hazelcast-jet-spring/src/main/resources/META-INF/spring.schemas
+++ b/hazelcast-jet-spring/src/main/resources/META-INF/spring.schemas
@@ -1,0 +1,2 @@
+http\://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-0.6.xsd=hazelcast-jet-spring-0.6.xsd
+https\://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-0.6.xsd=hazelcast-jet-spring-0-6.xsd

--- a/hazelcast-jet-spring/src/main/resources/hazelcast-jet-spring-0.6.xsd
+++ b/hazelcast-jet-spring/src/main/resources/hazelcast-jet-spring-0.6.xsd
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.hazelcast.com/schema/jet-spring"
+           xmlns:tool="http://www.springframework.org/schema/tool"
+           xmlns:hz="http://www.hazelcast.com/schema/spring"
+           targetNamespace="http://www.hazelcast.com/schema/jet-spring"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:import namespace="http://www.springframework.org/schema/tool"
+               schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+    <xs:import namespace="http://www.hazelcast.com/schema/spring"
+               schemaLocation="hazelcast-spring-3.10.xsd"/>
+
+    <xs:element name="instance">
+        <xs:annotation>
+            <xs:documentation>
+                Configure the hazelcast jet instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.jet.JetInstance"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hz:hazelcast-bean">
+                    <xs:sequence>
+                        <xs:element ref="hz:config" minOccurs="0"/>
+                        <xs:element name="instance-config" type="instance-config" minOccurs="0"/>
+                        <xs:element name="default-edge-config" type="edge-config" minOccurs="0"/>
+                        <xs:element name="properties" type="hz:properties" minOccurs="0"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="client">
+        <xs:annotation>
+            <xs:documentation>
+                Configure the Hazelcast Jet client
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.jet.JetInstance"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hz:hazelcast-bean">
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="spring-aware" type="xs:string" minOccurs="0"/>
+                        <xs:element name="group" type="hz:group" minOccurs="0"/>
+                        <xs:element name="properties" type="hz:properties" minOccurs="0"/>
+                        <xs:element name="network" type="hz:network-client" minOccurs="0"/>
+                        <xs:element name="security" type="hz:client-security" minOccurs="0"/>
+                        <xs:element name="listeners" type="hz:listeners" minOccurs="0"/>
+                        <xs:element name="serialization" type="hz:serialization" minOccurs="0"/>
+                        <xs:element name="proxy-factories" type="hz:proxy-factories" minOccurs="0"/>
+                        <xs:element name="load-balancer" type="hz:load-balancer" minOccurs="0"/>
+                        <xs:element name="near-cache" type="hz:near-cache-client" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="query-caches" type="hz:query-caches-client" minOccurs="0"/>
+                        <xs:element name="connection-strategy" type="hz:connection-strategy" minOccurs="0"/>
+                        <xs:element name="user-code-deployment" type="hz:user-code-deployment-client" minOccurs="0"/>
+                        <xs:element name="flake-id-generator" type="hz:client-flake-id-generator" minOccurs="0"/>
+                    </xs:choice>
+                    <xs:attribute name="executor-pool-size" type="xs:int"/>
+                    <xs:attribute name="credentials-ref" type="xs:string"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="hazelcast">
+        <xs:annotation>
+            <xs:documentation>
+                Obtain HazelcastInstance from JetInstance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hz:hazelcast-bean">
+                    <xs:attribute name="jet-instance-ref" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[The name of the JetInstance bean that this bean depends on.]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="map" type="hz:hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast Jet IMapJet instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.jet.IMapJet"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:element name="list" type="hz:hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast Jet IListJet instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.jet.IListJet"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="instance-config">
+        <xs:attribute name="cooperative-thread-Count" type="hz:parameterized-positive-integer"/>
+        <xs:attribute name="flow-control-period-ms" type="hz:parameterized-positive-integer"/>
+        <xs:attribute name="backup-count" type="hz:parameterized-backup-count"/>
+        <xs:attribute name="temp-dir" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="edge-config">
+        <xs:attribute name="queue-size" type="hz:parameterized-positive-integer"/>
+        <xs:attribute name="packet-size-limit" type="hz:parameterized-positive-integer"/>
+        <xs:attribute name="receive-window-multiplier" type="hz:parameterized-positive-integer"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/hazelcast-jet-spring/src/test/java/com/hazelcast/jet/spring/TestApplicationContext.java
+++ b/hazelcast-jet-spring/src/test/java/com/hazelcast/jet/spring/TestApplicationContext.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.spring;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.TcpIpConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.jet.IListJet;
+import com.hazelcast.jet.IMapJet;
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.EdgeConfig;
+import com.hazelcast.jet.config.InstanceConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
+import com.hazelcast.spring.context.SpringManagedContext;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"application-context-jet.xml"})
+public class TestApplicationContext {
+
+    @Resource(name = "jet-instance")
+    private JetInstance jetInstance;
+
+    @Resource(name = "jet-client")
+    private JetInstance jetClient;
+
+    @Resource(name = "hazelcast-instance")
+    private HazelcastInstance hazelcastInstance;
+
+    @Resource(name = "my-map-bean")
+    private IMapJet map;
+
+    @Resource(name = "my-list-bean")
+    private IListJet list;
+
+    @Resource(name = "my-queue-bean")
+    private IQueue queue;
+
+    @BeforeClass
+    @AfterClass
+    public static void start() {
+        Jet.shutdownAll();
+    }
+
+    @Test
+    public void test() {
+        assertNotNull(jetInstance);
+        assertNotNull(jetClient);
+        assertNotNull(hazelcastInstance);
+        assertNotNull(map);
+        assertNotNull(list);
+        assertNotNull(queue);
+
+        assertJetConfig();
+    }
+
+    private void assertJetConfig() {
+        JetConfig jetConfig = jetInstance.getConfig();
+        Config hazelcastConfig = jetConfig.getHazelcastConfig();
+        assertHazelcastConfig(hazelcastConfig);
+
+        InstanceConfig instanceConfig = jetConfig.getInstanceConfig();
+        assertEquals(4, instanceConfig.getBackupCount());
+        assertEquals(2, instanceConfig.getCooperativeThreadCount());
+        assertEquals(200, instanceConfig.getFlowControlPeriodMs());
+        assertEquals("springTempDir", instanceConfig.getTempDir());
+
+        EdgeConfig edgeConfig = jetConfig.getDefaultEdgeConfig();
+        assertEquals(8, edgeConfig.getQueueSize());
+        assertEquals(3, edgeConfig.getPacketSizeLimit());
+        assertEquals(5, edgeConfig.getReceiveWindowMultiplier());
+
+        assertEquals("bar", jetConfig.getProperties().getProperty("foo"));
+    }
+
+    private void assertHazelcastConfig(Config cfg) {
+        assertTrue(cfg.getManagedContext() instanceof SpringManagedContext);
+        assertEquals("jet-spring", cfg.getGroupConfig().getName());
+
+        NetworkConfig networkConfig = cfg.getNetworkConfig();
+        assertEquals(5707, networkConfig.getPort());
+        assertFalse(networkConfig.isPortAutoIncrement());
+
+        JoinConfig join = networkConfig.getJoin();
+        assertFalse(join.getMulticastConfig().isEnabled());
+
+        TcpIpConfig tcpIpConfig = join.getTcpIpConfig();
+        assertTrue(tcpIpConfig.isEnabled());
+        List<String> members = tcpIpConfig.getMembers();
+        assertEquals(1, members.size());
+        assertEquals("127.0.0.1:5707", members.get(0));
+
+        assertEquals(3, cfg.getMapConfig("map").getBackupCount());
+    }
+}

--- a/hazelcast-jet-spring/src/test/resources/com/hazelcast/jet/spring/application-context-jet.xml
+++ b/hazelcast-jet-spring/src/test/resources/com/hazelcast/jet/spring/application-context-jet.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:jet="http://www.hazelcast.com/schema/jet-spring"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.hazelcast.com/schema/jet-spring
+		http://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-0.6.xsd
+		http://www.hazelcast.com/schema/spring
+		http://www.hazelcast.com/schema/spring/hazelcast-spring-3.10.xsd">
+
+    <jet:instance id="jet-instance">
+        <hz:config>
+            <hz:spring-aware/>
+            <hz:group name="jet-spring" password="jet-spring-pass"/>
+            <hz:network port="5707" port-auto-increment="false">
+                <hz:join>
+                    <hz:multicast enabled="false"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:member>127.0.0.1:5707</hz:member>
+                    </hz:tcp-ip>
+                </hz:join>
+            </hz:network>
+            <hz:map name="map" backup-count="3">
+            </hz:map>
+        </hz:config>
+        <jet:instance-config backup-count="4" cooperative-thread-Count="2" flow-control-period-ms="200" temp-dir="springTempDir"/>
+        <jet:default-edge-config queue-size="8" packet-size-limit="3" receive-window-multiplier="5"/>
+        <jet:properties>
+            <hz:property name="foo">bar</hz:property>
+        </jet:properties>
+    </jet:instance>
+
+    <jet:client id="jet-client" depends-on="jet-instance">
+        <jet:group name="jet-spring" password="jet-spring-pass"/>
+        <jet:network>
+            <hz:member>127.0.0.1:5707</hz:member>
+        </jet:network>
+        <jet:spring-aware/>
+    </jet:client>
+
+
+    <jet:hazelcast jet-instance-ref="jet-instance" id="hazelcast-instance"/>
+
+    <jet:map instance-ref="jet-instance" name="my-map" id="my-map-bean"/>
+
+    <jet:list instance-ref="jet-client" name="my-list" id="my-list-bean"/>
+
+    <hz:queue instance-ref="hazelcast-instance" name="my-queue" id="my-queue-bean"/>
+
+</beans>

--- a/hazelcast-jet-spring/src/test/resources/com/hazelcast/jet/spring/application-context-jet.xml
+++ b/hazelcast-jet-spring/src/test/resources/com/hazelcast/jet/spring/application-context-jet.xml
@@ -28,7 +28,7 @@
     <jet:instance id="jet-instance">
         <hz:config>
             <hz:spring-aware/>
-            <hz:group name="jet-spring" password="jet-spring-pass"/>
+            <hz:group name="jet-spring"/>
             <hz:network port="5707" port-auto-increment="false">
                 <hz:join>
                     <hz:multicast enabled="false"/>
@@ -48,7 +48,7 @@
     </jet:instance>
 
     <jet:client id="jet-client" depends-on="jet-instance">
-        <jet:group name="jet-spring" password="jet-spring-pass"/>
+        <jet:group name="jet-spring"/>
         <jet:network>
             <hz:member>127.0.0.1:5707</hz:member>
         </jet:network>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>hazelcast-jet-core</module>
         <module>hazelcast-jet-kafka</module>
         <module>hazelcast-jet-hadoop</module>
+        <module>hazelcast-jet-spring</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
- Add `hazelcast-jet-spring` module which extends and shades `hazelcast-spring` module. 
- Add some checks for programmatic and declarative configurations. 

fixes https://github.com/hazelcast/hazelcast-jet/issues/740
fixes https://github.com/hazelcast/hazelcast-jet/issues/734

depends on:
- https://github.com/hazelcast/hazelcast/pull/12448
- https://github.com/hazelcast/hazelcast/pull/12463
- https://github.com/hazelcast/hazelcast/pull/12428