### PR TITLE
Convert argument of SinkBuilder createFn to Processor.Context

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.pipeline;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
+import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.function.DistributedBiConsumer;
 import com.hazelcast.jet.function.DistributedBiFunction;
@@ -30,7 +31,6 @@ import com.hazelcast.util.Preconditions;
 import javax.annotation.Nonnull;
 
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
-import static com.hazelcast.util.Preconditions.checkPositive;
 
 /**
  * See {@link Sinks#builder(DistributedBiFunction)}.
@@ -108,7 +108,7 @@ public final class SinkBuilder<W, T> {
      */
     @Nonnull
     public SinkBuilder<W, T> preferredLocalParallelism(int preferredLocalParallelism) {
-        checkPositive(preferredLocalParallelism, "Preferred local parallelism should be a positive number");
+        Vertex.checkLocalParallelism(preferredLocalParallelism);
         this.preferredLocalParallelism = preferredLocalParallelism;
         return this;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
@@ -30,6 +30,7 @@ import com.hazelcast.util.Preconditions;
 import javax.annotation.Nonnull;
 
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
+import static com.hazelcast.util.Preconditions.checkPositive;
 
 /**
  * See {@link Sinks#builder(DistributedBiFunction)}.
@@ -43,6 +44,7 @@ public final class SinkBuilder<W, T> {
     private DistributedBiConsumer<? super W, ? super T> onReceiveFn;
     private DistributedConsumer<? super W> flushFn = noopConsumer();
     private DistributedConsumer<? super W> destroyFn = noopConsumer();
+    private int preferredLocalParallelism = 2;
 
     /**
      * Use {@link Sinks#builder(DistributedBiFunction)}.
@@ -100,6 +102,18 @@ public final class SinkBuilder<W, T> {
     }
 
     /**
+     * Sets the local parallelism of the sink, default value is {@code 2}
+     *
+     * @param preferredLocalParallelism the local parallelism of the sink
+     */
+    @Nonnull
+    public SinkBuilder<W, T> preferredLocalParallelism(int preferredLocalParallelism) {
+        checkPositive(preferredLocalParallelism, "Preferred local parallelism should be a positive number");
+        this.preferredLocalParallelism = preferredLocalParallelism;
+        return this;
+    }
+
+    /**
      * Creates and returns the {@link Sink} with the components you supplied to
      * this builder.
      */
@@ -115,6 +129,6 @@ public final class SinkBuilder<W, T> {
                 flushFn,
                 destroyFn
         );
-        return new SinkImpl<>("custom-sink", ProcessorMetaSupplier.of(supplier, 2));
+        return new SinkImpl<>("custom-sink", ProcessorMetaSupplier.of(supplier, preferredLocalParallelism));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.Offloadable;
-import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.function.DistributedBiConsumer;
@@ -589,9 +589,10 @@ public final class Sinks {
      * These are the callback functions you can provide to implement the sink's
      * behavior:
      * <ol><li>
-     *     {@code createFn} creates the writer. Gets the local Jet instance and
-     *     global processor index as argument. It will be called once for each
-     *     worker thread. This component is required.
+     *     {@code createFn} creates the writer. Gets the processor context as
+     *     argument which can be used to obtain local Jet instance, global
+     *     processor index etc. It will be called once for each worker thread.
+     *     This component is required.
      * </li><li>
      *     {@code onReceiveFn} gets notified of each item the sink receives and
      *     (typically) passes it to the writer. This component is required.
@@ -609,7 +610,7 @@ public final class Sinks {
      */
     @Nonnull
     public static <W, T> SinkBuilder<W, T> builder(
-            @Nonnull DistributedBiFunction<? super JetInstance, Integer, ? extends W> createFn
+            @Nonnull DistributedFunction<Processor.Context, ? extends W> createFn
     ) {
         return new SinkBuilder<>(createFn);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -589,9 +589,9 @@ public final class Sinks {
      * These are the callback functions you can provide to implement the sink's
      * behavior:
      * <ol><li>
-     *     {@code createFn} creates the writer. Gets the local Jet instance as
-     *     argument. It will be called once for each worker thread. This
-     *     component is required.
+     *     {@code createFn} creates the writer. Gets the local Jet instance and
+     *     global processor index as argument. It will be called once for each
+     *     worker thread. This component is required.
      * </li><li>
      *     {@code onReceiveFn} gets notified of each item the sink receives and
      *     (typically) passes it to the writer. This component is required.
@@ -609,7 +609,7 @@ public final class Sinks {
      */
     @Nonnull
     public static <W, T> SinkBuilder<W, T> builder(
-            @Nonnull DistributedFunction<? super JetInstance, ? extends W> createFn
+            @Nonnull DistributedBiFunction<? super JetInstance, Integer, ? extends W> createFn
     ) {
         return new SinkBuilder<>(createFn);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinkBuilderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinkBuilderTest.java
@@ -101,7 +101,7 @@ public class SinkBuilderTest extends PipelineTestSupport {
     }
 
     private Sink<Integer> buildRandomFileSink(String listName) {
-        return Sinks.<File, Integer>builder((instance) ->
+        return Sinks.<File, Integer>builder((instance, index) ->
                 uncheckCall(() -> {
                     File directory = createTempDirectory();
                     File file = new File(directory, randomName());
@@ -116,7 +116,7 @@ public class SinkBuilderTest extends PipelineTestSupport {
 
     private Sink<Integer> buildSocketSink(int localPort) {
         return Sinks.<BufferedWriter, Integer>builder(
-                (jetInstance) -> uncheckCall(() -> getSocketWriter(localPort))
+                (jetInstance, index) -> uncheckCall(() -> getSocketWriter(localPort))
         ).onReceiveFn((s, item) -> uncheckRun(() -> s.append((char) item.intValue()).append('\n')))
          .flushFn(s -> uncheckRun(s::flush))
          .destroyFn(s -> uncheckRun(s::close))

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinkBuilderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinkBuilderTest.java
@@ -101,12 +101,12 @@ public class SinkBuilderTest extends PipelineTestSupport {
     }
 
     private Sink<Integer> buildRandomFileSink(String listName) {
-        return Sinks.<File, Integer>builder((instance, index) ->
+        return Sinks.<File, Integer>builder(context ->
                 uncheckCall(() -> {
                     File directory = createTempDirectory();
                     File file = new File(directory, randomName());
                     assertTrue(file.createNewFile());
-                    instance.getList(listName).add(directory.toPath().toString());
+                    context.jetInstance().getList(listName).add(directory.toPath().toString());
                     return file;
                 }))
                 .onReceiveFn((sink, item) -> uncheckRun(() -> {
@@ -115,12 +115,11 @@ public class SinkBuilderTest extends PipelineTestSupport {
     }
 
     private Sink<Integer> buildSocketSink(int localPort) {
-        return Sinks.<BufferedWriter, Integer>builder(
-                (jetInstance, index) -> uncheckCall(() -> getSocketWriter(localPort))
-        ).onReceiveFn((s, item) -> uncheckRun(() -> s.append((char) item.intValue()).append('\n')))
-         .flushFn(s -> uncheckRun(s::flush))
-         .destroyFn(s -> uncheckRun(s::close))
-         .build();
+        return Sinks.<BufferedWriter, Integer>builder(context -> uncheckCall(() -> getSocketWriter(localPort)))
+                .onReceiveFn((s, item) -> uncheckRun(() -> s.append((char) item.intValue()).append('\n')))
+                .flushFn(s -> uncheckRun(s::flush))
+                .destroyFn(s -> uncheckRun(s::close))
+                .build();
     }
 
     private static BufferedWriter getSocketWriter(int localPort) throws IOException {


### PR DESCRIPTION
Also add `preferredLocalParallelism` option to `SinkBuilder`
fixes https://github.com/hazelcast/hazelcast-jet/issues/884