### PR TITLE
Fix terminal snapshot when one is in progress

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -173,7 +173,7 @@ public class JetService
                       @Override
                       public void onFailure(Throwable t) {
                           logger.warning("Failed to notify master member that this member is shutting down, will retry in "
-                                  + NOTIFY_MEMBER_SHUTDOWN_DELAY + " seconds");
+                                  + NOTIFY_MEMBER_SHUTDOWN_DELAY + " seconds", t);
                           // recursive call
                           nodeEngine.getExecutionService().schedule(
                                   () -> notifyMasterWeAreShuttingDown(result), NOTIFY_MEMBER_SHUTDOWN_DELAY, SECONDS);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -577,8 +577,13 @@ public class JobCoordinationService {
             return;
         }
 
-        if (!isMaster() || !nodeEngine.isRunning()) {
-            scheduleSnapshot(jobId, executionId);
+        if (!isMaster()) {
+            logger.warning("Not starting snapshot, not a master, master is "
+                    + nodeEngine.getClusterService().getMasterAddress());
+            return;
+        }
+        if (!nodeEngine.isRunning()) {
+            logger.warning("Not starting snapshot, node engine is not running");
             return;
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -577,7 +577,7 @@ public class JobCoordinationService {
             return;
         }
 
-        if (!shouldStartJobs()) {
+        if (!isMaster() || !nodeEngine.isRunning()) {
             scheduleSnapshot(jobId, executionId);
             return;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
@@ -33,6 +33,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 public class NotifyMemberShutdownOperation extends Operation implements IdentifiedDataSerializable {
 
     public NotifyMemberShutdownOperation() {
+        setWaitTimeout(0);
     }
 
     @Override


### PR DESCRIPTION
The JobCoordinationService called `shouldStartJobs` to check whether to
start snapshots. It contained the condition that it doesn't start when
member is shutting down or migration is ongoing. These two conditions do
not apply to snapshots, however. For example, when a terminal snapshot
is started and another snapshot was ongoing, it was postponed. The next
snapshot was supposed to be terminal, but it couldn't start, because
member is shutting down...