### PR TITLE
Convert ReadMetricsOperation from blocking to async operation

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/LiveOperationRegistry.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/LiveOperationRegistry.java
@@ -16,27 +16,27 @@
 
 package com.hazelcast.jet.impl;
 
-import com.hazelcast.jet.impl.operation.AsyncJobOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.LiveOperations;
+import com.hazelcast.spi.Operation;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class LiveOperationRegistry {
     // memberAddress -> callId -> operation
-    final ConcurrentHashMap<Address, Map<Long, AsyncJobOperation>> liveOperations = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<Address, Map<Long, Operation>> liveOperations = new ConcurrentHashMap<>();
 
-    public void register(AsyncJobOperation operation) {
-        Map<Long, AsyncJobOperation> callIds = liveOperations.computeIfAbsent(operation.getCallerAddress(),
+    public void register(Operation operation) {
+        Map<Long, Operation> callIds = liveOperations.computeIfAbsent(operation.getCallerAddress(),
                 (key) -> new ConcurrentHashMap<>());
         if (callIds.putIfAbsent(operation.getCallId(), operation) != null) {
             throw new IllegalStateException("Duplicate operation during registration of operation=" + operation);
         }
     }
 
-    public void deregister(AsyncJobOperation operation) {
-        Map<Long, AsyncJobOperation> operations = liveOperations.get(operation.getCallerAddress());
+    public void deregister(Operation operation) {
+        Map<Long, Operation> operations = liveOperations.get(operation.getCallerAddress());
 
         if (operations == null) {
             throw new IllegalStateException("Missing address during de-registration of operation=" + operation);
@@ -47,7 +47,7 @@ public class LiveOperationRegistry {
         }
     }
 
-    void populate(LiveOperations liveOperations) {
+    public void populate(LiveOperations liveOperations) {
         this.liveOperations.forEach((key, value) -> value.keySet().forEach(callId -> liveOperations.add(key, callId)));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/JetMetricsService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/JetMetricsService.java
@@ -21,22 +21,26 @@ import com.hazelcast.internal.diagnostics.Diagnostics;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 import com.hazelcast.jet.config.MetricsConfig;
+import com.hazelcast.jet.impl.LiveOperationRegistry;
 import com.hazelcast.jet.impl.metrics.jmx.JmxPublisher;
 import com.hazelcast.jet.impl.metrics.management.ConcurrentArrayRingbuffer;
+import com.hazelcast.jet.impl.metrics.management.ConcurrentArrayRingbuffer.RingbufferSlice;
 import com.hazelcast.jet.impl.metrics.management.ManagementCenterPublisher;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ConfigurableService;
+import com.hazelcast.spi.LiveOperations;
+import com.hazelcast.spi.LiveOperationsTracker;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Notifier;
-import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.impl.operationparker.OperationParker;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -47,16 +51,16 @@ import static java.util.stream.Collectors.joining;
  * A service to render metrics at regular intervals and store them in a
  * ringbuffer from which the clients can read.
  */
-public class JetMetricsService implements ManagedService, ConfigurableService<MetricsConfig> {
+public class JetMetricsService implements ManagedService, ConfigurableService<MetricsConfig>, LiveOperationsTracker {
 
     public static final String SERVICE_NAME = "hz:impl:jetMetricsService";
 
     private final NodeEngineImpl nodeEngine;
     private final ILogger logger;
-
-    // keys used for synchronization of read operation
-    private final MetricsNotifyKey notifyKey = new MetricsNotifyKey();
-    private final Notifier notifier = new MetricsNotifier();
+    private final LiveOperationRegistry liveOperationRegistry;
+    // Holds futures for pending read metrics operations
+    private final ConcurrentMap<CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>>, Long>
+            futureMap = new ConcurrentHashMap<>();
 
     /**
      * Ringbuffer which stores a bounded history of metrics. For each round of collection,
@@ -75,6 +79,7 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
     public JetMetricsService(NodeEngine nodeEngine) {
         this.nodeEngine = (NodeEngineImpl) nodeEngine;
         this.logger = nodeEngine.getLogger(getClass());
+        this.liveOperationRegistry = new LiveOperationRegistry();
     }
 
     @Override
@@ -111,21 +116,41 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
         }, 1, config.getCollectionIntervalSeconds(), TimeUnit.SECONDS);
     }
 
-    /**
-     * Read metrics from the journal from the given sequence
-     */
-    public ConcurrentArrayRingbuffer.RingbufferSlice<Map.Entry<Long, byte[]>> readMetrics(long startSequence) {
-        if (!config.isEnabled()) {
-            throw new IllegalArgumentException("Metrics collection is not enabled");
-        }
-        return metricsJournal.copyFrom(startSequence);
+    public LiveOperationRegistry getLiveOperationRegistry() {
+        return liveOperationRegistry;
+    }
+
+    @Override
+    public void populate(LiveOperations liveOperations) {
+        liveOperationRegistry.populate(liveOperations);
     }
 
     /**
-     * key used for signalling pending read operations
+     * Read metrics from the journal from the given sequence
      */
-    public WaitNotifyKey waitNotifyKey() {
-        return notifyKey;
+    public CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> readMetrics(long startSequence) {
+        if (!config.isEnabled()) {
+            throw new IllegalArgumentException("Metrics collection is not enabled");
+        }
+        CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future = new CompletableFuture<>();
+        future.whenComplete((s, e) -> futureMap.remove(future));
+        futureMap.put(future, startSequence);
+
+        readFromJournal(future, startSequence);
+
+        return future;
+    }
+
+    private void readFromJournal(CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>> future, long sequence) {
+        try {
+            RingbufferSlice<Map.Entry<Long, byte[]>> slice = metricsJournal.copyFrom(sequence);
+            if (!slice.isEmpty()) {
+                future.complete(slice);
+            }
+        } catch (Exception e) {
+            logger.severe("Error reading from metrics journal, sequence: " + sequence, e);
+            future.completeExceptionally(e);
+        }
     }
 
     @Override
@@ -168,8 +193,7 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
             ManagementCenterPublisher publisher = new ManagementCenterPublisher(this.nodeEngine.getLoggingService(),
                     (blob, ts) -> {
                         metricsJournal.add(entry(ts, blob));
-                        OperationParker parker = nodeEngine.getService(OperationParker.SERVICE_NAME);
-                        parker.unpark(notifier);
+                        futureMap.forEach(this::readFromJournal);
                     }
             );
             publishers.add(publisher);
@@ -232,30 +256,6 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
 
         private void logError(String name, Object value, MetricsPublisher publisher, Exception e) {
             logger.fine("Error publishing metric to: " + publisher.name() + ", metric=" + name + ", value=" + value, e);
-        }
-    }
-
-    private class MetricsNotifier implements Notifier {
-        @Override
-        public boolean shouldNotify() {
-            return true;
-        }
-
-        @Override
-        public WaitNotifyKey getNotifiedKey() {
-            return notifyKey;
-        }
-    }
-
-    private static class MetricsNotifyKey implements WaitNotifyKey {
-        @Override
-        public String getServiceName() {
-            return JetMetricsService.SERVICE_NAME;
-        }
-
-        @Override
-        public String getObjectName() {
-            return "metricsJournal";
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/ConcurrentArrayRingbuffer.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/ConcurrentArrayRingbuffer.java
@@ -143,6 +143,10 @@ public class ConcurrentArrayRingbuffer<E> {
             return (Stream<E>) Arrays.stream(elements);
         }
 
+        public boolean isEmpty() {
+            return elements.length == 0;
+        }
+
         /**
          * The tail, this is the sequence where next call to {@link
          * ConcurrentArrayRingbuffer#copyFrom}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/JetReadMetricsMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/JetReadMetricsMessageTask.java
@@ -21,7 +21,6 @@ import com.hazelcast.client.impl.protocol.codec.JetReadMetricsCodec;
 import com.hazelcast.client.impl.protocol.codec.JetReadMetricsCodec.RequestParameters;
 import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
 import com.hazelcast.instance.Node;
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.InvocationBuilder;
@@ -53,9 +52,7 @@ public class JetReadMetricsMessageTask extends AbstractInvocationMessageTask<Req
                             + ", but local member is " + nodeEngine.getLocalMember().getUuid()
             );
         }
-        JetService service = getService(JetService.SERVICE_NAME);
-        int collectionInterval = service.getJetInstance().getConfig().getMetricsConfig().getCollectionIntervalSeconds();
-        return new ReadMetricsOperation(parameters.fromSequence, collectionInterval);
+        return new ReadMetricsOperation(parameters.fromSequence);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/ReadMetricsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/ReadMetricsOperation.java
@@ -16,22 +16,20 @@
 
 package com.hazelcast.jet.impl.metrics.management;
 
-import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
 import com.hazelcast.jet.impl.metrics.management.ConcurrentArrayRingbuffer.RingbufferSlice;
-import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ReadonlyOperation;
-import com.hazelcast.spi.WaitNotifyKey;
 
 import java.util.Map.Entry;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-public class ReadMetricsOperation extends Operation implements BlockingOperation, ReadonlyOperation {
+public class ReadMetricsOperation extends Operation implements ReadonlyOperation {
 
     private static final int MIN_TIMEOUT_SECONDS = 5;
     private long offset;
-    private RingbufferSlice<Entry<Long, byte[]>> resultSet;
 
     public ReadMetricsOperation(long offset, int collectionIntervalSeconds) {
         this.offset = offset;
@@ -40,8 +38,26 @@ public class ReadMetricsOperation extends Operation implements BlockingOperation
     }
 
     @Override
+    public void beforeRun() {
+        JetMetricsService service = getService();
+        service.getLiveOperationRegistry().register(this);
+    }
+
+    @Override
+    public void run() {
+        JetMetricsService service = getService();
+        CompletableFuture<RingbufferSlice<Entry<Long, byte[]>>> future = service.readMetrics(offset);
+        future.whenComplete((slice, error) -> doSendResponse(error != null ? error : slice));
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return false;
+    }
+
+    @Override
     public Object getResponse() {
-        return resultSet;
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -49,22 +65,12 @@ public class ReadMetricsOperation extends Operation implements BlockingOperation
         return JetMetricsService.SERVICE_NAME;
     }
 
-    @Override
-    public WaitNotifyKey getWaitKey() {
-        JetMetricsService service = getService();
-        return service.waitNotifyKey();
+    final void doSendResponse(Object value) {
+        try {
+            sendResponse(value);
+        } finally {
+            final JetService service = getService();
+            service.getLiveOperationRegistry().deregister(this);
+        }
     }
-
-    @Override
-    public boolean shouldWait() {
-        JetMetricsService service = getService();
-        this.resultSet = service.readMetrics(offset);
-        return resultSet.elements().isEmpty();
-    }
-
-    @Override
-    public void onWaitExpire() {
-        sendResponse(new OperationTimeoutException("No metrics were retrieved for " + getWaitTimeout() + "ms"));
-    }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncJobOperation.java
@@ -60,7 +60,7 @@ public abstract class AsyncJobOperation extends AbstractJobOperation {
         throw new UnsupportedOperationException();
     }
 
-    public final void doSendResponse(Object value) {
+    final void doSendResponse(Object value) {
         try {
             sendResponse(value);
         } finally {


### PR DESCRIPTION
ReadMetricsOperation was using wait/notify mechanism but it is not thread-safe, it is designed for partition-thread operations. With the change, `readMetrics` method returns a future which is used to return the response once a new metric arrived.