### PR TITLE
Prefer using job name in logs

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/JetInstance.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/JetInstance.java
@@ -75,6 +75,10 @@ public interface JetInstance {
     /**
      * Creates and returns a Jet job based on the supplied DAG and job
      * configuration. Jet will asynchronously start executing the job.
+     *
+     * <p>If the name in the JobConfig is null, it will set the generated jobId
+     * as a name. If the name looks like a previously assigned jobId, it will
+     * be replaced as well.
      */
     @Nonnull
     Job newJob(@Nonnull DAG dag, @Nonnull JobConfig config);
@@ -91,6 +95,10 @@ public interface JetInstance {
     /**
      * Creates and returns a Jet job based on the supplied pipeline and job
      * configuration. Jet will asynchronously start executing the job.
+     *
+     * <p>If the name in the JobConfig is null, it will set the generated jobId
+     * as a name. If the name looks like a previously assigned jobId, it will
+     * be replaced as well.
      */
     @Nonnull
     default Job newJob(@Nonnull Pipeline pipeline, @Nonnull JobConfig config) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -48,9 +48,7 @@ public class JobConfig implements Serializable {
     private JobClassLoaderFactory classLoaderFactory;
 
     /**
-     * Returns the name of the job or {@code null} if no name was given. At job
-     * submission time if no name is assigned, the assigned jobId will be set
-     * as the name.
+     * Returns the name of the job or {@code null} if no name was given.
      */
     @Nullable
     public String getName() {
@@ -62,8 +60,7 @@ public class JobConfig implements Serializable {
      * good to keep them unique to be able to distinguish them in logs or
      * Management Center.
      * <p>
-     * Default value is {@code null}, in this case a random job ID will be
-     * assigned at job submission time.
+     * Default value is {@code null}.
      *
      * @return {@code this} instance for fluent API
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -48,7 +48,9 @@ public class JobConfig implements Serializable {
     private JobClassLoaderFactory classLoaderFactory;
 
     /**
-     * Returns the name of the job or {@code null} if no name was given.
+     * Returns the name of the job or {@code null} if no name was given. At job
+     * submission time if no name is assigned, the assigned jobId will be set
+     * as the name.
      */
     @Nullable
     public String getName() {
@@ -61,7 +63,7 @@ public class JobConfig implements Serializable {
      * Management Center.
      * <p>
      * Default value is {@code null}, in this case a random job ID will be
-     * used.
+     * assigned at job submission time.
      *
      * @return {@code this} instance for fluent API
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -56,8 +56,12 @@ public class JobConfig implements Serializable {
     }
 
     /**
-     * Sets the name for the job. Job names do not have to be unique.
-     * Default value is {@code null}.
+     * Sets the name for the job. Job names do not have to be unique but it's
+     * good to keep them unique to be able to distinguish them in logs or
+     * Management Center.
+     * <p>
+     * Default value is {@code null}, in this case a random job ID will be
+     * used.
      *
      * @return {@code this} instance for fluent API
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
@@ -31,6 +31,9 @@ import com.hazelcast.jet.stream.impl.IMapDecorator;
 import javax.annotation.Nonnull;
 import java.util.function.Supplier;
 
+import static com.hazelcast.jet.Util.idToString;
+import static com.hazelcast.jet.impl.util.Util.idFromString;
+
 abstract class AbstractJetInstance implements JetInstance {
     private final HazelcastInstance hazelcastInstance;
     private final JetCacheManagerImpl cacheManager;
@@ -82,8 +85,18 @@ abstract class AbstractJetInstance implements JetInstance {
         hazelcastInstance.shutdown();
     }
 
-    protected long uploadResourcesAndAssignId(JobConfig config) {
+    long uploadResourcesAndAssignId(JobConfig config) {
         return jobRepository.get().uploadJobResources(config);
     }
 
+    void updateJobConfigName(JobConfig config, long jobId) {
+        // If the config doesn't have a name, insert jobId to it.
+        // Also, if the name looks like jobId, replace it. The reason for this is that
+        // it will create confusion if the user (hopefully intentionally) submits the job
+        // multiple times and the name would look like jobId, but it would be a
+        // different value.
+        if (config.getName() == null || idFromString(config.getName()) != -1) {
+            config.setName(idToString(jobId));
+        }
+    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
@@ -31,9 +31,6 @@ import com.hazelcast.jet.stream.impl.IMapDecorator;
 import javax.annotation.Nonnull;
 import java.util.function.Supplier;
 
-import static com.hazelcast.jet.Util.idToString;
-import static com.hazelcast.jet.impl.util.Util.idFromString;
-
 abstract class AbstractJetInstance implements JetInstance {
     private final HazelcastInstance hazelcastInstance;
     private final JetCacheManagerImpl cacheManager;
@@ -89,14 +86,4 @@ abstract class AbstractJetInstance implements JetInstance {
         return jobRepository.get().uploadJobResources(config);
     }
 
-    void updateJobConfigName(JobConfig config, long jobId) {
-        // If the config doesn't have a name, insert jobId to it.
-        // Also, if the name looks like jobId, replace it. The reason for this is that
-        // it will create confusion if the user (hopefully intentionally) submits the job
-        // multiple times and the name would look like jobId, but it would be a
-        // different value.
-        if (config.getName() == null || idFromString(config.getName()) != -1) {
-            config.setName(idToString(jobId));
-        }
-    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -138,11 +138,7 @@ public class ClientJobProxy extends AbstractJobProxy<HazelcastClientInstanceImpl
     }
 
     private ClientInvocation invocation(ClientMessage request, Address invocationAddr) {
-        return new ClientInvocation(container(), request, jobName(), invocationAddr);
-    }
-
-    private String jobName() {
-        return "jobId=" + idToString(getId());
+        return new ClientInvocation(container(), request, "jobId=" + idToString(getId()), invocationAddr);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
@@ -80,7 +80,6 @@ public class JetClientInstanceImpl extends AbstractJetInstance {
     @Nonnull @Override
     public Job newJob(@Nonnull DAG dag, @Nonnull JobConfig config) {
         long jobId = uploadResourcesAndAssignId(config);
-        updateJobConfigName(config, jobId);
         return new ClientJobProxy(client, jobId, dag, config);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
@@ -80,6 +80,7 @@ public class JetClientInstanceImpl extends AbstractJetInstance {
     @Nonnull @Override
     public Job newJob(@Nonnull DAG dag, @Nonnull JobConfig config) {
         long jobId = uploadResourcesAndAssignId(config);
+        updateJobConfigName(config, jobId);
         return new ClientJobProxy(client, jobId, dag, config);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
@@ -58,7 +58,6 @@ public class JetInstanceImpl extends AbstractJetInstance {
     @Nonnull @Override
     public Job newJob(@Nonnull DAG dag, @Nonnull JobConfig config) {
         long jobId = uploadResourcesAndAssignId(config);
-        updateJobConfigName(config, jobId);
         return new JobProxy((NodeEngineImpl) nodeEngine, jobId, dag, config);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
@@ -58,6 +58,7 @@ public class JetInstanceImpl extends AbstractJetInstance {
     @Nonnull @Override
     public Job newJob(@Nonnull DAG dag, @Nonnull JobConfig config) {
         long jobId = uploadResourcesAndAssignId(config);
+        updateJobConfigName(config, jobId);
         return new JobProxy((NodeEngineImpl) nodeEngine, jobId, dag, config);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -59,7 +59,6 @@ import static com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject.dese
 import static com.hazelcast.jet.impl.util.JetGroupProperty.JOB_SCAN_PERIOD;
 import static com.hazelcast.jet.impl.util.Util.getJetInstance;
 import static com.hazelcast.jet.impl.util.Util.idToString;
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static com.hazelcast.util.executor.ExecutorType.CACHED;
 import static java.util.Comparator.comparing;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -79,9 +78,9 @@ public class JobCoordinationService {
     private final SnapshotRepository snapshotRepository;
     private final ConcurrentMap<Long, MasterContext> masterContexts = new ConcurrentHashMap<>();
 
-    public JobCoordinationService(NodeEngineImpl nodeEngine, JetConfig config,
-                                  JobRepository jobRepository, JobExecutionService jobExecutionService,
-                                  SnapshotRepository snapshotRepository) {
+    JobCoordinationService(NodeEngineImpl nodeEngine, JetConfig config,
+                           JobRepository jobRepository, JobExecutionService jobExecutionService,
+                           SnapshotRepository snapshotRepository) {
         this.nodeEngine = nodeEngine;
         this.config = config;
         this.logger = nodeEngine.getLogger(getClass());
@@ -167,7 +166,7 @@ public class JobCoordinationService {
      */
     public CompletableFuture<Void> submitOrJoinJob(long jobId, Data dag, JobConfig config) {
         if (!isMaster()) {
-            throw new JetException("Cannot submit Job " + idToString(jobId) + ". Master address: "
+            throw new JetException("Cannot submit job " + idToString(jobId) + ". Master address: "
                     + nodeEngine.getClusterService().getMasterAddress());
         }
 
@@ -189,7 +188,7 @@ public class JobCoordinationService {
         // just try to initiate the coordination
         MasterContext prev = masterContexts.putIfAbsent(jobId, masterContext);
         if (prev != null) {
-            logger.fine("Joining to already started job " + idToString(jobId));
+            logger.fine("Joining to already started job " + prev.jobIdString());
             return prev.completionFuture();
         }
 
@@ -201,7 +200,7 @@ public class JobCoordinationService {
         // If there is no master context and job result at the same time, it means this is the first submission
         jobRepository.putNewJobRecord(jobRecord);
 
-        logger.info("Starting job " + idToString(jobId) + " based on submit request from client");
+        logger.info("Starting " + masterContext.jobIdString() + " based on submit request from client");
         nodeEngine.getExecutionService().execute(COORDINATOR_EXECUTOR_NAME, () -> tryStartJob(masterContext));
 
         return masterContext.completionFuture();
@@ -216,7 +215,7 @@ public class JobCoordinationService {
 
     public CompletableFuture<Void> joinSubmittedJob(long jobId) {
         if (!isMaster()) {
-            throw new JetException("Cannot join Job " + idToString(jobId) + ". Master address: "
+            throw new JetException("Cannot join job " + idToString(jobId) + ". Master address: "
                     + nodeEngine.getClusterService().getMasterAddress());
         }
 
@@ -255,7 +254,7 @@ public class JobCoordinationService {
             return;
         }
 
-        logger.info("Starting job " + idToString(masterContext.getJobId()) + " discovered by scanning of JobRecords");
+        logger.info("Starting job " + masterContext.jobIdString() + " discovered by scanning of JobRecords");
         tryStartJob(masterContext);
     }
 
@@ -264,8 +263,8 @@ public class JobCoordinationService {
         long jobId = masterContext.getJobId();
         JobResult jobResult = jobRepository.getJobResult(jobId);
         if (jobResult != null) {
-            logger.fine("Completing master context " + idToString(jobId) + " since already completed with result: " +
-                    jobResult);
+            logger.fine("Completing master context for " + masterContext.jobIdString()
+                    + " since already completed with result: " + jobResult);
             masterContext.setFinalResult(jobResult.getFailure());
             return masterContexts.remove(jobId, masterContext);
         }
@@ -274,7 +273,7 @@ public class JobCoordinationService {
                 && jobRepository.getExecutionIdCount(jobId) > 0) {
             String coordinator = nodeEngine.getNode().getThisUuid();
             Throwable result = new TopologyChangedException();
-            logger.info("Completing Job " + idToString(jobId) + " with " + result
+            logger.info("Completing job " + masterContext.jobIdString() + " with " + result
                     + " since auto-restart is disabled and the job has been executed before");
             jobRepository.completeJob(jobId, coordinator, System.currentTimeMillis(), result);
             masterContext.setFinalResult(result);
@@ -337,7 +336,7 @@ public class JobCoordinationService {
      */
     public JobStatus getJobStatus(long jobId) {
         if (!isMaster()) {
-            throw new JetException("Cannot query status of Job " + idToString(jobId) + ". Master address: "
+            throw new JetException("Cannot query status of job " + idToString(jobId) + ". Master address: "
                     + nodeEngine.getClusterService().getMasterAddress());
         }
 
@@ -380,7 +379,7 @@ public class JobCoordinationService {
      */
     public long getJobSubmissionTime(long jobId) {
         if (!isMaster()) {
-            throw new JetException("Cannot query submission time of Job " + idToString(jobId) + ". Master address: "
+            throw new JetException("Cannot query submission time of job " + idToString(jobId) + ". Master address: "
                     + nodeEngine.getClusterService().getMasterAddress());
         }
 
@@ -442,7 +441,7 @@ public class JobCoordinationService {
 
         boolean cancelled = masterContext.restartExecution();
         if (cancelled) {
-            logger.info("Job " + idToString(jobId) + " is going to be restarted");
+            logger.info(masterContext.jobIdString() + " is going to be restarted");
         } else {
             logger.warning("Cannot restart job " + idToString(jobId) + " because it is not currently being executed");
         }
@@ -457,7 +456,7 @@ public class JobCoordinationService {
     /**
      * Completes the job which is coordinated with the given master context object.
      */
-    void completeJob(MasterContext masterContext, long executionId, long completionTime, Throwable error) {
+    void completeJob(MasterContext masterContext, long completionTime, Throwable error) {
         // the order of operations is important.
 
         long jobId = masterContext.getJobId();
@@ -466,14 +465,14 @@ public class JobCoordinationService {
         jobRepository.completeJob(jobId, coordinator, completionTime, error);
 
         if (masterContexts.remove(masterContext.getJobId(), masterContext)) {
-            logger.fine(jobAndExecutionId(jobId, executionId) + " is completed");
+            logger.fine(masterContext.jobIdString() + " is completed");
         } else {
             MasterContext existing = masterContexts.get(jobId);
             if (existing != null) {
-                logger.severe("Different master context found to complete " + jobAndExecutionId(jobId, executionId)
+                logger.severe("Different master context found to complete " + masterContext.jobIdString()
                         + ", master context execution " + idToString(existing.getExecutionId()));
             } else {
-                logger.severe("No master context found to complete " + jobAndExecutionId(jobId, executionId));
+                logger.severe("No master context found to complete " + masterContext.jobIdString());
             }
         }
     }
@@ -483,82 +482,82 @@ public class JobCoordinationService {
      */
     void scheduleRestart(long jobId) {
         MasterContext masterContext = masterContexts.get(jobId);
-        if (masterContext != null) {
-            logger.fine("Scheduling restart on master for job " + idToString(jobId));
-            nodeEngine.getExecutionService().schedule(COORDINATOR_EXECUTOR_NAME, () -> restartJob(jobId),
-                    RETRY_DELAY_IN_MILLIS, MILLISECONDS);
-        } else {
+        if (masterContext == null) {
             logger.severe("Master context for job " + idToString(jobId) + " not found to schedule restart");
+            return;
         }
+        logger.fine("Scheduling restart on master for job " + idToString(jobId));
+        nodeEngine.getExecutionService().schedule(COORDINATOR_EXECUTOR_NAME, () -> restartJob(jobId),
+                RETRY_DELAY_IN_MILLIS, MILLISECONDS);
     }
 
     void scheduleSnapshot(long jobId, long executionId) {
         MasterContext masterContext = masterContexts.get(jobId);
-        if (masterContext != null) {
-            long snapshotInterval = masterContext.getJobConfig().getSnapshotIntervalMillis();
-            InternalExecutionService executionService = nodeEngine.getExecutionService();
-            if (logger.isFineEnabled()) {
-                logger.fine(jobAndExecutionId(jobId, executionId) + " snapshot is scheduled in "
-                        + snapshotInterval + "ms");
-            }
-            executionService.schedule(COORDINATOR_EXECUTOR_NAME, () -> beginSnapshot(jobId, executionId),
-                    snapshotInterval, MILLISECONDS);
-        } else {
-            logger.warning("MasterContext not found to schedule snapshot of " + jobAndExecutionId(jobId, executionId));
+        if (masterContext == null) {
+            logger.warning("MasterContext not found to schedule snapshot of " + idToString(jobId));
+            return;
         }
+        long snapshotInterval = masterContext.getJobConfig().getSnapshotIntervalMillis();
+        InternalExecutionService executionService = nodeEngine.getExecutionService();
+        if (logger.isFineEnabled()) {
+            logger.fine(masterContext.jobIdString() + " snapshot is scheduled in "
+                    + snapshotInterval + "ms");
+        }
+        executionService.schedule(COORDINATOR_EXECUTOR_NAME, () -> beginSnapshot(jobId, executionId),
+                snapshotInterval, MILLISECONDS);
     }
 
     private void beginSnapshot(long jobId, long executionId) {
         MasterContext masterContext = masterContexts.get(jobId);
-        if (masterContext != null) {
-            if (masterContext.completionFuture().isDone() || masterContext.isCancelled()
-                    || masterContext.jobStatus() != RUNNING) {
-                logger.fine("Not starting snapshot since " + jobAndExecutionId(jobId, executionId) + " is done.");
-                return;
-            }
-
-            if (!shouldStartJobs()) {
-                scheduleSnapshot(jobId, executionId);
-                return;
-            }
-
-            masterContext.beginSnapshot(executionId);
-        } else {
-            logger.warning("MasterContext not found to schedule snapshot of " + jobAndExecutionId(jobId, executionId));
+        if (masterContext == null) {
+            logger.warning("MasterContext not found to schedule snapshot of " + idToString(jobId));
+            return;
         }
+        if (masterContext.completionFuture().isDone() || masterContext.isCancelled()
+                || masterContext.jobStatus() != RUNNING) {
+            logger.fine("Not starting snapshot since " + masterContext.jobIdString() + " is done.");
+            return;
+        }
+
+        if (!shouldStartJobs()) {
+            scheduleSnapshot(jobId, executionId);
+            return;
+        }
+
+        masterContext.beginSnapshot(executionId);
     }
 
     void completeSnapshot(long jobId, long executionId, long snapshotId, boolean isSuccess,
                           long numBytes, long numKeys, long numChunks
     ) {
         MasterContext masterContext = masterContexts.get(jobId);
-        if (masterContext != null) {
-            try {
-                SnapshotStatus status = isSuccess ? SUCCESSFUL : FAILED;
-                long elapsed = snapshotRepository.setSnapshotComplete(jobId, snapshotId, status, numBytes, numKeys,
-                        numChunks);
-                logger.info(String.format("Snapshot %s for job %s completed with status %s in %dms, " +
-                                "%,d bytes, %,d keys in %,d chunks", snapshotId, idToString(jobId), status, elapsed,
-                                numBytes, numKeys, numChunks));
-            } catch (Exception e) {
-                logger.warning("Cannot update snapshot status for " + jobAndExecutionId(jobId, executionId) + " snapshot "
-                        + snapshotId + " isSuccess: " + isSuccess);
-                return;
-            }
-            try {
-                if (isSuccess) {
-                    snapshotRepository.deleteAllSnapshotsExceptOne(jobId, snapshotId);
-                } else {
-                    snapshotRepository.deleteSingleSnapshot(jobId, snapshotId);
-                }
-            } catch (Exception e) {
-                logger.warning("Cannot delete old snapshots for " + jobAndExecutionId(jobId, executionId));
-            }
-            scheduleSnapshot(jobId, executionId);
-        } else {
-            logger.warning("MasterContext not found to finalize snapshot of " + jobAndExecutionId(jobId, executionId)
+        if (masterContext == null) {
+            logger.warning("MasterContext not found to finalize snapshot of " + idToString(jobId)
                     + " with result: " + isSuccess);
+            return;
         }
+        try {
+            SnapshotStatus status = isSuccess ? SUCCESSFUL : FAILED;
+            long elapsed = snapshotRepository.setSnapshotComplete(jobId, snapshotId, status, numBytes, numKeys,
+                    numChunks);
+            logger.info(String.format("Snapshot %s for job %s completed with status %s in %dms, " +
+                            "%,d bytes, %,d keys in %,d chunks", snapshotId, idToString(jobId), status, elapsed,
+                            numBytes, numKeys, numChunks));
+        } catch (Exception e) {
+            logger.warning("Cannot update snapshot status for " + masterContext.jobIdString() + " snapshot "
+                    + snapshotId + " isSuccess: " + isSuccess);
+            return;
+        }
+        try {
+            if (isSuccess) {
+                snapshotRepository.deleteAllSnapshotsExceptOne(jobId, snapshotId);
+            } else {
+                snapshotRepository.deleteSingleSnapshot(jobId, snapshotId);
+            }
+        } catch (Exception e) {
+            logger.warning("Cannot delete old snapshots for " + masterContext.jobIdString());
+        }
+        scheduleSnapshot(jobId, executionId);
     }
 
     boolean shouldStartJobs() {
@@ -603,16 +602,16 @@ public class JobCoordinationService {
      */
     private void restartJob(long jobId) {
         MasterContext masterContext = masterContexts.get(jobId);
-        if (masterContext != null) {
-            if (masterContext.isCancelled()) {
-                tryStartJob(masterContext);
-                return;
-            }
-
-            tryStartJob(masterContext);
-        } else {
+        if (masterContext == null) {
             logger.severe("Master context for job " + idToString(jobId) + " not found to restart");
+            return;
         }
+
+        if (masterContext.isCancelled()) {
+            tryStartJob(masterContext);
+            return;
+        }
+        tryStartJob(masterContext);
     }
 
     // runs periodically to restart jobs on coordinator failure and perform gc
@@ -643,5 +642,4 @@ public class JobCoordinationService {
     private boolean isMaster() {
         return nodeEngine.getClusterService().isMaster();
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -260,7 +260,7 @@ public class JobCoordinationService {
 
     // If a job result is present, it completes the master context using the job result
     private boolean completeMasterContextIfJobAlreadyCompleted(MasterContext masterContext) {
-        long jobId = masterContext.getJobId();
+        long jobId = masterContext.jobId();
         JobResult jobResult = jobRepository.getJobResult(jobId);
         if (jobResult != null) {
             logger.fine("Completing master context for " + masterContext.jobIdString()
@@ -459,12 +459,12 @@ public class JobCoordinationService {
     void completeJob(MasterContext masterContext, long completionTime, Throwable error) {
         // the order of operations is important.
 
-        long jobId = masterContext.getJobId();
+        long jobId = masterContext.jobId();
         String coordinator = nodeEngine.getNode().getThisUuid();
 
         jobRepository.completeJob(jobId, coordinator, completionTime, error);
 
-        if (masterContexts.remove(masterContext.getJobId(), masterContext)) {
+        if (masterContexts.remove(masterContext.jobId(), masterContext)) {
             logger.fine(masterContext.jobIdString() + " is completed");
         } else {
             MasterContext existing = masterContexts.get(jobId);
@@ -581,7 +581,7 @@ public class JobCoordinationService {
 
         masterContexts.values().stream()
                       .filter(ctx -> name.equals(ctx.getJobConfig().getName()))
-                      .forEach(ctx -> jobs.put(ctx.getJobId(), ctx.getJobRecord().getCreationTime()));
+                      .forEach(ctx -> jobs.put(ctx.jobId(), ctx.getJobRecord().getCreationTime()));
 
         jobRepository.getJobResults(name)
                   .forEach(r -> jobs.put(r.getJobId(), r.getCreationTime()));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -540,8 +540,8 @@ public class JobCoordinationService {
             SnapshotStatus status = isSuccess ? SUCCESSFUL : FAILED;
             long elapsed = snapshotRepository.setSnapshotComplete(jobId, snapshotId, status, numBytes, numKeys,
                     numChunks);
-            logger.info(String.format("Snapshot %s for job %s completed with status %s in %dms, " +
-                            "%,d bytes, %,d keys in %,d chunks", snapshotId, idToString(jobId), status, elapsed,
+            logger.info(String.format("Snapshot %d for %s completed with status %s in %dms, " +
+                            "%,d bytes, %,d keys in %,d chunks", snapshotId, masterContext.jobIdString(), status, elapsed,
                             numBytes, numKeys, numChunks));
         } catch (Exception e) {
             logger.warning("Cannot update snapshot status for " + masterContext.jobIdString() + " snapshot "

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -45,7 +45,7 @@ import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryValue;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.idToString;
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
+import static com.hazelcast.jet.impl.util.Util.jobIdAndExecutionId;
 import static java.util.Collections.newSetFromMap;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -98,7 +98,7 @@ public class JobExecutionService {
     public void reset(String reason, Supplier<RuntimeException> exceptionSupplier) {
         executionContexts.values().forEach(exeCtx -> {
             String message = String.format("Completing %s locally. Reason: %s",
-                    jobAndExecutionId(exeCtx.jobId(), exeCtx.executionId()),
+                    exeCtx.jobNameAndExecutionId(),
                     reason);
             cancelAndComplete(exeCtx, message, exceptionSupplier.get());
         });
@@ -113,7 +113,7 @@ public class JobExecutionService {
              .filter(exeCtx -> exeCtx.coordinator().equals(address) || exeCtx.hasParticipant(address))
              .forEach(exeCtx -> {
                  String message = String.format("Completing %s locally. Reason: Coordinator %s left the cluster",
-                         jobAndExecutionId(exeCtx.jobId(), exeCtx.executionId()),
+                         exeCtx.jobNameAndExecutionId(),
                          address);
                  cancelAndComplete(exeCtx, message, new TopologyChangedException("Topology has been changed."));
              });
@@ -131,8 +131,7 @@ public class JobExecutionService {
                 completeExecution(executionId, t);
             }));
         } catch (Throwable e) {
-            logger.severe(String.format("Local cancellation of %s failed",
-                    jobAndExecutionId(exeCtx.jobId(), exeCtx.executionId())), e);
+            logger.severe(String.format("Local cancellation of %s failed", exeCtx.jobNameAndExecutionId()), e);
         }
     }
 
@@ -140,8 +139,8 @@ public class JobExecutionService {
      * Initiates the given execution if the local node accepts the coordinator
      * as its master, and has an up-to-date member list information.
      * <ul><li>
-     *   If the local node has a stale member list, it retries the init operation
-     *   until it receives the new member list from the master.
+     *     If the local node has a stale member list, it retries the init operation
+     *     until it receives the new member list from the master.
      * </li><li>
      *     If the local node detects that the member list changed after the init
      *     operation is sent but before executed, then it sends a graceful failure
@@ -164,15 +163,16 @@ public class JobExecutionService {
             if (current != null) {
                 throw new IllegalStateException(String.format(
                         "Execution context for %s for coordinator %s already exists for coordinator %s",
-                        jobAndExecutionId(jobId, executionId), coordinator, current.coordinator()));
+                        current.jobNameAndExecutionId(), coordinator, current.coordinator()));
             }
 
+            // search contexts for one with different executionId, but same jobId
             executionContexts.values().stream()
                              .filter(e -> e.jobId() == jobId)
                              .forEach(e -> logger.fine(String.format(
-                                     "Execution context for %s for coordinator %s already exists"
+                                     "Execution context for job %s for coordinator %s already exists"
                                              + " with local execution %s for coordinator %s",
-                                     jobAndExecutionId(jobId, executionId), coordinator, idToString(e.jobId()),
+                                     idToString(jobId), coordinator, idToString(e.executionId()),
                                      e.coordinator())));
 
             throw new RetryableHazelcastException();
@@ -187,7 +187,10 @@ public class JobExecutionService {
             executionContexts.put(executionId, created);
         }
 
-        logger.info("Execution plan for " + jobAndExecutionId(jobId, executionId) + " initialized");
+        // initial log entry with all of jobId, jobName, executionId
+        logger.info("Execution plan for jobId=" + idToString(jobId)
+                + ", jobName=" + (created.jobName() != null ? "'" + created.jobName() + "'" : "null")
+                + ", executionId=" + idToString(executionId) + " initialized");
     }
 
     private void verifyClusterInformation(long jobId, long executionId, Address coordinator,
@@ -198,7 +201,7 @@ public class JobExecutionService {
 
             throw new IllegalStateException(String.format(
                     "Coordinator %s cannot initialize %s. Reason: it is not the master, the master is %s",
-                    coordinator, jobAndExecutionId(jobId, executionId), masterAddress));
+                    coordinator, jobIdAndExecutionId(jobId, executionId), masterAddress));
         }
 
         ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngine.getClusterService();
@@ -216,7 +219,7 @@ public class JobExecutionService {
             throw new RetryableHazelcastException(String.format(
                     "Cannot initialize %s for coordinator %s, local member list version %s," +
                             " coordinator member list version %s",
-                    jobAndExecutionId(jobId, executionId), coordinator, localMemberListVersion,
+                    jobIdAndExecutionId(jobId, executionId), coordinator, localMemberListVersion,
                     coordinatorMemberListVersion));
         }
 
@@ -230,7 +233,7 @@ public class JobExecutionService {
                 throw new TopologyChangedException(String.format(
                         "Cannot initialize %s for coordinator %s: participant %s not found in local member list." +
                                 " Local member list version: %s, coordinator member list version: %s",
-                        jobAndExecutionId(jobId, executionId), coordinator, participant,
+                        jobIdAndExecutionId(jobId, executionId), coordinator, participant,
                         localMemberListVersion, coordinatorMemberListVersion));
             }
         }
@@ -238,7 +241,7 @@ public class JobExecutionService {
         if (!isLocalMemberParticipant) {
             throw new IllegalArgumentException(String.format(
                     "Cannot initialize %s since member %s is not in participants: %s",
-                    jobAndExecutionId(jobId, executionId), thisAddress, participants));
+                    jobIdAndExecutionId(jobId, executionId), thisAddress, participants));
         }
     }
 
@@ -257,7 +260,7 @@ public class JobExecutionService {
             throw new IllegalStateException(String.format(
                     "Coordinator %s cannot do '%s' for %s: it is not the master, the master is %s",
                     coordinator, callerOp.getClass().getSimpleName(),
-                    jobAndExecutionId(jobId, executionId), masterAddress));
+                    jobIdAndExecutionId(jobId, executionId), masterAddress));
         }
 
         failIfNotRunning();
@@ -266,11 +269,11 @@ public class JobExecutionService {
         if (executionContext == null) {
             throw new TopologyChangedException(String.format(
                     "%s not found for coordinator %s for '%s'",
-                    jobAndExecutionId(jobId, executionId), coordinator, callerOp.getClass().getSimpleName()));
+                    jobIdAndExecutionId(jobId, executionId), coordinator, callerOp.getClass().getSimpleName()));
         } else if (!(executionContext.coordinator().equals(coordinator) && executionContext.jobId() == jobId)) {
             throw new IllegalStateException(String.format(
                     "%s, originally from coordinator %s, cannot do '%s' by coordinator %s and execution %s",
-                    jobAndExecutionId(jobId, executionContext.executionId()), executionContext.coordinator(),
+                    executionContext.jobNameAndExecutionId(), executionContext.coordinator(),
                     callerOp.getClass().getSimpleName(), coordinator, idToString(executionId)));
         }
 
@@ -288,7 +291,7 @@ public class JobExecutionService {
             } finally {
                 classLoaders.remove(executionContext.jobId());
                 executionContextJobIds.remove(executionContext.jobId());
-                logger.fine("Completed execution of " + jobAndExecutionId(executionContext.jobId(), executionId));
+                logger.fine("Completed execution of " + executionContext.jobNameAndExecutionId());
             }
         } else {
             logger.fine("Execution " + idToString(executionId) + " not found for completion");

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
@@ -108,6 +108,7 @@ public class JobRecord implements IdentifiedDataSerializable {
     public String toString() {
         return "JobRecord{" +
                 "jobId=" + idToString(jobId) +
+                ", jobConfig.name=" + getConfig().getName() +
                 ", creationTime=" + toLocalDateTime(creationTime) +
                 ", dagJson=" + dagJson +
                 ", config=" + config +

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
@@ -108,7 +108,7 @@ public class JobRecord implements IdentifiedDataSerializable {
     public String toString() {
         return "JobRecord{" +
                 "jobId=" + idToString(jobId) +
-                ", jobConfig.name=" + getConfig().getName() +
+                ", name=" + getConfig().getName() +
                 ", creationTime=" + toLocalDateTime(creationTime) +
                 ", dagJson=" + dagJson +
                 ", config=" + config +

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRecord.java
@@ -54,6 +54,10 @@ public class JobRecord implements IdentifiedDataSerializable {
         return jobId;
     }
 
+    public String getJobNameOrId() {
+        return config.getName() != null ? config.getName() : idToString(jobId);
+    }
+
     public long getCreationTime() {
         return creationTime;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -219,7 +219,7 @@ public class JobRepository {
         JobRecord prev = jobRecords.putIfAbsent(jobId, jobRecord);
         if (prev != null && !prev.getDag().equals(jobRecord.getDag())) {
             throw new IllegalStateException("Cannot put job record for job " + idToString(jobId)
-                    + " because it already exists with a different dag");
+                    + " because it already exists with a different DAG");
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobResult.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobResult.java
@@ -101,7 +101,7 @@ public class JobResult implements IdentifiedDataSerializable {
         return "JobResult{" +
                 "coordinatorUUID='" + coordinatorUUID + '\'' +
                 ", jobId=" + idToString(jobId) +
-                ", jobConfig.name=" + jobConfig.getName() +
+                ", name=" + jobConfig.getName() +
                 ", creationTime=" + toLocalDateTime(creationTime) +
                 ", completionTime=" + toLocalDateTime(completionTime) +
                 ", failure=" + failure +

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/LiveOperationRegistry.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/LiveOperationRegistry.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.impl;
 
-import com.hazelcast.jet.impl.operation.AsyncOperation;
+import com.hazelcast.jet.impl.operation.AsyncJobOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.LiveOperations;
 
@@ -25,18 +25,18 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class LiveOperationRegistry {
     // memberAddress -> callId -> operation
-    final ConcurrentHashMap<Address, Map<Long, AsyncOperation>> liveOperations = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<Address, Map<Long, AsyncJobOperation>> liveOperations = new ConcurrentHashMap<>();
 
-    public void register(AsyncOperation operation) {
-        Map<Long, AsyncOperation> callIds = liveOperations.computeIfAbsent(operation.getCallerAddress(),
+    public void register(AsyncJobOperation operation) {
+        Map<Long, AsyncJobOperation> callIds = liveOperations.computeIfAbsent(operation.getCallerAddress(),
                 (key) -> new ConcurrentHashMap<>());
         if (callIds.putIfAbsent(operation.getCallId(), operation) != null) {
             throw new IllegalStateException("Duplicate operation during registration of operation=" + operation);
         }
     }
 
-    public void deregister(AsyncOperation operation) {
-        Map<Long, AsyncOperation> operations = liveOperations.get(operation.getCallerAddress());
+    public void deregister(AsyncJobOperation operation) {
+        Map<Long, AsyncJobOperation> operations = liveOperations.get(operation.getCallerAddress());
 
         if (operations == null) {
             throw new IllegalStateException("Missing address during de-registration of operation=" + operation);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -80,7 +80,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.Util.idToString;
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
+import static com.hazelcast.jet.impl.util.Util.jobNameAndExecutionId;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toList;
@@ -98,6 +98,7 @@ public class MasterContext {
     private final ILogger logger;
     private final JobRecord jobRecord;
     private final long jobId;
+    private final String jobNameOrId;
     private final NonCompletableFuture completionFuture = new NonCompletableFuture();
     private final CompletionToken cancellationToken;
     private final AtomicReference<JobStatus> jobStatus = new AtomicReference<>(NOT_STARTED);
@@ -116,6 +117,7 @@ public class MasterContext {
         this.logger = nodeEngine.getLogger(getClass());
         this.jobRecord = jobRecord;
         this.jobId = jobRecord.getJobId();
+        this.jobNameOrId = jobRecord.getConfig().getName() != null ? jobRecord.getConfig().getName() : idToString(jobId);
         this.cancellationToken = new CompletionToken(logger);
     }
 
@@ -248,19 +250,19 @@ public class MasterContext {
     private boolean setJobStatusToStarting() {
         JobStatus status = jobStatus();
         if (status == COMPLETED || status == FAILED) {
-            logger.severe("Cannot init job " + idToString(jobId) + ": it is already " + status);
+            logger.severe("Cannot init job " + jobNameOrId + ": it is already " + status);
             return false;
         }
 
         if (cancellationToken.isCompleted()) {
-            logger.fine("Skipping init job " + idToString(jobId) + ": is already cancelled.");
+            logger.fine("Skipping init job " + jobNameOrId + ": is already cancelled.");
             finalizeJob(new CancellationException());
             return false;
         }
 
         if (status == NOT_STARTED) {
             if (!jobStatus.compareAndSet(NOT_STARTED, STARTING)) {
-                logger.fine("Cannot init job " + idToString(jobId) + ": someone else is just starting it");
+                logger.fine("Cannot init job " + jobNameOrId + ": someone else is just starting it");
                 return false;
             }
 
@@ -269,7 +271,7 @@ public class MasterContext {
 
         status = jobStatus();
         if (!(status == STARTING || status == RESTARTING)) {
-            logger.severe("Cannot init job " + idToString(jobId) + ": status is " + status);
+            logger.severe("Cannot init job " + jobNameOrId + ": status is " + status);
             return false;
         }
 
@@ -282,7 +284,7 @@ public class MasterContext {
             return false;
         }
 
-        logger.fine("Rescheduling restart of job " + idToString(jobId) + ": quorum size " + quorumSize + " is not met");
+        logger.fine("Rescheduling restart of job " + jobNameOrId + ": quorum size " + quorumSize + " is not met");
         scheduleRestart();
         return true;
     }
@@ -292,7 +294,7 @@ public class MasterContext {
             return false;
         }
 
-        logger.fine("Rescheduling restart of job " + idToString(jobId) + ": cluster is not safe");
+        logger.fine("Rescheduling restart of job " + jobNameOrId + ": cluster is not safe");
         scheduleRestart();
         return true;
     }
@@ -434,15 +436,15 @@ public class MasterContext {
     void beginSnapshot(long executionId) {
         if (this.executionId != executionId) {
             // current execution is completed and probably a new execution has started
-            logger.warning("Not beginning snapshot since expected execution id " + idToString(this.executionId)
-                    + " does not match to " + jobAndExecutionId(jobId, executionId));
+            logger.warning("Not beginning snapshot since unexpected execution ID received for " + jobIdString()
+                    + ". Received execution ID: " + idToString(executionId));
             return;
         }
 
         List<String> vertexNames = vertices.stream().map(Vertex::getName).collect(Collectors.toList());
         long newSnapshotId = snapshotRepository.registerSnapshot(jobId, vertexNames);
 
-        logger.info(String.format("Starting snapshot %s for %s", newSnapshotId, jobAndExecutionId(jobId, executionId)));
+        logger.info(String.format("Starting snapshot %s for %s", newSnapshotId, jobIdString()));
         Function<ExecutionPlan, Operation> factory =
                 plan -> new SnapshotOperation(jobId, executionId, newSnapshotId);
 
@@ -457,7 +459,7 @@ public class MasterContext {
 
         boolean isSuccess = mergedResult.getError() == null;
         if (!isSuccess) {
-            logger.warning(jobAndExecutionId(jobId, executionId) + " snapshot " + snapshotId + " has failure, " +
+            logger.warning(jobIdString() + " snapshot " + snapshotId + " has failure, " +
                     "first failure: " + mergedResult.getError());
         }
         coordinationService.completeSnapshot(jobId, executionId, snapshotId, isSuccess,
@@ -556,7 +558,7 @@ public class MasterContext {
         jobStatus.set(status);
 
         try {
-            coordinationService.completeJob(this, executionId, System.currentTimeMillis(), failure);
+            coordinationService.completeJob(this, System.currentTimeMillis(), failure);
         } catch (RuntimeException e) {
             logger.warning("Completion of " + jobIdString() + " failed", e);
         } finally {
@@ -662,8 +664,8 @@ public class MasterContext {
         return getJobConfig().getProcessingGuarantee() != ProcessingGuarantee.NONE;
     }
 
-    private String jobIdString() {
-        return jobAndExecutionId(jobId, executionId);
+    String jobIdString() {
+        return jobNameAndExecutionId(jobNameOrId, executionId);
     }
 
     private static ClassLoader swapContextClassLoader(ClassLoader jobClassLoader) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -117,8 +117,7 @@ public class MasterContext {
         this.logger = nodeEngine.getLogger(getClass());
         this.jobRecord = jobRecord;
         this.jobId = jobRecord.getJobId();
-        this.jobName = jobRecord.getConfig().getName();
-        assert jobName != null : "null job name";
+        this.jobName = jobRecord.getJobNameOrId();
         this.cancellationToken = new CompletionToken(logger);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -121,7 +121,7 @@ public class MasterContext {
         this.cancellationToken = new CompletionToken(logger);
     }
 
-    public long getJobId() {
+    public long jobId() {
         return jobId;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -22,12 +22,14 @@ import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlan;
 import com.hazelcast.jet.impl.operation.SnapshotOperation.SnapshotOperationResult;
+import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +38,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -55,6 +56,7 @@ public class ExecutionContext {
     private final Set<Address> participants;
     private final Object executionLock = new Object();
     private final ILogger logger;
+    private String jobName;
 
     // dest vertex id --> dest ordinal --> sender addr --> receiver tasklet
     private Map<Integer, Map<Integer, Map<Address, ReceiverTasklet>>> receiverMap = emptyMap();
@@ -94,8 +96,9 @@ public class ExecutionContext {
         // available to be completed in the case of init failure
         procSuppliers = unmodifiableList(plan.getProcessorSuppliers());
         processors = plan.getProcessors();
-        snapshotContext = new SnapshotContext(nodeEngine.getLogger(SnapshotContext.class), jobId, executionId,
+        snapshotContext = new SnapshotContext(nodeEngine.getLogger(SnapshotContext.class), jobNameAndExecutionId(),
                 plan.lastSnapshotId(), plan.getJobConfig().getProcessingGuarantee());
+        jobName = plan.getJobConfig().getName();
         plan.initialize(nodeEngine, jobId, executionId, snapshotContext);
         snapshotContext.initTaskletCount(plan.getStoreSnapshotTaskletCount(), plan.getHigherPriorityVertexCount());
         receiverMap = unmodifiableMap(plan.getReceiverMap());
@@ -140,7 +143,7 @@ public class ExecutionContext {
             try {
                 processor.close(error);
             } catch (Throwable e) {
-                logger.severe(jobAndExecutionId(jobId, executionId)
+                logger.severe(jobNameAndExecutionId()
                         + " encountered an exception in Processor.close(), ignoring it", e);
             }
         }
@@ -149,7 +152,7 @@ public class ExecutionContext {
             try {
                 s.close(error);
             } catch (Throwable e) {
-                logger.severe(jobAndExecutionId(jobId, executionId)
+                logger.severe(jobNameAndExecutionId()
                         + " encountered an exception in ProcessorSupplier.complete(), ignoring it", e);
             }
         }
@@ -204,6 +207,12 @@ public class ExecutionContext {
         return executionId;
     }
 
+    public String jobNameAndExecutionId() {
+        return jobName != null
+                ? Util.jobNameAndExecutionId(jobName, executionId)
+                : Util.jobIdAndExecutionId(jobId, executionId);
+    }
+
     public Address coordinator() {
         return coordinator;
     }
@@ -219,5 +228,10 @@ public class ExecutionContext {
     // visible for testing only
     public SnapshotContext snapshotContext() {
         return snapshotContext;
+    }
+
+    @Nullable
+    public String jobName() {
+        return jobName;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -38,6 +38,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import static com.hazelcast.jet.Util.idToString;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
@@ -93,6 +94,9 @@ public class ExecutionContext {
 
     public ExecutionContext initialize(ExecutionPlan plan) {
         jobName = plan.getJobConfig().getName();
+        if (jobName == null) {
+            jobName = idToString(jobId);
+        }
         // Must be populated early, so all processor suppliers are
         // available to be completed in the case of init failure
         procSuppliers = unmodifiableList(plan.getProcessorSuppliers());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -92,13 +92,13 @@ public class ExecutionContext {
     }
 
     public ExecutionContext initialize(ExecutionPlan plan) {
+        jobName = plan.getJobConfig().getName();
         // Must be populated early, so all processor suppliers are
         // available to be completed in the case of init failure
         procSuppliers = unmodifiableList(plan.getProcessorSuppliers());
         processors = plan.getProcessors();
         snapshotContext = new SnapshotContext(nodeEngine.getLogger(SnapshotContext.class), jobNameAndExecutionId(),
                 plan.lastSnapshotId(), plan.getJobConfig().getProcessingGuarantee());
-        jobName = plan.getJobConfig().getName();
         plan.initialize(nodeEngine, jobId, executionId, snapshotContext);
         snapshotContext.initTaskletCount(plan.getStoreSnapshotTaskletCount(), plan.getHigherPriorityVertexCount());
         receiverMap = unmodifiableMap(plan.getReceiverMap());
@@ -208,9 +208,7 @@ public class ExecutionContext {
     }
 
     public String jobNameAndExecutionId() {
-        return jobName != null
-                ? Util.jobNameAndExecutionId(jobName, executionId)
-                : Util.jobIdAndExecutionId(jobId, executionId);
+        return Util.jobNameAndExecutionId(jobName, executionId);
     }
 
     public Address coordinator() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -59,7 +59,7 @@ import static com.hazelcast.jet.impl.execution.ProcessorState.SAVE_SNAPSHOT;
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.IDLE_MESSAGE;
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.NO_NEW_WM;
 import static com.hazelcast.jet.impl.util.ProgressState.NO_PROGRESS;
-import static com.hazelcast.jet.impl.util.Util.jobIdAndExecutionId;
+import static com.hazelcast.jet.impl.util.Util.jobNameAndExecutionId;
 import static com.hazelcast.jet.impl.util.Util.lazyAdd;
 import static com.hazelcast.jet.impl.util.Util.lazyIncrement;
 import static com.hazelcast.jet.impl.util.Util.sum;
@@ -218,7 +218,7 @@ public class ProcessorTasklet implements Tasklet {
         try {
             processor.close();
         } catch (Exception e) {
-            logger.severe(jobIdAndExecutionId(context.jobId(), context.executionId())
+            logger.severe(jobNameAndExecutionId(context.jobConfig().getName(), context.executionId())
                     + " encountered an exception in Processor.close(), ignoring it", e);
         }
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -59,7 +59,7 @@ import static com.hazelcast.jet.impl.execution.ProcessorState.SAVE_SNAPSHOT;
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.IDLE_MESSAGE;
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.NO_NEW_WM;
 import static com.hazelcast.jet.impl.util.ProgressState.NO_PROGRESS;
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
+import static com.hazelcast.jet.impl.util.Util.jobIdAndExecutionId;
 import static com.hazelcast.jet.impl.util.Util.lazyAdd;
 import static com.hazelcast.jet.impl.util.Util.lazyIncrement;
 import static com.hazelcast.jet.impl.util.Util.sum;
@@ -218,7 +218,7 @@ public class ProcessorTasklet implements Tasklet {
         try {
             processor.close();
         } catch (Exception e) {
-            logger.severe(jobAndExecutionId(context.jobId(), context.executionId())
+            logger.severe(jobIdAndExecutionId(context.jobId(), context.executionId())
                     + " encountered an exception in Processor.close(), ignoring it", e);
         }
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
 public class SnapshotContext {
@@ -34,8 +33,7 @@ public class SnapshotContext {
 
     private final ILogger logger;
 
-    private final long jobId;
-    private final long executionId;
+    private final String jobNameAndExecutionId;
     private final ProcessingGuarantee guarantee;
 
     /**
@@ -87,11 +85,10 @@ public class SnapshotContext {
     private final AtomicLong totalKeys = new AtomicLong();
     private final AtomicLong totalChunks = new AtomicLong();
 
-    SnapshotContext(ILogger logger, long jobId, long executionId, long lastSnapshotId,
+    SnapshotContext(ILogger logger, String jobNameAndExecutionId, long lastSnapshotId,
                     ProcessingGuarantee guarantee
     ) {
-        this.jobId = jobId;
-        this.executionId = executionId;
+        this.jobNameAndExecutionId = jobNameAndExecutionId;
         this.lastSnapshotId = new AtomicLong(lastSnapshotId);
         this.guarantee = guarantee;
         this.logger = logger;
@@ -142,7 +139,7 @@ public class SnapshotContext {
         if (numHigherPriorityTasklets == 0) {
             lastSnapshotId.set(snapshotId);
         } else {
-            logger.warning("Snapshot " + snapshotId + " for " + jobAndExecutionId(jobId, executionId) + " is postponed" +
+            logger.warning("Snapshot " + snapshotId + " for " + jobNameAndExecutionId + " is postponed" +
                     " until all higher priority vertices are completed (number of such vertices = "
                     + numHigherPriorityTasklets + ')');
             snapshotPostponed = true;
@@ -176,7 +173,7 @@ public class SnapshotContext {
             // after all higher priority vertices are done we can start the snapshot
             if (numHigherPriorityTasklets == 0 && snapshotPostponed) {
                 this.lastSnapshotId.incrementAndGet();
-                logger.info("Postponed snapshot " + this.lastSnapshotId + " for " + jobAndExecutionId(jobId, executionId)
+                logger.info("Postponed snapshot " + this.lastSnapshotId + " for " + jobNameAndExecutionId
                         + " started");
             }
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncJobOperation.java
@@ -22,12 +22,12 @@ import com.hazelcast.spi.ExceptionAction;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 
-public abstract class AsyncOperation extends AbstractJobOperation {
+public abstract class AsyncJobOperation extends AbstractJobOperation {
 
-    protected AsyncOperation() {
+    protected AsyncJobOperation() {
     }
 
-    protected AsyncOperation(long jobId) {
+    protected AsyncJobOperation(long jobId) {
         super(jobId);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteExecutionOperation.java
@@ -51,12 +51,12 @@ public class CompleteExecutionOperation extends Operation implements IdentifiedD
         JetService service = getService();
 
         Address callerAddress = getCallerAddress();
-        logger.fine("Completing execution " + idToString(executionId) + " from caller: " + callerAddress
+        logger.fine("Completing execution with ID " + idToString(executionId) + " from caller: " + callerAddress
                 + " with " + error);
 
         Address masterAddress = getNodeEngine().getMasterAddress();
         if (!callerAddress.equals(masterAddress)) {
-            throw new IllegalStateException("Caller " + callerAddress + " cannot complete execution of "
+            throw new IllegalStateException("Caller " + callerAddress + " cannot complete execution with ID "
                     + idToString(executionId) + " because it is not master. Master is: " + masterAddress);
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/CompleteExecutionOperation.java
@@ -51,12 +51,12 @@ public class CompleteExecutionOperation extends Operation implements IdentifiedD
         JetService service = getService();
 
         Address callerAddress = getCallerAddress();
-        logger.fine("Completing execution with ID " + idToString(executionId) + " from caller: " + callerAddress
+        logger.fine("Completing execution " + idToString(executionId) + " from caller: " + callerAddress
                 + " with " + error);
 
         Address masterAddress = getNodeEngine().getMasterAddress();
         if (!callerAddress.equals(masterAddress)) {
-            throw new IllegalStateException("Caller " + callerAddress + " cannot complete execution with ID "
+            throw new IllegalStateException("Caller " + callerAddress + " cannot complete execution "
                     + idToString(executionId) + " because it is not master. Master is: " + masterAddress);
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/InitExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/InitExecutionOperation.java
@@ -33,7 +33,7 @@ import java.util.Set;
 
 import static com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject.deserializeWithCustomClassLoader;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
+import static com.hazelcast.jet.impl.util.Util.jobIdAndExecutionId;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 
 public class InitExecutionOperation extends AbstractJobOperation {
@@ -61,7 +61,7 @@ public class InitExecutionOperation extends AbstractJobOperation {
         JetService service = getService();
 
         Address caller = getCallerAddress();
-        logger.fine("Initializing execution plan for " + jobAndExecutionId(jobId(), executionId) + " from " + caller);
+        logger.fine("Initializing execution plan for " + jobIdAndExecutionId(jobId(), executionId) + " from " + caller);
 
         ExecutionPlan plan = deserializePlan(serializedPlan);
         service.getJobExecutionService().initExecution(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
-public class JoinSubmittedJobOperation extends AsyncOperation {
+public class JoinSubmittedJobOperation extends AsyncJobOperation {
 
     public JoinSubmittedJobOperation() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
@@ -27,9 +27,8 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import java.io.IOException;
 
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
-import static com.hazelcast.jet.impl.util.Util.idToString;
 
-public class SnapshotOperation extends AsyncOperation {
+public class SnapshotOperation extends AsyncJobOperation {
 
     private long executionId;
     private long snapshotId;
@@ -54,10 +53,10 @@ public class SnapshotOperation extends AsyncOperation {
             if (result.getError() == null) {
                 logFine(getLogger(),
                         "Snapshot %s for job %s finished successfully on member",
-                        snapshotId, idToString(jobId()));
+                        snapshotId, ctx.jobNameAndExecutionId());
             } else {
                 getLogger().warning(String.format("Snapshot %d for job %s finished with an error on member",
-                        snapshotId, idToString(jobId())), result.getError());
+                        snapshotId, ctx.jobNameAndExecutionId()), result.getError());
                 // wrap the exception
                 result.error = new JetException("Exception during snapshot: " + result.error, result.error);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
@@ -52,10 +52,10 @@ public class SnapshotOperation extends AsyncJobOperation {
         ctx.beginSnapshot(snapshotId).thenAccept(result -> {
             if (result.getError() == null) {
                 logFine(getLogger(),
-                        "Snapshot %s for job %s finished successfully on member",
+                        "Snapshot %s for %s finished successfully on member",
                         snapshotId, ctx.jobNameAndExecutionId());
             } else {
-                getLogger().warning(String.format("Snapshot %d for job %s finished with an error on member",
+                getLogger().warning(String.format("Snapshot %d for %s finished with an error on member",
                         snapshotId, ctx.jobNameAndExecutionId()), result.getError());
                 // wrap the exception
                 result.error = new JetException("Exception during snapshot: " + result.error, result.error);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
@@ -27,9 +27,8 @@ import java.io.IOException;
 import java.util.concurrent.CancellationException;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
-import static com.hazelcast.jet.impl.util.Util.jobAndExecutionId;
 
-public class StartExecutionOperation extends AsyncOperation {
+public class StartExecutionOperation extends AsyncJobOperation {
 
     private long executionId;
 
@@ -46,16 +45,16 @@ public class StartExecutionOperation extends AsyncOperation {
         ExecutionContext execCtx = getExecutionCtx();
         Address coordinator = getCallerAddress();
         getLogger().info("Start execution of "
-                + jobAndExecutionId(jobId(), executionId) + " from coordinator " + coordinator);
+                + execCtx.jobNameAndExecutionId() + " from coordinator " + coordinator);
         execCtx.beginExecution().whenComplete(withTryCatch(getLogger(), (i, e) -> {
             if (e instanceof CancellationException) {
-                getLogger().fine("Execution of " + jobAndExecutionId(jobId(), executionId)
+                getLogger().fine("Execution of " + execCtx.jobNameAndExecutionId()
                         + " was cancelled");
             } else if (e != null) {
-                getLogger().fine("Execution of " + jobAndExecutionId(jobId(), executionId)
+                getLogger().fine("Execution of " + execCtx.jobNameAndExecutionId()
                         + " completed with failure", e);
             } else {
-                getLogger().fine("Execution of " + jobAndExecutionId(jobId(), executionId) + " completed");
+                getLogger().fine("Execution of " + execCtx.jobNameAndExecutionId() + " completed");
             }
             doSendResponse(e);
         }));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ConcurrentMemoizingSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ConcurrentMemoizingSupplier.java
@@ -47,7 +47,7 @@ final class ConcurrentMemoizingSupplier<T> implements Supplier<T> {
             }
             remembered = onceSupplier.get();
             if (remembered == null) {
-                throw new NullPointerException("Supplier returned null.");
+                throw new NullPointerException("Supplier returned null");
             }
             return remembered;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -48,7 +48,6 @@ import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -68,6 +67,7 @@ import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
+import java.util.regex.Pattern;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.Util.idToString;
@@ -80,6 +80,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
 
 public final class Util {
+
+    private static final Pattern ID_PATTERN = Pattern.compile("(\\p{XDigit}{4}-){3}\\p{XDigit}{4}");
 
     private static final int BUFFER_SIZE = 1 << 15;
     private static final DateTimeFormatter LOCAL_TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
@@ -329,13 +331,23 @@ public final class Util {
         return toZonedDateTime(timestamp).toLocalTime().format(LOCAL_TIME_FORMATTER);
     }
 
+    /**
+     * Parses the jobId formatted with {@link
+     * com.hazelcast.jet.Util#idToString(long)}.
+     *
+     * <p>The method is lenient: if the string doesn't match the structure
+     * output by {@code idToString} or if the string is null, it will return
+     * -1.
+     *
+     * @return the parsed ID or -1 if parsing failed.
+     */
     @SuppressWarnings("checkstyle:magicnumber")
     public static long idFromString(String str) {
-        if (str == null || str.length() != 19) {
+        if (str == null || !ID_PATTERN.matcher(str).matches()) {
             return -1;
         }
         str = str.replaceAll("-", "");
-        return new BigInteger(str, 16).longValue();
+        return Long.parseUnsignedLong(str, 16);
     }
 
     public static <K, V> EntryProcessor<K, V> entryProcessor(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -310,7 +310,11 @@ public final class Util {
         return Holder.NUMBER_GENERATOR.nextLong();
     }
 
-    public static String jobAndExecutionId(long jobId, long executionId) {
+    public static String jobNameAndExecutionId(String jobName, long executionId) {
+        return "job '" + jobName + "', execution " + idToString(executionId);
+    }
+
+    public static String jobIdAndExecutionId(long jobId, long executionId) {
         return "job " + idToString(jobId) + ", execution " + idToString(executionId);
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/LiveOperationRegistryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/LiveOperationRegistryTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.jet.impl;
 
-import com.hazelcast.jet.impl.operation.AsyncOperation;
+import com.hazelcast.jet.impl.operation.AsyncJobOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.CallsPerMember;
 import com.hazelcast.spi.OperationAccessor;
@@ -57,8 +57,8 @@ public class LiveOperationRegistryTest {
 
     @Test
     public void test_registerAndDeregister() throws UnknownHostException {
-        AsyncOperation op1 = createOperation("1.2.3.4", 1234, 2222L);
-        AsyncOperation op2 = createOperation("1.2.3.4", 1234, 2223L);
+        AsyncJobOperation op1 = createOperation("1.2.3.4", 1234, 2222L);
+        AsyncJobOperation op2 = createOperation("1.2.3.4", 1234, 2223L);
 
         r.register(op1);
         r.register(op2);
@@ -68,7 +68,7 @@ public class LiveOperationRegistryTest {
 
     @Test
     public void when_deregisterNotExistingAddress_then_fail() throws UnknownHostException {
-        AsyncOperation op1 = createOperation("1.2.3.4", 1234, 2222L);
+        AsyncJobOperation op1 = createOperation("1.2.3.4", 1234, 2222L);
         exception.expect(IllegalStateException.class);
         r.deregister(op1);
     }
@@ -101,8 +101,8 @@ public class LiveOperationRegistryTest {
         //callIds.
     }
 
-    private AsyncOperation createOperation(String host, int port, long callId) throws UnknownHostException {
-        AsyncOperation op = mock(AsyncOperation.class);
+    private AsyncJobOperation createOperation(String host, int port, long callId) throws UnknownHostException {
+        AsyncJobOperation op = mock(AsyncJobOperation.class);
         Address address = new Address(host, port);
 
         OperationAccessor.setCallerAddress(op, address);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -194,7 +194,7 @@ public class ProcessorTaskletTest_Snapshots {
         for (int i = 0; i < instreams.size(); i++) {
             instreams.get(i).setOrdinal(i);
         }
-        snapshotContext = new SnapshotContext(mock(ILogger.class), 0, 0, -1, guarantee);
+        snapshotContext = new SnapshotContext(mock(ILogger.class), "test job", -1, guarantee);
         snapshotContext.initTaskletCount(1, 0);
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 snapshotContext, snapshotCollector, -1);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
@@ -287,7 +287,7 @@ public class ProcessorTaskletTest_Watermarks {
         for (int i = 0; i < instreams.size(); i++) {
             instreams.get(i).setOrdinal(i);
         }
-        SnapshotContext snapshotContext = new SnapshotContext(mock(ILogger.class), 0, 0, -1, EXACTLY_ONCE);
+        SnapshotContext snapshotContext = new SnapshotContext(mock(ILogger.class), "test job", -1, EXACTLY_ONCE);
         snapshotContext.initTaskletCount(1, 0);
         final ProcessorTasklet t = new ProcessorTasklet(context, processor, instreams, outstreams,
                 snapshotContext, snapshotCollector, maxWatermarkRetainMillis);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
@@ -73,7 +73,7 @@ public class SnapshotContextTest {
     @Test
     public void test_snapShortStartAndDone() {
         SnapshotContext ssContext =
-                new SnapshotContext(mock(ILogger.class), 1, 1, 9, ProcessingGuarantee.EXACTLY_ONCE);
+                new SnapshotContext(mock(ILogger.class), "test job", 9, ProcessingGuarantee.EXACTLY_ONCE);
 
         ssContext.initTaskletCount(taskletCount, numHigherPriority);
         CompletableFuture<SnapshotOperationResult> future = null;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
@@ -61,7 +61,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
     private MockAsyncSnapshotWriter mockSsWriter;
 
     private void init(List<Object> inputData) {
-        ssContext = new SnapshotContext(Logger.getLogger(SnapshotContext.class), 1, 1, 1,
+        ssContext = new SnapshotContext(Logger.getLogger(SnapshotContext.class), "test job", 1,
                 ProcessingGuarantee.EXACTLY_ONCE);
         ssContext.initTaskletCount(1, 0);
         inputData = new ArrayList<>(inputData);


### PR DESCRIPTION
The following is used in log messages:

`AbstractJobProxy`: logs on the submitting client or member
```
  xxxx-xxxx-xxxx-xxxx (name ??)   - if config not loaded yet
  xxxx-xxxx-xxxx-xxxx (name '')   - if loaded, but name null
  xxxx-xxxx-xxxx-xxxx (name 'abc')
```

`MasterContext`: logs on coordinator member. Name is always known.
```
  job 'abc', execution xxx-xxx-xxx-xxx                - if name set
  job 'xxx-xxx-xxx-xxx', execution xxx-xxx-xxx-xxx    - if name not set
```

`ExecutionContext`: on each member, name not known for a short while
initially
```
  job 'abc', execution xxx-xxx-xxx-xxx              - if name set
  job xxx-xxx-xxx-xxx, execution xxx-xxx-xxx-xxx    - if name not set
```

Initial log, printed on each member on INFO level to give association for
jobId, jobName and executionId:

```
  Execution plan for jobId=xxx-xxx-xxx-xxx, jobName=null/'abc',
  executionId=xxx-xxx-xxx-xxx initialized
```

The important change is that if job name is set, job ID is not always
displayed. If the job name is not unique, we won't be able to tell the
jobs apart in logs. This is documented at `JobConfig.setName()` method.

Fixes #911