### PR TITLE
[MERGE TO 0.6.1] Don't call close eagerly in file sources

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -37,7 +37,6 @@ import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Traversers.traverseStream;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
-import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -79,11 +78,7 @@ public final class ReadFilesP<R> extends AbstractProcessor {
         directoryStream = Files.newDirectoryStream(directory, glob);
         outputTraverser = Traversers.traverseIterator(directoryStream.iterator())
                                     .filter(this::shouldProcessEvent)
-                                    .flatMap(this::processFile)
-                                    .onFirstNull(() -> {
-                                        uncheckRun(() -> close(null));
-                                        directoryStream = null;
-                                    });
+                                    .flatMap(this::processFile);
     }
 
     @Override


### PR DESCRIPTION
Previous behavior wasn't wrong, it was unnecessary.

Fixes #796 