### PR TITLE
Elasticity fixes

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -168,15 +168,13 @@ public class JobCoordinationService {
             scheduleScaleUp(RETRY_DELAY_IN_MILLIS);
         }
 
-        int count = 0;
+        boolean allSucceeded = true;
         Collection<Member> dataMembers = nodeEngine.getClusterService().getMembers(DATA_MEMBER_SELECTOR);
         for (MasterContext mc : masterContexts.values()) {
-            if (mc.maybeScaleUp(dataMembers)) {
-                count++;
-            }
+            allSucceeded &= mc.maybeScaleUp(dataMembers);
         }
-        if (count > 0) {
-            logger.info("Restarted " + count + " job(s) to make use of added members");
+        if (!allSucceeded) {
+            scheduleScaleUp(RETRY_DELAY_IN_MILLIS);
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -141,7 +141,7 @@ public class MasterContext {
      * It's true while a snapshot is in progress. It's used to prevent
      * concurrent snapshots.
      */
-    private volatile boolean snapshotInProgress;
+    private boolean snapshotInProgress;
 
     /**
      * If {@code true}, the snapshot that will be executed next will be
@@ -228,7 +228,9 @@ public class MasterContext {
         if (localStatus == SUSPENDED) {
             coordinationService.completeJob(this, System.currentTimeMillis(), new CancellationException());
         } else {
-            handleTermination(mode);
+            if (localStatus == RUNNING || localStatus == STARTING) {
+                handleTermination(mode);
+            }
         }
 
         return true;
@@ -511,6 +513,11 @@ public class MasterContext {
                 // cancel the scheduled snapshot from previous execution, so let's just ignore it.
                 logger.fine("Not beginning snapshot since unexpected execution ID received for " + jobIdString()
                         + ". Received execution ID: " + idToString(executionId));
+                return;
+            }
+
+            if (jobStatus != RUNNING) {
+                logger.fine("Not beginning snapshot, job is not RUNNING, but " + jobStatus);
                 return;
             }
 
@@ -904,9 +911,20 @@ public class MasterContext {
         return null; // nothing to wait for
     }
 
+    /**
+     * Checks if the job is running on all members and maybe restart it.
+     *
+     * <p>Returns {@code false}, if this method should be scheduled to
+     * be called later. That is, when the job is running, but we've
+     * failed to request the restart.
+     *
+     * <p>Returns {@code true}, if the job is not running, has
+     * auto-scaling disabled, is already running on all members or if
+     * we've managed to request a restart.
+     */
     boolean maybeScaleUp(Collection<Member> currentDataMembers) {
         if (!jobConfig().isAutoScaling()) {
-            return false;
+            return true;
         }
 
         // We only compare the number of our participating members and current members.
@@ -915,10 +933,15 @@ public class MasterContext {
         if (executionPlanMap == null || executionPlanMap.size() == currentDataMembers.size()) {
             LoggingUtil.logFine(logger, "Not up-scaling job %s: not running or already running on all members",
                     jobIdString());
-            return false;
+            return true;
         }
 
-        return requestTermination(TerminationMode.RESTART_GRACEFUL);
+        JobStatus localStatus = jobStatus;
+        if (localStatus == RUNNING && requestTermination(TerminationMode.RESTART_GRACEFUL)) {
+            logger.info("Requested restart of " + jobIdString() + " to make use of added member(s)");
+            return true;
+        }
+        return false;
     }
 
     private void assertLockHeld() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
@@ -21,10 +21,13 @@ import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.StuckForeverSourceP;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(HazelcastSerialClassRunner.class)
 public class ScaleUpTest extends JetTestSupport {
 
     private static final int NODE_COUNT = 2;
@@ -47,55 +50,55 @@ public class ScaleUpTest extends JetTestSupport {
     public void when_memberAdded_then_jobScaledUp() {
         setup(1000);
         instances[0].newJob(dag);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
 
         createJetMember(config);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT * 2 + 1, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT * 2 + 1, MockPS.initCount.get()));
     }
 
     @Test
     public void when_memberAddedAndAutoScalingDisabled_then_jobNotRestarted() {
         setup(1000);
         instances[0].newJob(dag, new JobConfig().setAutoScaling(false));
-        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
 
         createJetMember(config);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
     }
 
     @Test
     public void when_liteMemberAdded_then_jobNotRestarted() {
         setup(1000);
         instances[0].newJob(dag);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
 
         JetConfig config = new JetConfig();
         config.getHazelcastConfig().setLiteMember(true);
         createJetMember(config);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
     }
 
     @Test
     public void when_memberAddedAndAnotherAddedBeforeDelay_then_jobRestartedOnce() {
         setup(10_000);
         instances[0].newJob(dag);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
 
         createJetMember(config);
         sleepSeconds(1);
         createJetMember(config);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT * 2 + 2, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT * 2 + 2, MockPS.initCount.get()));
     }
 
     @Test
     public void when_memberAddedAndRemovedBeforeDelay_then_jobNotRestarted() {
         setup(12_000);
         instances[0].newJob(dag);
-        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 10);
+        assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
 
         JetInstance addedMember = createJetMember(config);
         sleepSeconds(1);
         addedMember.shutdown();
-        assertTrueAllTheTime(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 12);
+        assertTrueAllTheTime(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()), 15);
     }
 }


### PR DESCRIPTION
Contains:
- a snapshot could be begun if job was not running (due to upscaling...)
- if we fail to restart to scale-up, we'll schedule a retry
- we called `handleTermination` even if job was not running

The effect of the above was minor, either the 
`CompleteExecutionOperation` or `SnapshotOperation` were rejected by the 
target, which polluted the logs, but no real harm was done.