### PR TITLE
Fix totalParallelism passing in PeekWrappedP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
@@ -80,7 +80,7 @@ public final class PeekWrappedP<T> extends ProcessorWrapper {
             ILogger newLogger = nodeEngine.getLogger(
                     createLoggerName(wrapped.getClass().getName(), c.vertexName(), c.globalProcessorIndex()));
             context = new ProcCtx(c.jetInstance(), c.getSerializationService(), newLogger, c.vertexName(),
-                    c.globalProcessorIndex(), c.processingGuarantee(), c.localParallelism(), c.globalProcessorIndex());
+                    c.globalProcessorIndex(), c.processingGuarantee(), c.localParallelism(), c.totalParallelism());
         }
         super.init(outbox, context);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -494,7 +494,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         private final int numPartitions;
         private final int elementsInPartition;
 
-        private int globalParallelism;
+        private int totalParallelism;
         private int localParallelism;
 
         SequencesInPartitionsMetaSupplier(int numPartitions, int elementsInPartition) {
@@ -504,7 +504,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
 
         @Override
         public void init(@Nonnull Context context) {
-            globalParallelism = context.totalParallelism();
+            totalParallelism = context.totalParallelism();
             localParallelism = context.localParallelism();
         }
 
@@ -515,7 +515,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
                 int startIndex = addresses.indexOf(address) * localParallelism;
                 return count -> IntStream.range(0, count)
                                          .mapToObj(index -> new SequencesInPartitionsGeneratorP(
-                                                 assignedPtions(startIndex + index, globalParallelism, numPartitions),
+                                                 assignedPtions(startIndex + index, totalParallelism, numPartitions),
                                                  elementsInPartition))
                                          .collect(toList());
             };

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/impl/connector/kafka/StreamKafkaP.java
@@ -285,14 +285,14 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
 
         private final List<String> topics;
         private final int[] partitionCounts;
-        private final int globalParallelism;
+        private final int totalParallelism;
 
-        KafkaPartitionAssigner(List<String> topics, int[] partitionCounts, int globalParallelism) {
+        KafkaPartitionAssigner(List<String> topics, int[] partitionCounts, int totalParallelism) {
             Preconditions.checkTrue(topics.size() == partitionCounts.length,
                     "Different length between topics and partition counts");
             this.topics = topics;
             this.partitionCounts = partitionCounts;
-            this.globalParallelism = globalParallelism;
+            this.totalParallelism = totalParallelism;
         }
 
         Set<TopicPartition> topicPartitionsFor(int processorIndex) {
@@ -308,8 +308,8 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor implements Cl
         }
 
         private int processorIndexFor(int topicIndex, int partition) {
-            int startIndex = topicIndex * Math.max(1, globalParallelism / topics.size());
-            return (startIndex + partition) % globalParallelism;
+            int startIndex = topicIndex * Math.max(1, totalParallelism / topics.size());
+            return (startIndex + partition) % totalParallelism;
         }
     }
 

--- a/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/KafkaPartitionAssignerTest.java
+++ b/hazelcast-jet-kafka/src/test/java/com/hazelcast/jet/impl/connector/kafka/KafkaPartitionAssignerTest.java
@@ -130,8 +130,8 @@ public class KafkaPartitionAssignerTest {
         return new TopicPartition("topic-" + topicIndex, partition);
     }
 
-    private static KafkaPartitionAssigner assigner(int globalParallelism, int... partitionCounts) {
+    private static KafkaPartitionAssigner assigner(int totalParallelism, int... partitionCounts) {
         List<String> topics = IntStream.range(0, partitionCounts.length).mapToObj(i -> "topic-" + i).collect(toList());
-        return new KafkaPartitionAssigner(topics, partitionCounts, globalParallelism);
+        return new KafkaPartitionAssigner(topics, partitionCounts, totalParallelism);
     }
 }


### PR DESCRIPTION
Also rename all instances of `globalParallelism` to `totalParallelism`.