### PR TITLE
Usability improvements

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -61,9 +61,9 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 /**
- * Static utility class with factory methods for Jet processors. These
- * are meant to implement the internal vertices of the DAG; for other
- * kinds of processors refer to the {@link com.hazelcast.jet.core.processor
+ * Static utility class with factory methods for Jet processors. These are
+ * meant to implement the internal vertices of the DAG; for other kinds of
+ * processors refer to the {@linkplain com.hazelcast.jet.core.processor
  * package-level documentation}.
  * <p>
  * Many of the processors deal with an aggregating operation over stream
@@ -468,7 +468,7 @@ public final class Processors {
                 timestampKind,
                 winPolicy.toTumblingByFrame(),
                 aggrOp.withFinishFn(identity()),
-                TimestampedEntry::new,
+                TimestampedEntry::mapWindowResult,
                 false
         );
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -468,7 +468,7 @@ public final class Processors {
                 timestampKind,
                 winPolicy.toTumblingByFrame(),
                 aggrOp.withFinishFn(identity()),
-                TimestampedEntry::mapWindowResult,
+                TimestampedEntry::fromWindowResult,
                 false
         );
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedEntry.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedEntry.java
@@ -47,17 +47,6 @@ public final class TimestampedEntry<K, V> implements Map.Entry<K, V> {
     }
 
     /**
-     * This constructor exists in order to match the shape of the functional
-     * interface {@link KeyedWindowResultFunction}.
-     * <p>
-     * Constructs a timestamped entry with the supplied field values. Ignores
-     * the first argument.
-     */
-    public TimestampedEntry(long ignored, long timestamp, @Nonnull K key, @Nonnull V value) {
-        this(timestamp, key, value);
-    }
-
-    /**
      * Returns the timestamp of this entry.
      */
     public long getTimestamp() {
@@ -101,5 +90,18 @@ public final class TimestampedEntry<K, V> implements Map.Entry<K, V> {
     @Override
     public String toString() {
         return String.format("TimestampedEntry{ts=%s, key='%s', value='%s'}", toLocalTime(timestamp), key, value);
+    }
+
+    /**
+     * This method matches the shape of the functional interface {@link
+     * com.hazelcast.jet.function.KeyedWindowResultFunction
+     * KeyedWindowResultFunction}.
+     * <p>
+     * Constructs a {@code TimestampedEntry} using the window end time as the
+     * timestamp.
+     */
+    public static <K, V> TimestampedEntry<K, V> mapWindowResult(long winStart, long winEnd, @Nonnull K key,
+                                                                       @Nonnull V value) {
+        return new TimestampedEntry<>(winEnd, key, value);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedEntry.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedEntry.java
@@ -94,7 +94,6 @@ public final class TimestampedEntry<K, V> implements Map.Entry<K, V> {
 
     /**
      * This method matches the shape of the functional interface {@link
-     * com.hazelcast.jet.function.KeyedWindowResultFunction
      * KeyedWindowResultFunction}.
      * <p>
      * Constructs a {@code TimestampedEntry} using the window end time as the

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedEntry.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedEntry.java
@@ -99,8 +99,8 @@ public final class TimestampedEntry<K, V> implements Map.Entry<K, V> {
      * Constructs a {@code TimestampedEntry} using the window end time as the
      * timestamp.
      */
-    public static <K, V> TimestampedEntry<K, V> mapWindowResult(long winStart, long winEnd, @Nonnull K key,
-                                                                       @Nonnull V value) {
+    public static <K, V> TimestampedEntry<K, V> fromWindowResult(long winStart, long winEnd, @Nonnull K key,
+                                                                 @Nonnull V value) {
         return new TimestampedEntry<>(winEnd, key, value);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedItem.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedItem.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.jet.datamodel;
 
+import com.hazelcast.jet.function.WindowResultFunction;
+
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Objects;
@@ -82,7 +84,7 @@ public final class TimestampedItem<T> implements Serializable {
 
     /**
      * This method matches the shape of the functional interface {@link
-     * com.hazelcast.jet.function.WindowResultFunction WindowResultFunction}.
+     * WindowResultFunction}.
      * <p>
      * Constructs a {@code TimestampedItem} using the window end time as the
      * timestamp.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedItem.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedItem.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.datamodel;
 
-import com.hazelcast.jet.function.WindowResultFunction;
-
 import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.Objects;
@@ -42,17 +40,6 @@ public final class TimestampedItem<T> implements Serializable {
     public TimestampedItem(long timestamp, @Nonnull T item) {
         this.timestamp = timestamp;
         this.item = item;
-    }
-
-    /**
-     * This constructor exists in order to match the shape of the functional
-     * interface {@link WindowResultFunction}.
-     * <p>
-     * Constructs a timestamped item with the supplied field values. Ignores
-     * the first argument.
-     */
-    public TimestampedItem(long ignored, long timestamp, @Nonnull T item) {
-        this(timestamp, item);
     }
 
     /**
@@ -90,5 +77,17 @@ public final class TimestampedItem<T> implements Serializable {
     public String toString() {
         return "TimestampedItem{ts=" + toLocalTime(timestamp)
                 + ", value='" + item + "'}";
+    }
+
+
+    /**
+     * This method matches the shape of the functional interface {@link
+     * com.hazelcast.jet.function.WindowResultFunction WindowResultFunction}.
+     * <p>
+     * Constructs a {@code TimestampedItem} using the window end time as the
+     * timestamp.
+     */
+    public static <V> TimestampedItem<V> mapWindowResult(long winStart, long winEnd, @Nonnull V value) {
+        return new TimestampedItem<>(winEnd, value);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedItem.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/TimestampedItem.java
@@ -89,7 +89,7 @@ public final class TimestampedItem<T> implements Serializable {
      * Constructs a {@code TimestampedItem} using the window end time as the
      * timestamp.
      */
-    public static <V> TimestampedItem<V> mapWindowResult(long winStart, long winEnd, @Nonnull V value) {
+    public static <V> TimestampedItem<V> fromWindowResult(long winStart, long winEnd, @Nonnull V value) {
         return new TimestampedItem<>(winEnd, value);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -285,8 +285,12 @@ public interface GeneralStage<T> extends Stage {
 
     /**
      * Specifies the function that will extract the grouping key from the items
-     * in the associated pipeline stage, as first step in the construction of a
+     * in the associated pipeline stage, as a first step in the construction of a
      * group-and-aggregate stage.
+     * <p>
+     * <b>Warning:</b> make sure the extracted key is not-null, it would fail the
+     * job. Also make sure that it implements {@code equals()} and {@code
+     * hashCode()}.
      *
      * @param keyFn function that extracts the grouping key
      * @param <K> type of the key
@@ -314,7 +318,7 @@ public interface GeneralStage<T> extends Stage {
     /**
      * Adds a timestamp to each item in the stream using the supplied function
      * and specifies the allowed amount of disorder between them. As the stream
-     * moves on the timestamps must increase, but you can tell Jet to accept
+     * moves on, the timestamps must increase, but you can tell Jet to accept
      * some items that "come in late", i.e., have a lower timestamp than the
      * items before them. The {@code allowedLag} parameter controls by how much
      * the timestamp can be lower than the highest one observed so far. If
@@ -339,9 +343,16 @@ public interface GeneralStage<T> extends Stage {
      * watermark without causing dropped events. If you add the timestamps
      * later on, events from different partitions may be mixed, increasing
      * the perceived event lag and causing more dropped events.
+     * <p>
+     * <b>Warning:</b> make sure the property you access in {@code timestampFn}
+     * isn't null, it would fail the job. Also that there are no nonsensical
+     * values such as -1, MIN_VALUE, 2100-01-01 etc - we'll treat those as real
+     * timestamps and they can mess the logic.
      *
      * @param timestampFn a function that returns the timestamp for each item
-     * @param allowedLag the allowed lag behind the top observed timestamp
+     * @param allowedLag the allowed lag behind the top observed timestamp.
+     *                   Time unit is the same as the unit used by {@code
+     *                   timestampFn}
      *
      * @throws IllegalArgumentException if this stage already has timestamps
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -347,9 +347,10 @@ public interface GeneralStage<T> extends Stage {
      * <b>Warning:</b> make sure the property you access in {@code timestampFn}
      * isn't null, it would fail the job. Also that there are no nonsensical
      * values such as -1, MIN_VALUE, 2100-01-01 etc - we'll treat those as real
-     * timestamps and they can mess the logic.
+     * timestamps and they can cause unspecified behaviour.
      *
-     * @param timestampFn a function that returns the timestamp for each item
+     * @param timestampFn a function that returns the timestamp for each item,
+     *                    typically in milliseconds
      * @param allowedLag the allowed lag behind the top observed timestamp.
      *                   Time unit is the same as the unit used by {@code
      *                   timestampFn}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithGroupingAndWindow.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithGroupingAndWindow.java
@@ -88,7 +88,7 @@ public interface StageWithGroupingAndWindow<T, K> {
      */
     @Nonnull
     default StreamStage<TimestampedItem<T>> distinct() {
-        return distinct(TimestampedItem::mapWindowResult);
+        return distinct(TimestampedItem::fromWindowResult);
     }
 
     /**
@@ -128,7 +128,7 @@ public interface StageWithGroupingAndWindow<T, K> {
      */
     @Nonnull
     default <A, R> StreamStage<TimestampedEntry<K, R>> aggregate(@Nonnull AggregateOperation1<? super T, A, R> aggrOp) {
-        return aggregate(aggrOp, TimestampedEntry::mapWindowResult);
+        return aggregate(aggrOp, TimestampedEntry::fromWindowResult);
     }
 
     /**
@@ -194,7 +194,7 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull StreamStageWithGrouping<T1, ? extends K> stage1,
             @Nonnull AggregateOperation2<? super T, ? super T1, A, R> aggrOp
     ) {
-        return aggregate2(stage1, aggrOp, TimestampedEntry::mapWindowResult);
+        return aggregate2(stage1, aggrOp, TimestampedEntry::fromWindowResult);
     }
 
     /**
@@ -256,7 +256,7 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull AggregateOperation1<? super T1, ?, R1> aggrOp1
     ) {
         return aggregate2(stage1, aggregateOperation2(aggrOp0, aggrOp1, Tuple2::tuple2),
-                TimestampedEntry::mapWindowResult);
+                TimestampedEntry::fromWindowResult);
     }
 
     /**
@@ -332,7 +332,7 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull StreamStageWithGrouping<T2, ? extends K> stage2,
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, A, R> aggrOp
     ) {
-        return aggregate3(stage1, stage2, aggrOp, TimestampedEntry::mapWindowResult);
+        return aggregate3(stage1, stage2, aggrOp, TimestampedEntry::fromWindowResult);
     }
 
     /**
@@ -407,7 +407,7 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull AggregateOperation1<? super T2, ?, R2> aggrOp2
     ) {
         return aggregate3(stage1, stage2, aggregateOperation3(aggrOp0, aggrOp1, aggrOp2, Tuple3::tuple3),
-                TimestampedEntry::mapWindowResult);
+                TimestampedEntry::fromWindowResult);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithGroupingAndWindow.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithGroupingAndWindow.java
@@ -88,7 +88,7 @@ public interface StageWithGroupingAndWindow<T, K> {
      */
     @Nonnull
     default StreamStage<TimestampedItem<T>> distinct() {
-        return distinct(TimestampedItem::new);
+        return distinct(TimestampedItem::mapWindowResult);
     }
 
     /**
@@ -128,7 +128,7 @@ public interface StageWithGroupingAndWindow<T, K> {
      */
     @Nonnull
     default <A, R> StreamStage<TimestampedEntry<K, R>> aggregate(@Nonnull AggregateOperation1<? super T, A, R> aggrOp) {
-        return aggregate(aggrOp, TimestampedEntry::new);
+        return aggregate(aggrOp, TimestampedEntry::mapWindowResult);
     }
 
     /**
@@ -194,7 +194,7 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull StreamStageWithGrouping<T1, ? extends K> stage1,
             @Nonnull AggregateOperation2<? super T, ? super T1, A, R> aggrOp
     ) {
-        return aggregate2(stage1, aggrOp, TimestampedEntry::new);
+        return aggregate2(stage1, aggrOp, TimestampedEntry::mapWindowResult);
     }
 
     /**
@@ -255,7 +255,8 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull StreamStageWithGrouping<T1, ? extends K> stage1,
             @Nonnull AggregateOperation1<? super T1, ?, R1> aggrOp1
     ) {
-        return aggregate2(stage1, aggregateOperation2(aggrOp0, aggrOp1, Tuple2::tuple2), TimestampedEntry::new);
+        return aggregate2(stage1, aggregateOperation2(aggrOp0, aggrOp1, Tuple2::tuple2),
+                TimestampedEntry::mapWindowResult);
     }
 
     /**
@@ -331,7 +332,7 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull StreamStageWithGrouping<T2, ? extends K> stage2,
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, A, R> aggrOp
     ) {
-        return aggregate3(stage1, stage2, aggrOp, TimestampedEntry::new);
+        return aggregate3(stage1, stage2, aggrOp, TimestampedEntry::mapWindowResult);
     }
 
     /**
@@ -406,7 +407,7 @@ public interface StageWithGroupingAndWindow<T, K> {
             @Nonnull AggregateOperation1<? super T2, ?, R2> aggrOp2
     ) {
         return aggregate3(stage1, stage2, aggregateOperation3(aggrOp0, aggrOp1, aggrOp2, Tuple3::tuple3),
-                TimestampedEntry::new);
+                TimestampedEntry::mapWindowResult);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithWindow.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithWindow.java
@@ -137,7 +137,7 @@ public interface StageWithWindow<T> {
     default <A, R> StreamStage<TimestampedItem<R>> aggregate(
             @Nonnull AggregateOperation1<? super T, A, R> aggrOp
     ) {
-        return aggregate(aggrOp, TimestampedItem::mapWindowResult);
+        return aggregate(aggrOp, TimestampedItem::fromWindowResult);
     }
 
     /**
@@ -201,7 +201,7 @@ public interface StageWithWindow<T> {
             @Nonnull StreamStage<T1> stage1,
             @Nonnull AggregateOperation2<? super T, ? super T1, A, R> aggrOp
     ) {
-        return aggregate2(stage1, aggrOp, TimestampedItem::mapWindowResult);
+        return aggregate2(stage1, aggrOp, TimestampedItem::fromWindowResult);
     }
 
     /**
@@ -329,7 +329,7 @@ public interface StageWithWindow<T> {
             @Nonnull StreamStage<T2> stage2,
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, A, R> aggrOp
     ) {
-        return aggregate3(stage1, stage2, aggrOp, TimestampedItem::mapWindowResult);
+        return aggregate3(stage1, stage2, aggrOp, TimestampedItem::fromWindowResult);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithWindow.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithWindow.java
@@ -58,10 +58,14 @@ public interface StageWithWindow<T> {
     WindowDefinition windowDefinition();
 
     /**
-     * Specifes the function that will extract the grouping key from the
+     * Specifies the function that will extract the grouping key from the
      * items in the associated pipeline stage and moves on to the step in
      * which you'll complete the construction of a windowed group-and-aggregate
      * stage.
+     * <p>
+     * <b>Note:</b> make sure the extracted key is not-null, it would fail the
+     * job. Also make sure that it implements {@code equals()} and {@code
+     * hashCode()}.
      *
      * @param keyFn function that extracts the grouping key
      * @param <K> type of the key
@@ -133,7 +137,7 @@ public interface StageWithWindow<T> {
     default <A, R> StreamStage<TimestampedItem<R>> aggregate(
             @Nonnull AggregateOperation1<? super T, A, R> aggrOp
     ) {
-        return aggregate(aggrOp, TimestampedItem::new);
+        return aggregate(aggrOp, TimestampedItem::mapWindowResult);
     }
 
     /**
@@ -197,7 +201,7 @@ public interface StageWithWindow<T> {
             @Nonnull StreamStage<T1> stage1,
             @Nonnull AggregateOperation2<? super T, ? super T1, A, R> aggrOp
     ) {
-        return aggregate2(stage1, aggrOp, TimestampedItem::new);
+        return aggregate2(stage1, aggrOp, TimestampedItem::mapWindowResult);
     }
 
     /**
@@ -325,7 +329,7 @@ public interface StageWithWindow<T> {
             @Nonnull StreamStage<T2> stage2,
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, A, R> aggrOp
     ) {
-        return aggregate3(stage1, stage2, aggrOp, TimestampedItem::new);
+        return aggregate3(stage1, stage2, aggrOp, TimestampedItem::mapWindowResult);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder.java
@@ -111,6 +111,6 @@ public class WindowAggregateBuilder<R0> {
      */
     @Nonnull
     public StreamStage<TimestampedItem<ItemsByTag>> build() {
-        return build(TimestampedItem::mapWindowResult);
+        return build(TimestampedItem::fromWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder.java
@@ -111,6 +111,6 @@ public class WindowAggregateBuilder<R0> {
      */
     @Nonnull
     public StreamStage<TimestampedItem<ItemsByTag>> build() {
-        return build(TimestampedItem::new);
+        return build(TimestampedItem::mapWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder1.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder1.java
@@ -99,6 +99,6 @@ public class WindowAggregateBuilder1<T0> {
      */
     @Nonnull
     public <A, R> StreamStage<TimestampedItem<R>> build(@Nonnull AggregateOperation<A, R> aggrOp) {
-        return build(aggrOp, TimestampedItem::new);
+        return build(aggrOp, TimestampedItem::mapWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder1.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowAggregateBuilder1.java
@@ -99,6 +99,6 @@ public class WindowAggregateBuilder1<T0> {
      */
     @Nonnull
     public <A, R> StreamStage<TimestampedItem<R>> build(@Nonnull AggregateOperation<A, R> aggrOp) {
-        return build(aggrOp, TimestampedItem::mapWindowResult);
+        return build(aggrOp, TimestampedItem::fromWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder.java
@@ -104,6 +104,6 @@ public class WindowGroupAggregateBuilder<K, R0> {
      */
     @Nonnull
     public StreamStage<TimestampedEntry<K, ItemsByTag>> build() {
-        return build(TimestampedEntry::new);
+        return build(TimestampedEntry::mapWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder.java
@@ -104,6 +104,6 @@ public class WindowGroupAggregateBuilder<K, R0> {
      */
     @Nonnull
     public StreamStage<TimestampedEntry<K, ItemsByTag>> build() {
-        return build(TimestampedEntry::mapWindowResult);
+        return build(TimestampedEntry::fromWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder1.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder1.java
@@ -98,6 +98,6 @@ public class WindowGroupAggregateBuilder1<T0, K> {
     public <A, R> StreamStage<TimestampedEntry<K, R>> build(
             @Nonnull AggregateOperation<A, R> aggrOp
     ) {
-        return grAggBuilder.buildStream(aggrOp, TimestampedEntry::mapWindowResult);
+        return grAggBuilder.buildStream(aggrOp, TimestampedEntry::fromWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder1.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/WindowGroupAggregateBuilder1.java
@@ -98,6 +98,6 @@ public class WindowGroupAggregateBuilder1<T0, K> {
     public <A, R> StreamStage<TimestampedEntry<K, R>> build(
             @Nonnull AggregateOperation<A, R> aggrOp
     ) {
-        return grAggBuilder.buildStream(aggrOp, TimestampedEntry::new);
+        return grAggBuilder.buildStream(aggrOp, TimestampedEntry::mapWindowResult);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -169,7 +169,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
                     aggrOp.withFinishFn(identity())
             ));
             Vertex aggregateStage2 = dag.newVertex("aggregateStage2",
-                    combineToSlidingWindowP(wDef, aggrOp, TimestampedEntry::new));
+                    combineToSlidingWindowP(wDef, aggrOp, TimestampedEntry::mapWindowResult));
 
             dag.edge(between(insWm, aggregateStage1)
                     .partitioned(entryKey()))
@@ -184,7 +184,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
                     TimestampKind.EVENT,
                     wDef,
                     aggrOp,
-                    TimestampedEntry::new));
+                    TimestampedEntry::mapWindowResult));
 
             dag.edge(between(insWm, aggregate)
                     .distributed()

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -169,7 +169,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
                     aggrOp.withFinishFn(identity())
             ));
             Vertex aggregateStage2 = dag.newVertex("aggregateStage2",
-                    combineToSlidingWindowP(wDef, aggrOp, TimestampedEntry::mapWindowResult));
+                    combineToSlidingWindowP(wDef, aggrOp, TimestampedEntry::fromWindowResult));
 
             dag.edge(between(insWm, aggregateStage1)
                     .partitioned(entryKey()))
@@ -184,7 +184,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
                     TimestampKind.EVENT,
                     wDef,
                     aggrOp,
-                    TimestampedEntry::mapWindowResult));
+                    TimestampedEntry::fromWindowResult));
 
             dag.edge(between(insWm, aggregate)
                     .distributed()

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
@@ -119,7 +119,7 @@ public class Processors_slidingWindowingIntegrationTest extends JetTestSupport {
                             TimestampKind.EVENT,
                             wDef,
                             counting,
-                            TimestampedEntry::mapWindowResult));
+                            TimestampedEntry::fromWindowResult));
             dag
                     .edge(between(insertPP, slidingWin).partitioned(MyEvent::getKey).distributed())
                     .edge(between(slidingWin, sink));
@@ -134,7 +134,7 @@ public class Processors_slidingWindowingIntegrationTest extends JetTestSupport {
                             counting.withFinishFn(identity())
                     ));
             Vertex slidingWin = dag.newVertex("slidingWin",
-                    combineToSlidingWindowP(wDef, counting, TimestampedEntry::mapWindowResult));
+                    combineToSlidingWindowP(wDef, counting, TimestampedEntry::fromWindowResult));
             dag
                     .edge(between(insertPP, accumulateByFrame).partitioned(keyFn))
                     .edge(between(accumulateByFrame, slidingWin).partitioned(entryKey()).distributed())

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
@@ -119,7 +119,7 @@ public class Processors_slidingWindowingIntegrationTest extends JetTestSupport {
                             TimestampKind.EVENT,
                             wDef,
                             counting,
-                            TimestampedEntry::new));
+                            TimestampedEntry::mapWindowResult));
             dag
                     .edge(between(insertPP, slidingWin).partitioned(MyEvent::getKey).distributed())
                     .edge(between(slidingWin, sink));
@@ -134,7 +134,7 @@ public class Processors_slidingWindowingIntegrationTest extends JetTestSupport {
                             counting.withFinishFn(identity())
                     ));
             Vertex slidingWin = dag.newVertex("slidingWin",
-                    combineToSlidingWindowP(wDef, counting, TimestampedEntry::new));
+                    combineToSlidingWindowP(wDef, counting, TimestampedEntry::mapWindowResult));
             dag
                     .edge(between(insertPP, accumulateByFrame).partitioned(keyFn))
                     .edge(between(accumulateByFrame, slidingWin).partitioned(entryKey()).distributed())

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
@@ -107,8 +107,8 @@ public class SlidingWindowPTest {
                         TimestampKind.EVENT,
                         windowDef,
                         operation,
-                        TimestampedEntry::mapWindowResult)
-                : combineToSlidingWindowP(windowDef, operation, TimestampedEntry::mapWindowResult);
+                        TimestampedEntry::fromWindowResult)
+                : combineToSlidingWindowP(windowDef, operation, TimestampedEntry::fromWindowResult);
 
         // new supplier to save the last supplied instance
         supplier = () -> lastSuppliedProcessor = (SlidingWindowP) procSupplier.get();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowPTest.java
@@ -107,8 +107,8 @@ public class SlidingWindowPTest {
                         TimestampKind.EVENT,
                         windowDef,
                         operation,
-                        TimestampedEntry::new)
-                : combineToSlidingWindowP(windowDef, operation, TimestampedEntry::new);
+                        TimestampedEntry::mapWindowResult)
+                : combineToSlidingWindowP(windowDef, operation, TimestampedEntry::mapWindowResult);
 
         // new supplier to save the last supplied instance
         supplier = () -> lastSuppliedProcessor = (SlidingWindowP) procSupplier.get();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_CoGroupTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_CoGroupTest.java
@@ -52,7 +52,7 @@ public class SlidingWindowP_CoGroupTest {
                 TimestampKind.FRAME,
                 tumblingWinPolicy(1),
                 aggregateOperation2(toList(), toList()),
-                TimestampedEntry::new);
+                TimestampedEntry::mapWindowResult);
 
         Entry<String, String> entry1 = entry("k1", "a");
         Entry<String, String> entry2 = entry("k2", "b");

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_CoGroupTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_CoGroupTest.java
@@ -52,7 +52,7 @@ public class SlidingWindowP_CoGroupTest {
                 TimestampKind.FRAME,
                 tumblingWinPolicy(1),
                 aggregateOperation2(toList(), toList()),
-                TimestampedEntry::mapWindowResult);
+                TimestampedEntry::fromWindowResult);
 
         Entry<String, String> entry1 = entry("k1", "a");
         Entry<String, String> entry2 = entry("k2", "b");

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_FrameCombiningTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_FrameCombiningTest.java
@@ -47,7 +47,7 @@ public class SlidingWindowP_FrameCombiningTest {
     public void when_multipleFrames_then_combine() {
         TestSupport
                 .verifyProcessor(
-                        combineToSlidingWindowP(slidingWinPolicy(8, 4), toSet(), TimestampedEntry::mapWindowResult))
+                        combineToSlidingWindowP(slidingWinPolicy(8, 4), toSet(), TimestampedEntry::fromWindowResult))
                 .input(asList(
                         frame(2, set("a")),
                         frame(4, set("b")),

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_FrameCombiningTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_FrameCombiningTest.java
@@ -46,7 +46,8 @@ public class SlidingWindowP_FrameCombiningTest {
     @Test
     public void when_multipleFrames_then_combine() {
         TestSupport
-                .verifyProcessor(combineToSlidingWindowP(slidingWinPolicy(8, 4), toSet(), TimestampedEntry::new))
+                .verifyProcessor(
+                        combineToSlidingWindowP(slidingWinPolicy(8, 4), toSet(), TimestampedEntry::mapWindowResult))
                 .input(asList(
                         frame(2, set("a")),
                         frame(4, set("b")),

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_failoverTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_failoverTest.java
@@ -62,7 +62,7 @@ public class SlidingWindowP_failoverTest {
                 singletonList((DistributedToLongFunction<Entry<?, Long>>) Entry::getValue),
                 wDef,
                 aggrOp,
-                TimestampedEntry::new,
+                TimestampedEntry::mapWindowResult,
                 true);
 
         Outbox outbox = new TestOutbox(128);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_failoverTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_failoverTest.java
@@ -62,7 +62,7 @@ public class SlidingWindowP_failoverTest {
                 singletonList((DistributedToLongFunction<Entry<?, Long>>) Entry::getValue),
                 wDef,
                 aggrOp,
-                TimestampedEntry::mapWindowResult,
+                TimestampedEntry::fromWindowResult,
                 true);
 
         Outbox outbox = new TestOutbox(128);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
@@ -97,7 +97,7 @@ public class SlidingWindowP_twoStageSnapshotTest {
         );
 
         DistributedSupplier<Processor> procSupplier2 = combineToSlidingWindowP(windowDef, aggrOp,
-                TimestampedEntry::mapWindowResult);
+                TimestampedEntry::fromWindowResult);
 
         // new supplier to save the last supplied instance
         stage1Supplier = () -> lastSuppliedStage1Processor = (SlidingWindowP<?, ?, ?, ?>) procSupplier1.get();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_twoStageSnapshotTest.java
@@ -96,7 +96,8 @@ public class SlidingWindowP_twoStageSnapshotTest {
                 ((AggregateOperation1<? super Entry<Long, Long>, LongAccumulator, ?>) aggrOp).withFinishFn(identity())
         );
 
-        DistributedSupplier<Processor> procSupplier2 = combineToSlidingWindowP(windowDef, aggrOp, TimestampedEntry::new);
+        DistributedSupplier<Processor> procSupplier2 = combineToSlidingWindowP(windowDef, aggrOp,
+                TimestampedEntry::mapWindowResult);
 
         // new supplier to save the last supplied instance
         stage1Supplier = () -> lastSuppliedStage1Processor = (SlidingWindowP<?, ?, ?, ?>) procSupplier1.get();

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
@@ -27,7 +27,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
-import java.util.Map.Entry;
 import java.util.Properties;
 
 /**
@@ -42,8 +41,8 @@ public final class KafkaProcessors {
     }
 
     /**
-     * Returns a supplier of processors for
-     * {@link KafkaSources#kafka(Properties, DistributedFunction, String...)}.
+     * Returns a supplier of processors for {@link
+     * KafkaSources#kafka(Properties, DistributedFunction, String, String...)}.
      */
     public static <K, V, T> ProcessorMetaSupplier streamKafkaP(
             @Nonnull Properties properties,
@@ -56,20 +55,6 @@ public final class KafkaProcessors {
         return ProcessorMetaSupplier.of(
                 StreamKafkaP.processorSupplier(properties, Arrays.asList(topics), projectionFn, wmGenParams),
                 PREFERRED_LOCAL_PARALLELISM
-        );
-    }
-
-    /**
-     * Returns a supplier of processors for
-     * {@link KafkaSources#kafka(Properties, String...)}.
-     */
-    public static <K, V> ProcessorMetaSupplier streamKafkaP(
-            @Nonnull Properties properties,
-            @Nonnull WatermarkGenerationParams<Entry<K, V>> wmGenParams,
-            @Nonnull String... topics
-    ) {
-        return KafkaProcessors.<K, V, Entry<K, V>>streamKafkaP(
-                properties, StreamKafkaP::recordToEntry, wmGenParams, topics
         );
     }
 

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.kafka;
 
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.pipeline.StreamSource;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -25,6 +26,7 @@ import javax.annotation.Nonnull;
 import java.util.Map.Entry;
 import java.util.Properties;
 
+import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.kafka.KafkaProcessors.streamKafkaP;
 import static com.hazelcast.jet.pipeline.Sources.streamFromProcessorWithWatermarks;
 
@@ -37,15 +39,16 @@ public final class KafkaSources {
     }
 
     /**
-     * Convenience for {@link #kafka(Properties, DistributedFunction, String...)}
+     * Convenience for {@link #kafka(Properties, DistributedFunction, String, String...)}
      * wrapping the output in {@code Map.Entry}.
      */
     @Nonnull
     public static <K, V> StreamSource<Entry<K, V>> kafka(
             @Nonnull Properties properties,
-            @Nonnull String... topics
+            @Nonnull String topic,
+            @Nonnull String... moreTopics
     ) {
-        return streamFromProcessorWithWatermarks("streamKafka", w -> streamKafkaP(properties, w, topics));
+        return KafkaSources.<K, V, Entry<K, V>>kafka(properties, r -> entry(r.key(), r.value()), topic, moreTopics);
     }
 
     /**
@@ -62,14 +65,15 @@ public final class KafkaSources {
      * If snapshotting is enabled, partition offsets are saved to the snapshot.
      * After restart, the source emits the events from the same offset.
      * <p>
-     * If snapshotting is disabled, the source commits the offsets to Kafka
-     * using {@link KafkaConsumer#commitSync()}. Note however that offsets can
-     * be committed before or after the event is fully processed.
+     * If and only if snapshotting is disabled, the source commits the offsets
+     * to Kafka using {@link KafkaConsumer#commitSync()}. Note however that
+     * offsets can be committed before or after the event is fully processed.
+     * You can configure {@code group.id} in this case.
      * <p>
      * If you add Kafka partitions at run-time, consumption from them will
      * start after a delay, based on the {@code metadata.max.age.ms} Kafka
      * property. Note, however, that events from them can be dropped as late if
-     * the allowed lag is not enough.
+     * the allowed lag is not large enough.
      * <p>
      * The processor completes only in the case of an error or if the job is
      * cancelled. IO failures are generally handled by Kafka producer and
@@ -88,19 +92,29 @@ public final class KafkaSources {
      * byte[]} for messages and deserialize manually in a subsequent mapping
      * step.
      *
-     * @param properties   consumer properties broker address and key/value deserializers
+     * @param properties consumer properties broker address and key/value
+     *                  deserializers
      * @param projectionFn function to create output objects from the Kafka record.
-     *                     If the projection returns a {@code null} for an item, that item
-     *                     will be filtered out.
-     * @param topics       the list of topics
+     *                    If the projection returns a {@code null} for an item,
+     *                    that item will be filtered out.
+     * @param topic the topic to consume
+     * @param moreTopics more topics to consume
      */
     @Nonnull
     public static <K, V, T> StreamSource<T> kafka(
             @Nonnull Properties properties,
             @Nonnull DistributedFunction<ConsumerRecord<K, V>, T> projectionFn,
-            @Nonnull String... topics
+            @Nonnull String topic,
+            @Nonnull String... moreTopics
     ) {
         return streamFromProcessorWithWatermarks("streamKafka",
-                w -> streamKafkaP(properties, projectionFn, w, topics));
+                w -> streamKafkaP(properties, projectionFn, w, merge(topic, moreTopics)));
+    }
+
+    private static String[] merge(String s0, String[] others) {
+        String[] res = new String[others.length + 1];
+        res[0] = s0;
+        System.arraycopy(others, 0, res, 1, others.length);
+        return res;
     }
 }

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.kafka;
 
 import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.pipeline.StreamSource;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -55,12 +56,11 @@ public final class KafkaSources {
      * Returns a source that consumes one or more Apache Kafka topics and emits
      * items from them as {@code Map.Entry} instances.
      * <p>
-     * The source creates a {@code KafkaConsumer} for each {@link
-     * com.hazelcast.jet.core.Processor processor} instance using the supplied
-     * {@code properties}. It assigns a subset of Kafka partitions to each of
-     * them using manual partition assignment (it ignores the {@code group.id}
-     * property). Default local parallelism for this processor is 2 (or less
-     * if less CPUs are available).
+     * The source creates a {@code KafkaConsumer} for each {@link Processor}
+     * instance using the supplied {@code properties}. It assigns a subset of
+     * Kafka partitions to each of them using manual partition assignment (it
+     * ignores the {@code group.id} property). Default local parallelism for
+     * this processor is 2 (or less if less CPUs are available).
      * <p>
      * If snapshotting is enabled, partition offsets are saved to the snapshot.
      * After restart, the source emits the events from the same offset.
@@ -79,8 +79,7 @@ public final class KafkaSources {
      * cancelled. IO failures are generally handled by Kafka producer and
      * do not cause the processor to fail.
      * Kafka consumer also does not return from {@code poll(timeout)} if the
-     * cluster is down. If {@link
-     * com.hazelcast.jet.config.JobConfig#setSnapshotIntervalMillis(long)
+     * cluster is down. If {@link JobConfig#setSnapshotIntervalMillis(long)
      * snapshotting is enabled}, entire job might be blocked. This is a known
      * issue of Kafka (KAFKA-1894).
      * Refer to Kafka documentation for details.

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
@@ -311,9 +311,4 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
             return (startIndex + partition) % totalParallelism;
         }
     }
-
-    @Nonnull
-    public static <K, V> Entry<K, V> recordToEntry(ConsumerRecord<K, V> r) {
-        return entry(r.key(), r.value());
-    }
 }


### PR DESCRIPTION
- kafka source requires to give at least one topic (uses `String topic,
String ... moreTopics` method contract). Also better documentation of
offset committing.

- add javadoc warnings about null key, null timestamps or nonsensical
timestamps returned in lambdas

- check for null key returned from edge partitioner key extractor and
print a better error message

- remove the constructor in TimestampedEntry and TimestampedItem with
(with `ignored` parameter). It was hard to figure out what this is for.
Replaced with a static method.
