### PR TITLE
Fix situation DONE_ITEM generated a WM

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -30,6 +30,7 @@ import java.util.function.Consumer;
 
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.NO_NEW_WM;
+import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.MADE_PROGRESS;
 
 /**
@@ -107,7 +108,7 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
                 receivedBarriers.clear(queueIndex);
                 numActiveQueues--;
                 if (maybeEmitWm(watermarkCoalescer.queueDone(queueIndex), dest)) {
-                    return MADE_PROGRESS;
+                    return numActiveQueues == 0 ? DONE : MADE_PROGRESS;
                 }
             } else if (itemDetector.item instanceof Watermark) {
                 long wmTimestamp = ((Watermark) itemDetector.item).timestamp();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -271,6 +271,9 @@ public class ProcessorTasklet implements Tasklet {
     }
 
     private void fillInbox(long now) {
+        assert inbox.isEmpty() : "inbox is not empty";
+        assert pendingWatermark == null : "null wm expected, but was " + pendingWatermark;
+
         if (instreamCursor == null) {
             return;
         }
@@ -289,21 +292,9 @@ public class ProcessorTasklet implements Tasklet {
             result = currInstream.drainTo(inbox.queue()::add);
             progTracker.madeProgress(result.isMadeProgress());
 
-            if (result.isDone()) {
-                assert pendingWatermark == null;
-                receivedBarriers.clear(currInstream.ordinal());
-                long wm = watermarkCoalescer.queueDone(currInstream.ordinal());
-                if (wm != NO_NEW_WM) {
-                    pendingWatermark = new Watermark(wm);
-                }
-                instreamCursor.remove();
-                numActiveOrdinals--;
-            }
-
             // check if the last drained item is special
             Object lastItem = inbox.queue().peekLast();
             if (lastItem instanceof Watermark) {
-                assert pendingWatermark == null;
                 long newWmValue = ((Watermark) inbox.queue().removeLast()).timestamp();
                 long wm = watermarkCoalescer.observeWm(now, currInstream.ordinal(), newWmValue);
                 if (wm != NO_NEW_WM) {
@@ -314,6 +305,20 @@ public class ProcessorTasklet implements Tasklet {
                 observeSnapshot(currInstream.ordinal(), barrier.snapshotId());
             } else if (lastItem != null && !(lastItem instanceof BroadcastItem)) {
                 watermarkCoalescer.observeEvent(currInstream.ordinal());
+            }
+
+            if (result.isDone()) {
+                receivedBarriers.clear(currInstream.ordinal());
+                long wm = watermarkCoalescer.queueDone(currInstream.ordinal());
+                // Note that there can be a WM received from upstream and the result can be done after single drain.
+                // In this case we might overwrite the WM here, but that's fine since the second WM should be newer.
+                if (wm != NO_NEW_WM) {
+                    assert pendingWatermark == null || pendingWatermark.timestamp() < wm
+                            : "trying to assign lower WM. Old=" + pendingWatermark.timestamp() + ", new=" + wm;
+                    pendingWatermark = new Watermark(wm);
+                }
+                instreamCursor.remove();
+                numActiveOrdinals--;
             }
 
             // pop current priority group

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -353,7 +353,8 @@ public class ProcessorTasklet implements Tasklet {
      * otherwise to PROCESS_INBOX.
      */
     private ProcessorState initialProcessingState() {
-        return instreamCursor == null ? COMPLETE : PROCESS_INBOX;
+        return pendingWatermark != null ? PROCESS_WATERMARK
+                : instreamCursor == null ? COMPLETE : PROCESS_INBOX;
     }
 
     /**

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_IntegrationTest.java
@@ -302,7 +302,7 @@ public class WatermarkCoalescer_IntegrationTest extends JetTestSupport {
                 if (item instanceof SerializableWm) {
                     item = new Watermark(((SerializableWm) item).timestamp);
                 } else if (item instanceof Delay) {
-                    getLogger().info("will wait " + MILLISECONDS.toNanos(((Delay) item).millis) + " ms");
+                    getLogger().info("will wait " + ((Delay) item).millis + " ms");
                     nextItemAt = System.nanoTime() + MILLISECONDS.toNanos(((Delay) item).millis);
                     pos++;
                     return false;


### PR DESCRIPTION
When processing DONE_ITEM we can generate a WM. The CIES.drainTo added
the WM to inbox, returned MADE_PROGRESS result and a subsequent call to
CIES.isDone() returned `true`. This confused the algorithm.

We fix it by returning DONE result in this situation and by fixing
ProcessorTasklet to handle this situation.