### PR TITLE
Introduce file source/sink builders

### DIFF
--- a/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroProcessors.java
+++ b/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroProcessors.java
@@ -52,17 +52,17 @@ public final class AvroProcessors {
     public static <W, R> ProcessorMetaSupplier readFilesP(
             @Nonnull String directory,
             @Nonnull String glob,
+            boolean sharedFileSystem,
             @Nonnull DistributedSupplier<DatumReader<W>> datumReaderSupplier,
-            @Nonnull DistributedBiFunction<String, W, R> mapOutputFn,
-            boolean sharedFileSystem
+            @Nonnull DistributedBiFunction<String, W, R> mapOutputFn
     ) {
-        return ReadFilesP.metaSupplier(directory, glob,
+        return ReadFilesP.metaSupplier(directory, glob, sharedFileSystem,
                 path -> uncheckCall(() -> {
                     DataFileReader<W> reader = new DataFileReader<>(path.toFile(), datumReaderSupplier.get());
                     return StreamSupport.stream(reader.spliterator(), false)
                                         .onClose(() -> uncheckRun(reader::close));
                 }),
-                mapOutputFn, sharedFileSystem);
+                mapOutputFn);
     }
 
     /**

--- a/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroSinks.java
+++ b/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroSinks.java
@@ -43,14 +43,14 @@ public final class AvroSinks {
      * files. Each processor will write to its own file whose name is equal to
      * the processor's global index (an integer unique to each processor of the
      * vertex), but a single pathname is used to resolve the containing
-     * directory of all files, on all cluster members.
+     * directory of all files, on all cluster members. The sink always
+     * overwrites the files.
      * <p>
      * The sink creates a {@link DataFileWriter} for each processor using the
      * supplied {@code datumWriterSupplier} with the given {@link Schema}.
      * <p>
      * No state is saved to snapshot for this sink. After the job is restarted,
-     * the items will likely be duplicated, providing an <i>at-least-once</i>
-     * guarantee.
+     * the items will be missing since files will be overwritten.
      * <p>
      * The default local parallelism for this sink is 1.
      *

--- a/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroSinks.java
+++ b/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroSinks.java
@@ -66,6 +66,7 @@ public final class AvroSinks {
             @Nonnull DistributedSupplier<Schema> schemaSupplier,
             @Nonnull DistributedSupplier<DatumWriter<R>> datumWriterSupplier
     ) {
+
         return Sinks.fromProcessor("avroFilesSink(" + directoryName + ')',
                 AvroProcessors.writeFilesP(directoryName, schemaSupplier, datumWriterSupplier));
     }

--- a/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroSources.java
+++ b/hazelcast-jet-avro/src/main/java/com/hazelcast/jet/avro/AvroSources.java
@@ -19,7 +19,8 @@ package com.hazelcast.jet.avro;
 import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.jet.pipeline.BatchSource;
-import com.hazelcast.jet.pipeline.Sources;
+import com.hazelcast.jet.pipeline.FileSourceBuilder;
+import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
@@ -28,7 +29,10 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
 
 import javax.annotation.Nonnull;
-import java.io.File;
+import java.util.stream.StreamSupport;
+
+import static com.hazelcast.jet.impl.util.Util.uncheckCall;
+import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 
 /**
  * Contains factory methods for Apache Avro sources.
@@ -39,81 +43,53 @@ public final class AvroSources {
     }
 
     /**
-     * A source that reads records from Apache Avro files in a directory (but
-     * not its subdirectories).
-     * <p>
-     * If {@code sharedFileSystem} is {@code true}, Jet will assume all members
-     * see the same files. They will split the work so that each member will
-     * read a part of the files. If {@code sharedFileSystem} is {@code false},
-     * each member will read all files in the directory, assuming the are
-     * local.
-     * <p>
-     * The source does not save any state to snapshot. If the job is restarted,
-     * it will re-emit all entries.
-     * <p>
-     * Any {@code IOException} will cause the job to fail. The files must not
-     * change while being read; if they do, the behavior is unspecified.
-     * <p>
-     * The default local parallelism for this processor is 2 (or 1 if just 1
-     * CPU is available).
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom Avro file source for the Pipeline API. The source reads records
+     * from Apache Avro files in a directory (but not its subdirectories).
      *
      * @param directory           parent directory of the files
-     * @param glob                the globbing mask, see {@link
-     *                            java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
-     *                            Use {@code "*"} for all files.
-     * @param sharedFileSystem    {@code true} if files are in a shared storage
-     *                                        visible to all members, {@code
-     *                                        false} otherwise
-     * @param datumReaderSupplier the datum reader supplier
-     * @param mapOutputFn         function to create output items. Parameters are
-     *                            {@code fileName} and {@code W}.
      * @param <W>                 the type of the records
      * @param <R>                 the type of the emitted value
      */
     @Nonnull
-    public static <W, R> BatchSource<R> files(
+    public static <W, R> FileSourceBuilder<W, R> filesBuilder(
             @Nonnull String directory,
-            @Nonnull String glob,
-            boolean sharedFileSystem,
-            @Nonnull DistributedSupplier<DatumReader<W>> datumReaderSupplier,
-            @Nonnull DistributedBiFunction<String, W, ? extends R> mapOutputFn
+            @Nonnull DistributedSupplier<DatumReader<W>> datumReaderSupplier
     ) {
-        return Sources.batchFromProcessor("avroFilesSource(" + new File(directory, glob) + ')',
-                AvroProcessors.readFilesP(directory, glob, sharedFileSystem, datumReaderSupplier, mapOutputFn));
+        return new FileSourceBuilder<>(directory, "avroFilesSource",
+                path -> uncheckCall(() -> {
+                    DataFileReader<W> reader = new DataFileReader<>(path.toFile(), datumReaderSupplier.get());
+                    return StreamSupport.stream(reader.spliterator(), false)
+                                        .onClose(() -> uncheckRun(reader::close));
+                }));
     }
 
     /**
-     * Convenience for {@link
-     * #files(String, String, boolean, DistributedSupplier, DistributedBiFunction)}
-     * which reads all the files in the supplied directory as specific records
-     * using supplied {@code recordClass}. If {@code recordClass} implements
-     * {@link SpecificRecord}, {@link SpecificDatumReader} is used to read the
-     * records, {@link ReflectDatumReader} is used otherwise.
+     * Convenience for {@link #filesBuilder(String, DistributedSupplier)} which
+     * reads all the files in the supplied directory as specific records using
+     * supplied {@code recordClass}. If {@code recordClass} implements {@link
+     * SpecificRecord}, {@link SpecificDatumReader} is used to read the records,
+     * {@link ReflectDatumReader} is used otherwise.
      */
     @Nonnull
-    public static <R> BatchSource<R> files(
-            @Nonnull String directory,
-            boolean sharedFileSystem,
-            @Nonnull Class<R> recordClass
-    ) {
-        return files(directory, "*", sharedFileSystem, () -> SpecificRecord.class.isAssignableFrom(recordClass) ?
-                        new SpecificDatumReader<>(recordClass) : new ReflectDatumReader<>(recordClass),
-                (s, r) -> r);
+    public static <R> BatchSource<R> files(@Nonnull String directory, @Nonnull Class<R> recordClass) {
+        return AvroSources.<R, R>filesBuilder(directory, () -> SpecificRecord.class.isAssignableFrom(recordClass) ?
+                new SpecificDatumReader<>(recordClass) : new ReflectDatumReader<>(recordClass)).build();
     }
 
     /**
-     * Convenience for {@link
-     * #files(String, String, boolean, DistributedSupplier, DistributedBiFunction)}
-     * which reads all the files in the supplied directory as generic records and
+     * Convenience for {@link #filesBuilder(String, DistributedSupplier)} which
+     * reads all the files in the supplied directory as generic records and
      * emits the results of transforming each generic record with the supplied
      * mapping function.
      */
     @Nonnull
     public static <R> BatchSource<R> files(
             @Nonnull String directory,
-            boolean sharedFileSystem,
             @Nonnull DistributedBiFunction<String, GenericRecord, R> mapOutputFn
     ) {
-        return files(directory, "*", sharedFileSystem, GenericDatumReader::new, mapOutputFn);
+        return AvroSources.<GenericRecord, R>filesBuilder(directory, GenericDatumReader::new)
+                .mapOutputFn(mapOutputFn)
+                .build();
     }
 }

--- a/hazelcast-jet-avro/src/test/java/com/hazelcast/jet/avro/AvroSourceTest.java
+++ b/hazelcast-jet-avro/src/test/java/com/hazelcast/jet/avro/AvroSourceTest.java
@@ -70,7 +70,7 @@ public class AvroSourceTest extends JetTestSupport {
     @Test
     public void testReflectReader() {
         Pipeline p = Pipeline.create();
-        p.drawFrom(AvroSources.files(directory.getPath(), false, User.class))
+        p.drawFrom(AvroSources.files(directory.getPath(), User.class))
          .drainTo(Sinks.list(list.getName()));
 
         jet.newJob(p).join();
@@ -81,7 +81,7 @@ public class AvroSourceTest extends JetTestSupport {
     @Test
     public void testSpecificReader() {
         Pipeline p = Pipeline.create();
-        p.drawFrom(AvroSources.files(directory.getPath(), false, SpecificUser.class))
+        p.drawFrom(AvroSources.files(directory.getPath(), SpecificUser.class))
          .drainTo(Sinks.list(list.getName()));
 
         jet.newJob(p).join();
@@ -92,7 +92,7 @@ public class AvroSourceTest extends JetTestSupport {
     @Test
     public void testGenericReader() {
         Pipeline p = Pipeline.create();
-        p.drawFrom(AvroSources.files(directory.getPath(), false, (file, record) -> toUser(record)))
+        p.drawFrom(AvroSources.files(directory.getPath(), (file, record) -> toUser(record)))
          .drainTo(Sinks.list(list.getName()));
 
         jet.newJob(p).join();

--- a/hazelcast-jet-avro/src/test/java/com/hazelcast/jet/avro/AvroSourceTest.java
+++ b/hazelcast-jet-avro/src/test/java/com/hazelcast/jet/avro/AvroSourceTest.java
@@ -70,7 +70,7 @@ public class AvroSourceTest extends JetTestSupport {
     @Test
     public void testReflectReader() {
         Pipeline p = Pipeline.create();
-        p.drawFrom(AvroSources.files(directory.getPath(), User.class, false))
+        p.drawFrom(AvroSources.files(directory.getPath(), false, User.class))
          .drainTo(Sinks.list(list.getName()));
 
         jet.newJob(p).join();
@@ -81,7 +81,7 @@ public class AvroSourceTest extends JetTestSupport {
     @Test
     public void testSpecificReader() {
         Pipeline p = Pipeline.create();
-        p.drawFrom(AvroSources.files(directory.getPath(), SpecificUser.class, false))
+        p.drawFrom(AvroSources.files(directory.getPath(), false, SpecificUser.class))
          .drainTo(Sinks.list(list.getName()));
 
         jet.newJob(p).join();
@@ -92,7 +92,7 @@ public class AvroSourceTest extends JetTestSupport {
     @Test
     public void testGenericReader() {
         Pipeline p = Pipeline.create();
-        p.drawFrom(AvroSources.files(directory.getPath(), (file, record) -> toUser(record), false))
+        p.drawFrom(AvroSources.files(directory.getPath(), false, (file, record) -> toUser(record)))
          .drainTo(Sinks.list(list.getName()));
 
         jet.newJob(p).join();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -50,7 +50,6 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Static utility class with factories of sink processors (the terminators
@@ -236,8 +235,7 @@ public final class SinkProcessors {
     }
 
     /**
-     * Returns a supplier of processors for
-     * {@link Sinks#files(String, DistributedFunction, Charset, boolean)}.
+     * Returns a supplier of processors for {@link Sinks#filesBuilder}.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeFileP(
@@ -251,24 +249,6 @@ public final class SinkProcessors {
         return WriteFileP.metaSupplier(directoryName, toStringFn, charset.name(), append);
     }
 
-    /**
-     * Returns a supplier of processors for
-     * {@link Sinks#files(String, DistributedFunction)}.
-     */
-    @Nonnull
-    public static <T> ProcessorMetaSupplier writeFileP(
-            @Nonnull String directoryName, @Nonnull DistributedFunction<T, String> toStringFn
-    ) {
-        return writeFileP(directoryName, toStringFn, UTF_8, false);
-    }
-
-    /**
-     * Returns a supplier of processors for {@link Sinks#files(String)}.
-     */
-    @Nonnull
-    public static ProcessorMetaSupplier writeFileP(@Nonnull String directoryName) {
-        return writeFileP(directoryName, Object::toString, UTF_8, false);
-    }
 
     /**
      * Shortcut for {@link #writeBufferedP(DistributedFunction,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -66,7 +66,7 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier writeMapP(@Nonnull String mapName) {
-        return HazelcastWriters.writeMapP(mapName, null);
+        return HazelcastWriters.writeMapSupplier(mapName, null);
     }
 
     /**
@@ -75,7 +75,7 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier writeRemoteMapP(@Nonnull String mapName, @Nonnull ClientConfig clientConfig) {
-        return HazelcastWriters.writeMapP(mapName, clientConfig);
+        return HazelcastWriters.writeMapSupplier(mapName, clientConfig);
     }
 
     /**
@@ -90,7 +90,7 @@ public final class SinkProcessors {
             @Nonnull DistributedFunction<E, V> toValueFn,
             @Nonnull DistributedBinaryOperator<V> mergeFn
     ) {
-        return HazelcastWriters.mergeMapP(mapName, null, toKeyFn, toValueFn, mergeFn);
+        return HazelcastWriters.mergeMapSupplier(mapName, null, toKeyFn, toValueFn, mergeFn);
     }
 
     /**
@@ -106,7 +106,7 @@ public final class SinkProcessors {
             @Nonnull DistributedFunction<E, V> toValueFn,
             @Nonnull DistributedBinaryOperator<V> mergeFn
     ) {
-        return HazelcastWriters.mergeMapP(mapName, clientConfig, toKeyFn, toValueFn, mergeFn);
+        return HazelcastWriters.mergeMapSupplier(mapName, clientConfig, toKeyFn, toValueFn, mergeFn);
     }
 
     /**
@@ -119,7 +119,7 @@ public final class SinkProcessors {
             @Nonnull DistributedFunction<E, K> toKeyFn,
             @Nonnull DistributedBiFunction<V, E, V> updateFn
     ) {
-        return HazelcastWriters.updateMapP(mapName, null, toKeyFn, updateFn);
+        return HazelcastWriters.updateMapSupplier(mapName, null, toKeyFn, updateFn);
     }
 
     /**
@@ -134,7 +134,7 @@ public final class SinkProcessors {
             @Nonnull DistributedFunction<E, K> toKeyFn,
             @Nonnull DistributedBiFunction<V, E, V> updateFn
     ) {
-        return HazelcastWriters.updateMapP(mapName, clientConfig, toKeyFn, updateFn);
+        return HazelcastWriters.updateMapSupplier(mapName, clientConfig, toKeyFn, updateFn);
     }
 
     /**
@@ -148,7 +148,7 @@ public final class SinkProcessors {
             @Nonnull DistributedFunction<T, EntryProcessor<K, V>> toEntryProcessorFn
 
     ) {
-        return HazelcastWriters.updateMapP(mapName, null, toKeyFn, toEntryProcessorFn);
+        return HazelcastWriters.updateMapSupplier(mapName, null, toKeyFn, toEntryProcessorFn);
     }
 
     /**
@@ -163,7 +163,7 @@ public final class SinkProcessors {
             @Nonnull DistributedFunction<T, K> toKeyFn,
             @Nonnull DistributedFunction<T, EntryProcessor<K, V>> toEntryProcessorFn
     ) {
-        return HazelcastWriters.updateMapP(mapName, clientConfig, toKeyFn, toEntryProcessorFn);
+        return HazelcastWriters.updateMapSupplier(mapName, clientConfig, toKeyFn, toEntryProcessorFn);
     }
 
     /**
@@ -172,7 +172,7 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier writeCacheP(@Nonnull String cacheName) {
-        return HazelcastWriters.writeCacheP(cacheName, null);
+        return HazelcastWriters.writeCacheSupplier(cacheName, null);
     }
 
     /**
@@ -183,7 +183,7 @@ public final class SinkProcessors {
     public static ProcessorMetaSupplier writeRemoteCacheP(
             @Nonnull String cacheName, @Nonnull ClientConfig clientConfig
     ) {
-        return HazelcastWriters.writeCacheP(cacheName, clientConfig);
+        return HazelcastWriters.writeCacheSupplier(cacheName, clientConfig);
     }
 
     /**
@@ -192,7 +192,7 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier writeListP(@Nonnull String listName) {
-        return HazelcastWriters.writeListP(listName, null);
+        return HazelcastWriters.writeListSupplier(listName, null);
     }
 
     /**
@@ -201,7 +201,7 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier writeRemoteListP(@Nonnull String listName, @Nonnull ClientConfig clientConfig) {
-        return HazelcastWriters.writeListP(listName, clientConfig);
+        return HazelcastWriters.writeListSupplier(listName, clientConfig);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -336,16 +336,17 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link Sources#fileWatcher(String, Charset, String)}.
+     * {@link Sources#fileWatcher(String, Charset, String, boolean)}.
      */
     @Nonnull
     public static ProcessorMetaSupplier streamFilesP(
             @Nonnull String watchedDirectory,
             @Nonnull Charset charset,
             @Nonnull String glob,
-            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn
+            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn,
+            boolean sharedFileSystem
     ) {
-        return StreamFilesP.metaSupplier(watchedDirectory, charset.name(), glob, mapOutputFn);
+        return StreamFilesP.metaSupplier(watchedDirectory, charset.name(), glob, mapOutputFn, sharedFileSystem);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -71,7 +71,7 @@ public final class SourceProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier readMapP(@Nonnull String mapName) {
-        return ReadWithPartitionIteratorP.readMapP(mapName);
+        return ReadWithPartitionIteratorP.readMapSupplier(mapName);
     }
 
     /**
@@ -84,7 +84,7 @@ public final class SourceProcessors {
             @Nonnull Predicate<K, V> predicate,
             @Nonnull Projection<Entry<K, V>, T> projectionFn
     ) {
-        return ReadWithPartitionIteratorP.readMapP(mapName, predicate, projectionFn);
+        return ReadWithPartitionIteratorP.readMapSupplier(mapName, predicate, projectionFn);
     }
 
     /**
@@ -97,7 +97,7 @@ public final class SourceProcessors {
             @Nonnull Predicate<K, V> predicate,
             @Nonnull DistributedFunction<Entry<K, V>, T> projectionFn
     ) {
-        return ReadWithPartitionIteratorP.readMapP(mapName, predicate, toProjection(projectionFn));
+        return ReadWithPartitionIteratorP.readMapSupplier(mapName, predicate, toProjection(projectionFn));
     }
 
 
@@ -129,7 +129,7 @@ public final class SourceProcessors {
         checkSerializable(predicateFn, "predicateFn");
         checkSerializable(projectionFn, "projectionFn");
 
-        return StreamEventJournalP.streamMapP(mapName, predicateFn, projectionFn, initialPos, wmGenParams);
+        return StreamEventJournalP.streamMapSupplier(mapName, predicateFn, projectionFn, initialPos, wmGenParams);
     }
 
     /**
@@ -138,7 +138,7 @@ public final class SourceProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier readRemoteMapP(@Nonnull String mapName, @Nonnull ClientConfig clientConfig) {
-        return ReadWithPartitionIteratorP.readRemoteMapP(mapName, clientConfig);
+        return ReadWithPartitionIteratorP.readRemoteMapSupplier(mapName, clientConfig);
     }
 
     /**
@@ -152,7 +152,7 @@ public final class SourceProcessors {
             @Nonnull Predicate<K, V> predicate,
             @Nonnull Projection<Entry<K, V>, T> projection
     ) {
-        return ReadWithPartitionIteratorP.readRemoteMapP(mapName, clientConfig, projection, predicate);
+        return ReadWithPartitionIteratorP.readRemoteMapSupplier(mapName, clientConfig, projection, predicate);
     }
 
     /**
@@ -166,7 +166,7 @@ public final class SourceProcessors {
             @Nonnull Predicate<K, V> predicate,
             @Nonnull DistributedFunction<Entry<K, V>, T> projectionFn
     ) {
-        return ReadWithPartitionIteratorP.readRemoteMapP(
+        return ReadWithPartitionIteratorP.readRemoteMapSupplier(
                 mapName, clientConfig, toProjection(projectionFn), predicate
         );
     }
@@ -200,7 +200,7 @@ public final class SourceProcessors {
             @Nonnull JournalInitialPosition initialPos,
             @Nonnull WatermarkGenerationParams<T> wmGenParams
     ) {
-        return StreamEventJournalP.streamRemoteMapP(
+        return StreamEventJournalP.streamRemoteMapSupplier(
                 mapName, clientConfig, predicateFn, projectionFn, initialPos, wmGenParams);
     }
 
@@ -210,7 +210,7 @@ public final class SourceProcessors {
      */
     @Nonnull
     public static ProcessorMetaSupplier readCacheP(@Nonnull String cacheName) {
-        return ReadWithPartitionIteratorP.readCacheP(cacheName);
+        return ReadWithPartitionIteratorP.readCacheSupplier(cacheName);
     }
 
     /**
@@ -239,7 +239,7 @@ public final class SourceProcessors {
             @Nonnull JournalInitialPosition initialPos,
             @Nonnull WatermarkGenerationParams<T> wmGenParams
     ) {
-        return StreamEventJournalP.streamCacheP(cacheName, predicateFn, projectionFn, initialPos,
+        return StreamEventJournalP.streamCacheSupplier(cacheName, predicateFn, projectionFn, initialPos,
                 wmGenParams);
     }
 
@@ -251,7 +251,7 @@ public final class SourceProcessors {
     public static ProcessorMetaSupplier readRemoteCacheP(
             @Nonnull String cacheName, @Nonnull ClientConfig clientConfig
     ) {
-        return ReadWithPartitionIteratorP.readRemoteCacheP(cacheName, clientConfig);
+        return ReadWithPartitionIteratorP.readRemoteCacheSupplier(cacheName, clientConfig);
     }
 
     /**
@@ -282,7 +282,7 @@ public final class SourceProcessors {
             @Nonnull JournalInitialPosition initialPos,
             @Nonnull WatermarkGenerationParams<T> wmGenParams
     ) {
-        return StreamEventJournalP.streamRemoteCacheP(cacheName, clientConfig, predicateFn, projectionFn, initialPos,
+        return StreamEventJournalP.streamRemoteCacheSupplier(cacheName, clientConfig, predicateFn, projectionFn, initialPos,
                 wmGenParams);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -316,22 +316,22 @@ public final class SourceProcessors {
 
     /**
      * Returns a supplier of processors for
-     * {@link Sources#files(String, Charset, String, DistributedBiFunction, boolean)}.
+     * {@link Sources#files(String, Charset, String, boolean, DistributedBiFunction)}.
      */
     @Nonnull
     public static <R> ProcessorMetaSupplier readFilesP(
             @Nonnull String directory,
             @Nonnull Charset charset,
             @Nonnull String glob,
-            @Nonnull DistributedBiFunction<String, String, R> mapOutputFn,
-            boolean sharedFileSystem
+            boolean sharedFileSystem,
+            @Nonnull DistributedBiFunction<String, String, R> mapOutputFn
     ) {
         checkSerializable(mapOutputFn, "mapOutputFn");
 
         String charsetName = charset.name();
-        return ReadFilesP.metaSupplier(directory, glob,
+        return ReadFilesP.metaSupplier(directory, glob, sharedFileSystem,
                 path -> uncheckCall(() -> Files.lines(path, Charset.forName(charsetName))),
-                mapOutputFn, sharedFileSystem);
+                mapOutputFn);
     }
 
     /**
@@ -343,10 +343,10 @@ public final class SourceProcessors {
             @Nonnull String watchedDirectory,
             @Nonnull Charset charset,
             @Nonnull String glob,
-            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn,
-            boolean sharedFileSystem
+            boolean sharedFileSystem,
+            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn
     ) {
-        return StreamFilesP.metaSupplier(watchedDirectory, charset.name(), glob, mapOutputFn, sharedFileSystem);
+        return StreamFilesP.metaSupplier(watchedDirectory, charset.name(), glob, sharedFileSystem, mapOutputFn);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -282,8 +282,8 @@ public final class SourceProcessors {
             @Nonnull JournalInitialPosition initialPos,
             @Nonnull WatermarkGenerationParams<T> wmGenParams
     ) {
-        return StreamEventJournalP.streamRemoteCacheSupplier(cacheName, clientConfig, predicateFn, projectionFn, initialPos,
-                wmGenParams);
+        return StreamEventJournalP
+                .streamRemoteCacheSupplier(cacheName, clientConfig, predicateFn, projectionFn, initialPos, wmGenParams);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -32,6 +32,7 @@ import com.hazelcast.jet.impl.connector.StreamEventJournalP;
 import com.hazelcast.jet.impl.connector.StreamFilesP;
 import com.hazelcast.jet.impl.connector.StreamJmsP;
 import com.hazelcast.jet.impl.connector.StreamSocketP;
+import com.hazelcast.jet.pipeline.FileSourceBuilder;
 import com.hazelcast.jet.pipeline.JournalInitialPosition;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.journal.EventJournalMapEvent;
@@ -315,8 +316,8 @@ public final class SourceProcessors {
     }
 
     /**
-     * Returns a supplier of processors for
-     * {@link Sources#files(String, Charset, String, boolean, DistributedBiFunction)}.
+     * Returns a supplier of processors for {@link Sources#filesBuilder}.
+     * See {@link FileSourceBuilder#build} for more details.
      */
     @Nonnull
     public static <R> ProcessorMetaSupplier readFilesP(
@@ -335,8 +336,8 @@ public final class SourceProcessors {
     }
 
     /**
-     * Returns a supplier of processors for
-     * {@link Sources#fileWatcher(String, Charset, String, boolean)}.
+     * Returns a supplier of processors for {@link Sources#filesBuilder}.
+     * See {@link FileSourceBuilder#buildWatcher} for more details.
      */
     @Nonnull
     public static ProcessorMetaSupplier streamFilesP(
@@ -346,6 +347,8 @@ public final class SourceProcessors {
             boolean sharedFileSystem,
             @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn
     ) {
+        checkSerializable(mapOutputFn, "mapOutputFn");
+
         return StreamFilesP.metaSupplier(watchedDirectory, charset.name(), glob, sharedFileSystem, mapOutputFn);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -76,7 +76,7 @@ public final class HazelcastWriters {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <T, K, V> ProcessorMetaSupplier mergeMapP(
+    public static <T, K, V> ProcessorMetaSupplier mergeMapSupplier(
             @Nonnull String name,
             @Nullable ClientConfig clientConfig,
             @Nonnull DistributedFunction<T, K> toKeyFn,
@@ -87,7 +87,7 @@ public final class HazelcastWriters {
         checkSerializable(toValueFn, "toValueFn");
         checkSerializable(mergeFn, "mergeFn");
 
-        return updateMapP(name, clientConfig, toKeyFn, (V oldValue, T item) -> {
+        return updateMapSupplier(name, clientConfig, toKeyFn, (V oldValue, T item) -> {
             V newValue = toValueFn.apply(item);
             if (oldValue == null) {
                 return newValue;
@@ -98,7 +98,7 @@ public final class HazelcastWriters {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <T, K, V> ProcessorMetaSupplier updateMapP(
+    public static <T, K, V> ProcessorMetaSupplier updateMapSupplier(
             @Nonnull String name,
             @Nullable ClientConfig clientConfig,
             @Nonnull DistributedFunction<T, K> toKeyFn,
@@ -146,7 +146,7 @@ public final class HazelcastWriters {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static <T, K, V> ProcessorMetaSupplier updateMapP(
+    public static <T, K, V> ProcessorMetaSupplier updateMapSupplier(
             @Nonnull String name,
             @Nullable ClientConfig clientConfig,
             @Nonnull DistributedFunction<T, K> toKeyFn,
@@ -169,7 +169,7 @@ public final class HazelcastWriters {
 
     @Nonnull
     @SuppressWarnings("unchecked")
-    public static ProcessorMetaSupplier writeMapP(@Nonnull String name, @Nullable ClientConfig clientConfig) {
+    public static ProcessorMetaSupplier writeMapSupplier(@Nonnull String name, @Nullable ClientConfig clientConfig) {
         boolean isLocal = clientConfig == null;
         return preferLocalParallelismOne(new HazelcastWriterSupplier<>(
                 serializableConfig(clientConfig),
@@ -191,7 +191,7 @@ public final class HazelcastWriters {
     }
 
     @Nonnull
-    public static ProcessorMetaSupplier writeCacheP(@Nonnull String name, @Nullable ClientConfig clientConfig) {
+    public static ProcessorMetaSupplier writeCacheSupplier(@Nonnull String name, @Nullable ClientConfig clientConfig) {
         boolean isLocal = clientConfig == null;
         return preferLocalParallelismOne(new HazelcastWriterSupplier<>(
                 serializableConfig(clientConfig),
@@ -203,7 +203,7 @@ public final class HazelcastWriters {
     }
 
     @Nonnull
-    public static ProcessorMetaSupplier writeListP(@Nonnull String name, @Nullable ClientConfig clientConfig) {
+    public static ProcessorMetaSupplier writeListSupplier(@Nonnull String name, @Nullable ClientConfig clientConfig) {
         boolean isLocal = clientConfig == null;
         return preferLocalParallelismOne(new HazelcastWriterSupplier<>(
                 serializableConfig(clientConfig),

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -61,10 +61,9 @@ public final class ReadFilesP<W, R> extends AbstractProcessor {
     private Traverser<R> outputTraverser;
     private Stream<W> currentStream;
 
-    private ReadFilesP(@Nonnull String directory, @Nonnull String glob,
+    private ReadFilesP(@Nonnull String directory, @Nonnull String glob, boolean sharedFileSystem,
                        @Nonnull DistributedFunction<Path, Stream<W>> readFileFn,
-                       @Nonnull DistributedBiFunction<String, W, R> mapOutputFn,
-                       boolean sharedFileSystem) {
+                       @Nonnull DistributedBiFunction<String, W, R> mapOutputFn) {
         this.directory = Paths.get(directory);
         this.glob = glob;
         this.readFileFn = readFileFn;
@@ -140,11 +139,11 @@ public final class ReadFilesP<W, R> extends AbstractProcessor {
     public static <W, R> ProcessorMetaSupplier metaSupplier(
             @Nonnull String directory,
             @Nonnull String glob,
+            boolean sharedFileSystem,
             @Nonnull DistributedFunction<Path, Stream<W>> readFileFn,
-            @Nonnull DistributedBiFunction<String, W, R> mapOutputFn,
-            boolean sharedFileSystem
+            @Nonnull DistributedBiFunction<String, W, R> mapOutputFn
     ) {
-        return ProcessorMetaSupplier.of(() -> new ReadFilesP<>(directory, glob, readFileFn, mapOutputFn, sharedFileSystem),
+        return ProcessorMetaSupplier.of(() -> new ReadFilesP<>(directory, glob, sharedFileSystem, readFileFn, mapOutputFn),
                 2);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
@@ -139,7 +139,8 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
                         .iterator(FETCH_SIZE, partition, PREFETCH_VALUES));
     }
 
-    public static ProcessorMetaSupplier readRemoteCacheSupplier(@Nonnull String cacheName, @Nonnull ClientConfig clientConfig) {
+    public static ProcessorMetaSupplier readRemoteCacheSupplier(@Nonnull String cacheName,
+                                                                @Nonnull ClientConfig clientConfig) {
         return new RemoteClusterMetaSupplier<>(clientConfig,
                 instance -> partition -> ((ClientCacheProxy) instance.getCacheManager().getCache(cacheName))
                         .iterator(FETCH_SIZE, partition, PREFETCH_VALUES));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadWithPartitionIteratorP.java
@@ -90,13 +90,13 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
         };
     }
 
-    public static <T> ProcessorMetaSupplier readMapP(@Nonnull String mapName) {
+    public static <T> ProcessorMetaSupplier readMapSupplier(@Nonnull String mapName) {
         return new LocalClusterMetaSupplier<T>(
                 instance -> partition -> ((MapProxyImpl) instance.getMap(mapName))
                         .iterator(FETCH_SIZE, partition, PREFETCH_VALUES));
     }
 
-    public static <T> ProcessorMetaSupplier readRemoteMapP(
+    public static <T> ProcessorMetaSupplier readRemoteMapSupplier(
             @Nonnull String mapName, @Nonnull ClientConfig clientConfig
     ) {
         return new RemoteClusterMetaSupplier<T>(clientConfig,
@@ -104,7 +104,7 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
                         .iterator(FETCH_SIZE, partition, PREFETCH_VALUES));
     }
 
-    public static <K, V, T> ProcessorMetaSupplier readMapP(
+    public static <K, V, T> ProcessorMetaSupplier readMapSupplier(
             @Nonnull String mapName,
             @Nonnull Predicate<K, V> predicate,
             @Nonnull Projection<Map.Entry<K, V>, T> projection
@@ -119,7 +119,7 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
                 });
     }
 
-    public static <K, V, T> ProcessorMetaSupplier readRemoteMapP(
+    public static <K, V, T> ProcessorMetaSupplier readRemoteMapSupplier(
             @Nonnull String mapName,
             @Nonnull ClientConfig clientConfig,
             @Nonnull Projection<Entry<K, V>, T> projection,
@@ -133,13 +133,13 @@ public final class ReadWithPartitionIteratorP<T> extends AbstractProcessor {
                         .iterator(FETCH_SIZE, partition, projection, predicate));
     }
 
-    public static ProcessorMetaSupplier readCacheP(@Nonnull String cacheName) {
+    public static ProcessorMetaSupplier readCacheSupplier(@Nonnull String cacheName) {
         return new LocalClusterMetaSupplier<>(
                 instance -> partition -> ((CacheProxy) instance.getCacheManager().getCache(cacheName))
                         .iterator(FETCH_SIZE, partition, PREFETCH_VALUES));
     }
 
-    public static ProcessorMetaSupplier readRemoteCacheP(@Nonnull String cacheName, @Nonnull ClientConfig clientConfig) {
+    public static ProcessorMetaSupplier readRemoteCacheSupplier(@Nonnull String cacheName, @Nonnull ClientConfig clientConfig) {
         return new RemoteClusterMetaSupplier<>(clientConfig,
                 instance -> partition -> ((ClientCacheProxy) instance.getCacheManager().getCache(cacheName))
                         .iterator(FETCH_SIZE, partition, PREFETCH_VALUES));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamEventJournalP.java
@@ -470,7 +470,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
     }
 
     @SuppressWarnings("unchecked")
-    public static <K, V, T> ProcessorMetaSupplier streamMapP(
+    public static <K, V, T> ProcessorMetaSupplier streamMapSupplier(
             @Nonnull String mapName,
             @Nonnull DistributedPredicate<EventJournalMapEvent<K, V>> predicate,
             @Nonnull DistributedFunction<EventJournalMapEvent<K, V>, T> projection,
@@ -486,7 +486,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
     }
 
     @SuppressWarnings("unchecked")
-    public static <K, V, T> ProcessorMetaSupplier streamRemoteMapP(
+    public static <K, V, T> ProcessorMetaSupplier streamRemoteMapSupplier(
             @Nonnull String mapName,
             @Nonnull ClientConfig clientConfig,
             @Nonnull DistributedPredicate<EventJournalMapEvent<K, V>> predicate,
@@ -502,7 +502,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
     }
 
     @SuppressWarnings("unchecked")
-    public static <K, V, T> ProcessorMetaSupplier streamCacheP(
+    public static <K, V, T> ProcessorMetaSupplier streamCacheSupplier(
             @Nonnull String cacheName,
             @Nonnull DistributedPredicate<EventJournalCacheEvent<K, V>> predicate,
             @Nonnull DistributedFunction<EventJournalCacheEvent<K, V>, T> projection,
@@ -517,7 +517,7 @@ public final class StreamEventJournalP<E, T> extends AbstractProcessor {
     }
 
     @SuppressWarnings("unchecked")
-    public static <K, V, T> ProcessorMetaSupplier streamRemoteCacheP(
+    public static <K, V, T> ProcessorMetaSupplier streamRemoteCacheSupplier(
             @Nonnull String cacheName,
             @Nonnull ClientConfig clientConfig,
             @Nonnull DistributedPredicate<EventJournalCacheEvent<K, V>> predicate,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
@@ -93,8 +93,8 @@ public class StreamFilesP<R> extends AbstractProcessor {
     private final Path watchedDirectory;
     private final Charset charset;
     private final PathMatcher glob;
-    private final DistributedBiFunction<String, String, R> mapOutputFn;
     private final boolean sharedFileSystem;
+    private final DistributedBiFunction<String, String, R> mapOutputFn;
 
     private final Queue<Path> eventQueue = new ArrayDeque<>();
 
@@ -109,13 +109,13 @@ public class StreamFilesP<R> extends AbstractProcessor {
     private int processorIndex;
 
     StreamFilesP(@Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob,
-                 @Nonnull DistributedBiFunction<String, String, R> mapOutputFn, boolean sharedFileSystem
+                 boolean sharedFileSystem, @Nonnull DistributedBiFunction<String, String, R> mapOutputFn
     ) {
         this.watchedDirectory = Paths.get(watchedDirectory);
         this.charset = charset;
         this.glob = FileSystems.getDefault().getPathMatcher("glob:" + glob);
-        this.mapOutputFn = mapOutputFn;
         this.sharedFileSystem = sharedFileSystem;
+        this.mapOutputFn = mapOutputFn;
         setCooperative(false);
     }
 
@@ -348,11 +348,11 @@ public class StreamFilesP<R> extends AbstractProcessor {
             @Nonnull String watchedDirectory,
             @Nonnull String charset,
             @Nonnull String glob,
-            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn,
-            boolean sharedFileSystem
+            boolean sharedFileSystem,
+            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn
     ) {
         return ProcessorMetaSupplier.of(() ->
-                new StreamFilesP<>(watchedDirectory, Charset.forName(charset), glob, mapOutputFn, sharedFileSystem), 2);
+                new StreamFilesP<>(watchedDirectory, Charset.forName(charset), glob, sharedFileSystem, mapOutputFn), 2);
     }
 
     private static WatchEvent.Modifier[] getHighSensitivityModifiers() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.impl.connector;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
-import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.impl.util.ReflectionUtils;
 import com.hazelcast.logging.ILogger;
@@ -46,7 +45,6 @@ import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Queue;
-import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
@@ -56,7 +54,6 @@ import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
 import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Private API. Access via {@link
@@ -96,9 +93,8 @@ public class StreamFilesP<R> extends AbstractProcessor {
     private final Path watchedDirectory;
     private final Charset charset;
     private final PathMatcher glob;
-    private final int parallelism;
-    private final int id;
     private final DistributedBiFunction<String, String, R> mapOutputFn;
+    private final boolean sharedFileSystem;
 
     private final Queue<Path> eventQueue = new ArrayDeque<>();
 
@@ -109,21 +105,25 @@ public class StreamFilesP<R> extends AbstractProcessor {
     private String currentFileName;
     private FileInputStream currentInputStream;
     private Reader currentReader;
+    private int parallelism;
+    private int processorIndex;
 
     StreamFilesP(@Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob,
-                 int parallelism, int id, @Nonnull DistributedBiFunction<String, String, R> mapOutputFn
+                 @Nonnull DistributedBiFunction<String, String, R> mapOutputFn, boolean sharedFileSystem
     ) {
         this.watchedDirectory = Paths.get(watchedDirectory);
         this.charset = charset;
         this.glob = FileSystems.getDefault().getPathMatcher("glob:" + glob);
-        this.parallelism = parallelism;
-        this.id = id;
         this.mapOutputFn = mapOutputFn;
+        this.sharedFileSystem = sharedFileSystem;
         setCooperative(false);
     }
 
     @Override
     protected void init(@Nonnull Context context) throws Exception {
+        processorIndex = sharedFileSystem ? context.globalProcessorIndex() : context.localProcessorIndex();
+        parallelism = sharedFileSystem ? context.totalParallelism() : context.localParallelism();
+
         try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(watchedDirectory)) {
             for (Path file : directoryStream) {
                 if (Files.isRegularFile(file)) {
@@ -212,7 +212,7 @@ public class StreamFilesP<R> extends AbstractProcessor {
     }
 
     private boolean belongsToThisProcessor(Path path) {
-        return ((path.hashCode() & Integer.MAX_VALUE) % parallelism) == id;
+        return ((path.hashCode() & Integer.MAX_VALUE) % parallelism) == processorIndex;
     }
 
     private void processFile() {
@@ -348,14 +348,11 @@ public class StreamFilesP<R> extends AbstractProcessor {
             @Nonnull String watchedDirectory,
             @Nonnull String charset,
             @Nonnull String glob,
-            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn
+            @Nonnull DistributedBiFunction<String, String, ?> mapOutputFn,
+            boolean sharedFileSystem
     ) {
-        return ProcessorMetaSupplier.of((ProcessorSupplier)
-                count -> IntStream.range(0, count)
-                        .mapToObj(i -> new StreamFilesP(watchedDirectory, Charset.forName(charset), glob, count, i,
-                                mapOutputFn))
-                        .collect(toList()),
-                2);
+        return ProcessorMetaSupplier.of(() ->
+                new StreamFilesP<>(watchedDirectory, Charset.forName(charset), glob, mapOutputFn, sharedFileSystem), 2);
     }
 
     private static WatchEvent.Modifier[] getHighSensitivityModifiers() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ContextFactory.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ContextFactory.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.function.DistributedConsumer;
 import com.hazelcast.jet.function.DistributedFunction;
 
@@ -96,9 +97,8 @@ public final class ContextFactory<C> implements Serializable {
      * Returns a copy of this {@link ContextFactory} with the
      * <em>isCooperative</em> flag set to {@code false}. The context factory is
      * cooperative by default. Call this method if your transform function
-     * doesn't follow the {@linkplain
-     * com.hazelcast.jet.core.Processor#isCooperative() cooperative processor
-     * contract}.
+     * doesn't follow the {@linkplain Processor#isCooperative() cooperative
+     * processor contract}.
      *
      * @return a copy of this factory with the {@code isCooperative} flag set
      * to {@code false}.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSinkBuilder.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeFileP;
 
 /**
- * See {@link Sinks#filesBuilder}
+ * See {@link Sinks#filesBuilder}.
  *
  * @param <T> type of the items the sink accepts
  */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSinkBuilder.java
@@ -38,7 +38,7 @@ public final class FileSinkBuilder<T> {
     private boolean append;
 
     /**
-     * Use {@link Sinks#filesBuilder}
+     * Use {@link Sinks#filesBuilder}.
      */
     FileSinkBuilder(@Nonnull String directoryName) {
         this.directoryName = directoryName;
@@ -65,7 +65,7 @@ public final class FileSinkBuilder<T> {
 
     /**
      * Sets whether to append ({@code true}) or overwrite ({@code false})
-     * an existing file. Default value is {@code false}
+     * an existing file. Default value is {@code false}.
      */
     public FileSinkBuilder<T> append(boolean append) {
         this.append = append;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSinkBuilder.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.pipeline;
+
+import com.hazelcast.jet.function.DistributedFunction;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import static com.hazelcast.jet.core.processor.SinkProcessors.writeFileP;
+
+/**
+ * See {@link Sinks#filesBuilder}
+ *
+ * @param <T> type of the items the sink accepts
+ */
+public final class FileSinkBuilder<T> {
+
+    private final String directoryName;
+
+    private DistributedFunction<T, String> toStringFn = Object::toString;
+    private Charset charset = StandardCharsets.UTF_8;
+    private boolean append;
+
+    /**
+     * Use {@link Sinks#filesBuilder}
+     */
+    FileSinkBuilder(@Nonnull String directoryName) {
+        this.directoryName = directoryName;
+    }
+
+    /**
+     * Sets the function which converts the item to its string representation.
+     * Each item is followed with a platform-specific line separator. Default
+     * value is {@link Object#toString}.
+     */
+    public FileSinkBuilder<T> toStringFn(@Nonnull DistributedFunction<T, String> toStringFn) {
+        this.toStringFn = toStringFn;
+        return this;
+    }
+
+    /**
+     * Sets the character set used to encode the files. Default value is {@link
+     * java.nio.charset.StandardCharsets#UTF_8}.
+     */
+    public FileSinkBuilder<T> charset(@Nonnull Charset charset) {
+        this.charset = charset;
+        return this;
+    }
+
+    /**
+     * Sets whether to append ({@code true}) or overwrite ({@code false})
+     * an existing file. Default value is {@code false}
+     */
+    public FileSinkBuilder<T> append(boolean append) {
+        this.append = append;
+        return this;
+    }
+
+    /**
+     * Creates and returns the file {@link Sink} with the supplied components.
+     */
+    public Sink<T> build() {
+        return Sinks.fromProcessor("filesSink(" + directoryName + ')',
+                writeFileP(directoryName, toStringFn, charset, append));
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.pipeline;
+
+import com.hazelcast.jet.core.processor.SourceProcessors;
+import com.hazelcast.jet.function.DistributedBiFunction;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.nio.charset.Charset;
+
+import static com.hazelcast.jet.core.processor.SourceProcessors.readFilesP;
+import static com.hazelcast.jet.pipeline.Sources.batchFromProcessor;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Builder for a file source which reads lines from files in a directory (but not
+ * its subdirectories) and emits output object created by {@code mapOutputFn}
+ *
+ * @param <R> the type of the items the source emits
+ */
+public final class FileSourceBuilder<R> {
+
+    private static final String GLOB_WILDCARD = "*";
+
+    private final String directory;
+
+    private Charset charset = UTF_8;
+    private String glob = GLOB_WILDCARD;
+    private boolean sharedFileSystem;
+    private DistributedBiFunction<String, String, ? extends R> mapOutputFn = (file, line) -> (R) line;
+
+    /**
+     * Use {@link Sources#filesBuilder}
+     */
+    FileSourceBuilder(@Nonnull String directory) {
+        this.directory = directory;
+    }
+
+    /**
+     * Sets the character set used to encode the files. Default value is {@link
+     * java.nio.charset.StandardCharsets#UTF_8}.
+     */
+    public FileSourceBuilder<R> charset(@Nonnull Charset charset) {
+        this.charset = charset;
+        return this;
+    }
+
+    /**
+     * Sets the globbing mask, see {@link
+     * java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
+     * Default value is {@code "*"} which means all files.
+     */
+    public FileSourceBuilder<R> glob(@Nonnull String glob) {
+        this.glob = glob;
+        return this;
+    }
+
+    /**
+     * Sets if files are in a shared storage visible to all members. Default
+     * value is {@code false}
+     * <p>
+     * If {@code sharedFileSystem} is {@code true}, Jet will assume all members
+     * see the same files. They will split the work so that each member will
+     * read a part of the files. If {@code sharedFileSystem} is {@code false},
+     * each member will read all files in the directory, assuming the are
+     * local.
+     */
+    public FileSourceBuilder<R> sharedFileSystem(boolean sharedFileSystem) {
+        this.sharedFileSystem = sharedFileSystem;
+        return this;
+    }
+
+    /**
+     * Sets the function which creates output object from each line. Default value
+     * is {@code (file, line) -> line}.
+     */
+    public FileSourceBuilder<R> mapOutputFn(@Nonnull DistributedBiFunction<String, String, ? extends R> mapOutputFn) {
+        this.mapOutputFn = mapOutputFn;
+        return this;
+    }
+
+    /**
+     * Builds a source which reads lines from files in a directory (but not its
+     * subdirectories) and emits output object created by {@code mapOutputFn}
+     * <p>
+     * The source does not save any state to snapshot. If the job is restarted,
+     * it will re-emit all entries.
+     * <p>
+     * Any {@code IOException} will cause the job to fail. The files must not
+     * change while being read; if they do, the behavior is unspecified.
+     * <p>
+     * The default local parallelism for this processor is 2 (or 1 if just 1
+     * CPU is available).
+     */
+    public BatchSource<R> build() {
+        return batchFromProcessor("filesSource(" + new File(directory, glob) + ')',
+                readFilesP(directory, charset, glob, sharedFileSystem, mapOutputFn));
+    }
+
+    /**
+     * Builds a source that emits a stream of lines of text coming from files in
+     * the watched directory (but not its subdirectories). It will emit only
+     * new contents added after startup: both new files and new content
+     * appended to existing ones.
+     * <p>
+     * If, during the scanning phase, the source observes a file that doesn't
+     * end with a newline, it will assume that there is a line just being
+     * written. This line won't appear in its output.
+     * <p>
+     * The source completes when the directory is deleted. However, in order
+     * to delete the directory, all files in it must be deleted and if you
+     * delete a file that is currently being read from, the job may encounter
+     * an {@code IOException}. The directory must be deleted on all nodes if
+     * {@code sharedFileSystem} is {@code false}.
+     * <p>
+     * Any {@code IOException} will cause the job to fail.
+     * <p>
+     * The source does not save any state to snapshot. If the job is restarted,
+     * lines added after the restart will be emitted, which gives at-most-once
+     * behavior.
+     * <p>
+     * The default local parallelism for this processor is 2 (or 1 if just 1
+     * CPU is available).
+     *
+     * <h3>Limitation on Windows</h3>
+     * On Windows the {@code WatchService} is not notified of appended lines
+     * until the file is closed. If the file-writing process keeps the file
+     * open while appending, the processor may fail to observe the changes.
+     * It will be notified if any process tries to open that file, such as
+     * looking at the file in Explorer. This holds for Windows 10 with the NTFS
+     * file system and might change in future. You are advised to do your own
+     * testing on your target Windows platform.
+     *
+     * <h3>Use the latest JRE</h3>
+     * The underlying JDK API ({@link java.nio.file.WatchService}) has a
+     * history of unreliability and this source may experience infinite
+     * blocking, missed, or duplicate events as a result. Such problems may be
+     * resolved by upgrading the JRE to the latest version.
+     */
+    public StreamSource<R> buildWatcher() {
+        return Sources.streamFromProcessor("fileWatcherSource(" + directory + '/' + glob + ')',
+                SourceProcessors.streamFilesP(directory, charset, glob, sharedFileSystem, mapOutputFn));
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -492,8 +492,9 @@ public final class Sinks {
      * vertex), but a single pathname is used to resolve the containing
      * directory of all files, on all cluster members.
      * <p>
-     * No state is saved to snapshot for this sink. After the job is restarted,
-     * the items will likely be duplicated, providing an <i>at-least-once</i>
+     * No state is saved to snapshot for this sink. If the job is restarted and
+     * {@linkplain FileSinkBuilder#append(boolean) appending} is enabled, the
+     * items will likely be duplicated, providing an <i>at-least-once</i>
      * guarantee.
      * <p>
      * The default local parallelism for this sink is 1.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -40,7 +40,6 @@ import static com.hazelcast.jet.core.processor.SinkProcessors.mergeRemoteMapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.updateMapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.updateRemoteMapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeCacheP;
-import static com.hazelcast.jet.core.processor.SinkProcessors.writeFileP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeListP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeMapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeRemoteCacheP;
@@ -483,16 +482,15 @@ public final class Sinks {
     }
 
     /**
-     * Returns a sink that that writes the items it receives to files. Each
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom file sink for the Pipeline API. See javadoc on {@link
+     * FileSinkBuilder} for more details.
+     * <p>
+     * The sink writes the items it receives to files. Each
      * processor will write to its own file whose name is equal to the
      * processor's global index (an integer unique to each processor of the
      * vertex), but a single pathname is used to resolve the containing
      * directory of all files, on all cluster members.
-     * <p>
-     * The sink converts an item to its string representation using the
-     * supplied {@code toStringFn} function and encodes the string using the
-     * supplied {@code Charset}. It follows each item with a platform-specific
-     * line separator.
      * <p>
      * No state is saved to snapshot for this sink. After the job is restarted,
      * the items will likely be duplicated, providing an <i>at-least-once</i>
@@ -500,43 +498,20 @@ public final class Sinks {
      * <p>
      * The default local parallelism for this sink is 1.
      *
-     * @param directoryName directory to create the files in. Will be created
-     *                      if it doesn't exist. Must be the same on all members.
-     * @param toStringFn a function to convert items to String (a formatter)
-     * @param charset charset used to encode the file output
-     * @param append whether to append ({@code true}) or overwrite ({@code false})
-     *               an existing file
+     * @param <T> type of the items the sink accepts
      */
     @Nonnull
-    public static <T> Sink<T> files(
-            @Nonnull String directoryName,
-            @Nonnull DistributedFunction<T, String> toStringFn,
-            @Nonnull Charset charset,
-            boolean append
-    ) {
-        return fromProcessor("filesSink(" + directoryName + ')',
-                writeFileP(directoryName, toStringFn, charset, append));
+    public static <T> FileSinkBuilder<T> filesBuilder(@Nonnull String directoryName) {
+        return new FileSinkBuilder<>(directoryName);
     }
 
     /**
-     * Convenience for {@link #files(String, DistributedFunction, Charset,
-     * boolean)} with the UTF-8 charset and with overwriting of existing files.
-     */
-    @Nonnull
-    public static <T> Sink<T> files(
-            @Nonnull String directoryName,
-            @Nonnull DistributedFunction<T, String> toStringFn
-    ) {
-        return files(directoryName, toStringFn, UTF_8, false);
-    }
-
-    /**
-     * Convenience for {@link #files(String, DistributedFunction, Charset,
-     * boolean)} with the UTF-8 charset and with overwriting of existing files.
+     * Convenience for {@link #filesBuilder} with the UTF-8 charset and with
+     * overwriting of existing files.
      */
     @Nonnull
     public static <T> Sink<T> files(@Nonnull String directoryName) {
-        return files(directoryName, Object::toString, UTF_8, false);
+        return Sinks.<T>filesBuilder(directoryName).build();
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -843,20 +843,20 @@ public final class Sources {
      */
     @Nonnull
     public static StreamSource<String> fileWatcher(
-            @Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob
+            @Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob, boolean sharedFileSystem
     ) {
         return streamFromProcessor("fileWatcherSource(" + watchedDirectory + '/' + glob + ')',
-                streamFilesP(watchedDirectory, charset, glob, (file, line) -> line)
+                streamFilesP(watchedDirectory, charset, glob, (file, line) -> line, sharedFileSystem)
         );
     }
 
     /**
-     * Convenience for {@link #fileWatcher(String, Charset, String)
-     * streamFiles(watchedDirectory, UTF_8, "*")}.
+     * Convenience for {@link #fileWatcher(String, Charset, String, boolean)
+     * streamFiles(watchedDirectory, UTF_8, "*", false)}.
      */
     @Nonnull
     public static StreamSource<String> fileWatcher(@Nonnull String watchedDirectory) {
-        return fileWatcher(watchedDirectory, UTF_8, GLOB_WILDCARD);
+        return fileWatcher(watchedDirectory, UTF_8, GLOB_WILDCARD, false);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -749,11 +749,11 @@ public final class Sources {
      *      .charset(UTF_8)
      *      .glob(GLOB_WILDCARD)
      *      .sharedFileSystem(false)
-     *      .mapToOutputFn((file, line) -> line)
+     *      .mapToOutputFn((fileName, line) -> line)
      *      .build()
      * }</pre>
      *
-     * See the {@linkplain #filesBuilder(String)}.
+     * See {@link #filesBuilder(String)}.
      */
     @Nonnull
     public static BatchSource<String> files(@Nonnull String directory) {
@@ -766,11 +766,11 @@ public final class Sources {
      *      .charset(UTF_8)
      *      .glob(GLOB_WILDCARD)
      *      .sharedFileSystem(false)
-     *      .mapToOutputFn((file, line) -> line)
+     *      .mapToOutputFn((fileName, line) -> line)
      *      .buildWatcher()
      * }</pre>
      *
-     * See the {@linkplain #filesBuilder(String)}.
+     * See {@link #filesBuilder(String)}.
      */
     @Nonnull
     public static StreamSource<String> fileWatcher(@Nonnull String watchedDirectory) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -734,10 +734,10 @@ public final class Sources {
 
     /**
      * Returns a builder object that offers a step-by-step fluent API to build
-     * a custom File source for the Pipeline API. The source reads lines from
-     * files in a directory (but not its subdirectories). See javadoc on {@link
-     * FileSourceBuilder#build()} and {@link FileSourceBuilder#buildWatcher()}
-     * for more details.
+     * a custom source to read files for the Pipeline API. The source reads
+     * lines from files in a directory (but not its subdirectories). Using this
+     * builder you can build {@linkplain FileSourceBuilder#build() batching} or
+     * {@linkplain FileSourceBuilder#buildWatcher() streaming} reader.
      */
     @Nonnull
     public static <R> FileSourceBuilder<String, R> filesBuilder(@Nonnull String directory) {
@@ -745,7 +745,9 @@ public final class Sources {
     }
 
     /**
-     * Shortcut for <pre>{@code
+     * A source to read all files in a directory in a batch way.
+     * <p>
+     * This method is a shortcut for: <pre>{@code
      *   filesBuilder(directory)
      *      .charset(UTF_8)
      *      .glob(GLOB_WILDCARD)
@@ -762,7 +764,11 @@ public final class Sources {
     }
 
     /**
-     * Shortcut for <pre>{@code
+     * A source to stream lines added to files in a directory. This is a
+     * streaming source, it will watch directory and emit lines as they are
+     * appended to files in that directory.
+     * <p>
+     * This method is a shortcut for: <pre>{@code
      *   filesBuilder(directory)
      *      .charset(UTF_8)
      *      .glob(GLOB_WILDCARD)

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.WatermarkGenerationParams;
 import com.hazelcast.jet.core.WatermarkSourceUtil;
-import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedPredicate;
 import com.hazelcast.jet.function.DistributedSupplier;
@@ -41,7 +40,6 @@ import com.hazelcast.query.PredicateBuilder;
 import javax.annotation.Nonnull;
 import javax.jms.ConnectionFactory;
 import javax.jms.Message;
-import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -52,14 +50,12 @@ import static com.hazelcast.jet.Util.cachePutEvents;
 import static com.hazelcast.jet.Util.mapEventToEntry;
 import static com.hazelcast.jet.Util.mapPutEvents;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readCacheP;
-import static com.hazelcast.jet.core.processor.SourceProcessors.readFilesP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readListP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteCacheP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteListP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readRemoteMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamCacheP;
-import static com.hazelcast.jet.core.processor.SourceProcessors.streamFilesP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamRemoteCacheP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamRemoteMapP;
@@ -80,8 +76,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * documentation of individual methods.
  */
 public final class Sources {
-
-    private static final String GLOB_WILDCARD = "*";
 
     private Sources() {
     }
@@ -739,129 +733,48 @@ public final class Sources {
     }
 
     /**
-     * A source that emits lines from files in a directory (but not its
-     * subdirectories).
-     * <p>
-     * If {@code sharedFileSystem} is {@code true}, Jet will assume all members
-     * see the same files. They will split the work so that each member will
-     * read a part of the files. If {@code sharedFileSystem} is {@code false},
-     * each member will read all files in the directory, assuming the are
-     * local.
-     * <p>
-     * The source does not save any state to snapshot. If the job is restarted,
-     * it will re-emit all entries.
-     * <p>
-     * Any {@code IOException} will cause the job to fail. The files must not
-     * change while being read; if they do, the behavior is unspecified.
-     * <p>
-     * The default local parallelism for this processor is 2 (or 1 if just 1
-     * CPU is available).
-     *
-     * @param directory parent directory of the files
-     * @param charset charset to use to decode the files
-     * @param glob the globbing mask, see {@link
-     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
-     *             Use {@code "*"} for all files.
-     * @param sharedFileSystem {@code true} if files are in a shared storage
-     *                         visible to all members, {@code false} otherwise
-     * @param mapOutputFn function to create output items. Parameters are
-     *                    {@code fileName} and {@code line}.
+     * Returns a builder object that offers a step-by-step fluent API to build
+     * a custom File source for the Pipeline API. See javadoc on {@link
+     * FileSourceBuilder#build()} and {@link FileSourceBuilder#buildWatcher()}
+     * for more details.
      */
     @Nonnull
-    public static <R> BatchSource<R> files(
-            @Nonnull String directory,
-            @Nonnull Charset charset,
-            @Nonnull String glob,
-            boolean sharedFileSystem,
-            @Nonnull DistributedBiFunction<String, String, ? extends R> mapOutputFn
-    ) {
-        return batchFromProcessor("filesSource(" + new File(directory, glob) + ')',
-                readFilesP(directory, charset, glob, sharedFileSystem, mapOutputFn));
+    public static <R> FileSourceBuilder<R> filesBuilder(@Nonnull String directory) {
+        return new FileSourceBuilder<>(directory);
     }
 
     /**
      * Shortcut for <pre>{@code
-     *   files(directory, UTF_8, GLOB_WILDCARD, (file, line) -> line, false)
+     *   filesBuilder(directory)
+     *      .charset(UTF_8)
+     *      .glob(GLOB_WILDCARD)
+     *      .sharedFileSystem(false)
+     *      .mapToOutputFn((file, line) -> line)
+     *      .build()
      * }</pre>
      *
-     * See the {@linkplain #files(String, Charset, String, boolean,
-     * DistributedBiFunction) full method}.
+     * See the {@linkplain #filesBuilder(String)}.
      */
     @Nonnull
     public static BatchSource<String> files(@Nonnull String directory) {
-        return files(directory, UTF_8, GLOB_WILDCARD, false, (file, line) -> line);
+        return Sources.<String>filesBuilder(directory).build();
     }
 
     /**
-     * A source that emits a stream of lines of text coming from files in
-     * the watched directory (but not its subdirectories). It will emit only
-     * new contents added after startup: both new files and new content
-     * appended to existing ones.
-     * <p>
-     * If {@code sharedFileSystem} is {@code true}, Jet will assume all members
-     * see the same files. They will split the work so that each member will
-     * read a part of the files. If {@code sharedFileSystem} is {@code false},
-     * each member will read all files in the directory, assuming the are
-     * local.
-     * <p>
-     * If, during the scanning phase, the source observes a file that doesn't
-     * end with a newline, it will assume that there is a line just being
-     * written. This line won't appear in its output.
-     * <p>
-     * The source completes when the directory is deleted. However, in order
-     * to delete the directory, all files in it must be deleted and if you
-     * delete a file that is currently being read from, the job may encounter
-     * an {@code IOException}. The directory must be deleted on all nodes if
-     * {@code sharedFileSystem} is {@code false}.
-     * <p>
-     * Any {@code IOException} will cause the job to fail.
-     * <p>
-     * The source does not save any state to snapshot. If the job is restarted,
-     * lines added after the restart will be emitted, which gives at-most-once
-     * behavior.
-     * <p>
-     * The default local parallelism for this processor is 2 (or 1 if just 1
-     * CPU is available).
+     * Shortcut for <pre>{@code
+     *   filesBuilder(directory)
+     *      .charset(UTF_8)
+     *      .glob(GLOB_WILDCARD)
+     *      .sharedFileSystem(false)
+     *      .mapToOutputFn((file, line) -> line)
+     *      .buildWatcher()
+     * }</pre>
      *
-     * <h3>Limitation on Windows</h3>
-     * On Windows the {@code WatchService} is not notified of appended lines
-     * until the file is closed. If the file-writing process keeps the file
-     * open while appending, the processor may fail to observe the changes.
-     * It will be notified if any process tries to open that file, such as
-     * looking at the file in Explorer. This holds for Windows 10 with the NTFS
-     * file system and might change in future. You are advised to do your own
-     * testing on your target Windows platform.
-     *
-     * <h3>Use the latest JRE</h3>
-     * The underlying JDK API ({@link java.nio.file.WatchService}) has a
-     * history of unreliability and this source may experience infinite
-     * blocking, missed, or duplicate events as a result. Such problems may be
-     * resolved by upgrading the JRE to the latest version.
-     *
-     * @param watchedDirectory pathname to the source directory
-     * @param charset charset to use to decode the files
-     * @param glob the globbing mask, see {@link
-     *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
-     *             Use {@code "*"} for all files.
-     * @param sharedFileSystem {@code true} if files are in a shared storage
-     *                         visible to all members, {@code false} otherwise
-     */
-    @Nonnull
-    public static StreamSource<String> fileWatcher(
-            @Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob, boolean sharedFileSystem
-    ) {
-        return streamFromProcessor("fileWatcherSource(" + watchedDirectory + '/' + glob + ')',
-                streamFilesP(watchedDirectory, charset, glob, sharedFileSystem, (file, line) -> line)
-        );
-    }
-
-    /**
-     * Convenience for {@link #fileWatcher(String, Charset, String, boolean)
-     * streamFiles(watchedDirectory, UTF_8, "*", false)}.
+     * See the {@linkplain #filesBuilder(String)}.
      */
     @Nonnull
     public static StreamSource<String> fileWatcher(@Nonnull String watchedDirectory) {
-        return fileWatcher(watchedDirectory, UTF_8, GLOB_WILDCARD, false);
+        return Sources.<String>filesBuilder(watchedDirectory).buildWatcher();
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -734,12 +734,13 @@ public final class Sources {
 
     /**
      * Returns a builder object that offers a step-by-step fluent API to build
-     * a custom File source for the Pipeline API. See javadoc on {@link
+     * a custom File source for the Pipeline API. The source reads lines from
+     * files in a directory (but not its subdirectories). See javadoc on {@link
      * FileSourceBuilder#build()} and {@link FileSourceBuilder#buildWatcher()}
      * for more details.
      */
     @Nonnull
-    public static <R> FileSourceBuilder<R> filesBuilder(@Nonnull String directory) {
+    public static <R> FileSourceBuilder<String, R> filesBuilder(@Nonnull String directory) {
         return new FileSourceBuilder<>(directory);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -762,21 +762,21 @@ public final class Sources {
      * @param glob the globbing mask, see {@link
      *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
      *             Use {@code "*"} for all files.
-     * @param mapOutputFn function to create output items. Parameters are
-     *                    {@code fileName} and {@code line}.
      * @param sharedFileSystem {@code true} if files are in a shared storage
      *                         visible to all members, {@code false} otherwise
+     * @param mapOutputFn function to create output items. Parameters are
+     *                    {@code fileName} and {@code line}.
      */
     @Nonnull
     public static <R> BatchSource<R> files(
             @Nonnull String directory,
             @Nonnull Charset charset,
             @Nonnull String glob,
-            @Nonnull DistributedBiFunction<String, String, ? extends R> mapOutputFn,
-            boolean sharedFileSystem
+            boolean sharedFileSystem,
+            @Nonnull DistributedBiFunction<String, String, ? extends R> mapOutputFn
     ) {
         return batchFromProcessor("filesSource(" + new File(directory, glob) + ')',
-                readFilesP(directory, charset, glob, mapOutputFn, sharedFileSystem));
+                readFilesP(directory, charset, glob, sharedFileSystem, mapOutputFn));
     }
 
     /**
@@ -784,12 +784,12 @@ public final class Sources {
      *   files(directory, UTF_8, GLOB_WILDCARD, (file, line) -> line, false)
      * }</pre>
      *
-     * See the {@linkplain #files(String, Charset, String,
-     * DistributedBiFunction, boolean) full method}.
+     * See the {@linkplain #files(String, Charset, String, boolean,
+     * DistributedBiFunction) full method}.
      */
     @Nonnull
     public static BatchSource<String> files(@Nonnull String directory) {
-        return files(directory, UTF_8, GLOB_WILDCARD, (file, line) -> line, false);
+        return files(directory, UTF_8, GLOB_WILDCARD, false, (file, line) -> line);
     }
 
     /**
@@ -843,13 +843,15 @@ public final class Sources {
      * @param glob the globbing mask, see {@link
      *             java.nio.file.FileSystem#getPathMatcher(String) getPathMatcher()}.
      *             Use {@code "*"} for all files.
+     * @param sharedFileSystem {@code true} if files are in a shared storage
+     *                         visible to all members, {@code false} otherwise
      */
     @Nonnull
     public static StreamSource<String> fileWatcher(
             @Nonnull String watchedDirectory, @Nonnull Charset charset, @Nonnull String glob, boolean sharedFileSystem
     ) {
         return streamFromProcessor("fileWatcherSource(" + watchedDirectory + '/' + glob + ')',
-                streamFilesP(watchedDirectory, charset, glob, (file, line) -> line, sharedFileSystem)
+                streamFilesP(watchedDirectory, charset, glob, sharedFileSystem, (file, line) -> line)
         );
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -798,9 +798,11 @@ public final class Sources {
      * new contents added after startup: both new files and new content
      * appended to existing ones.
      * <p>
-     * To be useful, the source should be configured to read data local to each
-     * member. For example, if the pathname resolves to a shared network
-     * filesystem visible by multiple members, they will emit duplicate data.
+     * If {@code sharedFileSystem} is {@code true}, Jet will assume all members
+     * see the same files. They will split the work so that each member will
+     * read a part of the files. If {@code sharedFileSystem} is {@code false},
+     * each member will read all files in the directory, assuming the are
+     * local.
      * <p>
      * If, during the scanning phase, the source observes a file that doesn't
      * end with a newline, it will assume that there is a line just being
@@ -809,7 +811,8 @@ public final class Sources {
      * The source completes when the directory is deleted. However, in order
      * to delete the directory, all files in it must be deleted and if you
      * delete a file that is currently being read from, the job may encounter
-     * an {@code IOException}. The directory must be deleted on all nodes.
+     * an {@code IOException}. The directory must be deleted on all nodes if
+     * {@code sharedFileSystem} is {@code false}.
      * <p>
      * Any {@code IOException} will cause the job to fail.
      * <p>

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadFilesPTest.java
@@ -120,7 +120,7 @@ public class ReadFilesPTest extends JetTestSupport {
         }
 
         DAG dag = new DAG();
-        Vertex reader = dag.newVertex("reader", readFilesP(directory.getPath(), UTF_8, glob, Util::entry, false))
+        Vertex reader = dag.newVertex("reader", readFilesP(directory.getPath(), UTF_8, glob, false, Util::entry))
                 .localParallelism(1);
         Vertex writer = dag.newVertex("writer", writeListP(list.getName())).localParallelism(1);
         dag.edge(between(reader, writer));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -94,7 +94,7 @@ public class StreamFilesPTest extends JetTestSupport {
 
     @Test
     public void when_metaSupplier_then_returnsCorrectProcessors() {
-        ProcessorMetaSupplier metaSupplier = streamFilesP(workDir.getAbsolutePath(), UTF_8, "*", Util::entry, false);
+        ProcessorMetaSupplier metaSupplier = streamFilesP(workDir.getAbsolutePath(), UTF_8, "*", false, Util::entry);
         Address a = new Address();
         ProcessorSupplier supplier = metaSupplier.get(singletonList(a)).apply(a);
         supplier.init(new TestProcessorContext());
@@ -297,10 +297,9 @@ public class StreamFilesPTest extends JetTestSupport {
         if (glob == null) {
             glob = "*";
         }
-        processor = new StreamFilesP<>(workDir.getAbsolutePath(), UTF_8, glob, Util::entry, false);
+        processor = new StreamFilesP<>(workDir.getAbsolutePath(), UTF_8, glob, false, Util::entry);
         outbox = new TestOutbox(1);
         Context ctx = new TestProcessorContext()
-                .setLocalParallelism(1)
                 .setLogger(Logger.getLogger(StreamFilesP.class));
         processor.init(outbox, ctx);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesPTest.java
@@ -94,7 +94,7 @@ public class StreamFilesPTest extends JetTestSupport {
 
     @Test
     public void when_metaSupplier_then_returnsCorrectProcessors() {
-        ProcessorMetaSupplier metaSupplier = streamFilesP(workDir.getAbsolutePath(), UTF_8, "*", Util::entry);
+        ProcessorMetaSupplier metaSupplier = streamFilesP(workDir.getAbsolutePath(), UTF_8, "*", Util::entry, false);
         Address a = new Address();
         ProcessorSupplier supplier = metaSupplier.get(singletonList(a)).apply(a);
         supplier.init(new TestProcessorContext());
@@ -260,7 +260,7 @@ public class StreamFilesPTest extends JetTestSupport {
         Thread.sleep(2000);
         logger.info("complete1");
         writeToFile(file1, " complete1\n");
-        Thread.sleep(1000);
+        Thread.sleep(2000);
         logger.info("complete2");
         writeToFile(file2, " complete2\n");
 
@@ -297,9 +297,10 @@ public class StreamFilesPTest extends JetTestSupport {
         if (glob == null) {
             glob = "*";
         }
-        processor = new StreamFilesP(workDir.getAbsolutePath(), UTF_8, glob, 1, 0, Util::entry);
+        processor = new StreamFilesP<>(workDir.getAbsolutePath(), UTF_8, glob, Util::entry, false);
         outbox = new TestOutbox(1);
         Context ctx = new TestProcessorContext()
+                .setLocalParallelism(1)
                 .setLogger(Logger.getLogger(StreamFilesP.class));
         processor.init(outbox, ctx);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
@@ -271,7 +271,7 @@ public class StreamFilesP_integrationTest extends JetTestSupport {
 
     private DAG buildDag() {
         DAG dag = new DAG();
-        Vertex reader = dag.newVertex("reader", streamFilesP(directory.getPath(), UTF_8, "*", Util::entry))
+        Vertex reader = dag.newVertex("reader", streamFilesP(directory.getPath(), UTF_8, "*", Util::entry, false))
                            .localParallelism(1);
         Vertex writer = dag.newVertex("writer", writeListP(list.getName())).localParallelism(1);
         dag.edge(between(reader, writer));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.jet.impl.connector;
 
+import com.hazelcast.jet.IListJet;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Util;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
-import com.hazelcast.jet.IListJet;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -271,7 +271,7 @@ public class StreamFilesP_integrationTest extends JetTestSupport {
 
     private DAG buildDag() {
         DAG dag = new DAG();
-        Vertex reader = dag.newVertex("reader", streamFilesP(directory.getPath(), UTF_8, "*", Util::entry, false))
+        Vertex reader = dag.newVertex("reader", streamFilesP(directory.getPath(), UTF_8, "*", false, Util::entry))
                            .localParallelism(1);
         Vertex writer = dag.newVertex("writer", writeListP(list.getName())).localParallelism(1);
         dag.edge(between(reader, writer));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastParallelClassRunner.class)
 public class StreamFilesP_readCompleteLineTest {
 
-    private StreamFilesP<String> p = new StreamFilesP<>("", UTF_8, "*", (file, line) -> line, false);
+    private StreamFilesP<String> p = new StreamFilesP<>("", UTF_8, "*", false, (file, line) -> line);
 
     @Test
     public void when_emptyFile_then_null() throws Exception {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_readCompleteLineTest.java
@@ -28,7 +28,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastParallelClassRunner.class)
 public class StreamFilesP_readCompleteLineTest {
 
-    private StreamFilesP p = new StreamFilesP("", UTF_8, "*", 0, 0, (file, line) -> line);
+    private StreamFilesP<String> p = new StreamFilesP<>("", UTF_8, "*", (file, line) -> line, false);
 
     @Test
     public void when_emptyFile_then_null() throws Exception {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
@@ -86,6 +86,7 @@ public class StreamJmsPTest extends JetTestSupport {
         initializeProcessor(topicName, false);
         sleepSeconds(1);
         String message2 = sendMessage(topicName, false);
+        sleepSeconds(1);
 
         Queue<Object> queue = outbox.queue(0);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteFilePTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteFilePTest.java
@@ -243,7 +243,10 @@ public class WriteFilePTest extends JetTestSupport {
         // Given
         Pipeline p = Pipeline.create();
         p.drawFrom(Sources.<String>list(list.getName()))
-         .drainTo(Sinks.files(directory.toString(), val -> Integer.toString(Integer.parseInt(val) - 1)));
+         .drainTo(Sinks.<String>filesBuilder(directory.toString())
+                       .toStringFn(val -> Integer.toString(Integer.parseInt(val) - 1))
+                       .build());
+
         addItemsToList(1, 11);
 
         // When
@@ -307,7 +310,11 @@ public class WriteFilePTest extends JetTestSupport {
         }
         Pipeline p = Pipeline.create();
         p.drawFrom(Sources.<String>list(list.getName()))
-         .drainTo(Sinks.files(directory.toString(), toStringFn, charset, append));
+         .drainTo(Sinks.<String>filesBuilder(directory.toString())
+                 .toStringFn(toStringFn)
+                 .charset(charset)
+                 .append(append)
+                 .build());
         return p;
     }
 

--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/hadoop/HdfsSources.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/hadoop/HdfsSources.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.hadoop;
 
 import com.hazelcast.jet.Util;
+import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.hadoop.impl.ReadHdfsP.MetaSupplier;
 import com.hazelcast.jet.pipeline.BatchSource;
@@ -41,8 +42,8 @@ public final class HdfsSources {
      * the results of transforming each record (a key-value pair) with the
      * supplied mapping function.
      * <p>
-     * This source splits and balances the input data among Jet {@link
-     * com.hazelcast.jet.core.Processor processors}, doing its best to achieve
+     * This source splits and balances the input data among Jet {@linkplain
+     * Processor processors}, doing its best to achieve
      * data locality. To this end the Jet cluster topology should be aligned
      * with Hadoop's &mdash; on each Hadoop member there should be a Jet
      * member.


### PR DESCRIPTION
Also add shared file system support to StreamFilesP

[Breaking Change for Public API]
- Adds a new boolean parameter `sharedFileSystem` to `SourceProcessors.streamFilesP`
- Changes `Sources.files` and `Sources.fileWatcher` to `Sources.filesBuilder`
- Changes `Sinks.files` to `Sinks.filesBuilder`
