### PR TITLE
Convert assertEquals to assertEventually

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -239,7 +239,7 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
         };
 
         Consumer<JetInstance[]> afterMerge = instances -> {
-            assertEquals(secondSubClusterSize, MockPS.receivedCloseErrors.size());
+            assertTrueEventually(() -> assertEquals(secondSubClusterSize, MockPS.receivedCloseErrors.size()), 20);
             MockPS.receivedCloseErrors.forEach(t -> assertTrue(t instanceof TopologyChangedException));
 
             try {


### PR DESCRIPTION
since we complete the jobs on `JetService.reset`  asynchronously, we need to check eventually

fixes https://github.com/hazelcast/hazelcast-jet/issues/1097