### PR TITLE
Improve TestSupport

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestInbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestInbox.java
@@ -83,4 +83,9 @@ public final class TestInbox implements Inbox {
     public int size() {
        return queue.size();
     }
+
+    @Override
+    public String toString() {
+        return queue.toString();
+    }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -384,14 +384,14 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         Processor p2 = processors2.next();
         assertFalse(processors2.hasNext());
 
-        TestSupport.verifyProcessor(p1).expectOutput(asList(
+        TestSupport.verifyProcessor(() -> p1).expectOutput(asList(
                 entry(0, 0),
                 entry(2, 0),
                 entry(0, 1),
                 entry(2, 1)
         ));
 
-        TestSupport.verifyProcessor(p2).expectOutput(asList(
+        TestSupport.verifyProcessor(() -> p2).expectOutput(asList(
                 entry(1, 0),
                 entry(1, 1)
         ));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -145,13 +145,13 @@ public class ProcessorsTest {
         TestSupport
                 .verifyProcessor(flatMapUsingContextP(
                         ContextFactory.withCreateFn(procContext -> context)
-                                      .withDestroyFn(c -> c[0]++),
+                                      .withDestroyFn(c -> c[0] = 0),
                         (int[] c, Integer item) -> Traverser.over(item, c[0] += item)))
                 .disableSnapshots()
                 .input(asList(1, 2, 3))
                 .expectOutput(asList(1, 1, 2, 3, 3, 6));
 
-        assertEquals(7, context[0]);
+        assertEquals(0, context[0]);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadIListPTest.java
@@ -55,7 +55,7 @@ public class ReadIListPTest extends JetTestSupport {
         List<Object> data = IntStream.range(0, listLength).boxed().collect(toList());
         list.addAll(data);
         TestSupport
-                .verifyProcessor(new ReadIListP(list.getName(), null))
+                .verifyProcessor(() -> new ReadIListP(list.getName(), null))
                 .jetInstance(instance)
                 .disableSnapshots()
                 .disableLogging()

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_stage1Test.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SlidingWindowP_stage1Test.java
@@ -17,11 +17,13 @@
 package com.hazelcast.jet.impl.processor;
 
 import com.hazelcast.jet.accumulator.LongAccumulator;
+import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.TimestampKind;
 import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.datamodel.TimestampedEntry;
 import com.hazelcast.jet.function.DistributedFunction;
+import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.jet.function.DistributedToLongFunction;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -33,6 +35,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 
@@ -54,31 +57,38 @@ public class SlidingWindowP_stage1Test {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private SlidingWindowP processor;
+    private List<SlidingWindowP> suppliedProcessors = new ArrayList<>();
+    private DistributedSupplier<Processor> supplier;
 
     @Before
     @SuppressWarnings("unchecked")
     public void before() {
         DistributedFunction<Entry<Long, Long>, Object> keyFn = x -> KEY;
         DistributedToLongFunction<Entry<Long, Long>> timestampFn = Entry::getKey;
-        processor = (SlidingWindowP) Processors.accumulateByFrameP(
-                singletonList(keyFn),
-                singletonList(timestampFn),
-                TimestampKind.EVENT,
-                slidingWinPolicy(16, 4),
-                summingLong(Entry<Long, Long>::getValue).withFinishFn(identity())
-        ).get();
+        supplier = () -> {
+            SlidingWindowP res = (SlidingWindowP) Processors.accumulateByFrameP(
+                    singletonList(keyFn),
+                    singletonList(timestampFn),
+                    TimestampKind.EVENT,
+                    slidingWinPolicy(16, 4),
+                    summingLong(Entry<Long, Long>::getValue).withFinishFn(identity())
+            ).get();
+            suppliedProcessors.add(res);
+            return res;
+        };
     }
 
     @After
     public void after() {
-        assertTrue("map not empty after emitting everything: " + processor.tsToKeyToAcc,
-                processor.tsToKeyToAcc.isEmpty());
+        for (SlidingWindowP processor : suppliedProcessors) {
+            assertTrue("map not empty after emitting everything: " + processor.tsToKeyToAcc,
+                    processor.tsToKeyToAcc.isEmpty());
+        }
     }
 
     @Test
     public void smokeTest() {
-        verifyProcessor(processor)
+        verifyProcessor(supplier)
                 .disableSnapshots()
                 .disableCompleteCall()
                 .input(asList(
@@ -109,7 +119,7 @@ public class SlidingWindowP_stage1Test {
 
     @Test
     public void when_gapInWmAfterEvent_then_frameAndWmEmitted() {
-        verifyProcessor(processor)
+        verifyProcessor(supplier)
                 .disableSnapshots()
                 .disableCompleteCall()
                 .input(asList(
@@ -131,7 +141,7 @@ public class SlidingWindowP_stage1Test {
                 wm(12)
         );
 
-        verifyProcessor(processor)
+        verifyProcessor(supplier)
                 .disableSnapshots()
                 .disableCompleteCall()
                 .input(someWms)
@@ -140,7 +150,7 @@ public class SlidingWindowP_stage1Test {
 
     @Test
     public void when_batch_then_emitEverything() {
-        verifyProcessor(processor)
+        verifyProcessor(supplier)
                 .disableSnapshots()
                 .input(asList(
                         entry(0L, 1L), // to frame 4
@@ -160,7 +170,7 @@ public class SlidingWindowP_stage1Test {
 
     @Test
     public void when_wmNeverReceived_then_emitEverythingInComplete() {
-        verifyProcessor(processor)
+        verifyProcessor(supplier)
                 .disableSnapshots()
                 .input(asList(entry(0L, 1L), // to frame 4
                         entry(4L, 1L) // to frame 8
@@ -175,7 +185,7 @@ public class SlidingWindowP_stage1Test {
 
     @Test
     public void when_lateEvent_then_ignore() {
-        verifyProcessor(processor)
+        verifyProcessor(supplier)
                 .disableSnapshots()
                 .disableCompleteCall()
                 .input(asList(wm(16),


### PR DESCRIPTION
Previously we tested only inbox with one item. This commit adds two
testing scenarios: inbox with 1 item and inbox with all items. For
multiple instreams it's all items from one ordinal and the all from
another ordinal. After this change, more cooperative emission problems
are caught.

Fixes #887, where there is an example of a previously uncaught problem.