### PR TITLE
Fix quorum protection test failure

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -296,12 +296,12 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
         assertOpenEventually(StuckProcessor.executionStarted);
 
         for (int i = 1; i < clusterSize; i++) {
-            instances[i].getHazelcastInstance().getLifecycleService().terminate();
+            instances[i].shutdown();
         }
 
         StuckProcessor.proceedLatch.countDown();
 
-        assertTrueEventually(() -> assertEquals(RESTARTING, job.getStatus()));
+        assertTrueEventually(() -> assertEquals(RESTARTING, job.getStatus()), 10);
 
         createJetMember(jetConfig);
 


### PR DESCRIPTION
Fixes #918 

By looking at the test output it seems to me that we've lost the JobRecord. There are 5 members in the test, we terminate 4 of them forcefully. This is only a hypothesis, i couldn't reproduce it locally. I tried to terminate instances at once in parallel to increase the chance of losing a partition, because one `terminate` call takes about 50ms, which might be enough for the backup to pick up and replicate.
```
12:50:01,500 ERROR || - [StartExecutionOperation] hz._hzInstance_69_jet.generic-operation.thread-3 - [127.0.0.1]:5067 [jet] [0.7-SNAPSHOT] Job with id d454-ac6b-9a41-212f not found
com.hazelcast.jet.core.JobNotFoundException: Job with id d454-ac6b-9a41-212f not found
	at com.hazelcast.jet.impl.JobCoordinationService.getJobConfig(JobCoordinationService.java:415)
	at com.hazelcast.jet.impl.JobCoordinationService.getClassLoader(JobCoordinationService.java:107)
	at com.hazelcast.jet.impl.JetService.getClassLoader(JetService.java:159)
	at com.hazelcast.jet.impl.execution.ExecutionContext.beginExecution(ExecutionContext.java:124)
	at com.hazelcast.jet.impl.operation.StartExecutionOperation.doRun(StartExecutionOperation.java:50)
	at com.hazelcast.jet.impl.operation.AsyncOperation.run(AsyncOperation.java:44)
	at com.hazelcast.spi.Operation.call(Operation.java:148)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.call(OperationRunnerImpl.java:202)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:191)
	at com.hazelcast.spi.impl.operationservice.impl.OperationRunnerImpl.run(OperationRunnerImpl.java:405)
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.process(OperationThread.java:115)
	at com.hazelcast.spi.impl.operationexecutor.impl.OperationThread.run(OperationThread.java:100)
```