### PR TITLE
Remove direct cache signatures from Sources and Sinks

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.pipeline;
 
-import com.hazelcast.cache.ICache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
@@ -595,27 +594,6 @@ public final class Sinks {
     @Nonnull
     public static <T extends Entry> Sink<T> cache(@Nonnull String cacheName) {
         return fromProcessor("cacheSink(" + cacheName + ')', writeCacheP(cacheName));
-    }
-
-    /**
-     * Returns a sink that puts {@code Map.Entry}s it receives into a Hazelcast
-     * {@code ICache} with the specified name.
-     * <p>
-     * <strong>NOTE:</strong> Jet only remembers the name of the cache you
-     * supply and acquires a cache with that name on the local cluster. If you
-     * supply a cache instance from another cluster, no error will be thrown to
-     * indicate this.
-     * <p>
-     * This sink provides the exactly-once guarantee thanks to <i>idempotent
-     * updates</i>. It means that the value with the same key is not appended,
-     * but overwritten. After the job is restarted from snapshot, duplicate
-     * items will not change the state in the target map.
-     * <p>
-     * The default local parallelism for this sink is 1.
-     */
-    @Nonnull
-    public static <K, V> Sink<Entry<K, V>> cache(@Nonnull ICache<? super K, ? super V> cache) {
-        return cache(cache.getName());
     }
 
     /**

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -133,27 +133,6 @@ public class SinksTest extends PipelineTestSupport {
     }
 
     @Test
-    public void cache_byRef() {
-        // Given
-        List<Integer> input = sequence(itemCount);
-        putToBatchSrcCache(input);
-        ICache<String, Integer> sinkCache = jet().getCacheManager().getCache(sinkName);
-
-        // When
-        Sink<Entry<String, Integer>> sink = Sinks.cache(sinkCache);
-
-        // Then
-        p.drawFrom(Sources.<String, Integer>cache(srcName)).drainTo(sink);
-        execute();
-        List<Entry<String, Integer>> expected = input.stream()
-                                                     .map(i -> entry(String.valueOf(i), i))
-                                                     .collect(toList());
-        ICache<String, Integer> cache = jet().getCacheManager().getCache(sinkName);
-        assertEquals(expected.size(), cache.size());
-        expected.forEach(entry -> assertEquals(entry.getValue(), cache.get(entry.getKey())));
-    }
-
-    @Test
     public void remoteCache() {
         // Given
         List<Integer> input = sequence(itemCount);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
@@ -284,24 +284,6 @@ public class SourcesTest extends PipelineTestSupport {
     }
 
     @Test
-    public void cache_byRef() {
-        // Given
-        List<Integer> input = sequence(itemCount);
-        putToBatchSrcCache(input);
-
-        // When
-        BatchSource<Entry<String, Integer>> source = Sources.cache(srcCache);
-
-        // Then
-        p.drawFrom(source).drainTo(sink);
-        execute();
-        List<Entry<String, Integer>> expected = input.stream()
-                                                     .map(i -> entry(String.valueOf(i), i))
-                                                     .collect(toList());
-        assertEquals(toBag(expected), sinkToBag());
-    }
-
-    @Test
     public void remoteCache() {
         // Given
         List<Integer> input = sequence(itemCount);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
@@ -329,19 +329,6 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
     }
 
     @Test
-    public void cacheJournal_byRef() {
-        // Given
-        String cacheName = JOURNALED_CACHE_PREFIX + randomName();
-        ICache<String, Integer> cache = jet().getCacheManager().getCache(cacheName);
-
-        // When
-        StreamSource<Entry<String, Integer>> source = Sources.cacheJournal(cache, START_FROM_OLDEST);
-
-        // Then
-        testCacheJournal(cache, source);
-    }
-
-    @Test
     public void remoteCacheJournal() {
         // Given
         String cacheName = JOURNALED_CACHE_PREFIX + randomName();
@@ -400,21 +387,6 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
         // When
         StreamSource<Integer> source = Sources.cacheJournal(
                 cacheName, p, EventJournalCacheEvent::getNewValue, START_FROM_OLDEST);
-
-        // Then
-        testCacheJournal_withPredicateAndProjection(cache, source);
-    }
-
-    @Test
-    public void cacheJournalByRef_withPredicateAndProjectionFn() {
-        // Given
-        String cacheName = JOURNALED_CACHE_PREFIX + randomName();
-        DistributedPredicate<EventJournalCacheEvent<String, Integer>> p = e -> e.getNewValue() % 2 == 0;
-        ICache<String, Integer> cache = jet().getCacheManager().getCache(cacheName);
-
-        // When
-        StreamSource<Integer> source = Sources.cacheJournal(
-                cache, p, EventJournalCacheEvent::getNewValue, START_FROM_OLDEST);
 
         // Then
         testCacheJournal_withPredicateAndProjection(cache, source);


### PR DESCRIPTION
Adding direct cache signatures to Sources and Sinks creates a direct dependency to cache api which should stay optional