### PR TITLE
Don't shrink RWIN during lulls

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
@@ -204,7 +204,7 @@ public class ReceiverTasklet implements Tasklet {
         return ackedSeqCompressed + receiveWindowCompressed;
     }
 
-    // The calls to this method are always ordered by happens-before
+    // Only one thread writes to ackedSeq
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
     long ackItem(long itemWeight) {
         return ackedSeq += itemWeight;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
@@ -47,11 +47,11 @@ public class ReceiverTaskletSendLimitTest {
     }
 
     @Test
-    public void when_noData_then_rwinHalvedEachTime() throws Exception {
+    public void when_noData_then_rwinRemainsUnchanged() throws Exception {
         double expectedSeq = INITIAL_RECEIVE_WINDOW_COMPRESSED;
         for (int i = 0; i < 10; i++) {
             assertEquals((long) expectedSeq, tasklet.updateAndGetSendSeqLimitCompressed(START + i * ACK_PERIOD));
-            expectedSeq = ceil(expectedSeq / 2);
+            expectedSeq = ceil(expectedSeq);
         }
     }
 
@@ -92,6 +92,7 @@ public class ReceiverTaskletSendLimitTest {
 
         // When
         long seqLimit = 0;
+        tasklet.numWaitingInInbox = 1;
         for (int i = 0; i < hiccupIters; i++, iter++) {
             seqLimit = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD);
         }
@@ -99,7 +100,7 @@ public class ReceiverTaskletSendLimitTest {
         // Then
         final long ackedSeqCompressed = (warmupIters * ackedSeqsPerIter) >> COMPRESSED_SEQ_UNIT_LOG2;
         final long rwin = seqLimit - ackedSeqCompressed;
-        assertTrue(rwin == 0 || rwin == 1);
+        assertTrue("rwin=" + rwin, rwin == 0 || rwin == 1);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
@@ -91,8 +91,8 @@ public class ReceiverTaskletSendLimitTest {
         }
 
         // When
+        tasklet.setNumWaitingInInbox(1);
         long seqLimit = 0;
-        tasklet.numWaitingInInbox = 1;
         for (int i = 0; i < hiccupIters; i++, iter++) {
             seqLimit = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD);
         }


### PR DESCRIPTION
We gradually expand and shrink rwin based on the amount of data we've processed during the flow control period. This works well if the stream of data is regular. If it is burst-and-lull (i.e. a burst of data and then nothing for a while), then during the lull the rwin shrinks to 1. When the burst occurs, we apply a lot of backpressure unnecessarily.

This fix works around the problem by not shrinking the rwin if there are no items waiting in the inbox. The `call` method processes data from inbox. During a lull, the inbox is normally empty - we avoid shrinking the rwin in this situation. When inbox is not-empty, it means that we are actively processing data and shrinking/expanding works as before. Expansion of the rwin is unaffected by this change.

Fixex #785