### PR TITLE
[BACKPORT] Optimize snapshot storage (#822)

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -383,6 +383,9 @@ public class Edge implements IdentifiedDataSerializable {
         if (isDistributed()) {
             b.append(".distributed()");
         }
+        if (getPriority() != 0) {
+            b.append(".priority(").append(getPriority()).append(')');
+        }
         return b.toString();
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.jet.Traverser;
+import com.hazelcast.jet.core.AbstractProcessor;
+import com.hazelcast.jet.core.BroadcastKey;
+import com.hazelcast.jet.impl.execution.BroadcastEntry;
+import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl.SnapshotDataValueTerminator;
+import com.hazelcast.nio.BufferObjectDataInput;
+
+import javax.annotation.Nonnull;
+import java.util.Map.Entry;
+
+import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.impl.util.Util.uncheckCall;
+
+public class ExplodeSnapshotP extends AbstractProcessor {
+
+    private FlatMapper<byte[], Object> flatMapper = flatMapper(this::traverser);
+    private InternalSerializationService serializationService;
+
+    @Override
+    protected void init(@Nonnull Context context) {
+        serializationService =
+                ((HazelcastInstanceImpl) context.jetInstance().getHazelcastInstance()).getSerializationService();
+    }
+
+    private Traverser<Object> traverser(byte[] data) {
+        BufferObjectDataInput in = serializationService.createObjectDataInput(data);
+
+        return () -> uncheckCall(() -> {
+            Object key = in.readObject();
+            if (key == SnapshotDataValueTerminator.INSTANCE) {
+                in.close();
+                return null;
+            }
+            Object value = in.readObject();
+            return key instanceof BroadcastKey
+                    ? new BroadcastEntry(key, value)
+                    : entry(key, value);
+        });
+    }
+
+    @Override
+    protected boolean tryProcess0(@Nonnull Object item) throws Exception {
+        return flatMapper.tryProcess(((Entry<Integer, byte[]>) item).getValue());
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SnapshotRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SnapshotRepository.java
@@ -18,10 +18,10 @@ package com.hazelcast.jet.impl;
 
 import com.hazelcast.aggregation.impl.MaxByAggregator;
 import com.hazelcast.core.IMap;
+import com.hazelcast.jet.IMapJet;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.impl.execution.SnapshotRecord;
 import com.hazelcast.jet.impl.execution.SnapshotRecord.SnapshotStatus;
-import com.hazelcast.jet.IMapJet;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.query.Predicate;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/InboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/InboundEdgeStream.java
@@ -17,8 +17,7 @@
 package com.hazelcast.jet.impl.execution;
 
 import com.hazelcast.jet.impl.util.ProgressState;
-
-import java.util.function.Consumer;
+import com.hazelcast.util.function.Predicate;
 
 /**
  * The inbound side of a data stream corresponding to a single DAG edge identified by its ordinal. In the
@@ -31,7 +30,10 @@ public interface InboundEdgeStream {
 
     int priority();
 
-    ProgressState drainTo(Consumer<Object> dest);
+    /**
+     * Passes the items from the queues to the predicate while it returns {@code true}.
+     */
+    ProgressState drainTo(Predicate<Object> dest);
 
     boolean isDone();
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -138,7 +138,7 @@ public class SnapshotContext {
             lastSnapshotId.set(snapshotId);
         } else {
             logger.warning("Snapshot " + snapshotId + " for " + jobAndExecutionId(jobId, executionId) + " is postponed" +
-                    " until all higher priority vertices are completed (number of vertices = "
+                    " until all higher priority vertices are completed (number of such vertices = "
                     + numHigherPriorityTasklets + ')');
             snapshotPostponed = true;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
@@ -18,57 +18,60 @@ package com.hazelcast.jet.impl.execution;
 
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.impl.SnapshotRepository;
-import com.hazelcast.jet.impl.util.AsyncMapWriter;
+import com.hazelcast.jet.impl.util.AsyncSnapshotWriter;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.jet.impl.util.ProgressTracker;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.NodeEngine;
 
 import javax.annotation.Nonnull;
 import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.DONE;
 import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.DRAIN;
 import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.FLUSH;
 import static com.hazelcast.jet.impl.execution.StoreSnapshotTasklet.State.REACHED_BARRIER;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class StoreSnapshotTasklet implements Tasklet {
+
     long pendingSnapshotId;
 
-    private final ProgressTracker progTracker = new ProgressTracker();
+    private final SnapshotContext snapshotContext;
     private final long jobId;
     private final InboundEdgeStream inboundEdgeStream;
-    private final SnapshotContext snapshotContext;
-    private final AsyncMapWriter mapWriter;
-    private final boolean isHigherPrioritySource;
-    private final String vertexName;
     private final ILogger logger;
+    private final String vertexName;
+    private final boolean isHigherPrioritySource;
 
-    private final AtomicInteger numActiveFlushes = new AtomicInteger();
+    private final AsyncSnapshotWriter ssWriter;
+    private final ProgressTracker progTracker = new ProgressTracker();
     private State state = DRAIN;
     private boolean hasReachedBarrier;
-    private boolean inputIsDone;
+    private Entry<Data, Data> pendingEntry;
 
-    public StoreSnapshotTasklet(SnapshotContext snapshotContext, long jobId, InboundEdgeStream inboundEdgeStream,
-                                NodeEngine nodeEngine, String vertexName, boolean isHigherPrioritySource) {
+    public StoreSnapshotTasklet(
+            SnapshotContext snapshotContext,
+            long jobId,
+            InboundEdgeStream inboundEdgeStream,
+            AsyncSnapshotWriter ssWriter,
+            ILogger logger,
+            String vertexName,
+            boolean isHigherPrioritySource
+    ) {
         this.snapshotContext = snapshotContext;
         this.jobId = jobId;
         this.inboundEdgeStream = inboundEdgeStream;
+        this.logger = logger;
         this.vertexName = vertexName;
         this.isHigherPrioritySource = isHigherPrioritySource;
 
-        this.mapWriter = new AsyncMapWriter(nodeEngine);
+        this.ssWriter = ssWriter;
         this.pendingSnapshotId = snapshotContext.lastSnapshotId() + 1;
-        this.mapWriter.setMapName(currMapName());
-        this.logger = nodeEngine.getLogger(StoreSnapshotTasklet.class + "." + vertexName + "#snapshot");
+
+        resetCurrentMap();
     }
 
-    @Nonnull
-    @Override
+    @Nonnull @Override
     public ProgressState call() {
         progTracker.reset();
         stateMachineStep();
@@ -79,6 +82,13 @@ public class StoreSnapshotTasklet implements Tasklet {
         switch (state) {
             case DRAIN:
                 progTracker.notDone();
+                if (pendingEntry != null) {
+                    if (!ssWriter.offer(pendingEntry)) {
+                        return;
+                    }
+                    progTracker.madeProgress();
+                }
+                pendingEntry = null;
                 ProgressState result = inboundEdgeStream.drainTo(o -> {
                     if (o instanceof SnapshotBarrier) {
                         SnapshotBarrier barrier = (SnapshotBarrier) o;
@@ -86,14 +96,21 @@ public class StoreSnapshotTasklet implements Tasklet {
                                 pendingSnapshotId + ", but barrier was " + barrier.snapshotId() + ", this=" + this;
                         hasReachedBarrier = true;
                     } else {
-                        mapWriter.put((Entry<Data, Data>) o);
+                        if (!ssWriter.offer((Entry<Data, Data>) o)) {
+                            pendingEntry = (Entry<Data, Data>) o;
+                            return false;
+                        }
                     }
+                    return true;
                 });
                 if (result.isDone()) {
-                    inputIsDone = true;
+                    assert ssWriter.isEmpty() : "input is done, but we had some entries and not the barrier";
+                    snapshotContext.taskletDone(pendingSnapshotId - 1, isHigherPrioritySource);
+                    state = DONE;
+                    progTracker.reset();
                 }
-                if (result.isMadeProgress()) {
-                    progTracker.madeProgress();
+                progTracker.madeProgress(result.isMadeProgress());
+                if (hasReachedBarrier) {
                     state = FLUSH;
                     stateMachineStep();
                 }
@@ -101,42 +118,34 @@ public class StoreSnapshotTasklet implements Tasklet {
 
             case FLUSH:
                 progTracker.notDone();
-                CompletableFuture<Void> future = new CompletableFuture<>();
-                future.whenComplete(withTryCatch(logger, (r, t) -> {
-                    // this callback may be called from a non-tasklet thread
-                    if (t != null) {
-                        logger.severe("Error writing to snapshot map '" + currMapName() + "'", t);
-                        snapshotContext.reportError(t);
-                    }
-                    // numActiveFlushes must be decremented last otherwise we may miss the error
-                    numActiveFlushes.decrementAndGet();
-                }));
-                if (mapWriter.tryFlushAsync(future)) {
+                if (ssWriter.flush()) {
                     progTracker.madeProgress();
-                    numActiveFlushes.incrementAndGet();
-                    state = inputIsDone ? DONE : hasReachedBarrier ? REACHED_BARRIER : DRAIN;
+                    state = REACHED_BARRIER;
                 }
                 return;
 
             case REACHED_BARRIER:
-                progTracker.notDone();
-                if (numActiveFlushes.get() == 0) {
-                    snapshotContext.snapshotDoneForTasklet();
-                    pendingSnapshotId++;
-                    mapWriter.setMapName(currMapName());
-                    state = inputIsDone ? DONE : DRAIN;
-                    hasReachedBarrier = false;
-                }
-                return;
-
-            case DONE:
-                if (numActiveFlushes.get() != 0) {
+                if (ssWriter.hasPendingAsyncOps()) {
                     progTracker.notDone();
+                    return;
                 }
-                snapshotContext.taskletDone(pendingSnapshotId - 1, isHigherPrioritySource);
+                // check for writing error
+                Throwable error = ssWriter.getError();
+                if (error != null) {
+                    logger.severe("Error writing to snapshot map '" + currMapName() + "'", error);
+                    snapshotContext.reportError(error);
+                }
+                progTracker.madeProgress();
+                snapshotContext.snapshotDoneForTasklet();
+                pendingSnapshotId++;
+                resetCurrentMap();
+                hasReachedBarrier = false;
+                state = DRAIN;
+                progTracker.notDone();
                 return;
 
             default:
+                // note State.DONE also goes here
                 throw new JetException("Unexpected state: " + state);
         }
     }
@@ -145,15 +154,23 @@ public class StoreSnapshotTasklet implements Tasklet {
         return SnapshotRepository.snapshotDataMapName(jobId, pendingSnapshotId, vertexName);
     }
 
+    private void resetCurrentMap() {
+        ssWriter.setCurrentMap(currMapName());
+    }
+
     @Override
     public String toString() {
         return StoreSnapshotTasklet.class.getSimpleName() + '{' + vertexName + '}';
     }
 
     enum State {
+        /** Draining the queue, flushing as necessary. */
         DRAIN,
+        /** Wait until we are able to flush remaining buffers. */
         FLUSH,
+        /** Wait for flushes to complete, then go to {@link #DRAIN} again. */
         REACHED_BARRIER,
+        /** Input is done, terminal state. */
         DONE
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -42,6 +42,7 @@ import com.hazelcast.jet.impl.execution.StoreSnapshotTasklet;
 import com.hazelcast.jet.impl.execution.Tasklet;
 import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
 import com.hazelcast.jet.impl.execution.init.Contexts.ProcSupplierCtx;
+import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
@@ -137,7 +138,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             StoreSnapshotTasklet ssTasklet = new StoreSnapshotTasklet(snapshotContext, jobId,
                     new ConcurrentInboundEdgeStream(ssConveyor, 0, 0, lastSnapshotId, true, -1,
                             "ssFrom:" + vertex.name()),
-                    nodeEngine, vertex.name(), vertex.isHigherPriorityUpstream());
+                    new AsyncSnapshotWriterImpl(nodeEngine), nodeEngine.getLogger(StoreSnapshotTasklet.class),
+                    vertex.name(), vertex.isHigherPriorityUpstream());
             tasklets.add(ssTasklet);
 
             int localProcessorIdx = 0;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
@@ -43,6 +43,7 @@ import com.hazelcast.jet.impl.operation.SnapshotOperation;
 import com.hazelcast.jet.impl.operation.SubmitJobOperation;
 import com.hazelcast.jet.impl.processor.SessionWindowP;
 import com.hazelcast.jet.impl.processor.SnapshotKey;
+import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
@@ -79,6 +80,8 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
     public static final int GET_JOB_SUBMISSION_TIME_OP = 25;
     public static final int GET_JOB_CONFIG_OP = 26;
     public static final int RESTART_JOB_OP = 27;
+    public static final int ASYNC_SNAPSHOT_WRITER_SNAPSHOT_DATA_KEY = 28;
+    public static final int ASYNC_SNAPSHOT_WRITER_SNAPSHOT_DATA_VALUE_TERMINATOR = 29;
 
     public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(JET_IMPL_DS_FACTORY, JET_IMPL_DS_FACTORY_ID);
 
@@ -154,6 +157,10 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
                     return new GetJobConfigOperation();
                 case RESTART_JOB_OP:
                     return new RestartJobOperation();
+                case ASYNC_SNAPSHOT_WRITER_SNAPSHOT_DATA_KEY:
+                    return new AsyncSnapshotWriterImpl.SnapshotDataKey();
+                case ASYNC_SNAPSHOT_WRITER_SNAPSHOT_DATA_VALUE_TERMINATOR:
+                    return AsyncSnapshotWriterImpl.SnapshotDataValueTerminator.INSTANCE;
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/VertexDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/VertexDef.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.jet.core.ProcessorSupplier;
-import com.hazelcast.jet.impl.MasterContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -96,24 +95,18 @@ public class VertexDef implements IdentifiedDataSerializable {
     }
 
     /**
-     * Returns true in any of the following cases:
-     * <ul><li>
-     *     the priority of this vertex is {@link
-     *     MasterContext#SNAPSHOT_RESTORE_EDGE_PRIORITY}
-     * </li><li>
-     *     this vertex is a higher-priority source for some of its downstream
-     *     vertices
-     * </li><li>
-     *     it sits upstream of a vertex that satisfies the above condition
-     * </li></ul>
+     * Returns true in any of the following cases:<ul>
+     *     <li>this vertex is a higher-priority source for some of its
+     *         downstream vertices
+     *     <li>it sits upstream of such a vertex
+     * </ul>
      */
     boolean isHigherPriorityUpstream() {
         for (EdgeDef outboundEdge : outboundEdges) {
             VertexDef downstream = outboundEdge.destVertex();
-            if (outboundEdge.priority() == MasterContext.SNAPSHOT_RESTORE_EDGE_PRIORITY
-                    || downstream.isHigherPriorityUpstream()
-                    || downstream.inboundEdges.stream()
-                                              .anyMatch(edge -> edge.priority() > outboundEdge.priority())) {
+            if (downstream.inboundEdges.stream()
+                                       .anyMatch(edge -> edge.priority() > outboundEdge.priority())
+                    || downstream.isHigherPriorityUpstream()) {
                 return true;
             }
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
@@ -34,6 +34,7 @@ import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratin
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.CollectionUtil;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -47,8 +48,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.Util.entry;
-import static com.hazelcast.jet.impl.util.Util.tryIncrement;
+import static com.hazelcast.jet.impl.JetService.MAX_PARALLEL_ASYNC_OPS;
 import static com.hazelcast.jet.impl.util.Util.callbackOf;
+import static com.hazelcast.jet.impl.util.Util.tryIncrement;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
 
 /**
@@ -56,8 +58,6 @@ import static com.hazelcast.util.CollectionUtil.toIntArray;
  * Not thread-safe.
  */
 public class AsyncMapWriter {
-
-    public static final int MAX_PARALLEL_ASYNC_OPS = 1000;
 
     // These magic values are copied from com.hazelcast.spi.impl.operationservice.impl.InvokeOnPartitions
     private static final int TRY_COUNT = 10;
@@ -83,9 +83,9 @@ public class AsyncMapWriter {
         this.outputBuffers = new MapEntries[partitionService.getPartitionCount()];
         this.serializationService = nodeEngine.getSerializationService();
         this.executionService = nodeEngine.getExecutionService();
-        this.logger = nodeEngine.getLogger(AsyncMapWriter.class);
+        this.logger = nodeEngine.getLogger(getClass());
         JetService jetService = nodeEngine.getService(JetService.SERVICE_NAME);
-        this.numConcurrentOps = jetService.numConcurrentPutAllOps();
+        this.numConcurrentOps = jetService.numConcurrentAsyncOps();
     }
 
     public void put(Map.Entry<Data, Data> entry) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.nio.serialization.Data;
+
+import javax.annotation.CheckReturnValue;
+import java.util.Map.Entry;
+
+public interface AsyncSnapshotWriter {
+    void setCurrentMap(String mapName);
+
+    @CheckReturnValue
+    boolean offer(Entry<? extends Data, ? extends Data> entry);
+
+    @CheckReturnValue
+    boolean flush();
+
+    boolean hasPendingAsyncOps();
+
+    /**
+     * @return any error occurred during writing to underlying map. Error is
+     * reported only once, next call will return {@code null} unless another
+     * error happens.
+     */
+    Throwable getError();
+
+    boolean isEmpty();
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
@@ -1,0 +1,420 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.PartitionAware;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.internal.serialization.impl.SerializationConstants;
+import com.hazelcast.jet.impl.JetService;
+import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Bits;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.partition.IPartitionService;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class AsyncSnapshotWriterImpl implements AsyncSnapshotWriter {
+
+    private static final int MAX_CHUNK_SIZE = 128 * 1024;
+
+    final int usableChunkSize; // this includes the serialization header for byte[], but not the terminator
+    final byte[] serializedByteArrayHeader = new byte[3 * Bits.INT_SIZE_IN_BYTES];
+    final byte[] valueTerminator;
+    final AtomicInteger numConcurrentAsyncOps;
+
+    private final IPartitionService partitionService;
+
+    private final CustomByteArrayOutputStream[] buffers;
+    private final int[] partitionKeys;
+    private final int[] partitionSequences;
+    private final ILogger logger;
+    private final NodeEngine nodeEngine;
+    private final boolean useBigEndian;
+    private IMap<SnapshotDataKey, byte[]> currentMap;
+    private final AtomicReference<Throwable> lastError = new AtomicReference<>();
+    private final AtomicInteger numActiveFlushes = new AtomicInteger();
+
+    // stats
+    private long totalKeys;
+    private long totalChunks;
+    private long totalPayloadBytes;
+
+    private final ExecutionCallback<Void> callback = new ExecutionCallback<Void>() {
+        @Override
+        public void onResponse(Void response) {
+            numActiveFlushes.decrementAndGet();
+            numConcurrentAsyncOps.decrementAndGet();
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            logger.severe("Error writing to snapshot map '" + currentMap.getName() + "'", t);
+            lastError.compareAndSet(null, t);
+            numActiveFlushes.decrementAndGet();
+            numConcurrentAsyncOps.decrementAndGet();
+        }
+    };
+
+    public AsyncSnapshotWriterImpl(NodeEngine nodeEngine) {
+        this(MAX_CHUNK_SIZE, nodeEngine);
+    }
+
+    // for test
+    AsyncSnapshotWriterImpl(int chunkSize, NodeEngine nodeEngine) {
+        this.nodeEngine = nodeEngine;
+        this.partitionService = nodeEngine.getPartitionService();
+        this.logger = nodeEngine.getLogger(getClass());
+
+        useBigEndian = !nodeEngine.getHazelcastInstance().getConfig().getSerializationConfig().isUseNativeByteOrder()
+                || ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+
+        Bits.writeInt(serializedByteArrayHeader, Bits.INT_SIZE_IN_BYTES, SerializationConstants.CONSTANT_TYPE_BYTE_ARRAY,
+                useBigEndian);
+
+        buffers = new CustomByteArrayOutputStream[partitionService.getPartitionCount()];
+        for (int i = 0; i < buffers.length; i++) {
+            buffers[i] = new CustomByteArrayOutputStream(chunkSize);
+            buffers[i].write(serializedByteArrayHeader, 0, serializedByteArrayHeader.length);
+        }
+
+        JetService jetService = nodeEngine.getService(JetService.SERVICE_NAME);
+        this.partitionKeys = jetService.getSharedPartitionKeys();
+        this.partitionSequences = new int[partitionService.getPartitionCount()];
+
+        this.numConcurrentAsyncOps = jetService.numConcurrentAsyncOps();
+
+        byte[] valueTerminatorWithHeader = nodeEngine.getSerializationService().toData(
+                SnapshotDataValueTerminator.INSTANCE).toByteArray();
+        valueTerminator = Arrays.copyOfRange(valueTerminatorWithHeader, HeapData.TYPE_OFFSET,
+                valueTerminatorWithHeader.length);
+        usableChunkSize = chunkSize - valueTerminator.length;
+    }
+
+    @Override
+    public void setCurrentMap(String mapName) {
+        assert isEmpty() : "writer not empty";
+
+        if (currentMap != null && logger.isFineEnabled()) {
+            logger.fine(String.format("Stats for %s: keys=%,d, chunks=%,d, bytes=%,d",
+                    currentMap.getName(), totalKeys, totalChunks, totalPayloadBytes));
+        }
+
+        currentMap = nodeEngine.getHazelcastInstance().getMap(mapName);
+
+        // reset stats
+        totalKeys = totalChunks = totalPayloadBytes = 0;
+    }
+
+    @Override
+    @CheckReturnValue
+    public boolean offer(Entry<? extends Data, ? extends Data> entry) {
+        int partitionId = partitionService.getPartitionId(entry.getKey());
+        int length = entry.getKey().totalSize() + entry.getValue().totalSize() - 2 * HeapData.TYPE_OFFSET;
+
+        // if single entry is larger than usableChunkSize, send it alone. We avoid adding it to the ByteArrayOutputStream,
+        // since it will grow beyond maximum capacity and never shrink again.
+        if (length > usableChunkSize) {
+            return putAsyncToMap(partitionId, () -> {
+                byte[] data = new byte[serializedByteArrayHeader.length + length + valueTerminator.length];
+                int offset = 0;
+                System.arraycopy(serializedByteArrayHeader, 0, data, offset, serializedByteArrayHeader.length);
+                offset += serializedByteArrayHeader.length - Bits.INT_SIZE_IN_BYTES;
+
+                Bits.writeInt(data, offset, length + valueTerminator.length, useBigEndian);
+                offset += Bits.INT_SIZE_IN_BYTES;
+
+                copyWithoutHeader(entry.getKey(), data, offset);
+                offset += entry.getKey().totalSize() - HeapData.TYPE_OFFSET;
+
+                copyWithoutHeader(entry.getValue(), data, offset);
+                System.arraycopy(valueTerminator, 0, data, length, valueTerminator.length);
+
+                return new HeapData(data);
+            });
+        }
+
+        // if the buffer will exceed usableChunkSize after adding this entry, flush it first
+        if (buffers[partitionId].size() + length > usableChunkSize && !flush(partitionId)) {
+            return false;
+        }
+
+        // append to buffer
+        writeWithoutHeader(entry.getKey(), buffers[partitionId]);
+        writeWithoutHeader(entry.getValue(), buffers[partitionId]);
+        totalKeys++;
+        return true;
+    }
+
+    private void copyWithoutHeader(Data src, byte[] dst, int dstOffset) {
+        byte[] bytes = src.toByteArray();
+        System.arraycopy(bytes, HeapData.TYPE_OFFSET, dst, dstOffset, bytes.length - HeapData.TYPE_OFFSET);
+    }
+
+    private void writeWithoutHeader(Data src, OutputStream dst) {
+        byte[] bytes = src.toByteArray();
+        try {
+            dst.write(bytes, HeapData.TYPE_OFFSET, bytes.length - HeapData.TYPE_OFFSET);
+        } catch (IOException e) {
+            throw new RuntimeException(e); // should never happen
+        }
+    }
+
+    @CheckReturnValue
+    private boolean flush(int partitionId) {
+        return containsOnlyHeader(buffers[partitionId])
+                || putAsyncToMap(partitionId, () -> getBufferContentsAndClear(buffers[partitionId]));
+    }
+
+    private boolean containsOnlyHeader(CustomByteArrayOutputStream buffer) {
+        return buffer.size() == serializedByteArrayHeader.length;
+    }
+
+    private Data getBufferContentsAndClear(CustomByteArrayOutputStream buffer) {
+        buffer.write(valueTerminator, 0, valueTerminator.length);
+        final byte[] data = buffer.toByteArray();
+        updateSerializedBytesLength(data);
+        totalPayloadBytes += buffer.size;
+        totalChunks++;
+        buffer.reset();
+        buffer.write(serializedByteArrayHeader, 0, serializedByteArrayHeader.length);
+        return new HeapData(data);
+    }
+
+    private void updateSerializedBytesLength(byte[] data) {
+        // update the array length at the beginning of the buffer
+        // the length is the third int value in the serialized data
+        Bits.writeInt(data, 2 * Bits.INT_SIZE_IN_BYTES, data.length - serializedByteArrayHeader.length, useBigEndian);
+    }
+
+    @CheckReturnValue
+    private boolean putAsyncToMap(int partitionId, Supplier<Data> dataSupplier) {
+        if (!Util.tryIncrement(numConcurrentAsyncOps, 1, JetService.MAX_PARALLEL_ASYNC_OPS)) {
+            return false;
+        }
+
+        // we put a Data instance to the map directly to avoid the serialization of the byte array
+        ICompletableFuture<Void> future = ((IMap) currentMap).setAsync(
+                new SnapshotDataKey(partitionKeys[partitionId], partitionSequences[partitionId]++), dataSupplier.get());
+        future.andThen(callback);
+        numActiveFlushes.incrementAndGet();
+        return true;
+    }
+
+    /**
+     * Flush all partitions.
+     *
+     * @return {@code true} on success, {@code false} if we weren't able to
+     * flush some partitions due to the limit on number of parallel async ops.
+     */
+    @Override
+    @CheckReturnValue
+    public boolean flush() {
+        for (int i = 0; i < buffers.length; i++) {
+            if (!flush(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean hasPendingAsyncOps() {
+        return numActiveFlushes.get() > 0;
+    }
+
+    @Override
+    public Throwable getError() {
+        return lastError.getAndSet(null);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return numActiveFlushes.get() == 0 && Arrays.stream(buffers).allMatch(this::containsOnlyHeader);
+    }
+
+    int partitionKey(int partitionId) {
+        return partitionKeys[partitionId];
+    }
+
+    public static final class SnapshotDataKey implements IdentifiedDataSerializable, PartitionAware {
+        int partitionKey;
+        int sequence;
+
+        // for deserialization
+        public SnapshotDataKey() {
+        }
+
+        SnapshotDataKey(int partitionKey, int sequence) {
+            this.partitionKey = partitionKey;
+            this.sequence = sequence;
+        }
+
+        @Override
+        public Object getPartitionKey() {
+            return partitionKey;
+        }
+
+        @Override
+        public String toString() {
+            return "SnapshotDataKey{partitionKey=" + partitionKey + ", sequence=" + sequence + '}';
+        }
+
+        @Override
+        public int getFactoryId() {
+            return JetInitDataSerializerHook.FACTORY_ID;
+        }
+
+        @Override
+        public int getId() {
+            return JetInitDataSerializerHook.ASYNC_SNAPSHOT_WRITER_SNAPSHOT_DATA_KEY;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeInt(partitionKey);
+            out.writeInt(sequence);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            partitionKey = in.readInt();
+            sequence = in.readInt();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SnapshotDataKey that = (SnapshotDataKey) o;
+            return partitionKey == that.partitionKey &&
+                    sequence == that.sequence;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(partitionKey, sequence);
+        }
+    }
+
+    public static final class SnapshotDataValueTerminator implements IdentifiedDataSerializable {
+
+        public static final IdentifiedDataSerializable INSTANCE = new SnapshotDataValueTerminator();
+
+        private SnapshotDataValueTerminator() { }
+
+        @Override
+        public int getFactoryId() {
+            return JetInitDataSerializerHook.FACTORY_ID;
+        }
+
+        @Override
+        public int getId() {
+            return JetInitDataSerializerHook.ASYNC_SNAPSHOT_WRITER_SNAPSHOT_DATA_VALUE_TERMINATOR;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) {
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) {
+        }
+    }
+
+    /**
+     * Non-synchronized variant of {@code java.io.ByteArrayOutputStream} with capacity limit.
+     */
+    static class CustomByteArrayOutputStream extends OutputStream {
+
+        private static final byte[] EMPTY_BYTE_ARRAY = {};
+
+        private byte[] data;
+        private int size;
+        private int capacityLimit;
+
+        CustomByteArrayOutputStream(int capacityLimit) {
+            this.capacityLimit = capacityLimit;
+            // initial capacity is 0. It will take several reallocations to reach typical capacity,
+            // but it's also common to remain at 0 - for partitions not assigned to us.
+            data = EMPTY_BYTE_ARRAY;
+        }
+
+        @Override
+        public void write(int b) {
+            ensureCapacity(size + 1);
+            data[size] = (byte) b;
+            size++;
+        }
+
+        public void write(@Nonnull byte[] b, int off, int len) {
+            if ((off < 0) || (off > b.length) || (len < 0) || ((off + len) - b.length > 0)) {
+                throw new IndexOutOfBoundsException("off=" + off + ", len=" + len);
+            }
+            ensureCapacity(size + len);
+            System.arraycopy(b, off, data, size, len);
+            size += len;
+        }
+
+        private void ensureCapacity(int minCapacity) {
+            if (minCapacity - data.length > 0) {
+                int newCapacity = data.length;
+                do {
+                    newCapacity = Math.max(1, newCapacity << 1);
+                } while (newCapacity - minCapacity < 0);
+                if (newCapacity - capacityLimit > 0) {
+                    throw new IllegalStateException("buffer full");
+                }
+                data = Arrays.copyOf(data, newCapacity);
+            }
+        }
+
+        void reset() {
+            size = 0;
+        }
+
+        @Nonnull
+        byte[] toByteArray() {
+            return Arrays.copyOf(data, size);
+        }
+
+        int size() {
+            return size;
+        }
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -38,6 +38,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -139,6 +140,7 @@ public final class Util {
      * @param limit maximum value the {@code value} can take (inclusive)
      * @return {@code true}, if successful, {@code false}, if {@code limit} would be exceeded.
      */
+    @CheckReturnValue
     public static boolean tryIncrement(AtomicInteger value, int increment, int limit) {
         int prev;
         int next;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -367,9 +367,8 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
                            .orElse(null);
     }
 
-    // This is a "test of a test" - it checks, that SequencesInPartitionsGeneratorP generates correct output
     @Test
-    @Ignore
+    @Ignore("This is a \"test of a test\" - it checks, that SequencesInPartitionsGeneratorP generates correct output")
     public void test_SequencesInPartitionsGeneratorP() throws Exception {
         SequencesInPartitionsMetaSupplier pms = new SequencesInPartitionsMetaSupplier(3, 2);
         pms.init(new TestProcessorMetaSupplierContext().setLocalParallelism(1).setTotalParallelism(2));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.impl.util.AsyncMapWriter.MAX_PARALLEL_ASYNC_OPS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -128,7 +127,7 @@ public class AsyncMapWriterTest extends JetTestSupport {
     public void when_flushedSeveralTimes_then_doesPut() throws Exception {
         // When
         List<CompletableFuture> futures = new ArrayList<>();
-        for (int i = 0; i < MAX_PARALLEL_ASYNC_OPS; i++) {
+        for (int i = 0; i < JetService.MAX_PARALLEL_ASYNC_OPS; i++) {
             CompletableFuture<Void> future = new CompletableFuture<>();
             writer.put(i, i);
             assertTrue("tryFlushAsync returned false", writer.tryFlushAsync(future));
@@ -137,7 +136,7 @@ public class AsyncMapWriterTest extends JetTestSupport {
 
         // Then
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
-        for (int i = 0; i < MAX_PARALLEL_ASYNC_OPS; i++) {
+        for (int i = 0; i < JetService.MAX_PARALLEL_ASYNC_OPS; i++) {
             assertEquals(i, map.get(i));
         }
     }
@@ -152,12 +151,12 @@ public class AsyncMapWriterTest extends JetTestSupport {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         JetService service = nodeEngine.getService(JetService.SERVICE_NAME);
-        service.numConcurrentPutAllOps().set(MAX_PARALLEL_ASYNC_OPS - NODE_COUNT + 1);
+        service.numConcurrentAsyncOps().set(JetService.MAX_PARALLEL_ASYNC_OPS - NODE_COUNT + 1);
         // When
         boolean flushed = writer.tryFlushAsync(future);
 
         // Then
-        assertFalse("tryFlushAsync should fail", flushed);
+        assertFalse("tryFlushAsync should return false", flushed);
     }
 
     @Test
@@ -167,7 +166,7 @@ public class AsyncMapWriterTest extends JetTestSupport {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         JetService service = nodeEngine.getService(JetService.SERVICE_NAME);
-        service.numConcurrentPutAllOps().set(MAX_PARALLEL_ASYNC_OPS - NODE_COUNT);
+        service.numConcurrentAsyncOps().set(JetService.MAX_PARALLEL_ASYNC_OPS - NODE_COUNT);
         // When
         boolean flushed = writer.tryFlushAsync(future);
         assertTrue("tryFlushAsync returned false", flushed);
@@ -191,7 +190,7 @@ public class AsyncMapWriterTest extends JetTestSupport {
         CompletableFuture<Void> future = new CompletableFuture<>();
 
         JetService service = nodeEngine.getService(JetService.SERVICE_NAME);
-        service.numConcurrentPutAllOps().set(MAX_PARALLEL_ASYNC_OPS - NODE_COUNT);
+        service.numConcurrentAsyncOps().set(JetService.MAX_PARALLEL_ASYNC_OPS - NODE_COUNT);
 
         // When
         boolean flushed = writer.tryFlushAsync(future);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.client.map.helpers.AMapStore;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.impl.JetService;
+import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl.CustomByteArrayOutputStream;
+import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl.SnapshotDataKey;
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Serializable;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.impl.util.Util.uncheckCall;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Stream.generate;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+@Category(QuickTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class AsyncSnapshotWriterImplTest extends JetTestSupport {
+
+    private static final String ALWAYS_FAILING_MAP = "alwaysFailingMap";
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private AsyncSnapshotWriterImpl writer;
+    private IMap<SnapshotDataKey, byte[]> map;
+    private InternalSerializationService serializationService;
+    private InternalPartitionService partitionService;
+
+    @Before
+    public void before() {
+        JetConfig jetConfig = new JetConfig();
+        Config config = jetConfig.getHazelcastConfig();
+        config.getMapConfig(ALWAYS_FAILING_MAP)
+              .getMapStoreConfig()
+              .setEnabled(true)
+              .setImplementation(new AsyncMapWriterTest.AlwaysFailingMapStore());
+
+        JetInstance instance = createJetMember(jetConfig);
+        NodeEngineImpl nodeEngine = ((HazelcastInstanceImpl) instance.getHazelcastInstance()).node.nodeEngine;
+        serializationService = ((HazelcastInstanceImpl) instance.getHazelcastInstance()).getSerializationService();
+        partitionService = nodeEngine.getPartitionService();
+        writer = new AsyncSnapshotWriterImpl(128, nodeEngine);
+        writer.setCurrentMap("map1");
+        map = instance.getHazelcastInstance().getMap("map1");
+        assertTrue(writer.usableChunkSize > 0);
+    }
+
+    @After
+    public void after() {
+        assertTrue(writer.flush());
+        assertTrueEventually(() -> assertFalse(uncheckCall(() -> writer.hasPendingAsyncOps())));
+        assertTrue(writer.isEmpty());
+
+        shutdownFactory();
+    }
+
+    @Test
+    public void when_writeOneKeyAndFlush_then_written() {
+        // When
+        Entry<Data, Data> entry = entry(serialize("k"), serialize("v"));
+        assertTrue(writer.offer(entry));
+        assertTrueAllTheTime(() -> assertTrue(map.isEmpty()), 1);
+        assertFalse(writer.isEmpty());
+        assertTrue(writer.flush());
+
+        // Then
+        assertTargetMapEntry("k", 0, serializedLength(entry));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void when_chunkSizeWouldExceedLimit_then_flushedAutomatically() {
+        // When
+        Entry<Data, Data> entry = entry(serialize("k"), serialize("v"));
+        int entriesInChunk = (writer.usableChunkSize - writer.serializedByteArrayHeader.length) / serializedLength(entry);
+        assertTrue("entriesInChunk=" + entriesInChunk, entriesInChunk > 1 && entriesInChunk < 10);
+
+        for (int i = 0; i < entriesInChunk; i++) {
+            assertTrue(writer.offer(entry));
+        }
+        assertTrueAllTheTime(() ->
+                assertTrue(
+                        map.entrySet().stream()
+                           .map(Entry::toString)
+                           .collect(joining(", ", "[", "]")),
+                        map.isEmpty()), 1);
+        // this entry will cause automatic flush
+        assertTrue(writer.offer(entry));
+
+        // Then
+        assertTargetMapEntry("k", 0, serializedLength(entry) * entriesInChunk);
+        assertFalse(writer.isEmpty());
+
+        // When - try once more
+        for (int i = 1; i < entriesInChunk; i++) {
+            assertTrue(writer.offer(entry));
+        }
+        assertTrueAllTheTime(() -> assertEquals(1, map.size()), 1);
+        // this entry will cause automatic flush
+        assertTrue(writer.offer(entry));
+
+        // Then
+        assertTargetMapEntry("k", 1, serializedLength(entry) * entriesInChunk);
+    }
+
+    @Test
+    public void when_twoPartitions_then_twoEntries() {
+        // When
+        Entry<Data, Data> entry1 = entry(serialize("k"), serialize("v"));
+        Entry<Data, Data> entry2 = entry(serialize("kk"), serialize("vv"));
+        assertTrue(writer.offer(entry1));
+        assertTrue(writer.offer(entry2));
+        assertTrue(writer.flush());
+
+        // Then
+        assertTargetMapEntry("k", 0, serializedLength(entry1));
+        assertTargetMapEntry("kk", 0, serializedLength(entry2));
+    }
+
+    @Test
+    public void when_singleLargeEntry_then_flushedImmediately() {
+        // When
+        Entry<Data, Data> entry = entry(serialize("k"), serialize(generate(() -> "a").limit(128).collect(joining())));
+        assertTrue("entry not longer than usable chunk size", serializedLength(entry) > writer.usableChunkSize);
+        assertTrue(writer.offer(entry));
+
+        // Then
+        assertTargetMapEntry("k", 0, serializedLength(entry));
+    }
+
+    @Test
+    public void when_cannotAutoFlush_then_offerReturnsFalse() {
+        // When
+        // artificially increase number of async ops so that the writer cannot proceed
+        writer.numConcurrentAsyncOps.set(JetService.MAX_PARALLEL_ASYNC_OPS);
+        Entry<Data, Data> entry = entry(serialize("k"), serialize("v"));
+        int entriesInChunk = (writer.usableChunkSize - writer.serializedByteArrayHeader.length) / serializedLength(entry);
+        assertTrue("entriesInChunk=" + entriesInChunk, entriesInChunk > 1 && entriesInChunk < 10);
+        for (int i = 0; i < entriesInChunk; i++) {
+            assertTrue(writer.offer(entry));
+        }
+
+        // Then
+        assertFalse("offer should not have succeeded, too many parallel operations", writer.offer(entry));
+
+        writer.numConcurrentAsyncOps.set(0);
+        assertTrue("offer should have succeeded", writer.offer(entry));
+        assertTargetMapEntry("k", 0, serializedLength(entry) * entriesInChunk);
+    }
+
+    @Test
+    public void when_cannotFlushRemaining_then_returnsFalse() {
+        // When
+        // artificially increase number of async ops so that the writer cannot proceed
+        writer.numConcurrentAsyncOps.set(JetService.MAX_PARALLEL_ASYNC_OPS);
+        Entry<Data, Data> entry1 = entry(serialize("k"), serialize("v"));
+        Entry<Data, Data> entry2 = entry(serialize("kk"), serialize("vv"));
+        assertTrue(writer.offer(entry1));
+        assertTrue(writer.offer(entry2));
+
+        // Then
+        assertFalse(writer.flush());
+        assertTrueAllTheTime(() -> assertTrue(map.isEmpty()), 1);
+
+        // When - release one parallel op - we should be able to flush one buffer, but not the other
+        writer.numConcurrentAsyncOps.decrementAndGet();
+        // Then
+        assertFalse(writer.flush());
+        assertTrueEventually(() -> assertEquals(1, map.size()), 1);
+        assertTrueAllTheTime(() -> assertEquals(1, map.size()), 1);
+
+        // When - release another parallel op - we should be able to flush the remaining buffer
+        writer.numConcurrentAsyncOps.decrementAndGet();
+        // Then
+        assertTrue(writer.flush());
+
+        assertTargetMapEntry("k", 0, serializedLength(entry1));
+        assertTargetMapEntry("kk", 0, serializedLength(entry2));
+    }
+
+    @Test
+    public void when_error_then_reported() {
+        // When
+        writer.setCurrentMap(ALWAYS_FAILING_MAP);
+        Entry<Data, Data> entry = entry(serialize("k"), serialize("v"));
+        assertTrue(writer.offer(entry));
+        assertTrue(writer.flush());
+
+        // Then
+        assertTrueEventually(() ->
+                assertThat(String.valueOf(writer.getError()), CoreMatchers.containsString("Always failing store")), 2);
+    }
+
+    @Test
+    public void test_serializeAndDeserialize() throws Exception {
+        // This is the way we serialize and deserialize objects into the snapshot. We depend on some internals of IMDG:
+        // - using the HeapData.toByteArray() from offset 4
+        // - concatenate them into one array
+        // - read that array with createObjectDataInput(byte[])
+        // Purpose of this test is to check that they didn't change anything...
+
+        Data serialized1 = serializationService.toData("foo");
+        Data serialized2 = serializationService.toData("bar");
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        Stream.of(serialized1, serialized2).forEach(serialized -> {
+            Assert.assertTrue("unexpected class: " + serialized.getClass(), serialized instanceof HeapData);
+            byte[] bytes = serialized.toByteArray();
+            os.write(bytes, HeapData.TYPE_OFFSET, bytes.length - HeapData.TYPE_OFFSET);
+        });
+
+        BufferObjectDataInput in = serializationService.createObjectDataInput(os.toByteArray());
+        Assert.assertEquals("foo", in.readObject());
+        Assert.assertEquals("bar", in.readObject());
+    }
+
+    private void assertTargetMapEntry(String key, int sequence, int entryLength) {
+        int partitionKey = writer.partitionKey(partitionService.getPartitionId(key));
+        SnapshotDataKey mapKey = new SnapshotDataKey(partitionKey, sequence);
+        int entryLengthWithTerminator = entryLength + writer.valueTerminator.length;
+        assertTrueEventually(() ->
+                assertEquals(entryLengthWithTerminator, map.get(mapKey).length), 3);
+    }
+
+    private int serializedLength(Entry<Data, Data> entry) {
+        return entry.getKey().totalSize() + entry.getValue().totalSize() - 8;
+    }
+
+    private Data serialize(String str) {
+        return serializationService.toData(str);
+    }
+
+    public static class AlwaysFailingMapStore extends AMapStore implements Serializable {
+        @Override
+        public void store(Object o, Object o2) {
+            throw new RuntimeException("Always failing store");
+        }
+    }
+
+
+    /* ***********************************/
+    /* CustomByteArrayOutputStream tests */
+    /* ***********************************/
+
+    @Test
+    public void when_bufferExceeded_then_thrown() {
+        // Given
+        CustomByteArrayOutputStream os = new CustomByteArrayOutputStream(4);
+        os.write(1);
+        os.write(1);
+        os.write(1);
+        os.write(1);
+
+        // Then
+        exception.expect(RuntimeException.class);
+        // When
+        os.write(1);
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/MockAsyncSnapshotWriter.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/MockAsyncSnapshotWriter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map.Entry;
+
+public class MockAsyncSnapshotWriter implements AsyncSnapshotWriter {
+
+    public boolean ableToOffer = true;
+    public boolean ableToFlushRemaining = true;
+    public boolean hasPendingFlushes;
+    public Throwable failure;
+
+    private final Deque<Entry<? extends Data, ? extends Data>> entries = new ArrayDeque<>();
+    private boolean isFlushed = true;
+
+    @Override
+    public void setCurrentMap(String mapName) {
+    }
+
+    @Override
+    public boolean offer(Entry<? extends Data, ? extends Data> entry) {
+        if (!ableToOffer) {
+            return false;
+        }
+        entries.add(entry);
+        isFlushed = false;
+        return true;
+    }
+
+    @Override
+    public boolean flush() {
+        if (ableToFlushRemaining) {
+            hasPendingFlushes = !isFlushed;
+            isFlushed = true;
+        }
+        return ableToFlushRemaining;
+    }
+
+    @Override
+    public boolean hasPendingAsyncOps() {
+        return hasPendingFlushes;
+    }
+
+    @Override
+    public Throwable getError() {
+        try {
+            return failure;
+        } finally {
+            failure = null;
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return isFlushed && !hasPendingFlushes;
+    }
+
+    public Entry<? extends Data, ? extends Data> poll() {
+        return entries.poll();
+    }
+}


### PR DESCRIPTION
Store the snapshot in 128kB chunks, not as individual entries. The 
previous implementation suffered from the IMap overhead of about 168 
bytes per entry so the main advantage is reduced heap usage. It also 
gives about 25% speedup in snapshot duration and reduces event latency 
hiccup while snapshot is taken.