### PR TITLE
Fix JobRestartWithSnapshotTest

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
@@ -72,9 +72,10 @@ public class AsyncSnapshotWriterImpl implements AsyncSnapshotWriter {
     private long totalChunks;
     private long totalPayloadBytes;
 
-    private final ExecutionCallback<Void> callback = new ExecutionCallback<Void>() {
+    private final ExecutionCallback<Object> callback = new ExecutionCallback<Object>() {
         @Override
-        public void onResponse(Void response) {
+        public void onResponse(Object response) {
+            assert response == null : "put operation overwrote a previous value: " + response;
             numActiveFlushes.decrementAndGet();
             numConcurrentAsyncOps.decrementAndGet();
         }
@@ -227,7 +228,7 @@ public class AsyncSnapshotWriterImpl implements AsyncSnapshotWriter {
         }
 
         // we put a Data instance to the map directly to avoid the serialization of the byte array
-        ICompletableFuture<Void> future = ((IMap) currentMap).setAsync(
+        ICompletableFuture<Object> future = ((IMap) currentMap).putAsync(
                 new SnapshotDataKey(partitionKeys[partitionId], partitionSequence), dataSupplier.get());
         partitionSequence += memberCount;
         future.andThen(callback);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SnapshotFailureTest.java
@@ -91,7 +91,7 @@ public class SnapshotFailureTest extends JetTestSupport {
         IMapJet<Object, Object> results = instance1.getMap("results");
 
         DAG dag = new DAG();
-        SequencesInPartitionsMetaSupplier sup = new SequencesInPartitionsMetaSupplier(numPartitions, numElements);
+        SequencesInPartitionsMetaSupplier sup = new SequencesInPartitionsMetaSupplier(numPartitions, numElements, false);
         Vertex generator = dag.newVertex("generator", peekOutputP(throttle(sup, 2)))
                               .localParallelism(1);
         Vertex writeMap = dag.newVertex("writeMap", writeMapP(results.getName())).localParallelism(1);


### PR DESCRIPTION
The batch source (SequencesInPartitionsGeneratorP) finished before the
last snapshot before the restart took place.

Also: use `putAsync` in `AsyncSnapshotWriter` instead of `setAsync` and
assert that the old value is `null`. Will help us to discover if we
overwrite keys.

Fixes #846