### PR TITLE
Fix SinkBuilder destroy before create, javadoc [backport of #826]

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
@@ -57,6 +57,10 @@ public interface Job {
 
     /**
      * Returns the time when the job was submitted to the cluster.
+     * <p>
+     * The time is assigned by reading {@code System.currentTimeMillis()} of
+     * the master member that executes the job for the first time. It doesn't
+     * change on restart.
      */
     long getSubmissionTime();
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.function.DistributedBiConsumer;
 import com.hazelcast.jet.function.DistributedConsumer;
@@ -28,27 +29,10 @@ import com.hazelcast.util.Preconditions;
 
 import javax.annotation.Nonnull;
 
-import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
 
 /**
- * Offers a step-by-step fluent API to build a custom {@link Sink} for the
- * Pipeline API. It allows you to keep a single-threaded, stateful writer
- * object in each instance of a Jet worker dedicated to driving the sink.
- * Its primary intended purpose is to serve as the holder of references to
- * external resources and optional buffers. These are the callback
- * functions you can provide to implement the sink's behavior:
- * <ol><li>
- *     {@code createFn} creates the writer. Gets the local Jet instance as
- *     argument. This component is required.
- * </li><li>
- *     {@code onReceiveFn} gets notified of each item the sink receives and
- *     (typically) passes it to the writer. This component is required.
- * </li><li>
- *     {@code flushFn} flushes the writer. This component is optional.
- * </li><li>
- *     {@code destroyFn} destroys the writer. This component is optional.
- * </li></ol>
+ * See {@link Sinks#builder(DistributedFunction)}.
  *
  * @param <W> type of the writer object
  * @param <T> type of the items the sink will accept
@@ -60,6 +44,9 @@ public final class SinkBuilder<W, T> {
     private DistributedConsumer<? super W> flushFn = noopConsumer();
     private DistributedConsumer<? super W> destroyFn = noopConsumer();
 
+    /**
+     * Use {@link Sinks#builder(DistributedFunction)}.
+     */
     SinkBuilder(@Nonnull DistributedFunction<? super JetInstance, ? extends W> createFn) {
         this.createFn = createFn;
     }
@@ -128,6 +115,6 @@ public final class SinkBuilder<W, T> {
                 flushFn,
                 destroyFn
         );
-        return new SinkImpl<>("custom-sink", preferLocalParallelismOne(supplier));
+        return new SinkImpl<>("custom-sink", ProcessorMetaSupplier.of(supplier, 2));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -567,11 +567,32 @@ public final class Sinks {
     }
 
     /**
-     * Returns a builder object that offers a step-by-step fluent API to build a
-     * custom sink. The argument is a factory function for the writer object the
-     * sink will delegate to for all operations.
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom {@link Sink} for the Pipeline API. It allows you to keep a
+     * single-threaded, stateful writer object in each instance of a Jet worker
+     * dedicated to driving the sink. Its primary intended purpose is to serve
+     * as the holder of references to external resources and optional buffers.
+     * Keep in mind that only the writer object may be stateful; the functions
+     * you provide must hold no mutable state of their own.
+     * <p>
+     * These are the callback functions you can provide to implement the sink's
+     * behavior:
+     * <ol><li>
+     *     {@code createFn} creates the writer. Gets the local Jet instance as
+     *     argument. It will be called once for each worker thread. This
+     *     component is required.
+     * </li><li>
+     *     {@code onReceiveFn} gets notified of each item the sink receives and
+     *     (typically) passes it to the writer. This component is required.
+     * </li><li>
+     *     {@code flushFn} flushes the writer. This component is optional.
+     * </li><li>
+     *     {@code destroyFn} destroys the writer. This component is optional.
+     * </li></ol>
+     * The returned sink will be non-cooperative and will have preferred local
+     * parallelism of 2. It also cannot participate in state snapshot saving
+     * (fault-tolerance): it will behave as an at-least-once sink.
      *
-     * @param createFn function that creates the internal writer object
      * @param <W> type of the writer object
      * @param <T> type of the items the sink will accept
      */

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
@@ -114,7 +114,7 @@ public class WriteBufferedPTest extends JetTestSupport {
         return SinkProcessors.writeBufferedP(
                 idx -> {
                     events.add("new");
-                    return null;
+                    return "foo";
                 },
                 (buffer, item) -> events.add("add:" + item),
                 buffer -> events.add("flush"),


### PR DESCRIPTION
`Processor.close` can be called even if `Processor.init` wasn't called:
avoid `destroyFn` call if `createFn` wasn't called.

Also change default local parallelism to 2.