### PR TITLE
Add JetClientConfig which uses the correct group name and password

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -29,6 +29,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.MetricsConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
@@ -84,6 +85,9 @@ public final class Jet {
 
     /**
      * Creates a Jet client with the given Hazelcast client configuration.
+     *
+     * {@link JetClientConfig} may be used to create a configuration with the
+     * default group name and password for Jet.
      */
     public static JetInstance newJetClient(ClientConfig config) {
         return getJetClientInstance(HazelcastClient.newHazelcastClient(config));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetClientConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetClientConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.config;
+
+import com.hazelcast.client.config.ClientConfig;
+
+/**
+ * A config object which is used for configuring the Jet client to
+ * connect to the Jet cluster.
+ * <p>
+ * See {@link ClientConfig} for actual config options.
+ */
+public class JetClientConfig extends ClientConfig {
+
+    /**
+     * Creates a new config instance with default group name and password for Jet
+     */
+    public JetClientConfig() {
+        getGroupConfig().setName(JetConfig.DEFAULT_GROUP_NAME);
+        getGroupConfig().setPassword(JetConfig.DEFAULT_GROUP_PASSWORD);
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
@@ -36,6 +36,20 @@ public class JetConfig {
      */
     public static final int DEFAULT_JET_MULTICAST_PORT = 54326;
 
+    /**
+     * The default group name for a Jet cluster
+     *
+     * See {@link com.hazelcast.config.GroupConfig}
+     */
+    public static final String DEFAULT_GROUP_NAME = "jet";
+
+    /**
+     * The default group password for a Jet cluster.
+     *
+     * See {@link com.hazelcast.config.GroupConfig}
+     */
+    public static final String DEFAULT_GROUP_PASSWORD = "jet-pass";
+
     private static final ILogger LOGGER = Logger.getLogger(JetConfig.class);
 
     private Config hazelcastConfig = defaultHazelcastConfig();
@@ -45,8 +59,8 @@ public class JetConfig {
     private Properties properties = new Properties();
 
     /**
-     * Creates a new JetConfig with the default configuration. Doesn't
-     * consider any files.
+     * Creates a new, empty {@code JetConfig} with the default configuration.
+     * Doesn't consider any configuration XML files.
      */
     public JetConfig() {
     }
@@ -267,8 +281,8 @@ public class JetConfig {
     private static Config defaultHazelcastConfig() {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setMulticastPort(DEFAULT_JET_MULTICAST_PORT);
-        config.getGroupConfig().setName("jet");
-        config.getGroupConfig().setPassword("jet-pass");
+        config.getGroupConfig().setName(DEFAULT_GROUP_NAME);
+        config.getGroupConfig().setPassword(DEFAULT_GROUP_PASSWORD);
         return config;
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetInstanceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetInstanceTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
@@ -55,7 +56,7 @@ public class JetInstanceTest extends JetTestSupport {
     }
 
     @Test
-    public void when_twoJetAndTwoHzInstancesCreated_then_twoClusterSOfTwoShouldBeFormed() {
+    public void when_twoJetAndTwoHzInstancesCreated_then_twoClustersOfTwoShouldBeFormed() {
         JetInstance jetInstance1 = Jet.newJetInstance();
         JetInstance jetInstance2 = Jet.newJetInstance();
 
@@ -64,6 +65,16 @@ public class JetInstanceTest extends JetTestSupport {
 
         assertEquals(2, jetInstance1.getCluster().getMembers().size());
         assertEquals(2, hazelcastInstance1.getCluster().getMembers().size());
+    }
+
+    @Test
+    public void when_jetClientCreated_then_connectsToJetCluster() {
+        JetInstance jetInstance1 = Jet.newJetInstance();
+        JetInstance jetInstance2 = Jet.newJetInstance();
+
+        JetInstance client = Jet.newJetClient(new JetClientConfig());
+
+        assertEquals(2, client.getHazelcastInstance().getCluster().getMembers().size());
     }
 
     @Test


### PR DESCRIPTION
Currently when you create a new `ClientConfig` object it doesn't have the correct group name and password to connect to the Jet cluster. This class is a convenience for overriding the default group name and password when creating a client config to connect to a Jet cluster.