### PR TITLE
Improve WM coalescing logging in CIES

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -74,6 +74,7 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
         receivedBarriers = new BitSet(conveyor.queueCount());
         pendingSnapshotId = lastSnapshotId + 1;
         logger = Logger.getLogger(ConcurrentInboundEdgeStream.class.getName() + "." + debugName);
+        logger.finest("Coalescing " + conveyor.queueCount() + " input queues");
     }
 
     @Override
@@ -119,8 +120,8 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
                 long wmTimestamp = ((Watermark) itemDetector.item).timestamp();
                 boolean forwarded = maybeEmitWm(watermarkCoalescer.observeWm(now, queueIndex, wmTimestamp), dest);
                 if (logger.isFinestEnabled()) {
-                    logger.finest("Received " + itemDetector.item + " from queue " + queueIndex + '/'
-                            + conveyor.queueCount() + (forwarded ? ", forwarded" : ", not forwarded"));
+                    logger.finest("Received " + itemDetector.item + " from queue " + queueIndex
+                            + (forwarded ? ", forwarded" : ", not forwarded"));
                 }
                 if (forwarded) {
                     return MADE_PROGRESS;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -173,7 +173,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                 // createOutboundEdgeStreams() populates localConveyorMap and edgeSenderConveyorMap.
                 // Also populates instance fields: senderMap, receiverMap, tasklets.
                 List<OutboundEdgeStream> outboundStreams = createOutboundEdgeStreams(vertex, localProcessorIdx);
-                List<InboundEdgeStream> inboundStreams = createInboundEdgeStreams(vertex, localProcessorIdx);
+                List<InboundEdgeStream> inboundStreams =
+                        createInboundEdgeStreams(vertex, localProcessorIdx, globalProcessorIndex);
 
                 OutboundCollector snapshotCollector = new ConveyorCollector(ssConveyor, localProcessorIdx, null);
 
@@ -469,13 +470,14 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         return service.getJetInstance().getConfig();
     }
 
-    private List<InboundEdgeStream> createInboundEdgeStreams(VertexDef srcVertex, int processorIdx) {
+    private List<InboundEdgeStream> createInboundEdgeStreams(VertexDef srcVertex, int localProcessorIdx,
+                                                             int globalProcessorIdx) {
         final List<InboundEdgeStream> inboundStreams = new ArrayList<>();
         for (EdgeDef inEdge : srcVertex.inboundEdges()) {
             // each tasklet has one input conveyor per edge
-            final ConcurrentConveyor<Object> conveyor = localConveyorMap.get(inEdge.edgeId())[processorIdx];
+            final ConcurrentConveyor<Object> conveyor = localConveyorMap.get(inEdge.edgeId())[localProcessorIdx];
             inboundStreams.add(newEdgeStream(inEdge, conveyor,
-                    "inputTo:" + inEdge.destVertex().name() + '#' + processorIdx));
+                    "inputTo:" + inEdge.destVertex().name() + '#' + globalProcessorIdx));
         }
         return inboundStreams;
     }


### PR DESCRIPTION
- remove confusing queue count after `/`
- use global processor index in `debugName`