### PR TITLE
Proactively check serializability in Pipeline API

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperation.java
@@ -28,6 +28,8 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Objects;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+
 /**
  * Contains primitives needed to compute an aggregated result of data
  * processing. Check out {@link AggregateOperations} to find the one
@@ -266,6 +268,7 @@ public interface AggregateOperation<A, R> extends Serializable {
      */
     @Nonnull
     static <A> AggregateOperationBuilder<A> withCreate(@Nonnull DistributedSupplier<A> createFn) {
+        checkSerializable(createFn, "createFn");
         return new AggregateOperationBuilder<>(createFn);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperationBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperationBuilder.java
@@ -30,6 +30,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
@@ -66,6 +67,7 @@ public final class AggregateOperationBuilder<A> {
      */
     @Nonnull
     public <T> Arity1<T, A> andAccumulate(@Nonnull DistributedBiConsumer<? super A, T> accumulateFn) {
+        checkSerializable(accumulateFn, "accumulateFn");
         return new Arity1<>(createFn, accumulateFn);
     }
 
@@ -79,6 +81,7 @@ public final class AggregateOperationBuilder<A> {
      */
     @Nonnull
     public <T0> Arity1<T0, A> andAccumulate0(@Nonnull DistributedBiConsumer<? super A, T0> accumulateFn0) {
+        checkSerializable(accumulateFn0, "accumulateFn0");
         return new Arity1<>(createFn, accumulateFn0);
     }
 
@@ -107,6 +110,7 @@ public final class AggregateOperationBuilder<A> {
     public <T> VarArity<A> andAccumulate(
             @Nonnull Tag<T> tag, @Nonnull DistributedBiConsumer<? super A, T> accumulateFn
     ) {
+        checkSerializable(accumulateFn, "accumulateFn");
         return new VarArity<>(createFn, tag, accumulateFn);
     }
 
@@ -141,6 +145,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public <T1> Arity2<T0, T1, A> andAccumulate1(@Nonnull DistributedBiConsumer<? super A, T1> accumulateFn1) {
+            checkSerializable(accumulateFn1, "accumulateFn1");
             return new Arity2<>(this, accumulateFn1);
         }
 
@@ -149,6 +154,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public Arity1<T0, A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
+            checkSerializable(combineFn, "combineFn");
             this.combineFn = combineFn;
             return this;
         }
@@ -158,6 +164,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public Arity1<T0, A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
+            checkSerializable(deductFn, "deductFn");
             this.deductFn = deductFn;
             return this;
         }
@@ -168,6 +175,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public <R> AggregateOperation1<T0, A, R> andFinish(@Nonnull DistributedFunction<? super A, R> finishFn) {
+            checkSerializable(finishFn, "finishFn");
             return new AggregateOperation1Impl<>(createFn, accumulateFn0, combineFn, deductFn, finishFn);
         }
 
@@ -218,6 +226,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public <T2> Arity3<T0, T1, T2, A> andAccumulate2(@Nonnull DistributedBiConsumer<? super A, T2> accumulateFn2) {
+            checkSerializable(accumulateFn2, "accumulateFn2");
             return new Arity3<>(this, accumulateFn2);
         }
 
@@ -226,6 +235,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public Arity2<T0, T1, A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
+            checkSerializable(combineFn, "combineFn");
             this.combineFn = combineFn;
             return this;
         }
@@ -235,6 +245,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public Arity2<T0, T1, A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
+            checkSerializable(deductFn, "deductFn");
             this.deductFn = deductFn;
             return this;
         }
@@ -245,6 +256,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public <R> AggregateOperation2<T0, T1, A, R> andFinish(@Nonnull DistributedFunction<? super A, R> finishFn) {
+            checkSerializable(finishFn, "finishFn");
             return new AggregateOperation2Impl<>(createFn,
                     accumulateFn0, accumulateFn1,
                     combineFn, deductFn, finishFn);
@@ -297,6 +309,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public Arity3<T0, T1, T2, A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
+            checkSerializable(combineFn, "combineFn");
             this.combineFn = combineFn;
             return this;
         }
@@ -306,6 +319,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public Arity3<T0, T1, T2, A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
+            checkSerializable(deductFn, "deductFn");
             this.deductFn = deductFn;
             return this;
         }
