### PR TITLE
Add getter for HazelcastClient on JetClientInstanceImpl

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
@@ -127,6 +127,11 @@ public class JetClientInstanceImpl extends AbstractJetInstance {
         );
     }
 
+    @Nonnull
+    public HazelcastClientInstanceImpl getHazelcastClient() {
+        return client;
+    }
+
     private List<Long> getJobIdsByName(String name) {
         ClientInvocation invocation = new ClientInvocation(
                 client, JetGetJobIdsByNameCodec.encodeRequest(name), null, masterAddress(client.getCluster())


### PR DESCRIPTION
Exposed HazelcastClient on JetClientInstanceImpl  
- to access connection manager so that connection listeners can be added 
- to fetch connected server version 