### PR TITLE
Fix for dependencies of hazelcast-jet-spring

### DIFF
--- a/hazelcast-jet-spring/pom.xml
+++ b/hazelcast-jet-spring/pom.xml
@@ -54,7 +54,6 @@
                 <configuration>
                     <createSourcesJar>true</createSourcesJar>
                     <createDependencyReducedPom>true</createDependencyReducedPom>
-                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                             <resource>META-INF/spring.handlers</resource>
@@ -90,19 +89,18 @@
             <version>${spring.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-spring</artifactId>
             <version>${hazelcast.version}</version>
-            <type>test-jar</type>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-core</artifactId>
             <version>${project.parent.version}</version>
-            <type>test-jar</type>
+            <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
hazelcast-jet-spring had dependency on `hazelcast-jet-core` and `hazelcast-spring` which in turn introduced dependencies on hazelcast.jar causing a conflict of versions when spring-boot was used. 

Fixes #977