### PR TITLE
Add jet shutdown hook, disable imdg one

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -68,9 +68,8 @@ public final class Jet {
         configureJetService(config);
         HazelcastInstanceImpl hazelcastInstance = ((HazelcastInstanceProxy)
                 Hazelcast.newHazelcastInstance(config.getHazelcastConfig())).getOriginal();
-        JetInstanceImpl jetInstance = new JetInstanceImpl(hazelcastInstance, config);
-        jetInstance.registerShutdownHook();
-        return jetInstance;
+        JetService service = hazelcastInstance.node.nodeEngine.getService(JetService.SERVICE_NAME);
+        return service.getJetInstance();
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -117,9 +117,12 @@ public final class Jet {
 
         Properties jetProps = jetConfig.getProperties();
         Properties hzProperties = hzConfig.getProperties();
+
+        // copy Jet Config properties as HZ properties
         for (String prop : jetProps.stringPropertyNames()) {
             hzProperties.setProperty(prop, jetProps.getProperty(prop));
         }
+
         HazelcastProperties properties = new HazelcastProperties(hzProperties);
 
         ServicesConfig servicesConfig = hzConfig.getServicesConfig();
@@ -127,7 +130,7 @@ public final class Jet {
                 .addServiceConfig(new ServiceConfig().setEnabled(true)
                         .setName(JetService.SERVICE_NAME)
                         .setClassName(JetService.class.getName())
-                        .setProperties(jetServiceProperties(properties.getString(SHUTDOWNHOOK_ENABLED)))
+                        .setProperties(jetServiceProperties(properties))
                         .setConfigObject(jetConfig));
 
         servicesConfig
@@ -154,13 +157,13 @@ public final class Jet {
         MetricsConfig metricsConfig = jetConfig.getMetricsConfig();
         applyMetricsConfig(hzConfig, metricsConfig);
 
-        // Force disable IMDG shutdown hook
+        // Force disable IMDG shutdown hook, we will use the Jet property instead
         hzConfig.setProperty(SHUTDOWNHOOK_ENABLED.getName(), "false");
     }
 
-    private static Properties jetServiceProperties(String shutdownHookEnabled) {
+    private static Properties jetServiceProperties(HazelcastProperties hzProperties) {
         Properties properties = new Properties();
-        properties.setProperty(SHUTDOWNHOOK_ENABLED.getName(), shutdownHookEnabled);
+        properties.setProperty(SHUTDOWNHOOK_ENABLED.getName(), hzProperties.getString(SHUTDOWNHOOK_ENABLED));
         return properties;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -33,7 +33,6 @@ import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.MetricsConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
-import com.hazelcast.jet.impl.JetInstanceImpl;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -29,6 +29,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.instance.Node;
 import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.MetricsConfig;
@@ -36,7 +37,9 @@ import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JetInstanceImpl;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
+import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.Properties;
@@ -45,6 +48,7 @@ import static com.hazelcast.jet.impl.JobRepository.JOB_RESULTS_MAP_NAME;
 import static com.hazelcast.jet.impl.config.XmlJetConfigBuilder.getClientConfig;
 import static com.hazelcast.jet.impl.metrics.JetMetricsService.applyMetricsConfig;
 import static com.hazelcast.jet.impl.util.JetGroupProperty.JOB_RESULTS_TTL_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_POLICY;
 
 /**
  * Entry point to the Jet product.
@@ -67,6 +71,7 @@ public final class Jet {
         configureJetService(config);
         HazelcastInstanceImpl hazelcastInstance = ((HazelcastInstanceProxy)
                 Hazelcast.newHazelcastInstance(config.getHazelcastConfig())).getOriginal();
+        Runtime.getRuntime().addShutdownHook(shutdownHookThread(hazelcastInstance));
         return new JetInstanceImpl(hazelcastInstance, config);
     }
 
@@ -150,5 +155,31 @@ public final class Jet {
         for (String prop : jetProps.stringPropertyNames()) {
             hzConfig.getProperties().setProperty(prop, jetProps.getProperty(prop));
         }
+        hzConfig.setProperty(GroupProperty.SHUTDOWNHOOK_ENABLED.getName(), "false");
+    }
+
+    private static Thread shutdownHookThread(HazelcastInstanceImpl hazelcastInstance) {
+        return new Thread(() -> {
+            Node node = hazelcastInstance.node;
+            if (node.isRunning()) {
+                String policy = node.getProperties().getString(SHUTDOWNHOOK_POLICY);
+                ILogger logger = node.getLogger(JetInstance.class);
+                logger.info("Running shutdown hook with policy: " + policy + ", Current state: " + node.getState());
+
+                JetService jetService = node.nodeEngine.getService(JetService.SERVICE_NAME);
+                jetService.shutDownJobs();
+
+                switch (policy) {
+                    case "TERMINATE":
+                        hazelcastInstance.getLifecycleService().terminate();
+                        break;
+                    case "GRACEFUL":
+                        hazelcastInstance.getLifecycleService().shutdown();
+                        break;
+                    default:
+                        throw new IllegalArgumentException("Unimplemented shutdown hook policy: " + policy);
+                }
+            }
+        });
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -35,6 +35,7 @@ import com.hazelcast.jet.config.MetricsConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
+import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -67,8 +68,7 @@ public final class Jet {
         configureJetService(config);
         HazelcastInstanceImpl hazelcastInstance = ((HazelcastInstanceProxy)
                 Hazelcast.newHazelcastInstance(config.getHazelcastConfig())).getOriginal();
-        JetService service = hazelcastInstance.node.nodeEngine.getService(JetService.SERVICE_NAME);
-        return service.getJetInstance();
+        return Util.getJetInstance(hazelcastInstance.node.nodeEngine);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -37,15 +37,16 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.util.Properties;
 
+import static com.hazelcast.jet.impl.JetService.JET_SHUTDOWN_HOOK_ENABLED;
 import static com.hazelcast.jet.impl.JobRepository.JOB_RESULTS_MAP_NAME;
 import static com.hazelcast.jet.impl.config.XmlJetConfigBuilder.getClientConfig;
 import static com.hazelcast.jet.impl.metrics.JetMetricsService.applyMetricsConfig;
 import static com.hazelcast.jet.impl.util.JetGroupProperty.JOB_RESULTS_TTL_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 
 /**
  * Entry point to the Jet product.
@@ -148,9 +149,13 @@ public final class Jet {
         applyMetricsConfig(hzConfig, metricsConfig);
 
         Properties jetProps = jetConfig.getProperties();
+        Properties hzProperties = hzConfig.getProperties();
         for (String prop : jetProps.stringPropertyNames()) {
-            hzConfig.getProperties().setProperty(prop, jetProps.getProperty(prop));
+            hzProperties.setProperty(prop, jetProps.getProperty(prop));
         }
-        hzConfig.setProperty(GroupProperty.SHUTDOWNHOOK_ENABLED.getName(), "false");
+        HazelcastProperties hazelcastProperties = new HazelcastProperties(hzProperties);
+        if (hazelcastProperties.getBoolean(JET_SHUTDOWN_HOOK_ENABLED)) {
+            hzConfig.setProperty(SHUTDOWNHOOK_ENABLED.getName(), "false");
+        }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
@@ -51,6 +51,7 @@ public class JetInstanceImpl extends AbstractJetInstance {
         this.nodeEngine = hazelcastInstance.node.getNodeEngine();
         this.config = config;
         this.shutdownHookThread = shutdownHookThread(nodeEngine);
+        Runtime.getRuntime().addShutdownHook(shutdownHookThread);
     }
 
     @Nonnull @Override
@@ -113,10 +114,6 @@ public class JetInstanceImpl extends AbstractJetInstance {
         jetService.shutDownJobs();
         super.shutdown();
         Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
-    }
-
-    public void registerShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(shutdownHookThread);
     }
 
     private Thread shutdownHookThread(NodeEngine nodeEngine) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
@@ -110,6 +110,4 @@ public class JetInstanceImpl extends AbstractJetInstance {
         jetService.shutDownJobs();
         super.shutdown();
     }
-
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -43,7 +43,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PacketHandler;
-import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -52,6 +51,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_POLICY;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -61,8 +61,6 @@ public class JetService
 
     public static final String SERVICE_NAME = "hz:impl:jetService";
     public static final int MAX_PARALLEL_ASYNC_OPS = 1000;
-    public static final HazelcastProperty JET_SHUTDOWN_HOOK_ENABLED =
-            new HazelcastProperty("hazelcast.jet.shutdownhook.enabled", true);
 
     private static final int NOTIFY_MEMBER_SHUTDOWN_DELAY = 5;
 
@@ -121,7 +119,7 @@ public class JetService
 
         jobCoordinationService.init();
 
-        if (nodeEngine.getProperties().getBoolean(JET_SHUTDOWN_HOOK_ENABLED)) {
+        if (Boolean.parseBoolean(properties.getProperty(SHUTDOWNHOOK_ENABLED.getName()))) {
             Runtime.getRuntime().addShutdownHook(shutdownHookThread);
         }
 
@@ -300,6 +298,6 @@ public class JetService
             } else {
                 jetInstance.shutdown();
             }
-        });
+        }, "jet.ShutdownThread");
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -133,7 +133,7 @@ public class JetService
     /**
      * Gracefully shuts down jobs on this member. Blocks until all are down.
      */
-    public void shutDownJobs() {
+    void shutDownJobs() {
         if (!shutdownInitiated.compareAndSet(false, true)) {
             logger.info("Shutdown requested, but already shut down or being shut down");
             return;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -133,7 +133,7 @@ public class JetService
     /**
      * Gracefully shuts down jobs on this member. Blocks until all are down.
      */
-    void shutDownJobs() {
+    public void shutDownJobs() {
         if (!shutdownInitiated.compareAndSet(false, true)) {
             logger.info("Shutdown requested, but already shut down or being shut down");
             return;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -120,6 +120,7 @@ public class JetService
         jobCoordinationService.init();
 
         if (Boolean.parseBoolean(properties.getProperty(SHUTDOWNHOOK_ENABLED.getName()))) {
+            logger.finest("Adding Jet shutdown hook");
             Runtime.getRuntime().addShutdownHook(shutdownHookThread);
         }
 


### PR DESCRIPTION
By default, imdg adds its own shutdown hook, which calls either shutdown or terminate according to the shutdown-hook-policy. We've introduced graceful shutdown of jobs but it is only called if explicitly called `JetInstance.shutdown()`. If the processor is killed externally jobs are not shutdown gracefully.

With this PR, we disable the imdg shutdown hook and add our own hook. In the hook, if the policy is graceful then the jobs and underlying imdg instance are shutdown gracefully otherwise we terminate the imdg instance without shutting down the jobs.