### PR TITLE
Simplify JMS builder APIs

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -35,7 +35,6 @@ import com.hazelcast.map.EntryProcessor;
 
 import javax.annotation.Nonnull;
 import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
 import javax.jms.Message;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
@@ -311,10 +310,7 @@ public final class SinkProcessors {
     }
 
     /**
-     * Returns a supplier of processors for {@link
-     * Sinks#jmsQueue(DistributedSupplier, DistributedFunction,
-     * DistributedBiFunction, DistributedBiConsumer, DistributedConsumer,
-     * String)}.
+     * Returns a supplier of processors for {@link Sinks#jmsQueueBuilder}.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeJmsQueueP(
@@ -329,22 +325,7 @@ public final class SinkProcessors {
     }
 
     /**
-     * Returns a supplier of processors for {@link
-     * Sinks#jmsQueue(DistributedSupplier, String)}.
-     */
-    @Nonnull
-    public static ProcessorMetaSupplier writeJmsQueueP(
-            @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
-            @Nonnull String name
-    ) {
-        return WriteJmsP.supplier(factorySupplier, name, false);
-    }
-
-    /**
-     * Returns a supplier of processors for {@link
-     * Sinks#jmsTopic(DistributedSupplier, DistributedFunction,
-     * DistributedBiFunction, DistributedBiConsumer, DistributedConsumer,
-     * String)}.
+     * Returns a supplier of processors for {@link Sinks#jmsTopicBuilder}.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeJmsTopicP(
@@ -356,17 +337,5 @@ public final class SinkProcessors {
             @Nonnull String name
     ) {
         return WriteJmsP.supplier(connectionSupplier, sessionF, messageFn, sendFn, flushFn, name, true);
-    }
-
-    /**
-     * Returns a supplier of processors for {@link
-     * Sinks#jmsTopic(DistributedSupplier, String)}.
-     */
-    @Nonnull
-    public static ProcessorMetaSupplier writeJmsTopicP(
-            @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
-            @Nonnull String name
-    ) {
-        return WriteJmsP.supplier(factorySupplier, name, true);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -40,7 +40,6 @@ import com.hazelcast.query.Predicate;
 
 import javax.annotation.Nonnull;
 import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
@@ -338,9 +337,7 @@ public final class SourceProcessors {
     }
 
     /**
-     * Returns a supplier of processors for
-     * {@link Sources#jmsQueue(DistributedSupplier, DistributedFunction,
-     * DistributedFunction, DistributedConsumer, DistributedFunction)}.
+     * Returns a supplier of processors for {@link Sources#jmsQueueBuilder}.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier streamJmsQueueP(
@@ -356,23 +353,7 @@ public final class SourceProcessors {
     }
 
     /**
-     * Returns a supplier of processors for
-     * {@link Sources#jmsQueue(DistributedSupplier, String)}.
-     */
-    @Nonnull
-    public static ProcessorMetaSupplier streamJmsQueueP(
-            @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
-            @Nonnull String name
-    ) {
-        return ProcessorMetaSupplier.of(
-                StreamJmsP.supplier(factorySupplier, name, true),
-                StreamJmsP.PREFERRED_LOCAL_PARALLELISM);
-    }
-
-    /**
-     * Returns a supplier of processors for
-     * {@link Sources#jmsTopic(DistributedSupplier, DistributedFunction,
-     * DistributedFunction, DistributedConsumer, DistributedFunction)}.
+     * Returns a supplier of processors for {@link Sources#jmsTopicBuilder}.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier streamJmsTopicP(
@@ -384,18 +365,6 @@ public final class SourceProcessors {
     ) {
         return ProcessorMetaSupplier.forceTotalParallelismOne(
                 StreamJmsP.supplier(connectionSupplier, sessionFn, consumerFn, flushFn, projectionFn));
-    }
-
-    /**
-     * Returns a supplier of processors for
-     * {@link Sources#jmsTopic(DistributedSupplier, String)}.
-     */
-    @Nonnull
-    public static ProcessorMetaSupplier streamJmsTopicP(
-            @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
-            @Nonnull String name
-    ) {
-        return ProcessorMetaSupplier.forceTotalParallelismOne(StreamJmsP.supplier(factorySupplier, name, false));
     }
 
     private static <I, O> Projection<I, O> toProjection(DistributedFunction<I, O> projectionFn) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamJmsP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamJmsP.java
@@ -27,16 +27,12 @@ import com.hazelcast.jet.function.DistributedSupplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
-import javax.jms.Destination;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
-import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static java.util.stream.IntStream.range;
@@ -91,29 +87,6 @@ public class StreamJmsP<T> extends AbstractProcessor {
             @Nonnull DistributedFunction<Message, T> projectionFn
     ) {
         return new Supplier<>(connectionSupplier, sessionFn, consumerFn, flushFn, projectionFn);
-    }
-
-    /**
-     * Private API. Use {@link
-     * com.hazelcast.jet.core.processor.SourceProcessors#streamJmsQueueP} or
-     * {@link com.hazelcast.jet.core.processor.SourceProcessors#streamJmsTopicP}
-     * instead.
-     */
-    @Nonnull
-    public static ProcessorSupplier supplier(
-            @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
-            @Nonnull String name,
-            boolean isQueue
-    ) {
-        return supplier(
-                () -> uncheckCall(() -> factorySupplier.get().createConnection()),
-                connection -> uncheckCall(() -> connection.createSession(false, Session.AUTO_ACKNOWLEDGE)),
-                session -> uncheckCall(() -> {
-                    Destination destination = isQueue ? session.createQueue(name) : session.createTopic(name);
-                    return session.createConsumer(destination);
-                }),
-                noopConsumer(), wholeItem()
-        );
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteJmsP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteJmsP.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedSupplier;
 
 import javax.jms.Connection;
-import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.Message;
 import javax.jms.MessageProducer;
@@ -35,7 +34,6 @@ import java.util.Collection;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeBufferedP;
-import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static java.util.stream.Collectors.toList;
@@ -70,23 +68,6 @@ public final class WriteJmsP {
         return ProcessorMetaSupplier.of(
                 new Supplier<>(connectionSupplier, sessionF, messageFn, sendFn, flushFn, name, isTopic),
                 PREFERRED_LOCAL_PARALLELISM);
-    }
-
-    /**
-     * Private API. Use {@link
-     * com.hazelcast.jet.core.processor.SinkProcessors#writeJmsQueueP} or
-     * {@link com.hazelcast.jet.core.processor.SinkProcessors#writeJmsTopicP}
-     * instead
-     */
-    public static ProcessorMetaSupplier supplier(DistributedSupplier<ConnectionFactory> factorySupplier,
-                                                 String name, boolean isTopic) {
-        return supplier(
-                () -> uncheckCall(() -> factorySupplier.get().createConnection()),
-                connection -> uncheckCall(() -> connection.createSession(false, Session.AUTO_ACKNOWLEDGE)),
-                (session, item) -> uncheckCall(() -> session.createTextMessage(item.toString())),
-                (producer, message) -> uncheckRun(() -> producer.send(message)),
-                noopConsumer(), name, isTopic
-        );
     }
 
     private static final class Supplier<T> implements ProcessorSupplier {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
@@ -130,7 +130,8 @@ public final class JmsSinkBuilder<T> {
      * Sets the function which creates the message from the item.
      * <p>
      * If not provided, the builder creates a function which wraps {@code
-     * item.toString()} into a {@link javax.jms.TextMessage}.
+     * item.toString()} into a {@link javax.jms.TextMessage}, unless the item
+     * is already an instance of {@code javax.jms.Message}.
      */
     public JmsSinkBuilder<T> messageFn(DistributedBiFunction<Session, T, Message> messageFn) {
         this.messageFn = messageFn;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
@@ -37,13 +37,14 @@ import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
- * See {@link JmsSinkBuilder#builder(DistributedSupplier)}
+ * See {@link Sinks#jmsQueueBuilder} or {@link Sinks#jmsTopicBuilder}.
  *
  * @param <T> type of the items the sink accepts
  */
 public final class JmsSinkBuilder<T> {
 
     private final DistributedSupplier<ConnectionFactory> factorySupplier;
+    private final boolean isTopic;
 
     private DistributedFunction<ConnectionFactory, Connection> connectionFn;
     private DistributedFunction<Connection, Session> sessionFn;
@@ -56,57 +57,13 @@ public final class JmsSinkBuilder<T> {
     private boolean transacted;
     private int acknowledgeMode = Session.AUTO_ACKNOWLEDGE;
     private String destinationName;
-    private boolean isTopic;
 
     /**
-     * Use {@link JmsSinkBuilder#builder(DistributedSupplier)}.
+     * Use {@link Sinks#jmsQueueBuilder} or {@link Sinks#jmsTopicBuilder}.
      */
-    private JmsSinkBuilder(@Nonnull DistributedSupplier<ConnectionFactory> factorySupplier) {
+    JmsSinkBuilder(@Nonnull DistributedSupplier<ConnectionFactory> factorySupplier, boolean isTopic) {
         this.factorySupplier = factorySupplier;
-    }
-
-    /**
-     * Returns a builder object that offers a step-by-step fluent API to build
-     * a custom JMS {@link StreamSource} for the Pipeline API.
-     * <p>
-     * These are the callback functions you can provide to implement the sink's
-     * behavior:
-     * <ol><li>
-     *     {@code factorySupplier} creates the connection factory. This
-     *     component is required.
-     * </li><li>
-     *     {@code destinationName} sets the name of the destination. This
-     *     component is required.
-     * </li><li>
-     *     {@code connectionFn} creates the connection. This component is
-     *     optional; if not provided, the builder creates a function which uses
-     *     {@code ConnectionFactory#createConnection(username, password)} to
-     *     create the connection. See {@link #connectionParams(String, String)}.
-     * </li><li>
-     *     {@code sessionFn} creates the session. This component is optional;
-     *     if not provided, the builder creates a function which uses {@code
-     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
-     *     to create the session. See {@link #sessionParams(boolean, int)}.
-     * </li><li>
-     *     {@code messageFn} creates the message from the item. This component is
-     *     optional; if not provided, the builder creates a function that wraps {@code
-     *     item.toString()} into a {@link javax.jms.TextMessage}.
-     * </li><li>
-     *     {@code sendFn} sends the message via message producer. This component
-     *     is optional; if not provided, the builder creates a function which sends
-     *     the message using {@code MessageProducer#send(Message message)}.
-     * </li><li>
-     *     {@code flushFn} flushes the session. This component is optional; if
-     *     not provided, the builder creates a no-op consumer.
-     * </li><li>
-     *     {@code topic} sets that the destination is a topic. This call is
-     *     optional; if not called, the builder treats the destination as a queue.
-     * </li></ol>
-     *
-     * @param <T> type of the items the source emits
-     */
-    public static <T> JmsSinkBuilder<T> builder(@Nonnull DistributedSupplier<ConnectionFactory> factorySupplier) {
-        return new JmsSinkBuilder<>(factorySupplier);
+        this.isTopic = isTopic;
     }
 
     /**
@@ -170,15 +127,6 @@ public final class JmsSinkBuilder<T> {
     }
 
     /**
-     * Sets that the destination is a topic. If not called, the destination
-     * will be treated as a queue.
-     */
-    public JmsSinkBuilder<T> topic() {
-        this.isTopic = true;
-        return this;
-    }
-
-    /**
      * Sets the function which creates the message from the item.
      * <p>
      * If not provided, the builder creates a function which wraps {@code
@@ -228,7 +176,8 @@ public final class JmsSinkBuilder<T> {
             sessionFn = connection -> uncheckCall(() -> connection.createSession(transactedLocal, acknowledgeModeLocal));
         }
         if (messageFn == null) {
-            messageFn = (session, item) -> uncheckCall(() -> session.createTextMessage(item.toString()));
+            messageFn = (session, item) -> uncheckCall(() ->
+                    item instanceof Message ? (Message) item : session.createTextMessage(item.toString()));
         }
         if (sendFn == null) {
             sendFn = (producer, message) -> uncheckRun(() -> producer.send(message));
@@ -245,8 +194,6 @@ public final class JmsSinkBuilder<T> {
     }
 
     private String sinkName() {
-        return String.format("jms%s(%s)", isTopic ? "Topic" : "Queue", destinationName);
+        return String.format("jms%sSink(%s)", isTopic ? "Topic" : "Queue", destinationName);
     }
-
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -637,43 +637,6 @@ public final class Sinks {
     /**
      * Returns a builder object that offers a step-by-step fluent API to build
      * a custom JMS queue sink for the Pipeline API.
-     * <p>
-     * These are the callback functions you can provide to implement the sink's
-     * behavior:
-     * <ol><li>
-     *     {@code factorySupplier} creates the connection factory. This
-     *     component is required.
-     * </li><li>
-     *     {@code destinationName} sets the name of the destination. This
-     *     component is required.
-     * </li><li>
-     *     {@code connectionFn} creates the connection. This component is
-     *     optional; if not provided, the builder creates a function which uses
-     *     {@code ConnectionFactory#createConnection(username, password)} to
-     *     create the connection. See {@link
-     *     JmsSinkBuilder#connectionParams(String, String)}.
-     * </li><li>
-     *     {@code sessionFn} creates the session. This component is optional;
-     *     if not provided, the builder creates a function which uses {@code
-     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
-     *     to create the session. See {@link
-     *     JmsSinkBuilder#sessionParams(boolean, int)}.
-     * </li><li>
-     *     {@code messageFn} creates the message from the item. This component is
-     *     optional; if not provided, the builder creates a function that wraps {@code
-     *     item.toString()} into a {@link javax.jms.TextMessage}, unless the item is
-     *     an instance of {@code javax.jms.Message}.
-     * </li><li>
-     *     {@code sendFn} sends the message via message producer. This component
-     *     is optional; if not provided, the builder creates a function which sends
-     *     the message using {@code MessageProducer#send(Message message)}.
-     * </li><li>
-     *     {@code flushFn} flushes the session. This component is optional; if
-     *     not provided, the builder creates a no-op consumer.
-     * </li><li>
-     *     {@code topic} sets that the destination is a topic. This call is
-     *     optional; if not called, the builder treats the destination as a queue.
-     * </li></ol>
      *
      * @param <T> type of the items the sink accepts
      */
@@ -705,43 +668,6 @@ public final class Sinks {
     /**
      * Returns a builder object that offers a step-by-step fluent API to build
      * a custom JMS topic sink for the Pipeline API.
-     * <p>
-     * These are the callback functions you can provide to implement the sink's
-     * behavior:
-     * <ol><li>
-     *     {@code factorySupplier} creates the connection factory. This
-     *     component is required.
-     * </li><li>
-     *     {@code destinationName} sets the name of the destination. This
-     *     component is required.
-     * </li><li>
-     *     {@code connectionFn} creates the connection. This component is
-     *     optional; if not provided, the builder creates a function which uses
-     *     {@code ConnectionFactory#createConnection(username, password)} to
-     *     create the connection. See {@link
-     *     JmsSinkBuilder#connectionParams(String, String)}.
-     * </li><li>
-     *     {@code sessionFn} creates the session. This component is optional;
-     *     if not provided, the builder creates a function which uses {@code
-     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
-     *     to create the session. See {@link
-     *     JmsSinkBuilder#sessionParams(boolean, int)}.
-     * </li><li>
-     *     {@code messageFn} creates the message from the item. This component is
-     *     optional; if not provided, the builder creates a function that wraps {@code
-     *     item.toString()} into a {@link javax.jms.TextMessage}, unless the item is
-     *     an instance of {@code javax.jms.Message}.
-     * </li><li>
-     *     {@code sendFn} sends the message via message producer. This component
-     *     is optional; if not provided, the builder creates a function which sends
-     *     the message using {@code MessageProducer#send(Message message)}.
-     * </li><li>
-     *     {@code flushFn} flushes the session. This component is optional; if
-     *     not provided, the builder creates a no-op consumer.
-     * </li><li>
-     *     {@code topic} sets that the destination is a topic. This call is
-     *     optional; if not called, the builder treats the destination as a queue.
-     * </li></ol>
      *
      * @param <T> type of the items the sink accepts
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -20,30 +20,21 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.Offloadable;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
-import com.hazelcast.jet.core.processor.SinkProcessors;
-import com.hazelcast.jet.function.DistributedBiConsumer;
 import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.function.DistributedBinaryOperator;
-import com.hazelcast.jet.function.DistributedConsumer;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.jet.impl.pipeline.SinkImpl;
 import com.hazelcast.map.EntryProcessor;
 
 import javax.annotation.Nonnull;
-import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
-import javax.jms.Message;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
 import java.nio.charset.Charset;
 import java.util.Map;
 
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.writeLoggerP;
 import static com.hazelcast.jet.core.processor.Processors.noopP;
-import static com.hazelcast.jet.core.processor.SinkProcessors.writeJmsQueueP;
-import static com.hazelcast.jet.core.processor.SinkProcessors.writeJmsTopicP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.mergeMapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.mergeRemoteMapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.updateMapP;
@@ -624,57 +615,11 @@ public final class Sinks {
     }
 
     /**
-     * Returns a sink which connects to a JMS provider and sends messages to the
-     * specified JMS queue.
-     * <p>
-     * Sink creates a single connection for each member using the given {@code
-     * connectionSupplier} and then creates a session and producer for each
-     * {@link com.hazelcast.jet.core.Processor processor} using the given
-     * {@code sessionFn} and {@code name}.
-     * <p>
-     * Sink converts an item to a {@link Message} using the given {@code
-     * messageFn} and sends this message using the given {@code sendFn}. After
-     * a batch of messages is sent, sink flushes the session using the given
-     * {@code flushFn}.
-     * <p>
-     * Behavior on job restart: the processor is stateless. If the job is
-     * restarted, duplicate events can occur. If you need exactly-once behavior,
-     * you must ensure idempotence on the application level.
-     * <p>
-     * IO failures are generally handled by JMS provider and do not cause the
-     * processor to fail. Most of the providers offer a configuration parameter
-     * to enable auto-reconnection, refer to provider documentation for details.
-     * <p>
-     * Default local parallelism for this processor is 4 (or less if less CPUs
-     * are available).
-     *
-     * @param connectionSupplier supplier to obtain connection to the JMS provider
-     * @param sessionF           function to create session from the JMS connection
-     * @param messageFn          function to create message from the item
-     * @param sendFn             function to send the message to JMS queue
-     * @param flushFn            function to commit the session for transacted sessions
-     * @param name               the name of the queue
-     */
-    @Nonnull
-    public static <T> Sink<T> jmsQueue(
-            @Nonnull DistributedSupplier<Connection> connectionSupplier,
-            @Nonnull DistributedFunction<Connection, Session> sessionF,
-            @Nonnull DistributedBiFunction<Session, T, Message> messageFn,
-            @Nonnull DistributedBiConsumer<MessageProducer, Message> sendFn,
-            @Nonnull DistributedConsumer<Session> flushFn,
-            @Nonnull String name
-    ) {
-        return fromProcessor("jmsQueueSink(" + name + ")",
-                SinkProcessors.writeJmsQueueP(connectionSupplier, sessionF, messageFn, sendFn, flushFn, name));
-    }
-
-    /**
-     * Convenience for {@link #jmsQueue(DistributedSupplier,
-     * DistributedFunction, DistributedBiFunction, DistributedBiConsumer,
-     * DistributedConsumer, String)}. Sink creates a connection without any
-     * authentication parameters and uses non-transacted sessions with {@code
-     * Session.AUTO_ACKNOWLEDGE} mode. Sink wraps {@code item.toString()} into
-     * a {@link javax.jms.TextMessage}
+     * Convenience for {@link #jmsQueueBuilder(DistributedSupplier)}. Creates a
+     * connection without any authentication parameters and uses non-transacted
+     * sessions with {@code Session.AUTO_ACKNOWLEDGE} mode. If a received item
+     * is not an instance of {@code javax.jms.Message}, the sink wraps {@code
+     * item.toString()} into a {@link javax.jms.TextMessage}.
      *
      * @param factorySupplier supplier to obtain JMS connection factory
      * @param name            the name of the queue
@@ -684,61 +629,65 @@ public final class Sinks {
             @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
             @Nonnull String name
     ) {
-        return fromProcessor("jmsQueueSink(" + name + ")", writeJmsQueueP(factorySupplier, name));
+        return Sinks.<T>jmsQueueBuilder(factorySupplier)
+                .destinationName(name)
+                .build();
     }
 
     /**
-     * Returns a sink which connects to a JMS provider and sends messages to the
-     * specified JMS topic.
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom JMS queue sink for the Pipeline API.
      * <p>
-     * Sink creates a single connection for each member using the given {@code
-     * connectionSupplier} and then creates a session and producer for each
-     * {@link com.hazelcast.jet.core.Processor processor} using the given
-     * {@code sessionFn} and {@code name}.
-     * <p>
-     * Sink converts an item to a {@link Message} using the given {@code
-     * messageFn} and sends this message using the given {@code sendFn}. After
-     * a batch of messages is sent, sink flushes the session using the given
-     * {@code flushFn}.
-     * <p>
-     * Behavior on job restart: the processor is stateless. If the job is
-     * restarted, duplicate events can occur. If you need exactly-once behavior,
-     * you must ensure idempotence on the application level.
-     * <p>
-     * IO failures are generally handled by JMS provider and do not cause the
-     * processor to fail. Most of the providers offer a configuration parameter
-     * to enable auto-reconnection, refer to provider documentation for details.
-     * <p>
-     * Default local parallelism for this processor is 4 (or less if less CPUs
-     * are available).
+     * These are the callback functions you can provide to implement the sink's
+     * behavior:
+     * <ol><li>
+     *     {@code factorySupplier} creates the connection factory. This
+     *     component is required.
+     * </li><li>
+     *     {@code destinationName} sets the name of the destination. This
+     *     component is required.
+     * </li><li>
+     *     {@code connectionFn} creates the connection. This component is
+     *     optional; if not provided, the builder creates a function which uses
+     *     {@code ConnectionFactory#createConnection(username, password)} to
+     *     create the connection. See {@link
+     *     JmsSinkBuilder#connectionParams(String, String)}.
+     * </li><li>
+     *     {@code sessionFn} creates the session. This component is optional;
+     *     if not provided, the builder creates a function which uses {@code
+     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
+     *     to create the session. See {@link
+     *     JmsSinkBuilder#sessionParams(boolean, int)}.
+     * </li><li>
+     *     {@code messageFn} creates the message from the item. This component is
+     *     optional; if not provided, the builder creates a function that wraps {@code
+     *     item.toString()} into a {@link javax.jms.TextMessage}, unless the item is
+     *     an instance of {@code javax.jms.Message}.
+     * </li><li>
+     *     {@code sendFn} sends the message via message producer. This component
+     *     is optional; if not provided, the builder creates a function which sends
+     *     the message using {@code MessageProducer#send(Message message)}.
+     * </li><li>
+     *     {@code flushFn} flushes the session. This component is optional; if
+     *     not provided, the builder creates a no-op consumer.
+     * </li><li>
+     *     {@code topic} sets that the destination is a topic. This call is
+     *     optional; if not called, the builder treats the destination as a queue.
+     * </li></ol>
      *
-     * @param connectionSupplier supplier to obtain connection to the JMS provider
-     * @param sessionF           function to create session from the JMS connection
-     * @param messageFn          function to create message from the item
-     * @param sendFn             function to send the message to JMS queue
-     * @param flushFn            function to commit the session for transacted sessions
-     * @param name               the name of the topic
+     * @param <T> type of the items the sink accepts
      */
     @Nonnull
-    public static <T> Sink<T> jmsTopic(
-            @Nonnull DistributedSupplier<Connection> connectionSupplier,
-            @Nonnull DistributedFunction<Connection, Session> sessionF,
-            @Nonnull DistributedBiFunction<Session, T, Message> messageFn,
-            @Nonnull DistributedBiConsumer<MessageProducer, Message> sendFn,
-            @Nonnull DistributedConsumer<Session> flushFn,
-            @Nonnull String name
-    ) {
-        return fromProcessor("jmsTopicSink(" + name + ")",
-                SinkProcessors.writeJmsTopicP(connectionSupplier, sessionF, messageFn, sendFn, flushFn, name));
+    public static <T> JmsSinkBuilder<T> jmsQueueBuilder(DistributedSupplier<ConnectionFactory> factorySupplier) {
+        return new JmsSinkBuilder<>(factorySupplier, false);
     }
 
     /**
-     * Convenience for {@link #jmsTopic(DistributedSupplier,
-     * DistributedFunction, DistributedBiFunction, DistributedBiConsumer,
-     * DistributedConsumer, String)}. Sink creates a connection without any
-     * authentication parameters and uses non-transacted sessions with {@code
-     * Session.AUTO_ACKNOWLEDGE} mode. Sink wraps {@code item.toString()} into
-     * a {@link javax.jms.TextMessage}
+     * Convenience for {@link #jmsTopicBuilder(DistributedSupplier)}. Creates a
+     * connection without any authentication parameters and uses non-transacted
+     * sessions with {@code Session.AUTO_ACKNOWLEDGE} mode. If a received item
+     * is not an instance of {@code javax.jms.Message}, the sink wraps {@code
+     * item.toString()} into a {@link javax.jms.TextMessage}.
      *
      * @param factorySupplier supplier to obtain JMS connection factory
      * @param name            the name of the queue
@@ -748,7 +697,56 @@ public final class Sinks {
             @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
             @Nonnull String name
     ) {
-        return fromProcessor("jmsTopicSink(" + name + ")", writeJmsTopicP(factorySupplier, name));
+        return Sinks.<T>jmsTopicBuilder(factorySupplier)
+                .destinationName(name)
+                .build();
     }
 
+    /**
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom JMS topic sink for the Pipeline API.
+     * <p>
+     * These are the callback functions you can provide to implement the sink's
+     * behavior:
+     * <ol><li>
+     *     {@code factorySupplier} creates the connection factory. This
+     *     component is required.
+     * </li><li>
+     *     {@code destinationName} sets the name of the destination. This
+     *     component is required.
+     * </li><li>
+     *     {@code connectionFn} creates the connection. This component is
+     *     optional; if not provided, the builder creates a function which uses
+     *     {@code ConnectionFactory#createConnection(username, password)} to
+     *     create the connection. See {@link
+     *     JmsSinkBuilder#connectionParams(String, String)}.
+     * </li><li>
+     *     {@code sessionFn} creates the session. This component is optional;
+     *     if not provided, the builder creates a function which uses {@code
+     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
+     *     to create the session. See {@link
+     *     JmsSinkBuilder#sessionParams(boolean, int)}.
+     * </li><li>
+     *     {@code messageFn} creates the message from the item. This component is
+     *     optional; if not provided, the builder creates a function that wraps {@code
+     *     item.toString()} into a {@link javax.jms.TextMessage}, unless the item is
+     *     an instance of {@code javax.jms.Message}.
+     * </li><li>
+     *     {@code sendFn} sends the message via message producer. This component
+     *     is optional; if not provided, the builder creates a function which sends
+     *     the message using {@code MessageProducer#send(Message message)}.
+     * </li><li>
+     *     {@code flushFn} flushes the session. This component is optional; if
+     *     not provided, the builder creates a no-op consumer.
+     * </li><li>
+     *     {@code topic} sets that the destination is a topic. This call is
+     *     optional; if not called, the builder treats the destination as a queue.
+     * </li></ol>
+     *
+     * @param <T> type of the items the sink accepts
+     */
+    @Nonnull
+    public static <T> JmsSinkBuilder<T> jmsTopicBuilder(DistributedSupplier<ConnectionFactory> factorySupplier) {
+        return new JmsSinkBuilder<>(factorySupplier, true);
+    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -868,36 +868,6 @@ public final class Sources {
     /**
      * Returns a builder object that offers a step-by-step fluent API to build
      * a custom JMS {@link StreamSource} for the Pipeline API.
-     * <p>
-     * These are the callback functions you can provide to implement the
-     * sources's behavior:
-     * <ol><li>
-     *     {@code factorySupplier} creates the connection factory. This
-     *     component is required.
-     * </li><li>
-     *     {@code connectionFn} creates the connection. This component is
-     *     optional; if not provided, the builder creates a function which uses
-     *     {@code ConnectionFactory#createConnection(username, password)} to
-     *     create the connection. See {@link JmsSourceBuilder#connectionParams}.
-     * </li><li>
-     *     {@code sessionFn} creates the session. This component is optional;
-     *     if not provided, the builder creates a function which uses {@code
-     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
-     *     to create the session. See {@link JmsSourceBuilder#sessionParams}.
-     * </li><li>
-     *     {@code consumerFn} creates the message consumer. This component is
-     *     optional; if not provided, the builder creates a function which uses
-     *     {@code Session#createConsumer(Destination destination)} to create the
-     *     consumer. Either {@code consumerFn} or {@code destinationName} should
-     *     be set. See {@link JmsSourceBuilder#destinationName(String)}.
-     * </li><li>
-     *     {@code projectionFn} creates the output object from a {@code Message}.
-     *     This component is optional; if not provided, identity function is
-     *     used instead.
-     * </li><li>
-     *     {@code flushFn} flushes the session. This component is optional; if
-     *     not provided builder creates a no-op consumer.
-     * </li></ol>
      *
      * @param <T> type of the items the source emits
      */
@@ -928,36 +898,6 @@ public final class Sources {
     /**
      * Returns a builder object that offers a step-by-step fluent API to build
      * a custom JMS {@link StreamSource} for the Pipeline API.
-     * <p>
-     * These are the callback functions you can provide to implement the
-     * sources's behavior:
-     * <ol><li>
-     *     {@code factorySupplier} creates the connection factory. This
-     *     component is required.
-     * </li><li>
-     *     {@code connectionFn} creates the connection. This component is
-     *     optional; if not provided, the builder creates a function which uses
-     *     {@code ConnectionFactory#createConnection(username, password)} to
-     *     create the connection. See {@link JmsSourceBuilder#connectionParams}.
-     * </li><li>
-     *     {@code sessionFn} creates the session. This component is optional;
-     *     if not provided, the builder creates a function which uses {@code
-     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
-     *     to create the session. See {@link JmsSourceBuilder#sessionParams}.
-     * </li><li>
-     *     {@code consumerFn} creates the message consumer. This component is
-     *     optional; if not provided, the builder creates a function which uses
-     *     {@code Session#createConsumer(Destination destination)} to create the
-     *     consumer. Either {@code consumerFn} or {@code destinationName} should
-     *     be set. See {@link JmsSourceBuilder#destinationName(String)}.
-     * </li><li>
-     *     {@code projectionFn} creates the output object from a {@code Message}.
-     *     This component is optional; if not provided, identity function is
-     *     used instead.
-     * </li><li>
-     *     {@code flushFn} flushes the session. This component is optional; if
-     *     not provided builder creates a no-op consumer.
-     * </li></ol>
      *
      * @param <T> type of the items the source emits
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.Util;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.WatermarkGenerationParams;
 import com.hazelcast.jet.function.DistributedBiFunction;
-import com.hazelcast.jet.function.DistributedConsumer;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedPredicate;
 import com.hazelcast.jet.function.DistributedSupplier;
@@ -34,11 +33,8 @@ import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicate;
 
 import javax.annotation.Nonnull;
-import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.Session;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Map;
@@ -58,8 +54,6 @@ import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteListP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamCacheP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamFilesP;
-import static com.hazelcast.jet.core.processor.SourceProcessors.streamJmsQueueP;
-import static com.hazelcast.jet.core.processor.SourceProcessors.streamJmsTopicP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamRemoteCacheP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamRemoteMapP;
@@ -853,60 +847,10 @@ public final class Sources {
     }
 
     /**
-     * Returns a source which connects to a JMS provider and consumes messages
-     * from the JMS queue using given message consumer. The source emits output
-     * objects created by given {@code projectionFn}.
-     * <p>
-     * The source creates a single connection for each member using the given
-     * {@code connectionSupplier} and then creates a session and consumer for
-     * each {@link com.hazelcast.jet.core.Processor processor} using the given
-     * {@code sessionFn} and {@code consumerFn}.
-     * <p>
-     * One may create a consumer for a topic instead of a queue in {@code
-     * consumerFn}. In that case each processor consumes the same messages and
-     * there will be duplicates. {@link #jmsTopic jmsTopic(...)} should be used
-     * instead.
-     * <p>
-     * After consuming each message, {@code flushFn} is called to commit the
-     * session.
-     * <p>
-     * The source does not save any state to snapshot. The source starts
-     * emitting items where it left from.
-     * <p>
-     * IO failures are generally handled by JMS provider and do not cause the
-     * processor to fail. Most of the providers offer a configuration parameter
-     * to enable auto-reconnection, refer to provider documentation for details.
-     * <p>
-     * Default local parallelism for this processor is 4 (or less if less CPUs
-     * are available).
-     *
-     * @param connectionSupplier supplier to obtain connection to the JMS provider
-     * @param sessionFn          function to create session from the JMS connection
-     * @param consumerFn         function to create consumer from the JMS session
-     * @param flushFn            function to commit the session for transacted sessions
-     * @param projectionFn       function to create output objects from the JMS message
-     *                           If the projection returns a {@code null} for a message,
-     *                           that message will be filtered out.
-     */
-    @Nonnull
-    public static <T> StreamSource<T> jmsQueue(
-            @Nonnull DistributedSupplier<Connection> connectionSupplier,
-            @Nonnull DistributedFunction<Connection, Session> sessionFn,
-            @Nonnull DistributedFunction<Session, MessageConsumer> consumerFn,
-            @Nonnull DistributedConsumer<Session> flushFn,
-            @Nonnull DistributedFunction<Message, T> projectionFn
-    ) {
-        return streamFromProcessor("jmsQueueSource",
-                streamJmsQueueP(connectionSupplier, sessionFn, consumerFn, flushFn, projectionFn));
-    }
-
-    /**
-     * Convenience for {@link #jmsQueue(DistributedSupplier,
-     * DistributedFunction, DistributedFunction, DistributedConsumer,
-     * DistributedFunction)}. This version creates a connection without any
-     * authentication parameters and uses non-transacted sessions with {@code
-     * Session.AUTO_ACKNOWLEDGE} mode. JMS {@link Message} objects are emitted
-     * to downstream.
+     * Convenience for {@link #jmsQueueBuilder(DistributedSupplier)}. This
+     * version creates a connection without any authentication parameters and
+     * uses non-transacted sessions with {@code Session.AUTO_ACKNOWLEDGE} mode.
+     * JMS {@link Message} objects are emitted to downstream.
      *
      * @param factorySupplier supplier to obtain JMS connection factory
      * @param name            the name of the queue
@@ -916,61 +860,57 @@ public final class Sources {
             @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
             @Nonnull String name
     ) {
-        return streamFromProcessor("jmsQueueSource(" + name + ")", streamJmsQueueP(factorySupplier, name));
+        return Sources.<Message>jmsQueueBuilder(factorySupplier)
+                .destinationName(name)
+                .build();
     }
 
     /**
-     * Returns a source which connects to a JMS provider and consumes messages
-     * from the JMS topic using given message consumer. The source emits output
-     * objects created by given {@code projectionFn}.
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom JMS {@link StreamSource} for the Pipeline API.
      * <p>
-     * Topic is a non-distributed source, if messages are consumed by multiple
-     * consumers, all of them will get the same messages. Therefore the source
-     * operates on a single member and with local parallelism of 1. Setting
-     * local parallelism to a value other than 1 causes {@code
-     * IllegalArgumentException}.
-     * <p>
-     * After consuming each message, {@code flushFn} is called to commit the
-     * session.
-     * <p>
-     * The source does not save any state to snapshot. Behavior of job restart
-     * changes according to the consumer. If it is a durable consumer and a
-     * unique client identifier is set for the connection then JMS provider
-     * persists items during restart and the source starts where it left from.
-     * If the consumer is non-durable then source emits the items published
-     * after the restart.
-     * <p>
-     * IO failures are generally handled by JMS provider and do not cause the
-     * processor to fail. Most of the providers offer a configuration parameter
-     * to enable auto-reconnection, refer to provider documentation for details.
+     * These are the callback functions you can provide to implement the
+     * sources's behavior:
+     * <ol><li>
+     *     {@code factorySupplier} creates the connection factory. This
+     *     component is required.
+     * </li><li>
+     *     {@code connectionFn} creates the connection. This component is
+     *     optional; if not provided, the builder creates a function which uses
+     *     {@code ConnectionFactory#createConnection(username, password)} to
+     *     create the connection. See {@link JmsSourceBuilder#connectionParams}.
+     * </li><li>
+     *     {@code sessionFn} creates the session. This component is optional;
+     *     if not provided, the builder creates a function which uses {@code
+     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
+     *     to create the session. See {@link JmsSourceBuilder#sessionParams}.
+     * </li><li>
+     *     {@code consumerFn} creates the message consumer. This component is
+     *     optional; if not provided, the builder creates a function which uses
+     *     {@code Session#createConsumer(Destination destination)} to create the
+     *     consumer. Either {@code consumerFn} or {@code destinationName} should
+     *     be set. See {@link JmsSourceBuilder#destinationName(String)}.
+     * </li><li>
+     *     {@code projectionFn} creates the output object from a {@code Message}.
+     *     This component is optional; if not provided, identity function is
+     *     used instead.
+     * </li><li>
+     *     {@code flushFn} flushes the session. This component is optional; if
+     *     not provided builder creates a no-op consumer.
+     * </li></ol>
      *
-     * @param connectionSupplier supplier to obtain connection to the JMS provider
-     * @param sessionFn          function to create session from the JMS connection
-     * @param consumerFn         function to create consumer from the JMS session
-     * @param flushFn            function to commit the session for transacted sessions
-     * @param projectionFn       function to create output objects from the JMS message
-     *                           If the projection returns a {@code null} for a message,
-     *                           that message will be filtered out.
+     * @param <T> type of the items the source emits
      */
     @Nonnull
-    public static <T> StreamSource<T> jmsTopic(
-            @Nonnull DistributedSupplier<Connection> connectionSupplier,
-            @Nonnull DistributedFunction<Connection, Session> sessionFn,
-            @Nonnull DistributedFunction<Session, MessageConsumer> consumerFn,
-            @Nonnull DistributedConsumer<Session> flushFn,
-            @Nonnull DistributedFunction<Message, T> projectionFn
-    ) {
-        return streamFromProcessor("jmsTopicSource",
-                streamJmsTopicP(connectionSupplier, sessionFn, consumerFn, flushFn, projectionFn));
+    public static <T> JmsSourceBuilder<T> jmsQueueBuilder(DistributedSupplier<ConnectionFactory> factorySupplier) {
+        return new JmsSourceBuilder<>(factorySupplier, false);
     }
 
     /**
-     * Convenience for {@link #jmsTopic(DistributedSupplier,
-     * DistributedFunction, DistributedFunction, DistributedConsumer,
-     * DistributedFunction)}. This version creates a connection without any
-     * authentication parameters and uses non-transacted sessions with {@code
-     * Session.AUTO_ACKNOWLEDGE} mode. JMS {@link Message} objects are emitted
-     * to downstream.
+     * Convenience for {@link #jmsTopicBuilder(DistributedSupplier)}. This
+     * version creates a connection without any authentication parameters and
+     * uses non-transacted sessions with {@code Session.AUTO_ACKNOWLEDGE} mode.
+     * JMS {@link Message} objects are emitted to downstream.
      *
      * @param factorySupplier supplier to obtain JMS connection factory
      * @param name            the name of the topic
@@ -980,6 +920,49 @@ public final class Sources {
             @Nonnull DistributedSupplier<ConnectionFactory> factorySupplier,
             @Nonnull String name
     ) {
-        return streamFromProcessor("jmsTopicSource(" + name + ")", streamJmsTopicP(factorySupplier, name));
+        return Sources.<Message>jmsTopicBuilder(factorySupplier)
+                .destinationName(name)
+                .build();
+    }
+
+    /**
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom JMS {@link StreamSource} for the Pipeline API.
+     * <p>
+     * These are the callback functions you can provide to implement the
+     * sources's behavior:
+     * <ol><li>
+     *     {@code factorySupplier} creates the connection factory. This
+     *     component is required.
+     * </li><li>
+     *     {@code connectionFn} creates the connection. This component is
+     *     optional; if not provided, the builder creates a function which uses
+     *     {@code ConnectionFactory#createConnection(username, password)} to
+     *     create the connection. See {@link JmsSourceBuilder#connectionParams}.
+     * </li><li>
+     *     {@code sessionFn} creates the session. This component is optional;
+     *     if not provided, the builder creates a function which uses {@code
+     *     Connection#createSession(boolean transacted, int acknowledgeMode)}
+     *     to create the session. See {@link JmsSourceBuilder#sessionParams}.
+     * </li><li>
+     *     {@code consumerFn} creates the message consumer. This component is
+     *     optional; if not provided, the builder creates a function which uses
+     *     {@code Session#createConsumer(Destination destination)} to create the
+     *     consumer. Either {@code consumerFn} or {@code destinationName} should
+     *     be set. See {@link JmsSourceBuilder#destinationName(String)}.
+     * </li><li>
+     *     {@code projectionFn} creates the output object from a {@code Message}.
+     *     This component is optional; if not provided, identity function is
+     *     used instead.
+     * </li><li>
+     *     {@code flushFn} flushes the session. This component is optional; if
+     *     not provided builder creates a no-op consumer.
+     * </li></ol>
+     *
+     * @param <T> type of the items the source emits
+     */
+    @Nonnull
+    public static <T> JmsSourceBuilder<T> jmsTopicBuilder(DistributedSupplier<ConnectionFactory> factorySupplier) {
+        return new JmsSourceBuilder<>(factorySupplier, true);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest.java
@@ -24,8 +24,6 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
-import com.hazelcast.jet.pipeline.JmsSinkBuilder;
-import com.hazelcast.jet.pipeline.JmsSourceBuilder;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
@@ -149,7 +147,7 @@ public class JmsIntegrationTest extends JetTestSupport {
 
     @Test
     public void sourceQueue_withBuilder() {
-        StreamSource<String> source = JmsSourceBuilder.<String>builder(() -> broker.createConnectionFactory())
+        StreamSource<String> source = Sources.<String>jmsQueueBuilder(() -> broker.createConnectionFactory())
                 .destinationName(destinationName)
                 .projectionFn(TEXT_MESSAGE_FN)
                 .build();
@@ -168,9 +166,8 @@ public class JmsIntegrationTest extends JetTestSupport {
 
     @Test
     public void sourceTopic_withBuilder() {
-        StreamSource<String> source = JmsSourceBuilder.<String>builder(() -> broker.createConnectionFactory())
+        StreamSource<String> source = Sources.<String>jmsTopicBuilder(() -> broker.createConnectionFactory())
                 .destinationName(destinationName)
-                .topic()
                 .projectionFn(TEXT_MESSAGE_FN)
                 .build();
 
@@ -191,7 +188,7 @@ public class JmsIntegrationTest extends JetTestSupport {
     public void sinkQueue_withBuilder() throws JMSException {
         populateList();
 
-        Sink<String> sink = JmsSinkBuilder.<String>builder(() -> broker.createConnectionFactory())
+        Sink<String> sink = Sinks.<String>jmsQueueBuilder(() -> broker.createConnectionFactory())
                 .destinationName(destinationName)
                 .build();
 
@@ -210,9 +207,8 @@ public class JmsIntegrationTest extends JetTestSupport {
     public void sinkTopic_withBuilder() throws JMSException {
         populateList();
 
-        Sink<String> sink = JmsSinkBuilder.<String>builder(() -> broker.createConnectionFactory())
+        Sink<String> sink = Sinks.<String>jmsTopicBuilder(() -> broker.createConnectionFactory())
                 .destinationName(destinationName)
-                .topic()
                 .build();
 
         Pipeline pipeline = Pipeline.create();


### PR DESCRIPTION
- move factory method to `Sources` and `Sinks` where they are easier to
discover

- `isTopic` is required in constructor, it was easy to forget to call
`.topic()`

- get rid of the most generic methods, builder has every feature they had

- sink can accept `javax.jms.Message` on input, doesn't convert
everything to `TextMessage`

- less code duplication (same non-trivial defaults both in builder and in
processor)
