### PR TITLE
Fix race when collecting responses from members

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -505,7 +505,8 @@ public class MasterContext {
 
     private void cancelExecutionInvocations(long jobId, long executionId, TerminationMode mode) {
         nodeEngine.getExecutionService().execute(ExecutionService.ASYNC_EXECUTOR, () ->
-                invokeOnParticipants(plan -> new TerminateExecutionOperation(jobId, executionId, mode), responses -> { }, null));
+                invokeOnParticipants(plan -> new TerminateExecutionOperation(jobId, executionId, mode),
+                        responses -> { }, null));
     }
 
     void beginSnapshot(long executionId) {
@@ -541,7 +542,8 @@ public class MasterContext {
         Function<ExecutionPlan, Operation> factory =
                 plan -> new SnapshotOperation(jobId, executionId, newSnapshotId, isTerminal);
 
-        invokeOnParticipants(factory, responses -> onSnapshotCompleted(responses, executionId, newSnapshotId, isTerminal), null);
+        invokeOnParticipants(factory,
+                responses -> onSnapshotCompleted(responses, executionId, newSnapshotId, isTerminal), null);
     }
 
     private void onSnapshotCompleted(Map<MemberInfo, Object> responses, long executionId, long snapshotId,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -104,15 +104,15 @@ import static java.util.stream.Collectors.toList;
  */
 public class MasterContext {
 
+    public static final int SNAPSHOT_RESTORE_EDGE_PRIORITY = Integer.MIN_VALUE;
+    public static final String SNAPSHOT_VERTEX_PREFIX = "__snapshot_";
+
     private static final Object NULL_OBJECT = new Object() {
         @Override
         public String toString() {
             return "NULL_OBJECT";
         }
     };
-
-    public static final int SNAPSHOT_RESTORE_EDGE_PRIORITY = Integer.MIN_VALUE;
-    public static final String SNAPSHOT_VERTEX_PREFIX = "__snapshot_";
 
     private final Object lock = new Object();
 
@@ -513,8 +513,7 @@ public class MasterContext {
 
     private void cancelExecutionInvocations(long jobId, long executionId, TerminationMode mode) {
         nodeEngine.getExecutionService().execute(ExecutionService.ASYNC_EXECUTOR, () ->
-                invokeOnParticipants(plan -> new TerminateExecutionOperation(jobId, executionId, mode),
-                        null, null));
+                invokeOnParticipants(plan -> new TerminateExecutionOperation(jobId, executionId, mode), null, null));
     }
 
     void beginSnapshot(long executionId) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -840,7 +840,7 @@ public class MasterContext {
                                   boolean success = response.compareAndSet(null, r == null ? throwable : r);
                                   assert success : "response=" + response.get();
                                   if (remainingCount.decrementAndGet() == 0) {
-                                      // unwrap the AtomicReferences. Can't use stream api because toMap doesn't support null values...
+                                      // unwrap the AtomicReferences. Can't use stream api, toMap doesn't allow null values
                                       Map<MemberInfo, Object> responses2 = new HashMap<>();
                                       for (Entry<MemberInfo, AtomicReference<Object>> entry : responses.entrySet()) {
                                           responses2.put(entry.getKey(), entry.getValue().get());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
@@ -143,8 +143,8 @@ public class SnapshotOperation extends AsyncJobOperation {
 
         /**
          * Merge other SnapshotOperationResult into this one. It adds the
-         * totals and if the other result has error, it will take it to this,
-         * unless there already was one.
+         * subtotals and if the other result has an error, it will store it
+         * into this, unless this result already has one.
          */
         public void merge(SnapshotOperationResult other) {
             numBytes += other.numBytes;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
@@ -1,4 +1,4 @@
-    /*
+/*
  * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,6 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.client.map.helpers.AMapStore;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.config.PartitioningStrategyConfig;
-import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JetConfig;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManualRestartTest.java
@@ -1,4 +1,4 @@
-/*
+    /*
  * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,8 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.client.map.helpers.AMapStore;
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.PartitioningStrategyConfig;
+import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JetConfig;
@@ -181,14 +183,14 @@ public class ManualRestartTest extends JetTestSupport {
         job.join();
 
         Map<Integer, Integer> actual = new ArrayList<>(instances[0].<Entry<Integer, Integer>>getList("sink")).stream()
-                .filter(e -> e.getKey() == 0)
+                .filter(e -> e.getKey() == 0) // we'll only check partition 0
                 .map(Entry::getValue)
                 .collect(Collectors.toMap(e -> e, e -> 1, (o, n) -> o + n, TreeMap::new));
 
-        assertEquals(actual.toString(), (Integer) 1, actual.get(0));
-        assertEquals(actual.toString(), (Integer) 1, actual.get(9999));
-        // the result should be some ones, then some twos and then some ones. The ones should be from the time
-        // when the source was replayed from last snapshot.
+        assertEquals("first item != 1, " + actual.toString(), (Integer) 1, actual.get(0));
+        assertEquals("last item != 1, " + actual.toString(), (Integer) 1, actual.get(9999));
+        // the result should be some ones, then some twos and then some ones. The twos should be during the time
+        // since the last successful snapshot until the actual termination, when there was reprocessing.
         boolean sawTwo = false;
         boolean sawOneAgain = false;
         for (Integer v : actual.values()) {


### PR DESCRIPTION
The `future` from the `invoke` method was added to the map at a time the
callback could already be executed. This will cause that some of the
responses will be missing when handling.

Fixes #1029: from the logs we see that only one of the member failed and
the error response from the failing member was indeed sent, but the
terminal snapshot was marked as successful despite of that. This
suggests that the response was lost, even though it never reproduced
locally. The window for race is quite small: the thread, that should
execute as the second one, has lot more work to do than the other one.