### PR TITLE
Fix SnapshotContext

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -340,7 +340,7 @@ public class MasterContext {
         MembersView membersView = getMembersView();
         ClassLoader previousCL = swapContextClassLoader(classLoader);
         try {
-            logger.info("Start executing " + jobIdString() + ", status " + jobStatus()
+            logger.info("Start executing " + jobIdString()
                     + ", execution graph in DOT format:\n" + dotString
                     + "\nHINT: You can use graphviz or http://viz-js.com to visualize the printed graph.");
             logger.fine("Building execution plan for " + jobIdString());
@@ -534,6 +534,10 @@ public class MasterContext {
 
             if (snapshotInProgress) {
                 logger.fine("Not beginning snapshot since one is already in progress " + jobIdString());
+                return;
+            }
+            if (terminalSnapshotFuture.isDone()) {
+                logger.fine("Not beginning snapshot since terminal snapshot is already completed");
                 return;
             }
             snapshotInProgress = true;
@@ -929,7 +933,7 @@ public class MasterContext {
         // If there is any member in our participants that is not among current data members,
         // this job will be restarted anyway. If it's the other way, then the sizes won't match.
         if (executionPlanMap == null || executionPlanMap.size() == currentDataMembers.size()) {
-            LoggingUtil.logFine(logger, "Not scaling job %s up: not running or already running on all members",
+            LoggingUtil.logFine(logger, "Not scaling %s up: not running or already running on all members",
                     jobIdString());
             return true;
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -45,6 +45,7 @@ import java.util.concurrent.locks.LockSupport;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import static com.hazelcast.jet.impl.util.LoggingUtil.logFinest;
 import static com.hazelcast.jet.impl.util.Util.lazyIncrement;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static java.lang.Thread.currentThread;
@@ -327,6 +328,7 @@ public class TaskletExecutionService {
         }
 
         private void dismissTasklet(TaskletTracker t) {
+            logFinest(logger, "Tasklet %s is done", t.tasklet);
             t.executionTracker.taskletDone();
             trackers.remove(t);
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImpl.java
@@ -240,6 +240,7 @@ public class AsyncSnapshotWriterImpl implements AsyncSnapshotWriter {
         }
         return true;
     }
+
     /**
      * Flush all partitions.
      *

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -96,5 +97,17 @@ public class SnapshotContextSimpleTest {
 
         // Then
         ssContext.snapshotDoneForTasklet(1, 1, 1);
+    }
+
+    @Test
+    public void test_lowerPriorityTaskletCompletedFirst() {
+        ssContext.initTaskletCount(2, 2);
+        CompletableFuture<SnapshotOperationResult> future = ssContext.startNewSnapshot(10, false);
+        assertEquals(9, ssContext.lastSnapshotId());
+        ssContext.taskletDone(9, true);
+        assertEquals(9, ssContext.lastSnapshotId());
+        ssContext.taskletDone(9, true);
+        assertEquals(10, ssContext.lastSnapshotId());
+        assertTrue(future.isDone());
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
@@ -20,9 +20,7 @@ import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.impl.operation.SnapshotOperation.SnapshotOperationResult;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelTest;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -39,7 +37,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 @RunWith(Parameterized.class)
-@Category(ParallelTest.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 public class SnapshotContextTest {
 


### PR DESCRIPTION
Fixes this scenario:
- snapshotContext has 2 higher priority tasklets
- startNewSnapshot called, but snapshot postponed due to higher priority
sources
- taskletDone called. It decremented numTasklets, but not
numRemainingTasklets. This is the problem. From now on, not enough calls
to snapshotDoneForTasklet will be made and the snapshot will get stuck.