### PR TITLE
[BACKPORT] Add custom class loader support (#770)

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobClassLoaderFactory.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobClassLoaderFactory.java
@@ -14,21 +14,27 @@
  * limitations under the License.
  */
 
-package com.hazelcast.jet.core;
+package com.hazelcast.jet.config;
 
-import com.hazelcast.jet.JetException;
-import com.hazelcast.jet.impl.util.Util;
+import javax.annotation.Nonnull;
+import java.io.Serializable;
 
 /**
- * Thrown when a job could not be found on the master node
+ * An interface that can be implemented to provide custom class loader for Jet
+ * job.
+ * <p>
+ * The classloader must be serializable: it is set in the {@link
+ * JobConfig#setClassLoaderFactory config} and sent to members in a serialized
+ * form.
+ * <p>
+ * It is useful in custom class-loading environments, for example in OSGi.
  */
-public class JobNotFoundException extends JetException {
+public interface JobClassLoaderFactory extends Serializable {
 
-    public JobNotFoundException(long jobId) {
-       super("Job with id " + Util.idToString(jobId) + " not found");
-    }
+    /**
+     * Return the class loader instance.
+     */
+    @Nonnull
+    ClassLoader getJobClassLoader();
 
-    public JobNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -45,6 +45,7 @@ public class JobConfig implements Serializable {
     private final List<ResourceConfig> resourceConfigs = new ArrayList<>();
     private boolean autoRestartEnabled = true;
     private int maxWatermarkRetainMillis = -1;
+    private JobClassLoaderFactory classLoaderFactory;
 
     /**
      * Returns the name of the job or {@code null} if no name was given.
@@ -391,4 +392,22 @@ public class JobConfig implements Serializable {
         return urlFile.substring(urlFile.lastIndexOf('/') + 1, urlFile.length());
     }
 
+    /**
+     * Sets a custom {@link JobClassLoaderFactory} that will be used to load
+     * job classes and resources on Jet members.
+     *
+     * @return {@code this} instance for fluent API
+     */
+    public JobConfig setClassLoaderFactory(@Nullable JobClassLoaderFactory classLoaderFactory) {
+        this.classLoaderFactory = classLoaderFactory;
+        return this;
+    }
+
+    /**
+     * Returns the configured {@link JobClassLoaderFactory}.
+     */
+    @Nullable
+    public JobClassLoaderFactory getClassLoaderFactory() {
+        return classLoaderFactory;
+    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -106,7 +106,7 @@ public class ExecutionContext {
     /**
      * Starts local execution of job by submitting tasklets to execution service. If
      * execution was cancelled earlier then execution will not be started.
-     *
+     * <p>
      * Returns a future which is completed only when all tasklets are completed. If
      * execution was already cancelled before this method is called then the returned
      * future is completed immediately. The future returned can't be cancelled,

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JobConfigTest.java
@@ -17,12 +17,13 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static org.junit.Assert.assertEquals;
@@ -38,7 +39,7 @@ public class JobConfigTest {
     public void when_setName_thenReturnsName() {
         // When
         JobConfig config = new JobConfig();
-        String name = "myjobname";
+        String name = "myJobName";
         config.setName(name);
 
         // Then
@@ -67,7 +68,7 @@ public class JobConfigTest {
 
 
     @Test
-    public void when_setProcessingGuarentee_thenReturnsProcessingGuarantee() {
+    public void when_setProcessingGuarantee_thenReturnsProcessingGuarantee() {
         // When
         JobConfig config = new JobConfig();
         config.setProcessingGuarantee(EXACTLY_ONCE);
@@ -170,7 +171,7 @@ public class JobConfigTest {
     }
 
     @Test
-    public void when_addResourceWithPathandId_thenReturnsResourceConfig() throws MalformedURLException {
+    public void when_addResourceWithPathAndId_thenReturnsResourceConfig() throws MalformedURLException {
         // When
         JobConfig config = new JobConfig();
         String path = "/path/to/my.txt";
@@ -210,7 +211,6 @@ public class JobConfigTest {
         assertEquals(file.toURI().toURL(), resourceConfig.getUrl());
         assertEquals("customId", resourceConfig.getId());
     }
-
 
     @Test
     public void when_addResourceWithURL_thenReturnsResourceConfig() throws MalformedURLException {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/LoadResource.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/LoadResource.java
@@ -21,6 +21,8 @@ import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.nio.Address;
+
+import javax.annotation.Nonnull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,12 +33,10 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.annotation.Nonnull;
 
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 public class LoadResource extends AbstractProcessor {
 
@@ -55,7 +55,7 @@ public class LoadResource extends AbstractProcessor {
             readFromStreamAndAssert(resource.openStream());
             readFromStreamAndAssert(resourceAsStream);
         } catch (Exception e) {
-            fail();
+            throw new RuntimeException(e);
         }
         return true;
     }


### PR DESCRIPTION
Also fix `JetClassLoader`: `getResourceAsStream` should delegate to parent
first. Done by removing the method, superclass implementation does it by
using `findResource`