### PR TITLE
Fix race in AsyncMapWriter

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncMapWriter.java
@@ -242,6 +242,10 @@ public class AsyncMapWriter {
                             // We should not handle pendingOps getting to 0 here, it will be increased again by
                             // the retry operations.
                             pendingOps.decrementAndGet();
+                            // TODO do more robust retry
+                            // On second try we should do individual partition-specific ops that can be retried on
+                            // different members as the partition migrates, not a PartitionIteratingOp.
+                            // See InvokeOnPartitions.retryFailedPartitions.
                             if (!tryRetry(partitions, entries, pendingOps, completionFuture)) {
                                 completionFuture.completeExceptionally(originalErr);
                             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/CancellationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/CancellationTest.java
@@ -259,13 +259,26 @@ public class CancellationTest extends JetTestSupport {
     }
 
     @Test
-    public void when_shutdown_then_jobFuturesCanceled() {
+    public void when_shutdownGracefully_then_jobFuturesCanceled() {
+        when_shutdown_then_jobFuturesCanceled(true);
+    }
+
+    @Test
+    public void when_shutdownForcefully_then_jobFuturesCanceled() {
+        when_shutdown_then_jobFuturesCanceled(false);
+    }
+
+    private void when_shutdown_then_jobFuturesCanceled(boolean graceful) {
         JetInstance jet = newInstance();
         DAG dag = new DAG();
         dag.newVertex("blocking", BlockingProcessor::new).localParallelism(1);
         jet.newJob(dag);
         assertTrueEventually(() -> assertTrue(BlockingProcessor.hasStarted), 3);
-        jet.shutdown();
+        if (graceful) {
+            jet.shutdown();
+        } else {
+            jet.getHazelcastInstance().shutdown();
+        }
         assertBlockingProcessorEventuallyNotRunning();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
@@ -136,7 +136,7 @@ public class ManualRestartTest extends JetTestSupport {
             job.join();
             fail();
         } catch (CancellationException ignored) {
-            System.out.println("Cancellation exception caught");
+            logger.info("Cancellation exception caught");
         }
 
         // Then, the job cannot restart

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
@@ -176,7 +176,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
         List<Entry> snapshotItems = new ArrayList<>();
         outbox.drainSnapshotQueueAndReset(snapshotItems, false);
 
-        System.out.println("Restoring journal");
+        logger.info("Restoring journal");
         // restore from snapshot
         assertRestore(snapshotItems);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamFilesP_integrationTest.java
@@ -286,9 +286,9 @@ public class StreamFilesP_integrationTest extends JetTestSupport {
 
     private void finishDirectory(Future<Void> jobFuture, File ... files) throws Exception {
         for (File file : files) {
-            System.out.println("deleting " + file + "...");
+            logger.info("deleting " + file + "...");
             assertTrueEventually(() -> assertTrue("Failed to delete " + file, file.delete()));
-            System.out.println("deleted " + file);
+            logger.info("deleted " + file);
         }
         assertTrueEventually(() -> assertTrue("Failed to delete " + directory, directory.delete()));
         assertTrueEventually(() -> assertTrue("job should complete eventually", jobFuture.isDone()));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamSocketPTest.java
@@ -90,7 +90,7 @@ public class StreamSocketPTest extends JetTestSupport {
         // split at any place: between \r\n, between the bytes of utf-16 sequence etc
         byte[] inputBytes = input.getBytes(UTF_16);
         for (int splitIndex = 0; splitIndex < inputBytes.length; splitIndex++) {
-            System.out.println("--------- runTest(" + splitIndex + ") ---------");
+            logger.info("--------- runTest(" + splitIndex + ") ---------");
             runTest(inputBytes, splitIndex);
         }
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteBufferedPTest.java
@@ -91,23 +91,19 @@ public class WriteBufferedPTest extends JetTestSupport {
     @Test
     public void when_writeBufferedJobFailed_then_bufferDisposed() throws Exception {
         JetInstance instance = createJetMember();
-        try {
-            DAG dag = new DAG();
-            Vertex source = dag.newVertex("source", StuckForeverSourceP::new);
-            Vertex sink = dag.newVertex("sink", getLoggingBufferedWriter()).localParallelism(1);
+        DAG dag = new DAG();
+        Vertex source = dag.newVertex("source", StuckForeverSourceP::new);
+        Vertex sink = dag.newVertex("sink", getLoggingBufferedWriter()).localParallelism(1);
 
-            dag.edge(Edge.between(source, sink));
+        dag.edge(Edge.between(source, sink));
 
-            Job job = instance.newJob(dag);
-            // wait for the job to initialize
-            Thread.sleep(5000);
-            job.cancel();
+        Job job = instance.newJob(dag);
+        // wait for the job to initialize
+        Thread.sleep(5000);
+        job.cancel();
 
-            assertTrueEventually(() -> assertTrue("No \"dispose\", only: " + events, events.contains("dispose")), 60);
-            System.out.println(events);
-        } finally {
-            instance.shutdown();
-        }
+        assertTrueEventually(() -> assertTrue("No \"dispose\", only: " + events, events.contains("dispose")), 60);
+        System.out.println(events);
     }
 
     // returns a processor that will not write anywhere, just log the events

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
@@ -227,7 +227,7 @@ public class AsyncMapWriterTest extends JetTestSupport {
         boolean flushed = writer.tryFlushAsync(future);
 
         // Then
-        assertTrue("tryFlush() returned false", flushed);
+        assertTrue("tryFlushAsync() returned false", flushed);
 
         Throwable actual = future.handle((r, e) -> e).join();
         assertNotNull("No exception was thrown", actual);
@@ -254,14 +254,14 @@ public class AsyncMapWriterTest extends JetTestSupport {
         boolean flushed = writer.tryFlushAsync(future);
 
         // Then
-        assertTrue("tryFlush() returned false", flushed);
+        assertTrue("tryFlushAsync() returned false", flushed);
         future.join();
         for (int i = 0; i < 100; i++) {
             assertEquals(i, map.get(i));
         }
     }
 
-    public static class AlwaysFailingMapStore extends AMapStore implements Serializable {
+    static class AlwaysFailingMapStore extends AMapStore implements Serializable {
 
         @Override
         public void store(Object o, Object o2) {
@@ -269,7 +269,7 @@ public class AsyncMapWriterTest extends JetTestSupport {
         }
     }
 
-    public static class RetryableMapStore extends AMapStore implements Serializable {
+    private static class RetryableMapStore extends AMapStore implements Serializable {
 
         private static volatile boolean failOnNext;
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncMapWriterTest.java
@@ -56,7 +56,6 @@ public class AsyncMapWriterTest extends JetTestSupport {
     private IMapJet<Object, Object> map;
     private NodeEngineImpl nodeEngine;
 
-
     @Before
     public void setup() {
         JetConfig jetConfig = new JetConfig();


### PR DESCRIPTION
The writer uses `PartitionIteratingOperation`, which can partly fail:
some partitions succeed, some fail. The failed partitions are retried.
The retrial is executed from an `ExecutionCallback`, which is called
once for each member. Both attempts use `invokeOnCluster`, which used a
`doneLatch` to track callbacks from members and when it got to 0, it
completed the future. The problem was if in the first attempt, two
members failed. It will cause two retry calls to `invokeOnCluster`. But
the first completed retry call completed the future before the second
one finishes, causing the test to (correctly) fail.

The solution is to use one `doneLatch` for both the initial attempt and
all retries. `invokeOnCluster` only increments and decrements it. If a
partition is retried, it is first incremented by the number of retry
operations so that it gets to 0 only when all retrials are successfully
done.

The test failed in about 0.1% of runs.

Fixes #975