### PR TITLE
Fix distinct()

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/TimestampKind.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/TimestampKind.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.core;
 
 /**
  * Enumerates the two possible kinds of timestamp: event timestamp and
- * frame timestamp. Used by the slidind window processors.
+ * frame timestamp. Used by the sliding window processors.
  */
 public enum TimestampKind {
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingImpl.java
@@ -21,14 +21,12 @@ import com.hazelcast.jet.aggregate.AggregateOperation2;
 import com.hazelcast.jet.aggregate.AggregateOperation3;
 import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.function.DistributedFunction;
+import com.hazelcast.jet.impl.pipeline.transform.DistinctTransform;
 import com.hazelcast.jet.impl.pipeline.transform.GroupTransform;
 import com.hazelcast.jet.pipeline.BatchStage;
-import com.hazelcast.jet.pipeline.ContextFactory;
 import com.hazelcast.jet.pipeline.StageWithGrouping;
 
 import javax.annotation.Nonnull;
-
-import java.util.HashSet;
 
 import static com.hazelcast.jet.impl.pipeline.ComputeStageImplBase.DONT_ADAPT;
 import static java.util.Arrays.asList;
@@ -45,9 +43,7 @@ public class StageWithGroupingImpl<T, K> extends StageWithGroupingBase<T, K> imp
 
     @Nonnull @Override
     public BatchStage<T> distinct() {
-        DistributedFunction<? super T, ? extends K> keyFn = keyFn();
-        return batchStage().filterUsingContext(ContextFactory.withCreateFn(jet -> new HashSet<>()),
-                (ctx, item) -> ctx.add(keyFn.apply(item)));
+        return computeStage.attach(new DistinctTransform<>(computeStage.transform, keyFn()), DONT_ADAPT);
     }
 
     @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.pipeline.transform;
+
+import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.function.DistributedFunction;
+import com.hazelcast.jet.impl.pipeline.Planner;
+import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
+import com.hazelcast.jet.pipeline.ContextFactory;
+
+import java.util.HashSet;
+
+import static com.hazelcast.jet.core.Edge.between;
+import static com.hazelcast.jet.core.Partitioner.HASH_CODE;
+import static com.hazelcast.jet.core.processor.Processors.filterUsingContextP;
+
+public class DistinctTransform<T, K> extends AbstractTransform {
+    private final DistributedFunction<? super T, ? extends K> keyFn;
+
+    public DistinctTransform(Transform upstream, DistributedFunction<? super T, ? extends K> keyFn) {
+        super("distinct", upstream);
+        this.keyFn = keyFn;
+    }
+
+    @Override
+    public void addToDag(Planner p) {
+        String namePrefix = p.uniqueVertexName(this.name(), "-step");
+        Vertex v1 = p.dag.newVertex(namePrefix + '1', distinctP(keyFn))
+                         .localParallelism(localParallelism());
+        PlannerVertex pv2 = p.addVertex(this, namePrefix + '2', localParallelism(), distinctP(keyFn));
+        p.addEdges(this, v1, (e, ord) -> e.partitioned(keyFn, HASH_CODE));
+        p.dag.edge(between(v1, pv2.v).distributed().partitioned(keyFn));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T, K> ProcessorSupplier distinctP(DistributedFunction<? super T, ? extends K> keyFn) {
+        return filterUsingContextP(ContextFactory.withCreateFn(jet -> new HashSet<>()),
+                (seenItems, item) -> seenItems.add(keyFn.apply((T) item)));
+    }
+}


### PR DESCRIPTION
It was implementd as `filterUsingContext()`, but that operation doesn't use partitioning.