### PR TITLE
Fix race when snapshot started after job was done

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -552,10 +552,13 @@ public class MasterContext {
             logger.warning(String.format("Execution of %s failed after %,d ms", jobIdString(), elapsed), failure);
         }
 
+        JobStatus status = isSuccess(failure) ? COMPLETED : FAILED;
+        jobStatus.set(status);
+
         try {
             coordinationService.completeJob(this, executionId, System.currentTimeMillis(), failure);
         } catch (RuntimeException e) {
-            logger.warning("Completion of " + jobIdString() + " failed", failure);
+            logger.warning("Completion of " + jobIdString() + " failed", e);
         } finally {
             setFinalResult(failure);
         }
@@ -594,8 +597,6 @@ public class MasterContext {
     }
 
     void setFinalResult(Throwable failure) {
-        JobStatus status = isSuccess(failure) ? COMPLETED : FAILED;
-        jobStatus.set(status);
         if (failure == null) {
             completionFuture.internalComplete();
         } else {


### PR DESCRIPTION
Fixes this scenario: the job completes (normaly or abruptly). It deletes
snapshot maps and then it marks CompletionFuture in MasterContext as
done.

In parallel, scheduled snapshot is about to start by calling
`JobCoordinationService.beginSnapshot`. It checks whether the
MasterContext is done. It sees it is not, so it goes to generate
snapshotId by looking at `LATEST_STARTED_SNAPSHOT_ID_KEY`, but it's null
since the map was deleted in parallel. So it starts the snapshot 0.

The `SnapshotOperation` will be rejected on members, but it recreates
the maps, which causes the maps to leak and the test to fail.

The fix reorders operations in `MasterContext.finalizeJob`: it first
completes the future and then goes on to delete maps.

Fixes #865