### PR TITLE
Fix test failure, job can manage to upscale

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetSplitBrainTestSupport.java
@@ -86,6 +86,7 @@ public abstract class JetSplitBrainTestSupport extends JetTestSupport {
         jetConfig.getInstanceConfig().setCooperativeThreadCount(PARALLELISM);
         jetConfig.getHazelcastConfig().setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5");
         jetConfig.getHazelcastConfig().setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
+        jetConfig.getInstanceConfig().setUpscaleDelayMillis(3000);
         onJetConfigCreated(jetConfig);
         return jetConfig;
     }


### PR DESCRIPTION
The test failed if the job upscaled (after default 10 second delay)
before the 5 second wait condition elapsed. Now, we wait for it to
upscale.

Fixes #990