### PR TITLE
Don't throw HzRetryableExc from terminateJob

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobNotFoundException.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobNotFoundException.java
@@ -28,6 +28,10 @@ public class JobNotFoundException extends JetException {
        super("Job with id " + Util.idToString(jobId) + " not found");
     }
 
+    public JobNotFoundException(String message) {
+        super(message);
+    }
+
     public JobNotFoundException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -106,10 +106,12 @@ public class ClientJobProxy extends AbstractJobProxy<HazelcastClientInstanceImpl
     @Override
     protected long doGetJobSubmissionTime() {
         ClientMessage request = JetGetJobSubmissionTimeCodec.encodeRequest(getId());
-        return uncheckCall(() -> {
+        try {
             ClientMessage response = invocation(request, masterAddress()).invoke().get();
             return JetGetJobSubmissionTimeCodec.decodeResponse(response).response;
-        });
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -409,7 +409,7 @@ public class JobCoordinationService {
                 // we'll eventually learn of the job through scanning of records or from a join operation
                 throw new RetryableHazelcastException(message);
             } else {
-                throw new JobNotFoundException(message);
+                throw new JobNotFoundException(jobId);
             }
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -403,8 +403,14 @@ public class JobCoordinationService {
 
         MasterContext masterContext = masterContexts.get(jobId);
         if (masterContext == null) {
-            throw new RetryableHazelcastException("No MasterContext found for job " + idToString(jobId)
-                    + " for " + terminationMode);
+            JobRecord jobRecord = jobRepository.getJobRecord(jobId);
+            String message = "No MasterContext found for job " + idToString(jobId) + " for " + terminationMode;
+            if (jobRecord != null) {
+                // we'll eventually learn of the job through scanning of records or from a join operation
+                throw new RetryableHazelcastException(message);
+            } else {
+                throw new JobNotFoundException(message);
+            }
         }
 
         // User can cancel in any state, other terminations are allowed only when running.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -462,7 +462,7 @@ public class JobRepository {
         public Object process(Entry<Long, JobRecord> entry) {
             JobRecord jobRecord = entry.getValue();
             if (jobRecord == null) {
-                return false;
+                throw new JobNotFoundException("JobRecord for job " + idToString(entry.getKey()) + " not found");
             }
 
             JobRecord newJobRecord = updateFn.apply(jobRecord);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Job_StaleInstanceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Job_StaleInstanceTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.core.Member;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.core.TestProcessors.StuckForeverSourceP;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
+import static com.hazelcast.test.HazelcastTestSupport.assertEqualsEventually;
+
+/**
+ * This class tests Job operations when a master doesn't know of the job
+ * because it restarted. All tests check that it fails as it should.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+public class Job_StaleInstanceTest {
+
+    private static JetTestInstanceFactory instanceFactory;
+    private static JetInstance client;
+    private static Job job;
+
+    @BeforeClass
+    public static void beforeClass() {
+        instanceFactory = new JetTestInstanceFactory();
+        JetInstance instance = instanceFactory.newMember();
+        DAG dag = new DAG();
+        dag.newVertex("v", StuckForeverSourceP::new);
+
+        client = instanceFactory.newClient();
+        job = client.newJob(dag);
+        assertEqualsEventually(() -> job.getStatus(), JobStatus.RUNNING);
+
+        instance.getHazelcastInstance().getLifecycleService().terminate();
+
+        instance = instanceFactory.newMember();
+
+        assertEqualsEventually(() -> firstItem(client.getHazelcastInstance().getCluster().getMembers())
+                        .map(Member::getAddress).orElse(null),
+                instance.getHazelcastInstance().getCluster().getLocalMember().getAddress());
+    }
+
+    private static <E> Optional<E> firstItem(Iterable<E> iterable) {
+        Iterator<E> iterator = iterable.iterator();
+        if (!iterator.hasNext()) {
+            return Optional.empty();
+        }
+        return Optional.of(iterator.next());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        instanceFactory.shutdownAll();
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_restart() {
+        job.restart();
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_suspend() {
+        job.suspend();
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_resume() {
+        job.resume();
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_cancel() {
+        job.cancel();
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_getStatus() {
+        job.getStatus();
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_getFuture() {
+        try {
+            job.getFuture().get();
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_submissionTime() {
+        job.getSubmissionTime();
+    }
+
+    @Test(expected = JobNotFoundException.class)
+    public void when_join() {
+        try {
+            job.join();
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.core.JobNotFoundException;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
@@ -180,14 +181,11 @@ public class JobRepositoryTest extends JetTestSupport {
         assertEquals(currentQuorumSize, jobRecord.getQuorumSize());
     }
 
-    @Test
-    public void when_jobIsMissing_then_jobQuorumSizeIsNotUpdated() {
+    @Test(expected = JobNotFoundException.class)
+    public void when_jobIsMissing_then_jobQuorumSizeUpdateFails() {
         long jobId = uploadResourcesForNewJob();
 
-        boolean success = jobRepository.updateJobQuorumSizeIfLargerThanCurrent(jobId, 1);
-
-        assertFalse(success);
-        assertNull(jobRepository.getJobRecord(jobId));
+        jobRepository.updateJobQuorumSizeIfLargerThanCurrent(jobId, 1);
     }
 
     private long uploadResourcesForNewJob() {


### PR DESCRIPTION
If JobRecord exists, we'll eventually learn of it, but otherwise there's
no point in retrying.

Also includes test for calling methods on stale Job instance.