@@ -318,6 +332,7 @@ public final class AggregateOperationBuilder<A> {
         public <R> AggregateOperation3<T0, T1, T2, A, R> andFinish(
                 @Nonnull DistributedFunction<? super A, R> finishFn
         ) {
+            checkSerializable(finishFn, "finishFn");
             return new AggregateOperation3Impl<>(createFn,
                     accumulateFn0, accumulateFn1, accumulateFn2,
                     combineFn, deductFn, finishFn);
@@ -377,6 +392,7 @@ public final class AggregateOperationBuilder<A> {
         public <T> VarArity<A> andAccumulate(
                 @Nonnull Tag<T> tag, @Nonnull DistributedBiConsumer<? super A, T> accumulateFn
         ) {
+            checkSerializable(accumulateFn, "accumulateFn");
             if (accumulateFnsByTag.putIfAbsent(tag.index(), accumulateFn) != null) {
                 throw new IllegalArgumentException("Tag with index " + tag.index() + " already registered");
             }
@@ -388,6 +404,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public VarArity<A> andCombine(@Nullable DistributedBiConsumer<? super A, ? super A> combineFn) {
+            checkSerializable(combineFn, "combineFn");
             this.combineFn = combineFn;
             return this;
         }
@@ -397,6 +414,7 @@ public final class AggregateOperationBuilder<A> {
          */
         @Nonnull
         public VarArity<A> andDeduct(@Nullable DistributedBiConsumer<? super A, ? super A> deductFn) {
+            checkSerializable(deductFn, "deductFn");
             this.deductFn = deductFn;
             return this;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
@@ -48,6 +48,7 @@ import java.util.Set;
 
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 /**
  * Utility class with factory methods for several useful aggregate
@@ -81,6 +82,7 @@ public final class AggregateOperations {
     public static <T> AggregateOperation1<T, LongAccumulator, Long> summingLong(
             @Nonnull DistributedToLongFunction<? super T> getLongValueFn
     ) {
+        checkSerializable(getLongValueFn, "getLongValueFn");
         return AggregateOperation
                 .withCreate(LongAccumulator::new)
                 .andAccumulate((LongAccumulator a, T item) -> a.add(getLongValueFn.applyAsLong(item)))
@@ -99,6 +101,7 @@ public final class AggregateOperations {
     public static <T> AggregateOperation1<T, DoubleAccumulator, Double> summingDouble(
             @Nonnull DistributedToDoubleFunction<? super T> getDoubleValueFn
     ) {
+        checkSerializable(getDoubleValueFn, "getDoubleValueFn");
         return AggregateOperation
                 .withCreate(DoubleAccumulator::new)
                 .andAccumulate((DoubleAccumulator a, T item) -> a.accumulate(getDoubleValueFn.applyAsDouble(item)))
@@ -120,6 +123,7 @@ public final class AggregateOperations {
     public static <T> AggregateOperation1<T, MutableReference<T>, T> minBy(
             @Nonnull DistributedComparator<? super T> comparator
     ) {
+        checkSerializable(comparator, "comparator");
         return maxBy(comparator.reversed());
     }
 
@@ -136,7 +140,8 @@ public final class AggregateOperations {
     public static <T> AggregateOperation1<T, MutableReference<T>, T> maxBy(
             @Nonnull DistributedComparator<? super T> comparator
     ) {
-        return AggregateOperation
+        checkSerializable(comparator, "comparator");
+                return AggregateOperation
                 .withCreate(MutableReference<T>::new)
                 .andAccumulate((MutableReference<T> a, T i) -> {
                     if (a.isNull() || comparator.compare(i, a.get()) > 0) {
@@ -162,6 +167,7 @@ public final class AggregateOperations {
     public static <T> AggregateOperation1<T, LongLongAccumulator, Double> averagingLong(
             @Nonnull DistributedToLongFunction<? super T> getLongValueFn
     ) {
+        checkSerializable(getLongValueFn, "getLongValueFn");
         // accumulator.value1 is count
         // accumulator.value2 is sum
         return AggregateOperation
@@ -196,6 +202,7 @@ public final class AggregateOperations {
     public static <T> AggregateOperation1<T, LongDoubleAccumulator, Double> averagingDouble(
             @Nonnull DistributedToDoubleFunction<? super T> getDoubleValueFn
     ) {
+        checkSerializable(getDoubleValueFn, "getDoubleValueFn");
         // accumulator.value1 is count
         // accumulator.value2 is sum
         return AggregateOperation
@@ -231,6 +238,7 @@ public final class AggregateOperations {
             @Nonnull DistributedToLongFunction<T> getXFn,
             @Nonnull DistributedToLongFunction<T> getYFn
     ) {
+        checkSerializable(getXFn, "getYFn");
         return AggregateOperation
                 .withCreate(LinTrendAccumulator::new)
                 .andAccumulate((LinTrendAccumulator a, T item) ->
@@ -275,6 +283,7 @@ public final class AggregateOperations {
             @Nonnull AggregateOperation1<? super T, A1, R1> op1,
             @Nonnull DistributedBiFunction<? super R0, ? super R1, R> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         DistributedBiConsumer<? super A0, ? super A0> combine0 = op0.combineFn();
         DistributedBiConsumer<? super A1, ? super A1> combine1 = op1.combineFn();
         DistributedBiConsumer<? super A0, ? super A0> deduct0 = op0.deductFn();
@@ -340,6 +349,7 @@ public final class AggregateOperations {
             @Nonnull AggregateOperation1<? super T, A2, ? extends R2> op2,
             @Nonnull DistributedTriFunction<? super R0, ? super R1, ? super R2, ? extends R> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         DistributedBiConsumer<? super A0, ? super A0> combine0 = op0.combineFn();
         DistributedBiConsumer<? super A1, ? super A1> combine1 = op1.combineFn();
         DistributedBiConsumer<? super A2, ? super A2> combine2 = op2.combineFn();
@@ -438,6 +448,7 @@ public final class AggregateOperations {
             @Nonnull AggregateOperation1<? super T1, A1, ? extends R1> op1,
             @Nonnull DistributedBiFunction<? super R0, ? super R1, ? extends R> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         DistributedBiConsumer<? super A0, ? super A0> combine0 = op0.combineFn();
         DistributedBiConsumer<? super A1, ? super A1> combine1 = op1.combineFn();
         DistributedBiConsumer<? super A0, ? super A0> deduct0 = op0.deductFn();
@@ -519,6 +530,7 @@ public final class AggregateOperations {
             @Nonnull AggregateOperation1<? super T2, A2, ? extends R2> op2,
             @Nonnull DistributedTriFunction<? super R0, ? super R1, ? super R2, ? extends R> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         DistributedBiConsumer<? super A0, ? super A0> combine0 = op0.combineFn();
         DistributedBiConsumer<? super A1, ? super A1> combine1 = op1.combineFn();
         DistributedBiConsumer<? super A2, ? super A2> combine2 = op2.combineFn();
@@ -668,6 +680,7 @@ public final class AggregateOperations {
             @Nonnull DistributedFunction<? super T, ? extends U> mapFn,
             @Nonnull AggregateOperation1<? super U, A, R> downstream
     ) {
+        checkSerializable(mapFn, "mapFn");
         DistributedBiConsumer<? super A, ? super U> downstreamAccumulateFn = downstream.accumulateFn();
         return AggregateOperation
                 .withCreate(downstream.createFn())
@@ -698,6 +711,7 @@ public final class AggregateOperations {
     public static <T, C extends Collection<T>> AggregateOperation1<T, C, C> toCollection(
             DistributedSupplier<C> createCollectionFn
     ) {
+        checkSerializable(createCollectionFn, "createCollectionFn");
         return AggregateOperation
                 .withCreate(createCollectionFn)
                 .<T>andAccumulate(Collection::add)
@@ -819,6 +833,11 @@ public final class AggregateOperations {
             DistributedBinaryOperator<U> mergeFn,
             DistributedSupplier<M> createMapFn
     ) {
+        checkSerializable(toKeyFn, "toKeyFn");
+        checkSerializable(toValueFn, "toValueFn");
+        checkSerializable(mergeFn, "mergeFn");
+        checkSerializable(createMapFn, "createMapFn");
+
         DistributedBiConsumer<M, T> accumulateFn =
                 (map, element) -> map.merge(toKeyFn.apply(element), toValueFn.apply(element), mergeFn);
         return AggregateOperation
@@ -904,6 +923,9 @@ public final class AggregateOperations {
             DistributedSupplier<M> createMapFn,
             AggregateOperation1<? super T, A, R> downstream
     ) {
+        checkSerializable(toKeyFn, "toKeyFn");
+        checkSerializable(createMapFn, "createMapFn");
+
         DistributedBiConsumer<? super Map<K, A>, T> accumulateFn = (m, t) -> {
             A acc = m.computeIfAbsent(toKeyFn.apply(t), k -> downstream.createFn().get());
             downstream.accumulateFn().accept(acc, t);
@@ -962,6 +984,11 @@ public final class AggregateOperations {
             @Nonnull DistributedBinaryOperator<A> combineAccValuesFn,
             @Nullable DistributedBinaryOperator<A> deductAccValueFn
     ) {
+        checkSerializable(emptyAccValue, "emptyAccValue");
+        checkSerializable(toAccValueFn, "toAccValueFn");
+        checkSerializable(combineAccValuesFn, "combineAccValuesFn");
+        checkSerializable(deductAccValueFn, "deductAccValueFn");
+
         // workaround for spotbugs issue: https://github.com/spotbugs/spotbugs/issues/552
         DistributedBinaryOperator<A> deductFn = deductAccValueFn;
         return AggregateOperation
@@ -1024,6 +1051,7 @@ public final class AggregateOperations {
     public static <T> AggregateOperation1<T, ArrayList<T>, List<T>> sorting(
             @Nonnull DistributedComparator<? super T> comparator
     ) {
+        checkSerializable(comparator, "comparator");
         return AggregateOperation
                 .withCreate(ArrayList<T>::new)
                 .<T>andAccumulate(ArrayList::add)

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AllOfAggregationBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AllOfAggregationBuilder.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.function.DistributedFunction;
 
 import javax.annotation.Nonnull;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,13 +29,12 @@ import static com.hazelcast.jet.datamodel.Tag.tag;
 import static com.hazelcast.jet.function.DistributedFunction.identity;
 
 /**
- * Offers a step-by-step API to create a composite of multiple
- * aggregate operations. To obtain it, call {@link
- * AggregateOperations#allOfBuilder()}.
+ * Offers a step-by-step API to create a composite of multiple aggregate
+ * operations. To obtain it, call {@link AggregateOperations#allOfBuilder()}.
  *
  * @param <T> the type of the input items
  */
-public final class AllOfAggregationBuilder<T> {
+public final class AllOfAggregationBuilder<T> implements Serializable {
 
     private final List<Tag> tags = new ArrayList<>();
     private final List<AggregateOperation1> operations = new ArrayList<>();
@@ -71,7 +71,8 @@ public final class AllOfAggregationBuilder<T> {
      * call the supplied {@code finishFn} to transform the {@link ItemsByTag}
      * it creates to the result type it emits as the actual result.
      *
-     * @param finishFn function to convert {@link ItemsByTag} to the target result type
+     * @param finishFn function to convert {@link ItemsByTag} to the target
+     *                result type
      */
     @Nonnull
     @SuppressWarnings({"unchecked", "ConstantConditions"})

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/DiagnosticProcessors.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
 import static com.hazelcast.jet.function.DistributedFunctions.alwaysTrue;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 /**
  * Static utility class with factories of sinks and wrappers that log
@@ -63,6 +64,8 @@ public final class DiagnosticProcessors {
     public static <T> ProcessorMetaSupplier writeLoggerP(
             @Nonnull DistributedFunction<T, ? extends CharSequence> toStringFn
     ) {
+        checkSerializable(toStringFn, "toStringFn");
+
         return preferLocalParallelismOne(() -> new WriteLoggerP<>(toStringFn));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -47,6 +47,7 @@ import java.nio.charset.Charset;
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -214,6 +215,8 @@ public final class SinkProcessors {
             @Nonnull DistributedFunction<T, String> toStringFn,
             @Nonnull Charset charset
     ) {
+        checkSerializable(toStringFn, "toStringFn");
+
         String charsetName = charset.name();
         return preferLocalParallelismOne(writeBufferedP(
                 index -> uncheckCall(
@@ -243,6 +246,8 @@ public final class SinkProcessors {
             @Nonnull Charset charset,
             boolean append
     ) {
+        checkSerializable(toStringFn, "toStringFn");
+
         return WriteFileP.metaSupplier(directoryName, toStringFn, charset.name(), append);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -51,6 +51,7 @@ import static com.hazelcast.jet.Util.cacheEventToEntry;
 import static com.hazelcast.jet.Util.cachePutEvents;
 import static com.hazelcast.jet.Util.mapEventToEntry;
 import static com.hazelcast.jet.Util.mapPutEvents;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 
 /**
@@ -124,6 +125,9 @@ public final class SourceProcessors {
             @Nonnull JournalInitialPosition initialPos,
             WatermarkGenerationParams<? super T> wmGenParams
     ) {
+        checkSerializable(predicateFn, "predicateFn");
+        checkSerializable(projectionFn, "projectionFn");
+
         return StreamEventJournalP.streamMapP(mapName, predicateFn, projectionFn, initialPos, wmGenParams);
     }
 
@@ -322,6 +326,8 @@ public final class SourceProcessors {
             @Nonnull DistributedBiFunction<String, String, R> mapOutputFn,
             boolean sharedFileSystem
     ) {
+        checkSerializable(mapOutputFn, "mapOutputFn");
+
         String charsetName = charset.name();
         return ReadFilesP.metaSupplier(directory, glob,
                 path -> uncheckCall(() -> Files.lines(path, Charset.forName(charsetName))),

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperation1Impl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperation1Impl.java
@@ -25,6 +25,8 @@ import com.hazelcast.jet.function.DistributedSupplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+
 public class AggregateOperation1Impl<T0, A, R>
         extends AggregateOperationImpl<A, R>
         implements AggregateOperation1<T0, A, R> {
@@ -46,8 +48,9 @@ public class AggregateOperation1Impl<T0, A, R>
 
     @Nonnull @Override
     public <NEW_T> AggregateOperation1<NEW_T, A, R> withAccumulateFn(
-            DistributedBiConsumer<? super A, ? super NEW_T> accumulateFn) {
-        return new AggregateOperation1Impl<>(createFn(), accumulateFn, combineFn(), deductFn(), finishFn());
+            DistributedBiConsumer<? super A, ? super NEW_T> newAccFn) {
+        checkSerializable(newAccFn, "newAccFn");
+        return new AggregateOperation1Impl<>(createFn(), newAccFn, combineFn(), deductFn(), finishFn());
     }
 
     @Nonnull @Override
@@ -65,6 +68,7 @@ public class AggregateOperation1Impl<T0, A, R>
     public <R1> AggregateOperation1<T0, A, R1> withFinishFn(
             @Nonnull DistributedFunction<? super A, R1> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         return new AggregateOperation1Impl<>(
                 createFn(), accumulateFn(),
                 combineFn(), deductFn(), finishFn);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperation2Impl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperation2Impl.java
@@ -25,6 +25,8 @@ import com.hazelcast.jet.function.DistributedSupplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+
 public class AggregateOperation2Impl<T0, T1, A, R>
         extends AggregateOperationImpl<A, R>
         implements AggregateOperation2<T0, T1, A, R> {
@@ -65,6 +67,7 @@ public class AggregateOperation2Impl<T0, T1, A, R>
     public <T0_NEW> AggregateOperation2<T0_NEW, T1, A, R> withAccumulateFn0(
             @Nonnull DistributedBiConsumer<? super A, ? super T0_NEW> newAccFn0
     ) {
+        checkSerializable(newAccFn0, "newAccFn0");
         return new AggregateOperation2Impl<>(
                 createFn(), newAccFn0, accumulateFn1(), combineFn(), deductFn(), finishFn());
     }
@@ -73,6 +76,7 @@ public class AggregateOperation2Impl<T0, T1, A, R>
     public <T1_NEW> AggregateOperation2<T0, T1_NEW, A, R> withAccumulateFn1(
             @Nonnull DistributedBiConsumer<? super A, ? super T1_NEW> newAccFn1
     ) {
+        checkSerializable(newAccFn1, "newAccFn1");
         return new AggregateOperation2Impl<>(
                 createFn(), accumulateFn0(), newAccFn1, combineFn(), deductFn(), finishFn());
     }
@@ -92,6 +96,7 @@ public class AggregateOperation2Impl<T0, T1, A, R>
     public <R1> AggregateOperation2<T0, T1, A, R1> withFinishFn(
             @Nonnull DistributedFunction<? super A, R1> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         return new AggregateOperation2Impl<>(createFn(), accumulateFns, combineFn(), deductFn(), finishFn);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperation3Impl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperation3Impl.java
@@ -25,6 +25,8 @@ import com.hazelcast.jet.function.DistributedSupplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+
 public class AggregateOperation3Impl<T0, T1, T2, A, R>
         extends AggregateOperationImpl<A, R>
         implements AggregateOperation3<T0, T1, T2, A, R> {
@@ -72,6 +74,7 @@ public class AggregateOperation3Impl<T0, T1, T2, A, R>
     public <T0_NEW> AggregateOperation3<T0_NEW, T1, T2, A, R> withAccumulateFn0(
             @Nonnull DistributedBiConsumer<? super A, ? super T0_NEW> newAccFn0
     ) {
+        checkSerializable(newAccFn0, "newAccFn0");
         return new AggregateOperation3Impl<>(
                 createFn(), newAccFn0, accumulateFn1(), accumulateFn2(), combineFn(), deductFn(), finishFn());
     }
@@ -80,6 +83,7 @@ public class AggregateOperation3Impl<T0, T1, T2, A, R>
     public <T1_NEW> AggregateOperation3<T0, T1_NEW, T2, A, R> withAccumulateFn1(
             @Nonnull DistributedBiConsumer<? super A, ? super T1_NEW> newAccFn1
     ) {
+        checkSerializable(newAccFn1, "newAccFn1");
         return new AggregateOperation3Impl<>(
                 createFn(), accumulateFn0(), newAccFn1, accumulateFn2(), combineFn(), deductFn(), finishFn());
     }
@@ -88,6 +92,7 @@ public class AggregateOperation3Impl<T0, T1, T2, A, R>
     public <T2_NEW> AggregateOperation3<T0, T1, T2_NEW, A, R> withAccumulateFn2(
             @Nonnull DistributedBiConsumer<? super A, ? super T2_NEW> newAccFn2
     ) {
+        checkSerializable(newAccFn2, "newAccFn2");
         return new AggregateOperation3Impl<>(
                 createFn(), accumulateFn0(), accumulateFn1(), newAccFn2, combineFn(), deductFn(), finishFn());
     }
@@ -107,6 +112,7 @@ public class AggregateOperation3Impl<T0, T1, T2, A, R>
     public <R1> AggregateOperation3<T0, T1, T2, A, R1> withFinishFn(
             @Nonnull DistributedFunction<? super A, R1> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         return new AggregateOperation3Impl<>(createFn(), accumulateFns, combineFn(), deductFn(), finishFn);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperationImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/aggregate/AggregateOperationImpl.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.function.DistributedSupplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class AggregateOperationImpl<A, R> implements AggregateOperation<A, R> {
@@ -95,6 +96,7 @@ public class AggregateOperationImpl<A, R> implements AggregateOperation<A, R> {
     public <R1> AggregateOperation<A, R1> withFinishFn(
             @Nonnull DistributedFunction<? super A, R1> finishFn
     ) {
+        checkSerializable(finishFn, "finishFn");
         return new AggregateOperationImpl<>(createFn(), accumulateFns, combineFn(), deductFn(), finishFn);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -61,6 +61,7 @@ import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelis
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.Util.callbackOf;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.tryIncrement;
 import static java.util.stream.Collectors.toList;
 
@@ -82,6 +83,10 @@ public final class HazelcastWriters {
             @Nonnull DistributedFunction<T, V> toValueFn,
             @Nonnull DistributedBinaryOperator<V> mergeFn
     ) {
+        checkSerializable(toKeyFn, "toKeyFn");
+        checkSerializable(toValueFn, "toValueFn");
+        checkSerializable(mergeFn, "mergeFn");
+
         return updateMapP(name, clientConfig, toKeyFn, (V oldValue, T item) -> {
             V newValue = toValueFn.apply(item);
             if (oldValue == null) {
@@ -99,6 +104,9 @@ public final class HazelcastWriters {
             @Nonnull DistributedFunction<T, K> toKeyFn,
             @Nonnull DistributedBiFunction<V, T, V> updateFn
     ) {
+        checkSerializable(toKeyFn, "toKeyFn");
+        checkSerializable(updateFn, "updateFn");
+
         boolean isLocal = clientConfig == null;
         return preferLocalParallelismOne(new HazelcastWriterSupplier<>(
                 serializableConfig(clientConfig),
@@ -144,6 +152,9 @@ public final class HazelcastWriters {
             @Nonnull DistributedFunction<T, K> toKeyFn,
             @Nonnull DistributedFunction<T, EntryProcessor<K, V>> toEntryProcessorFn
     ) {
+        checkSerializable(toKeyFn, "toKeyFn");
+        checkSerializable(toEntryProcessorFn, "toEntryProcessorFn");
+
         boolean isLocal = clientConfig == null;
         return preferLocalParallelismOne(new EntryProcessorWriterSupplier<>(
                         name,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
@@ -47,6 +47,7 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.client.HazelcastClient.newHazelcastClient;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.processorToPartitions;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -108,6 +109,9 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
             @Nonnull Predicate<K, V> predicate,
             @Nonnull Projection<Map.Entry<K, V>, T> projection
     ) {
+        checkSerializable(predicate, "predicate");
+        checkSerializable(projection, "projection");
+
         return new LocalClusterMetaSupplier<T>(
                 instance -> partition -> {
                     MapProxyImpl map = (MapProxyImpl) instance.<K, V>getMap(mapName);
@@ -121,6 +125,9 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
             @Nonnull Projection<Entry<K, V>, T> projection,
             @Nonnull Predicate<K, V> predicate
     ) {
+        checkSerializable(projection, "projection");
+        checkSerializable(predicate, "predicate");
+
         return new RemoteClusterMetaSupplier<T>(clientConfig,
                 instance -> partition -> ((ClientMapProxy) instance.getMap(mapName))
                         .iterator(FETCH_SIZE, partition, projection, predicate));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -65,6 +65,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.processorToPartitions;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_CURRENT;
 import static java.util.stream.Collectors.groupingBy;
@@ -476,6 +477,9 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
             @Nonnull JournalInitialPosition initialPos,
             WatermarkGenerationParams<? super T> wmGenParams
     ) {
+        checkSerializable(predicate, "predicate");
+        checkSerializable(projection, "projection");
+
         return new ClusterMetaSupplier<>(null,
                 instance -> (EventJournalReader<EventJournalMapEvent<K, V>>) instance.getMap(mapName),
                 predicate, projection, initialPos, wmGenParams);
@@ -489,6 +493,9 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
             @Nonnull DistributedFunction<EventJournalMapEvent<K, V>, T> projection,
             @Nonnull JournalInitialPosition initialPos,
             @Nonnull WatermarkGenerationParams<T> wmGenParams) {
+        checkSerializable(predicate, "predicate");
+        checkSerializable(projection, "projection");
+
         return new ClusterMetaSupplier<>(clientConfig,
                 instance -> (EventJournalReader<EventJournalMapEvent<K, V>>) instance.getMap(mapName),
                 predicate, projection, initialPos, wmGenParams);
@@ -501,6 +508,9 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
             @Nonnull DistributedFunction<EventJournalCacheEvent<K, V>, T> projection,
             @Nonnull JournalInitialPosition initialPos,
             @Nonnull WatermarkGenerationParams<T> wmGenParams) {
+        checkSerializable(predicate, "predicate");
+        checkSerializable(projection, "projection");
+
         return new ClusterMetaSupplier<>(null,
                 inst -> (EventJournalReader<EventJournalCacheEvent<K, V>>) inst.getCacheManager().getCache(cacheName),
                 predicate, projection, initialPos, wmGenParams);
@@ -514,6 +524,9 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
             @Nonnull DistributedFunction<EventJournalCacheEvent<K, V>, T> projection,
             @Nonnull JournalInitialPosition initialPos,
             @Nonnull WatermarkGenerationParams<T> wmGenParams) {
+        checkSerializable(predicate, "predicate");
+        checkSerializable(projection, "projection");
+
         return new ClusterMetaSupplier<>(clientConfig,
                 inst -> (EventJournalReader<EventJournalCacheEvent<K, V>>) inst.getCacheManager().getCache(cacheName),
                 predicate, projection, initialPos, wmGenParams);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/AggBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/AggBuilder.java
@@ -72,7 +72,6 @@ public class AggBuilder {
             @Nonnull CreateOutStageFn<OUT, OUT_STAGE> createOutStageFn,
             @Nullable WindowResultFunction<? super R, ? extends OUT> mapToOutputFn
     ) {
-        checkSerializable(createOutStageFn, "createOutStageFn");
         checkSerializable(mapToOutputFn, "mapToOutputFn");
 
         AggregateOperation adaptedAggrOp = wDef != null ? adaptAggregateOperation(aggrOp) : aggrOp;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/AggBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/AggBuilder.java
@@ -34,6 +34,7 @@ import static com.hazelcast.jet.datamodel.Tag.tag;
 import static com.hazelcast.jet.impl.pipeline.ComputeStageImplBase.DO_NOT_ADAPT;
 import static com.hazelcast.jet.impl.pipeline.ComputeStageImplBase.ensureJetEvents;
 import static com.hazelcast.jet.impl.pipeline.JetEventFunctionAdapter.adaptAggregateOperation;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -71,6 +72,9 @@ public class AggBuilder {
             @Nonnull CreateOutStageFn<OUT, OUT_STAGE> createOutStageFn,
             @Nullable WindowResultFunction<? super R, ? extends OUT> mapToOutputFn
     ) {
+        checkSerializable(createOutStageFn, "createOutStageFn");
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
+
         AggregateOperation adaptedAggrOp = wDef != null ? adaptAggregateOperation(aggrOp) : aggrOp;
         List<Transform> upstreamTransforms = upstreamStages
                 .stream()

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingAndWindowImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingAndWindowImpl.java
@@ -36,6 +36,7 @@ import static com.hazelcast.jet.impl.pipeline.ComputeStageImplBase.ensureJetEven
 import static com.hazelcast.jet.impl.pipeline.JetEventFunctionAdapter.adaptAggregateOperation1;
 import static com.hazelcast.jet.impl.pipeline.JetEventFunctionAdapter.adaptAggregateOperation2;
 import static com.hazelcast.jet.impl.pipeline.JetEventFunctionAdapter.adaptAggregateOperation3;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 
@@ -64,6 +65,7 @@ public class StageWithGroupingAndWindowImpl<T, K>
     public <R> StreamStage<R> distinct(
             @Nonnull WindowResultFunction<? super T, ? extends R> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         return aggregate(pickAny(), (start, end, key, item) -> mapToOutputFn.apply(start, end, item));
     }
 
@@ -73,6 +75,7 @@ public class StageWithGroupingAndWindowImpl<T, K>
             @Nonnull AggregateOperation1<? super T, A, R> aggrOp,
             @Nonnull KeyedWindowResultFunction<? super K, ? super R, OUT> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         ensureJetEvents(computeStage, "This pipeline stage");
         JetEventFunctionAdapter fnAdapter = ADAPT_TO_JET_EVENT;
         return computeStage.attach(new WindowGroupTransform<K, A, R, JetEvent<OUT>>(
@@ -92,6 +95,7 @@ public class StageWithGroupingAndWindowImpl<T, K>
             @Nonnull AggregateOperation2<? super T, ? super T1, A, R> aggrOp,
             @Nonnull KeyedWindowResultFunction<? super K, ? super R, OUT> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         ComputeStageImplBase stageImpl1 = ((StageWithGroupingBase) stage1).computeStage;
         ensureJetEvents(computeStage, "This pipeline stage");
         ensureJetEvents(stageImpl1, "stage1");
@@ -114,6 +118,7 @@ public class StageWithGroupingAndWindowImpl<T, K>
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, A, R> aggrOp,
             @Nonnull KeyedWindowResultFunction<? super K, ? super R, OUT> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         ComputeStageImplBase stageImpl1 = ((StageWithGroupingBase) stage1).computeStage;
         ComputeStageImplBase stageImpl2 = ((StageWithGroupingBase) stage2).computeStage;
         ensureJetEvents(computeStage, "This pipeline stage");

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
@@ -22,6 +22,8 @@ import com.hazelcast.jet.pipeline.GeneralStageWithGrouping;
 
 import javax.annotation.Nonnull;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+
 class StageWithGroupingBase<T, K> {
 
     @Nonnull
@@ -33,6 +35,7 @@ class StageWithGroupingBase<T, K> {
             @Nonnull ComputeStageImplBase<T> computeStage,
             @Nonnull DistributedFunction<? super T, ? extends K> keyFn
     ) {
+        checkSerializable(keyFn, "keyFn");
         this.computeStage = computeStage;
         this.keyFn = keyFn;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingImpl.java
@@ -55,7 +55,6 @@ public class StageWithGroupingImpl<T, K> extends StageWithGroupingBase<T, K> imp
             @Nonnull ContextFactory<C> contextFactory,
             @Nonnull DistributedBiFunction<? super C, ? super T, ? extends R> mapFn
     ) {
-        checkSerializable(mapFn, "mapFn");
         return computeStage.attachMapUsingKeyedContext(contextFactory, keyFn(), mapFn);
     }
 
@@ -64,7 +63,6 @@ public class StageWithGroupingImpl<T, K> extends StageWithGroupingBase<T, K> imp
             @Nonnull ContextFactory<C> contextFactory,
             @Nonnull DistributedBiPredicate<? super C, ? super T> filterFn
     ) {
-        checkSerializable(filterFn, "filterFn");
         return computeStage.attachFilterUsingKeyedContext(contextFactory, keyFn(), filterFn);
     }
 
@@ -73,7 +71,6 @@ public class StageWithGroupingImpl<T, K> extends StageWithGroupingBase<T, K> imp
             @Nonnull ContextFactory<C> contextFactory,
             @Nonnull DistributedBiFunction<? super C, ? super T, ? extends Traverser<? extends R>> flatMapFn
     ) {
-        checkSerializable(flatMapFn, "flatMapFn");
         return computeStage.attachFlatMapUsingKeyedContext(contextFactory, keyFn(), flatMapFn);
     }
 
@@ -82,6 +79,7 @@ public class StageWithGroupingImpl<T, K> extends StageWithGroupingBase<T, K> imp
             @Nonnull AggregateOperation1<? super T, A, ? extends R> aggrOp,
             @Nonnull DistributedBiFunction<? super K, ? super R, ? extends OUT> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         return computeStage.attach(new GroupTransform<>(
                         singletonList(computeStage.transform),
                         singletonList(keyFn()),
@@ -96,6 +94,7 @@ public class StageWithGroupingImpl<T, K> extends StageWithGroupingBase<T, K> imp
             @Nonnull AggregateOperation2<? super T, ? super T1, A, ? extends R> aggrOp,
             @Nonnull DistributedBiFunction<? super K, ? super R, ? extends OUT> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         return computeStage.attach(
                 new GroupTransform<>(
                         asList(computeStage.transform, transformOf(stage1)),
@@ -112,6 +111,7 @@ public class StageWithGroupingImpl<T, K> extends StageWithGroupingBase<T, K> imp
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, A, R> aggrOp,
             @Nonnull DistributedBiFunction<? super K, ? super R, ? extends OUT> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         return computeStage.attach(
                 new GroupTransform<>(
                         asList(computeStage.transform, transformOf(stage1), transformOf(stage2)),

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithGrouping.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithGrouping.java
@@ -29,6 +29,8 @@ import javax.annotation.Nonnull;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+
 /**
  * Represents an intermediate step when constructing a group-and-aggregate
  * pipeline stage. This is the base type for the batch and stream variants.
@@ -203,6 +205,7 @@ public interface GeneralStageWithGrouping<T, K> {
             @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp,
             @Nonnull DistributedBiFunction<K, R, OUT> mapToOutputFn
     ) {
+        checkSerializable(mapToOutputFn, "mapToOutputFn");
         // Early check for identity finish: tries to finish an empty accumulator, different instance
         // must be returned.
         Object emptyAcc = aggrOp.createFn().get();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
@@ -32,6 +32,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Session;
 
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -62,6 +63,7 @@ public final class JmsSinkBuilder<T> {
      * Use {@link Sinks#jmsQueueBuilder} or {@link Sinks#jmsTopicBuilder}.
      */
     JmsSinkBuilder(@Nonnull DistributedSupplier<ConnectionFactory> factorySupplier, boolean isTopic) {
+        checkSerializable(factorySupplier, "factorySupplier");
         this.factorySupplier = factorySupplier;
         this.isTopic = isTopic;
     }
@@ -87,6 +89,7 @@ public final class JmsSinkBuilder<T> {
      * connection. See {@link #connectionParams(String, String)}.
      */
     public JmsSinkBuilder<T> connectionFn(@Nonnull DistributedFunction<ConnectionFactory, Connection> connectionFn) {
+        checkSerializable(connectionFn, "connectionFn");
         this.connectionFn = connectionFn;
         return this;
     }
@@ -114,6 +117,7 @@ public final class JmsSinkBuilder<T> {
      * create the session. See {@link #sessionParams(boolean, int)}.
      */
     public JmsSinkBuilder<T> sessionFn(@Nonnull DistributedFunction<Connection, Session> sessionFn) {
+        checkSerializable(sessionFn, "sessionFn");
         this.sessionFn = sessionFn;
         return this;
     }
@@ -134,6 +138,7 @@ public final class JmsSinkBuilder<T> {
      * is already an instance of {@code javax.jms.Message}.
      */
     public JmsSinkBuilder<T> messageFn(DistributedBiFunction<Session, T, Message> messageFn) {
+        checkSerializable(messageFn, "messageFn");
         this.messageFn = messageFn;
         return this;
     }
@@ -145,6 +150,7 @@ public final class JmsSinkBuilder<T> {
      * {@code MessageProducer#send(Message message)}.
      */
     public JmsSinkBuilder<T> sendFn(DistributedBiConsumer<MessageProducer, Message> sendFn) {
+        checkSerializable(sendFn, "sendFn");
         this.sendFn = sendFn;
         return this;
     }
@@ -156,6 +162,7 @@ public final class JmsSinkBuilder<T> {
      * If not provided, the builder creates a no-op consumer.
      */
     public JmsSinkBuilder<T> flushFn(DistributedConsumer<Session> flushFn) {
+        checkSerializable(flushFn, "flushFn");
         this.flushFn = flushFn;
         return this;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSourceBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSourceBuilder.java
@@ -32,6 +32,7 @@ import javax.jms.MessageConsumer;
 import javax.jms.Session;
 
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -61,6 +62,7 @@ public final class JmsSourceBuilder<T> {
      * Use {@link Sources#jmsQueueBuilder} of {@link Sources#jmsTopicBuilder}.
      */
     JmsSourceBuilder(DistributedSupplier<ConnectionFactory> factorySupplier, boolean isTopic) {
+        checkSerializable(factorySupplier, "factorySupplier");
         this.factorySupplier = factorySupplier;
         this.isTopic = isTopic;
     }
@@ -86,6 +88,7 @@ public final class JmsSourceBuilder<T> {
      * connection. See {@link #connectionParams(String, String)}.
      */
     public JmsSourceBuilder<T> connectionFn(@Nonnull DistributedFunction<ConnectionFactory, Connection> connectionFn) {
+        checkSerializable(connectionFn, "connectionFn");
         this.connectionFn = connectionFn;
         return this;
     }
@@ -113,6 +116,7 @@ public final class JmsSourceBuilder<T> {
      * create the session. See {@link #sessionParams(boolean, int)}.
      */
     public JmsSourceBuilder<T> sessionFn(@Nonnull DistributedFunction<Connection, Session> sessionFn) {
+        checkSerializable(sessionFn, "sessionFn");
         this.sessionFn = sessionFn;
         return this;
     }
@@ -135,6 +139,7 @@ public final class JmsSourceBuilder<T> {
      * {@link #destinationName(String)}.
      */
     public JmsSourceBuilder<T> consumerFn(@Nonnull DistributedFunction<Session, MessageConsumer> consumerFn) {
+        checkSerializable(consumerFn, "consumerFn");
         this.consumerFn = consumerFn;
         return this;
     }
@@ -145,6 +150,7 @@ public final class JmsSourceBuilder<T> {
      * If not provided, the builder creates an identity function.
      */
     public JmsSourceBuilder<T> projectionFn(DistributedFunction<Message, T> projectionFn) {
+        checkSerializable(projectionFn, "projectionFn");
         this.projectionFn = projectionFn;
         return this;
     }
@@ -155,6 +161,7 @@ public final class JmsSourceBuilder<T> {
      * If not provided, the builder creates a no-op consumer.
      */
     public JmsSourceBuilder<T> flushFn(DistributedConsumer<Session> flushFn) {
+        checkSerializable(flushFn, "flushFn");
         this.flushFn = flushFn;
         return this;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JoinClause.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JoinClause.java
@@ -21,6 +21,8 @@ import com.hazelcast.jet.function.DistributedFunction;
 import java.io.Serializable;
 import java.util.Map.Entry;
 
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+
 /**
  * Specifies how to join an enriching stream to the primary stream in a
  * {@link BatchStage#hashJoin hash-join} operation. It holds three
@@ -57,6 +59,9 @@ public final class JoinClause<K, T0, T1, T1_OUT> implements Serializable {
             DistributedFunction<? super T1, ? extends K> rightKeyFn,
             DistributedFunction<? super T1, ? extends T1_OUT> rightProjectFn
     ) {
+        checkSerializable(leftKeyFn, "leftKeyFn");
+        checkSerializable(rightKeyFn, "rightKeyFn");
+        checkSerializable(rightProjectFn, "rightProjectFn");
         this.leftKeyFn = leftKeyFn;
         this.rightKeyFn = rightKeyFn;
         this.rightProjectFn = rightProjectFn;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/SinkBuilder.java
@@ -30,6 +30,7 @@ import com.hazelcast.util.Preconditions;
 import javax.annotation.Nonnull;
 
 import static com.hazelcast.jet.function.DistributedFunctions.noopConsumer;
+import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 /**
  * See {@link Sinks#builder(String, DistributedFunction)}.
@@ -50,6 +51,7 @@ public final class SinkBuilder<W, T> {
      * Use {@link Sinks#builder(String, DistributedFunction)}.
      */
     SinkBuilder(@Nonnull String name, DistributedFunction<Processor.Context, ? extends W> createFn) {
+        checkSerializable(createFn, "createFn");
         this.name = name;
         this.createFn = createFn;
     }
@@ -64,6 +66,7 @@ public final class SinkBuilder<W, T> {
      */
     @Nonnull
     public SinkBuilder<W, T> onReceiveFn(@Nonnull DistributedBiConsumer<? super W, ? super T> onReceiveFn) {
+        checkSerializable(onReceiveFn, "onReceiveFn");
         this.onReceiveFn = onReceiveFn;
         return this;
     }
@@ -81,6 +84,7 @@ public final class SinkBuilder<W, T> {
      */
     @Nonnull
     public SinkBuilder<W, T> flushFn(@Nonnull DistributedConsumer<? super W> flushFn) {
+        checkSerializable(flushFn, "flushFn");
         this.flushFn = flushFn;
         return this;
     }
@@ -98,6 +102,7 @@ public final class SinkBuilder<W, T> {
      */
     @Nonnull
     public SinkBuilder<W, T> destroyFn(@Nonnull DistributedConsumer<? super W> destroyFn) {
+        checkSerializable(destroyFn, "destroyFn");
         this.destroyFn = destroyFn;
         return this;
     }


### PR DESCRIPTION
Sometimes it's hard to figure out which lambda fails to serialize from 
the JVM's error message. This commit adds an early check so that the 
stack trace points directly to the delinquent lambda and its parameter 
name.