### PR TITLE
Eagerly close processors

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Util.java
@@ -25,12 +25,15 @@ import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.journal.EventJournalMapEvent;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Arrays;
 import java.util.Map.Entry;
 
 /**
  * Miscellaneous utility methods useful in DAG building logic.
  */
 public final class Util {
+    private static final char[] ID_TEMPLATE = "0000-0000-0000-0000".toCharArray();
+
     private Util() {
     }
 
@@ -92,5 +95,22 @@ public final class Util {
      */
     public static <K, V> DistributedFunction<EventJournalCacheEvent<K, V>, Entry<K, V>> cacheEventToEntry() {
         return e -> entry(e.getKey(), e.getNewValue());
+    }
+
+    /**
+     * Converts a {@code long} job or execution ID to a string representation.
+     * Currently it is an unsigned 16-digit hex number.
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    public static String idToString(long id) {
+        char[] buf = Arrays.copyOf(ID_TEMPLATE, ID_TEMPLATE.length);
+        String hexStr = Long.toHexString(id);
+        for (int i = hexStr.length() - 1, j = 18; i >= 0; i--, j--) {
+            buf[j] = hexStr.charAt(i);
+            if (j == 15 || j == 10 || j == 5) {
+                j--;
+            }
+        }
+        return new String(buf);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobNotFoundException.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobNotFoundException.java
@@ -17,7 +17,7 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetException;
-import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.jet.Util;
 
 /**
  * Thrown when a job could not be found on the master node

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -235,7 +235,7 @@ public interface Processor {
     }
 
     /**
-     * Called as the last method in the processor lifecycle*. It is called
+     * Called as the last method in the processor lifecycle. It is called
      * whether the job was successful or not, and strictly before {@link
      * ProcessorSupplier#close} is called on this member. The method might get
      * called even if {@link #init} method was not yet called.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * When Jet executes a DAG, it creates one or more instances of {@code
@@ -236,24 +235,19 @@ public interface Processor {
     }
 
     /**
-     * Called after the execution has finished on all members - successfully or
-     * not, before {@link ProcessorSupplier#close} is called. If the execution
-     * was <em>aborted</em> due to a member leaving the cluster it is called
-     * immediately. Int this case, it can happen that the job is still running
-     * on some other member (but not on this member).
+     * Called as the last method in the processor lifecycle*. It is called
+     * whether the job was successful or not, and strictly before {@link
+     * ProcessorSupplier#close} is called on this member. The method might get
+     * called even if {@link #init} method was not yet called.
      * <p>
-     * After this method no other methods are called.
+     * The method will be called right after {@link #complete()} returns {@code
+     * true}, that is before the job is finished. The job might still be
+     * running other processors.
      * <p>
-     * If this method throws an exception, it will be logged and ignored; it
-     * won't be reported as a job failure.
-     * <p>
-     * Note: this method can be called even if {@link #init} method was not
-     * called yet in case the job fails during the init phase.
-
-     * @param error the exception (if any) that caused the job to fail;
-     *              {@code null} in the case of successful job completion
+     * If this method throws an exception, it is logged but it won't be
+     * reported as a job failure or cause the job to fail.
      */
-    default void close(@Nullable Throwable error) throws Exception {
+    default void close() throws Exception {
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.logging.ILogger;
@@ -305,6 +306,25 @@ public interface ProcessorMetaSupplier extends Serializable {
          */
         @Nonnull
         JetInstance jetInstance();
+
+        /**
+         * Returns the job ID. Job id is unique for job submission and doesn't
+         * change when the job restarts. It's also unique for all running and
+         * archived jobs.
+         */
+        long jobId();
+
+        /**
+         * Returns the job execution ID. It's unique for one execution, but
+         * changes when the job restarts.
+         */
+        long executionId();
+
+        /**
+         * Returns the {@link JobConfig}.
+         */
+        @Nonnull
+        JobConfig jobConfig();
 
         /**
          * Returns the total number of {@code Processor}s that will be created

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
@@ -46,7 +46,7 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     }
 
     /**
-     * Set the jet instance.
+     * Sets the jet instance.
      */
     @Nonnull
     public TestProcessorMetaSupplierContext setJetInstance(@Nonnull JetInstance jetInstance) {
@@ -60,7 +60,7 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     }
 
     /**
-     * Set the job ID.
+     * Sets the job ID.
      */
     public TestProcessorMetaSupplierContext setJobId(long jobId) {
         this.jobId = jobId;
@@ -73,7 +73,7 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     }
 
     /**
-     * Set the execution ID.
+     * Sets the execution ID.
      */
     public TestProcessorMetaSupplierContext setExecutionId(long executionId) {
         this.executionId = executionId;
@@ -86,7 +86,7 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     }
 
     /**
-     * Set the job name.
+     * Sets the job name.
      */
     public TestProcessorMetaSupplierContext setJobConfig(@Nonnull JobConfig jobConfig) {
         this.jobConfig = jobConfig;
@@ -99,11 +99,27 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     }
 
     /**
-     * Set total parallelism.
+     * Sets the total parallelism.
      */
     @Nonnull
     public TestProcessorMetaSupplierContext setTotalParallelism(int totalParallelism) {
         this.totalParallelism = totalParallelism;
+        return this;
+    }
+
+    @Override
+    public int localParallelism() {
+        assert totalParallelism % localParallelism == 0 :
+                "totalParallelism=" + totalParallelism + " not divisible with localParallelism=" + localParallelism;
+        return localParallelism;
+    }
+
+    /**
+     * Sets local parallelism.
+     */
+    @Nonnull
+    public TestProcessorMetaSupplierContext setLocalParallelism(int localParallelism) {
+        this.localParallelism = localParallelism;
         return this;
     }
 
@@ -116,26 +132,10 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     }
 
     /**
-     * Set the logger.
+     * Sets the logger.
      */
     public TestProcessorMetaSupplierContext setLogger(@Nonnull ILogger logger) {
         this.logger = logger;
-        return this;
-    }
-
-    @Override
-    public int localParallelism() {
-        assert totalParallelism % localParallelism == 0 :
-                "totalParallelism=" + totalParallelism + " not divisible with localParallelism=" + localParallelism;
-        return localParallelism;
-    }
-
-    /**
-     * Set local parallelism.
-     */
-    @Nonnull
-    public TestProcessorMetaSupplierContext setLocalParallelism(int localParallelism) {
-        this.localParallelism = localParallelism;
         return this;
     }
 
@@ -150,7 +150,7 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     }
 
     /**
-     * Set the vertex name.
+     * Sets the vertex name.
      */
     @Nonnull
     public TestProcessorMetaSupplierContext setVertexName(@Nonnull String vertexName) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.core.test;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -32,6 +33,9 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     protected ILogger logger;
 
     private JetInstance jetInstance;
+    private long jobId = 1;
+    private long executionId = 1;
+    private JobConfig jobConfig = new JobConfig();
     private int totalParallelism = 1;
     private int localParallelism = 1;
     private String vertexName = "testVertex";
@@ -47,6 +51,45 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     @Nonnull
     public TestProcessorMetaSupplierContext setJetInstance(@Nonnull JetInstance jetInstance) {
         this.jetInstance = jetInstance;
+        return this;
+    }
+
+    @Override
+    public long jobId() {
+        return jobId;
+    }
+
+    /**
+     * Set the job ID.
+     */
+    public TestProcessorMetaSupplierContext setJobId(long jobId) {
+        this.jobId = jobId;
+        return this;
+    }
+
+    @Override
+    public long executionId() {
+        return executionId;
+    }
+
+    /**
+     * Set the execution ID.
+     */
+    public TestProcessorMetaSupplierContext setExecutionId(long executionId) {
+        this.executionId = executionId;
+        return this;
+    }
+
+    @Override @Nonnull
+    public JobConfig jobConfig() {
+        return jobConfig;
+    }
+
+    /**
+     * Set the job name.
+     */
+    public TestProcessorMetaSupplierContext setJobConfig(@Nonnull JobConfig jobConfig) {
+        this.jobConfig = jobConfig;
         return this;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -570,7 +570,7 @@ public final class TestSupport {
             assertTrue("complete returned true", !done[0] || runUntilCompletedTimeout <= 0);
         }
 
-        processor[0].close(null);
+        processor[0].close();
 
         // assert the outbox
         for (int i = 0; i < expectedOutputs.size(); i++) {
@@ -695,7 +695,7 @@ public final class TestSupport {
         // restore state to new processor
         assert outbox[0].queue(0).isEmpty();
         assert outbox[0].snapshotQueue().isEmpty();
-        processor[0].close(null);
+        processor[0].close();
         processor[0] = newProcessorFromSupplier();
         outbox[0] = createOutbox();
         initProcessor(processor[0], outbox[0]);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.memoizeConcurrent;
 import static com.hazelcast.jet.impl.util.Util.toLocalDateTime;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 
 /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -58,7 +58,7 @@ import static com.hazelcast.jet.impl.execution.SnapshotRecord.SnapshotStatus.SUC
 import static com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject.deserializeWithCustomClassLoader;
 import static com.hazelcast.jet.impl.util.JetGroupProperty.JOB_SCAN_PERIOD;
 import static com.hazelcast.jet.impl.util.Util.getJetInstance;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static com.hazelcast.util.executor.ExecutorType.CACHED;
 import static java.util.Comparator.comparing;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -44,7 +44,7 @@ import java.util.function.Supplier;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryValue;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static java.util.Collections.newSetFromMap;
 import static java.util.stream.Collectors.toMap;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
@@ -25,7 +25,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
 
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.toLocalDateTime;
 
 public class JobRecord implements IdentifiedDataSerializable {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -53,7 +53,7 @@ import java.util.jar.JarInputStream;
 import java.util.zip.DeflaterOutputStream;
 
 import static com.hazelcast.jet.Jet.INTERNAL_JET_OBJECTS_PREFIX;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static java.util.Collections.newSetFromMap;
 import static java.util.Comparator.comparing;
 import static java.util.concurrent.TimeUnit.HOURS;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobResult.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobResult.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.FAILED;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.toLocalDateTime;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -79,7 +79,7 @@ import static com.hazelcast.jet.impl.execution.init.ExecutionPlanBuilder.createE
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.partitioningBy;
@@ -205,7 +205,8 @@ public class MasterContext {
                     + ", execution graph in DOT format:\n" + dag.toDotString()
                     + "\nHINT: You can use graphviz or http://viz-js.com to visualize the printed graph.");
             logger.fine("Building execution plan for " + jobIdString());
-            executionPlanMap = createExecutionPlans(nodeEngine, membersView, dag, getJobConfig(), lastSnapshotId);
+            executionPlanMap = createExecutionPlans(nodeEngine, membersView, dag, jobId, executionId, getJobConfig(),
+                    lastSnapshotId);
         } catch (Exception e) {
             logger.severe("Exception creating execution plan for " + jobIdString(), e);
             finalizeJob(e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
@@ -37,7 +37,7 @@ import static com.hazelcast.jet.impl.util.Util.createObjectDataInput;
 import static com.hazelcast.jet.impl.util.Util.createObjectDataOutput;
 import static com.hazelcast.jet.impl.util.Util.getMemberConnection;
 import static com.hazelcast.jet.impl.util.Util.getRemoteMembers;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static com.hazelcast.nio.Packet.FLAG_JET_FLOW_CONTROL;
 import static com.hazelcast.nio.Packet.FLAG_URGENT;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SnapshotRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/SnapshotRepository.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
 import static com.hazelcast.jet.impl.util.Util.compute;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 
 public class SnapshotRepository {
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.function.DistributedBiFunction;
 import com.hazelcast.jet.function.DistributedFunction;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
@@ -111,7 +110,7 @@ public final class ReadFilesP<T, R> extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) throws IOException {
+    public void close() throws IOException {
         IOException ex = null;
         if (directoryStream != null) {
             try {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadIListP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadIListP.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import static com.hazelcast.client.HazelcastClient.newHazelcastClient;
 import static com.hazelcast.jet.Traversers.traverseIterable;
@@ -76,7 +75,7 @@ public final class ReadIListP extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) {
+    public void close() {
         if (client != null) {
             client.shutdown();
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamFilesP.java
@@ -24,7 +24,6 @@ import com.hazelcast.jet.impl.util.ReflectionUtils;
 import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -138,7 +137,7 @@ public class StreamFilesP<R> extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) {
+    public void close() {
         try {
             closeCurrentFile();
             getLogger().fine("Closing StreamFilesP");

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamJmsP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamJmsP.java
@@ -103,7 +103,7 @@ public class StreamJmsP<T> extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) {
+    public void close() {
         if (consumer != null) {
             uncheckRun(() -> consumer.close());
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamSocketP.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.processor.SourceProcessors;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -141,7 +140,7 @@ public final class StreamSocketP extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) throws IOException {
+    public void close() throws IOException {
         if (socketChannel != null) {
             getLogger().info("Closing socket " + hostAndPort());
             socketChannel.close();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
@@ -27,14 +27,13 @@ import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedSupplier;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public final class WriteBufferedP<B, T> implements Processor {
 
     private final DistributedFunction<? super Context, B> createFn;
     private final DistributedBiConsumer<? super B, ? super T> onReceiveFn;
     private final DistributedConsumer<? super B> flushFn;
-    private DistributedConsumer<? super B> destroyFn;
+    private final DistributedConsumer<? super B> destroyFn;
 
     private B buffer;
 
@@ -66,17 +65,13 @@ public final class WriteBufferedP<B, T> implements Processor {
 
     @Override
     public boolean complete() {
-        close(null);
         return true;
     }
 
     @Override
-    public void close(@Nullable Throwable error) {
-        // avoid double destroyFn call: close() method is called from complete(), as well as by
-        // the Jet engine
-        if (destroyFn != null && buffer != null) {
+    public void close() {
+        if (buffer != null) {
             destroyFn.accept(buffer);
-            destroyFn = null;
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -136,9 +136,9 @@ public class ExecutionContext {
         assert executionFuture == null || executionFuture.isDone()
                 : "If execution was begun, then completeExecution() should not be called before execution is done.";
 
-        for (Processor processor : processors) {
+        for (Tasklet tasklet : tasklets) {
             try {
-                processor.close(error);
+                tasklet.close();
             } catch (Throwable e) {
                 logger.severe(jobAndExecutionId(jobId, executionId)
                         + " encountered an exception in Processor.close(), ignoring it", e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotRecord.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import static com.hazelcast.jet.impl.execution.SnapshotRecord.SnapshotStatus.FAILED;
 import static com.hazelcast.jet.impl.execution.SnapshotRecord.SnapshotStatus.ONGOING;
 import static com.hazelcast.jet.impl.execution.SnapshotRecord.SnapshotStatus.SUCCESSFUL;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.Util.toLocalDateTime;
 import static com.hazelcast.util.Preconditions.checkFalse;
 import static com.hazelcast.util.Preconditions.checkTrue;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/Tasklet.java
@@ -19,17 +19,19 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.jet.impl.util.ProgressState;
 
 import javax.annotation.Nonnull;
-import java.util.concurrent.Callable;
 
-public interface Tasklet extends Callable<ProgressState> {
+public interface Tasklet {
 
     default void init() {
     }
 
-    @Override @Nonnull
+    @Nonnull
     ProgressState call();
 
     default boolean isCooperative() {
         return true;
+    }
+
+    default void close() {
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -17,12 +17,12 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.spi.serialization.SerializationService;
 
 import javax.annotation.Nonnull;
 
@@ -33,16 +33,21 @@ public final class Contexts {
 
     static class MetaSupplierCtx implements ProcessorMetaSupplier.Context {
         private final JetInstance jetInstance;
+        private final long jobId;
+        private final long executionId;
+        private final JobConfig jobConfig;
         private final ILogger logger;
         private final String vertexName;
         private final int localParallelism;
         private final int totalParallelism;
         private final int memberCount;
 
-        MetaSupplierCtx(
-                JetInstance jetInstance, ILogger logger, String vertexName, int localParallelism, int totalParallelism,
-                int memberCount) {
+        MetaSupplierCtx(JetInstance jetInstance, long jobId, long executionId, JobConfig jobConfig, ILogger logger,
+                        String vertexName, int localParallelism, int totalParallelism, int memberCount) {
             this.jetInstance = jetInstance;
+            this.jobId = jobId;
+            this.executionId = executionId;
+            this.jobConfig = jobConfig;
             this.logger = logger;
             this.vertexName = vertexName;
             this.totalParallelism = totalParallelism;
@@ -54,6 +59,21 @@ public final class Contexts {
         @Override
         public JetInstance jetInstance() {
             return jetInstance;
+        }
+
+        @Override
+        public long jobId() {
+            return jobId;
+        }
+
+        @Override
+        public long executionId() {
+            return executionId;
+        }
+
+        @Override @Nonnull
+        public JobConfig jobConfig() {
+            return jobConfig;
         }
 
         @Override
@@ -87,9 +107,10 @@ public final class Contexts {
         private final int memberIndex;
 
         ProcSupplierCtx(
-                JetInstance jetInstance, ILogger logger, String vertexName, int localParallelism, int totalParallelism,
-                int memberIndex, int memberCount) {
-            super(jetInstance, logger, vertexName, localParallelism, totalParallelism, memberCount);
+                JetInstance jetInstance, long jobId, long executionId, JobConfig jobConfig, ILogger logger,
+                String vertexName, int localParallelism, int totalParallelism, int memberIndex, int memberCount) {
+            super(jetInstance, jobId, executionId, jobConfig, logger, vertexName, localParallelism, totalParallelism,
+                    memberCount);
             this.memberIndex = memberIndex;
         }
 
@@ -103,15 +124,15 @@ public final class Contexts {
 
         private final int localProcessorIndex;
         private final int globalProcessorIndex;
-        private final SerializationService serService;
         private final ProcessingGuarantee processingGuarantee;
 
-        public ProcCtx(JetInstance instance, SerializationService serService, ILogger logger, String vertexName,
-                       int localProcessorIndex, int globalProcessorIndex, ProcessingGuarantee processingGuarantee,
-                       int localParallelism, int memberIndex, int memberCount) {
-            super(instance, logger, vertexName, localParallelism, memberCount * localParallelism,
-                    memberIndex, memberCount);
-            this.serService = serService;
+        @SuppressWarnings("checkstyle:ParameterNumber")
+        public ProcCtx(JetInstance instance, long jobId, long executionId, JobConfig jobConfig,
+                       ILogger logger, String vertexName, int localProcessorIndex,
+                       int globalProcessorIndex, ProcessingGuarantee processingGuarantee, int localParallelism,
+                       int memberIndex, int memberCount) {
+            super(instance, jobId, executionId, jobConfig, logger, vertexName, localParallelism,
+                    memberCount * localParallelism, memberIndex, memberCount);
             this.localProcessorIndex = localProcessorIndex;
             this.globalProcessorIndex = globalProcessorIndex;
             this.processingGuarantee = processingGuarantee;
@@ -130,10 +151,6 @@ public final class Contexts {
         @Override
         public ProcessingGuarantee processingGuarantee() {
             return processingGuarantee;
-        }
-
-        public SerializationService getSerializationService() {
-            return serService;
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -54,7 +54,8 @@ public final class ExecutionPlanBuilder {
     }
 
     public static Map<MemberInfo, ExecutionPlan> createExecutionPlans(
-            NodeEngine nodeEngine, MembersView membersView, DAG dag, JobConfig jobConfig, long lastSnapshotId
+            NodeEngine nodeEngine, MembersView membersView, DAG dag, long jobId, long executionId,
+            JobConfig jobConfig, long lastSnapshotId
     ) {
         final JetInstance instance = getJetInstance(nodeEngine);
         final int defaultParallelism = instance.getConfig().getInstanceConfig().getCooperativeThreadCount();
@@ -85,8 +86,8 @@ public final class ExecutionPlanBuilder {
                     e -> vertexIdMap.get(e.getDestName()), isJobDistributed);
             final ILogger logger = nodeEngine.getLogger(String.format("%s.%s#ProcessorMetaSupplier",
                     metaSupplier.getClass().getName(), vertex.getName()));
-            metaSupplier.init(new MetaSupplierCtx(instance, logger, vertex.getName(),
-                    localParallelism, totalParallelism, clusterSize));
+            metaSupplier.init(new MetaSupplierCtx(instance, jobId, executionId, jobConfig, logger,
+                    vertex.getName(), localParallelism, totalParallelism, clusterSize));
 
             Function<Address, ProcessorSupplier> procSupplierFn = metaSupplier.get(addresses);
             for (Entry<MemberInfo, ExecutionPlan> e : plans.entrySet()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteExecutionOperation.java
@@ -29,7 +29,7 @@ import com.hazelcast.spi.Operation;
 import java.io.IOException;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 
 public class CompleteExecutionOperation extends Operation implements IdentifiedDataSerializable {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
-import static com.hazelcast.jet.impl.util.Util.idToString;
+import static com.hazelcast.jet.Util.idToString;
 
 public class SnapshotOperation extends AsyncOperation {
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/PeekWrappedP.java
@@ -81,9 +81,9 @@ public final class PeekWrappedP<T> extends ProcessorWrapper {
             NodeEngine nodeEngine = ((HazelcastInstanceImpl) c.jetInstance().getHazelcastInstance()).node.nodeEngine;
             ILogger newLogger = nodeEngine.getLogger(
                     createLoggerName(wrapped.getClass().getName(), c.vertexName(), c.globalProcessorIndex()));
-            context = new ProcCtx(c.jetInstance(), c.getSerializationService(), newLogger, c.vertexName(),
-                    c.localProcessorIndex(), c.globalProcessorIndex(), c.processingGuarantee(), c.localParallelism(),
-                    c.memberIndex(), c.memberCount());
+            context = new ProcCtx(c.jetInstance(), c.jobId(), c.executionId(), c.jobConfig(),
+                    newLogger, c.vertexName(), c.localProcessorIndex(), c.globalProcessorIndex(), c.processingGuarantee(),
+                    c.localParallelism(), c.memberIndex(), c.memberCount());
         }
         super.init(outbox, context);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorWrapper.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorWrapper.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.Watermark;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * Base class for processor wrappers. Delegates all calls to the wrapped
@@ -86,7 +85,7 @@ public class ProcessorWrapper implements Processor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) throws Exception {
-        wrapped.close(error);
+    public void close() throws Exception {
+        wrapped.close();
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformUsingContextP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformUsingContextP.java
@@ -94,7 +94,7 @@ public final class TransformUsingContextP<C, T, R> extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) {
+    public void close() {
         // close() might be called even if init() was not called.
         // Only destroy the context if is not shared (i.e. it is our own).
         if (contextObject != null && !contextFactory.isSharedLocally()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -56,7 +56,6 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +70,7 @@ import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
 import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static java.lang.Math.abs;
 import static java.util.Collections.emptyList;
@@ -82,7 +82,6 @@ import static java.util.stream.IntStream.range;
 public final class Util {
 
     private static final int BUFFER_SIZE = 1 << 15;
-    private static final char[] ID_TEMPLATE = "0000-0000-0000-0000".toCharArray();
     private static final DateTimeFormatter LOCAL_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
 
     private Util() {
@@ -327,21 +326,8 @@ public final class Util {
     }
 
     @SuppressWarnings("checkstyle:magicnumber")
-    public static String idToString(long id) {
-        char[] buf = Arrays.copyOf(ID_TEMPLATE, ID_TEMPLATE.length);
-        String hexStr = Long.toHexString(id);
-        for (int i = hexStr.length() - 1, j = 18; i >= 0; i--, j--) {
-            buf[j] = hexStr.charAt(i);
-            if (j == 15 || j == 10 || j == 5) {
-                j--;
-            }
-        }
-        return new String(buf);
-    }
-
-    @SuppressWarnings("checkstyle:magicnumber")
     public static long idFromString(String str) {
-        if (str == null || str.length() != ID_TEMPLATE.length) {
+        if (str == null || str.length() != 19) {
             return -1;
         }
         str = str.replaceAll("-", "");

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/UtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/UtilTest.java
@@ -23,6 +23,7 @@ import org.junit.runner.RunWith;
 import java.util.Map.Entry;
 
 import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.Util.idToString;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -33,5 +34,16 @@ public class UtilTest {
         Entry<String, Integer> e = entry("key", 1);
         assertEquals("key", e.getKey());
         assertEquals(Integer.valueOf(1), e.getValue());
+    }
+
+    @Test
+    public void test_idToString() {
+        assertEquals("0000-0000-0000-0000", idToString(0));
+        assertEquals("0000-0000-0000-0001", idToString(1));
+        assertEquals("7fff-ffff-ffff-ffff", idToString(Long.MAX_VALUE));
+        assertEquals("8000-0000-0000-0000", idToString(Long.MIN_VALUE));
+        assertEquals("ffff-ffff-ffff-ffff", idToString(-1));
+        assertEquals("1122-10f4-7de9-8115", idToString(1234567890123456789L));
+        assertEquals("eedd-ef0b-8216-7eeb", idToString(-1234567890123456789L));
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/CancellationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/CancellationTest.java
@@ -28,7 +28,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -336,7 +335,7 @@ public class CancellationTest extends JetTestSupport {
         }
 
         @Override
-        public void close(@Nullable Throwable error) {
+        public void close() {
             isDone = true;
         }
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.nio.Address;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -60,7 +59,6 @@ public final class TestProcessors {
 
         MockP.initCount.set(0);
         MockP.closeCount.set(0);
-        MockP.receivedCloseErrors.clear();
 
         StuckProcessor.proceedLatch = new CountDownLatch(1);
         StuckProcessor.executionStarted = new CountDownLatch(totalParallelism);
@@ -251,7 +249,6 @@ public final class TestProcessors {
 
         static AtomicInteger initCount = new AtomicInteger();
         static AtomicInteger closeCount = new AtomicInteger();
-        static List<Throwable> receivedCloseErrors = new CopyOnWriteArrayList<>();
 
         private Exception initError;
         private Exception processError;
@@ -308,11 +305,8 @@ public final class TestProcessors {
         }
 
         @Override
-        public void close(@Nullable Throwable error) throws Exception {
+        public void close() throws Exception {
             closeCount.incrementAndGet();
-            if (error != null) {
-                receivedCloseErrors.add(error);
-            }
             if (closeError != null) {
                 throw closeError;
             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
@@ -57,7 +57,7 @@ public class StreamJmsPTest extends JetTestSupport {
 
     @After
     public void stopProcessor() throws Exception {
-        processor.close(null);
+        processor.close();
         processorConnection.close();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
@@ -55,7 +55,7 @@ public class WriteBufferedPTest extends JetTestSupport {
     }
 
     @Test
-    public void writeBuffered_smokeTest() {
+    public void writeBuffered_smokeTest() throws Exception {
         DistributedSupplier<Processor> supplier = getLoggingBufferedWriter();
         Processor p = supplier.get();
         Outbox outbox = mock(Outbox.class);
@@ -70,6 +70,7 @@ public class WriteBufferedPTest extends JetTestSupport {
         p.tryProcessWatermark(new Watermark(0)); // watermark should not be written
         p.process(0, inbox); // empty flush
         p.complete();
+        p.close();
 
         assertEquals(asList(
                 "new",

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
-import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
+import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Before;
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.MADE_PROGRESS;
@@ -58,16 +57,13 @@ public class ProcessorTaskletTest {
     private List<MockInboundStream> instreams;
     private List<OutboundEdgeStream> outstreams;
     private PassThroughProcessor processor;
-    private ProcCtx context;
+    private Processor.Context context;
 
     @Before
     public void setUp() {
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.processor = new PassThroughProcessor();
-        this.context = new ProcCtx(
-                null, new DefaultSerializationServiceBuilder().build(), null, null,
-                0, 0, NONE, 1, 0, 1
-        );
+        this.context = new TestProcessorContext();
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
     }
@@ -254,8 +250,8 @@ public class ProcessorTaskletTest {
             instreams.get(i).setOrdinal(i);
         }
 
-        final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
-                mock(SnapshotContext.class), new MockOutboundCollector(10), -1);
+        final ProcessorTasklet t = new ProcessorTasklet(context, new DefaultSerializationServiceBuilder().build(),
+                processor, instreams, outstreams, mock(SnapshotContext.class), new MockOutboundCollector(10), -1);
         t.init();
         return t;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Blocking.java
@@ -20,7 +20,7 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
-import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
+import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Before;
@@ -34,7 +34,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.MADE_PROGRESS;
@@ -52,7 +51,7 @@ public class ProcessorTaskletTest_Blocking {
 
     private static final int MOCK_INPUT_SIZE = 10;
     private static final int CALL_COUNT_LIMIT = 10;
-    private ProcCtx context;
+    private Processor.Context context;
     private List<Object> mockInput;
     private List<MockInboundStream> instreams;
     private List<OutboundEdgeStream> outstreams;
@@ -62,10 +61,7 @@ public class ProcessorTaskletTest_Blocking {
     @Before
     public void setUp() {
         this.processor = new PassThroughProcessor();
-        this.context = new ProcCtx(
-                null, new DefaultSerializationServiceBuilder().build(), null, null,
-                0, 0, NONE, 1,  0, 1
-        );
+        this.context = new TestProcessorContext();
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
@@ -294,8 +290,8 @@ public class ProcessorTaskletTest_Blocking {
         for (int i = 0; i < instreams.size(); i++) {
             instreams.get(i).setOrdinal(i);
         }
-        final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
-                mock(SnapshotContext.class), new MockOutboundCollector(10), -1);
+        final ProcessorTasklet t = new ProcessorTasklet(context, new DefaultSerializationServiceBuilder().build(),
+                processor, instreams, outstreams, mock(SnapshotContext.class), new MockOutboundCollector(10), -1);
         t.init();
         return t;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -21,9 +21,10 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
-import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
+import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.util.UuidUtil;
 import org.junit.Before;
@@ -63,7 +64,8 @@ public class ProcessorTaskletTest_Snapshots {
     private List<MockInboundStream> instreams;
     private List<OutboundEdgeStream> outstreams;
     private SnapshottableProcessor processor;
-    private ProcCtx context;
+    private Processor.Context context;
+    private SerializationService serializationService;
     private SnapshotContext snapshotContext;
     private MockOutboundCollector snapshotCollector;
 
@@ -71,10 +73,8 @@ public class ProcessorTaskletTest_Snapshots {
     public void setUp() {
         this.mockInput = IntStream.range(0, MOCK_INPUT_SIZE).boxed().collect(toList());
         this.processor = new SnapshottableProcessor();
-        this.context = new ProcCtx(
-                null, new DefaultSerializationServiceBuilder().build(), null, null,
-                0, 0, EXACTLY_ONCE, 1, 0, 1
-        );
+        this.serializationService = new DefaultSerializationServiceBuilder().build();
+        this.context = new TestProcessorContext().setProcessingGuarantee(EXACTLY_ONCE);
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
         this.snapshotCollector = new MockOutboundCollector(1024);
@@ -125,7 +125,7 @@ public class ProcessorTaskletTest_Snapshots {
         instreams.add(instream2);
         outstreams.add(outstream1);
 
-        Tasklet tasklet = createTasklet(ProcessingGuarantee.EXACTLY_ONCE);
+        Tasklet tasklet = createTasklet(EXACTLY_ONCE);
 
         // When
         callUntil(tasklet, NO_PROGRESS);
@@ -146,7 +146,7 @@ public class ProcessorTaskletTest_Snapshots {
         // Given
         MockOutboundStream outstream1 = new MockOutboundStream(0, 2);
         outstreams.add(outstream1);
-        Tasklet tasklet = createTasklet(ProcessingGuarantee.EXACTLY_ONCE);
+        Tasklet tasklet = createTasklet(EXACTLY_ONCE);
         processor.itemsToEmitInComplete = 4;
 
         // When
@@ -180,7 +180,7 @@ public class ProcessorTaskletTest_Snapshots {
         instreams.add(instream2);
         outstreams.add(outstream1);
 
-        Tasklet tasklet = createTasklet(ProcessingGuarantee.EXACTLY_ONCE);
+        Tasklet tasklet = createTasklet(EXACTLY_ONCE);
 
         // When
         callUntil(tasklet, DONE);
@@ -196,7 +196,7 @@ public class ProcessorTaskletTest_Snapshots {
         }
         snapshotContext = new SnapshotContext(mock(ILogger.class), 0, 0, -1, guarantee);
         snapshotContext.initTaskletCount(1, 0);
-        final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
+        final ProcessorTasklet t = new ProcessorTasklet(context, serializationService, processor, instreams, outstreams,
                 snapshotContext, snapshotCollector, -1);
         t.init();
         return t;
@@ -209,7 +209,7 @@ public class ProcessorTaskletTest_Snapshots {
     }
 
     private Object deserializeEntryValue(Entry e) {
-        return context.getSerializationService().toObject(e.getValue());
+        return serializationService.toObject(e.getValue());
     }
 
     private static void callUntil(Tasklet tasklet, ProgressState expectedState) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
@@ -21,7 +21,7 @@ import com.hazelcast.jet.core.Inbox;
 import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.Watermark;
-import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
+import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -54,16 +54,13 @@ public class ProcessorTaskletTest_Watermarks {
     private List<MockInboundStream> instreams;
     private List<OutboundEdgeStream> outstreams;
     private ProcessorWithWatermarks processor;
-    private ProcCtx context;
+    private Processor.Context context;
     private MockOutboundCollector snapshotCollector;
 
     @Before
     public void setUp() {
         this.processor = new ProcessorWithWatermarks();
-        this.context = new ProcCtx(
-                null, new DefaultSerializationServiceBuilder().build(), null, null,
-                0, 0, EXACTLY_ONCE, 1, 0, 1
-        );
+        this.context = new TestProcessorContext();
         this.instreams = new ArrayList<>();
         this.outstreams = new ArrayList<>();
         this.snapshotCollector = new MockOutboundCollector(0);
@@ -289,8 +286,8 @@ public class ProcessorTaskletTest_Watermarks {
         }
         SnapshotContext snapshotContext = new SnapshotContext(mock(ILogger.class), 0, 0, -1, EXACTLY_ONCE);
         snapshotContext.initTaskletCount(1, 0);
-        final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
-                snapshotContext, snapshotCollector, maxWatermarkRetainMillis);
+        final ProcessorTasklet t = new ProcessorTasklet(context, new DefaultSerializationServiceBuilder().build(),
+                processor, instreams, outstreams, snapshotContext, snapshotCollector, maxWatermarkRetainMillis);
         t.init();
         return t;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/DetermineLocalParallelismTest.java
@@ -89,7 +89,7 @@ public class DetermineLocalParallelismTest extends JetTestSupport {
         ExecutionPlanBuilder.createExecutionPlans(
                 nodeEngine,
                 ((ClusterServiceImpl) nodeEngine.getClusterService()).getMembershipManager().getMembersView(),
-                dag, new JobConfig(), NO_SNAPSHOT);
+                dag, 1, 1, new JobConfig(), NO_SNAPSHOT);
     }
 
     private static class ValidatingMetaSupplier implements ProcessorMetaSupplier {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/TransformUsingContextPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/TransformUsingContextPTest.java
@@ -70,9 +70,9 @@ public class TransformUsingContextPTest {
         assertEquals("context-0", outbox1.queue(0).poll());
         assertEquals(share ? "context-0" : "context-1", outbox2.queue(0).poll());
 
-        processors[0].close(null);
+        processors[0].close();
         assertEquals(share ? 0 : 1, destroyCounter[0]);
-        processors[1].close(null);
+        processors[1].close();
         assertEquals(share ? 0 : 2, destroyCounter[0]);
         supplier.close(null);
         assertEquals(share ? 1 : 2, destroyCounter[0]);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
@@ -102,17 +102,6 @@ public class UtilTest {
     }
 
     @Test
-    public void test_idToString() {
-        assertEquals("0000-0000-0000-0000", Util.idToString(0));
-        assertEquals("0000-0000-0000-0001", Util.idToString(1));
-        assertEquals("7fff-ffff-ffff-ffff", Util.idToString(Long.MAX_VALUE));
-        assertEquals("8000-0000-0000-0000", Util.idToString(Long.MIN_VALUE));
-        assertEquals("ffff-ffff-ffff-ffff", Util.idToString(-1));
-        assertEquals("1122-10f4-7de9-8115", Util.idToString(1234567890123456789L));
-        assertEquals("eedd-ef0b-8216-7eeb", Util.idToString(-1234567890123456789L));
-    }
-
-    @Test
     public void test_idFromString() {
         assertEquals(0, Util.idFromString("0000-0000-0000-0000"));
         assertEquals(1, Util.idFromString("0000-0000-0000-0001"));

--- a/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/WriteHdfsP.java
+++ b/hazelcast-jet-hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/WriteHdfsP.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.mapred.TaskAttemptContextImpl;
 import org.apache.hadoop.mapred.TaskAttemptID;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
@@ -79,7 +78,7 @@ public final class WriteHdfsP<T, K, V> extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) {
+    public void close() {
         uncheckRun(() -> {
             recordWriter.close(Reporter.NULL);
             if (outputCommitter.needsTaskCommit(taskAttemptContext)) {

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
@@ -34,7 +34,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.InterruptException;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -200,7 +199,7 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
     }
 
     @Override
-    public void close(@Nullable Throwable error) {
+    public void close() {
         if (consumer != null) {
             try {
                 consumer.close();


### PR DESCRIPTION
Fixes #867

Also contains:
- add `jobId()`, `executionId()` and `jobConfig()` to `Processor.Context`
- move `idToString` to public `Util` class (to format the ID from
`Processor.Context`)

Breaking change:
- `Processor.close()` methods no longer has `Throwable` parameter and it is called earlier (right after the processor completes, can be before the job completes).