### PR TITLE
Fix snapshot stats reporting

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
@@ -65,21 +65,20 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
      */
     private volatile int dataMapIndex = -1;
 
-    /*
-     * Stats for current successful snapshot.
-     */
-    private volatile long startTime = Long.MIN_VALUE;
-    private volatile long endTime = Long.MIN_VALUE;
-    private volatile long numBytes;
-    private volatile long numKeys;
-    private volatile long numChunks;
-
     /**
      * ID for the ongoing or the next snapshot. The value is incremented each
      * time we attempt a new snapshot.
      */
     private volatile long ongoingSnapshotId = NO_SNAPSHOT;
 
+    // === Stats for current successful snapshot ===
+    private volatile long startTime = Long.MIN_VALUE;
+    private volatile long endTime = Long.MIN_VALUE;
+    private volatile long numBytes;
+    private volatile long numKeys;
+    private volatile long numChunks;
+
+    // === Stats for last attempted snapshot ===
     /**
      * Start time of the ongoing snapshot or {@code Long.MIN_VALUE}, if there's
      * no ongoing snapshot.
@@ -92,6 +91,7 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
      */
     @Nullable
     private volatile String lastFailureText;
+    // === End of stats ===
 
     public JobExecutionRecord() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
@@ -75,20 +75,20 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
     private volatile long numChunks;
 
     /**
-     * ID for the ongoing snapshot. The value is incremented when we start a
-     * new snapshot.
-     * <p>
-     * If {@code ongoingSnapshotId == }{@link #snapshotId}, there's no ongoing
-     * snapshot. But if {@code ongoingSnapshotId > }{@link #snapshotId} it
-     * doesn't mean a snapshot is ongoing: it will happen when a snapshot
-     * fails. For next ongoing snapshot we'll increment the value again.
+     * ID for the ongoing or the next snapshot. The value is incremented each
+     * time we attempt a new snapshot.
      */
     private volatile long ongoingSnapshotId = NO_SNAPSHOT;
-    private volatile long ongoingSnapshotStartTime;
 
     /**
-     * Contains the error message for the failure of the last snapshot.
-     * if the last snapshot was successful, it's null.
+     * Start time of the ongoing snapshot or {@code Long.MIN_VALUE}, if there's
+     * no ongoing snapshot.
+     */
+    private volatile long ongoingSnapshotStartTime = Long.MIN_VALUE;
+
+    /**
+     * Contains the error message for the failure of the last attempted
+     * snapshot. If the last attempt was successful, it's null.
      */
     @Nullable
     private volatile String lastFailureText;
@@ -145,6 +145,7 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
         } else {
             // we don't update the other fields because they only pertain to a successful snapshot
         }
+        this.ongoingSnapshotStartTime = Long.MIN_VALUE;
     }
 
     public long snapshotId() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.core.Edge;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.impl.JobExecutionRecord.SnapshotStats;
 import com.hazelcast.jet.impl.TerminationMode.ActionAfterTerminate;
 import com.hazelcast.jet.impl.exception.JobTerminateRequestedException;
 import com.hazelcast.jet.impl.exception.ShutdownInProgressException;
@@ -585,11 +586,12 @@ public class MasterContext {
                 mergedResult.getNumBytes(), mergedResult.getNumKeys(), mergedResult.getNumChunks(),
                 mergedResult.getError());
         writeJobExecutionRecord(false);
+        SnapshotStats stats = jobExecutionRecord.snapshotStats();
         logger.info(String.format("Snapshot %d for %s completed with status %s in %dms, " +
                         "%,d bytes, %,d keys in %,d chunks, stored in data map %d",
                 snapshotId, jobIdString(), isSuccess ? "SUCCESS" : "FAILURE",
-                jobExecutionRecord.duration(), jobExecutionRecord.numBytes(),
-                jobExecutionRecord.numKeys(), jobExecutionRecord.numChunks(),
+                stats.duration(), stats.numBytes(),
+                stats.numKeys(), stats.numChunks(),
                 jobExecutionRecord.dataMapIndex()));
         jobRepository.clearSnapshotData(jobId, jobExecutionRecord.ongoingDataMapIndex());
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
@@ -102,7 +102,7 @@ public class StoreSnapshotTasklet implements Tasklet {
 
             case FLUSH:
                 progTracker.notDone();
-                if (ssWriter.flushAndReset()) {
+                if (ssWriter.flushAndResetMap()) {
                     progTracker.madeProgress();
                     state = REACHED_BARRIER;
                 }
@@ -122,6 +122,7 @@ public class StoreSnapshotTasklet implements Tasklet {
                 progTracker.madeProgress();
                 snapshotContext.snapshotDoneForTasklet(ssWriter.getTotalPayloadBytes(), ssWriter.getTotalKeys(),
                         ssWriter.getTotalChunks());
+                ssWriter.resetStats();
                 pendingSnapshotId++;
                 hasReachedBarrier = false;
                 state = DRAIN;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.execution.init;
 import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.jet.impl.JobExecutionRecord;
+import com.hazelcast.jet.impl.JobExecutionRecord.SnapshotStats;
 import com.hazelcast.jet.impl.JobRecord;
 import com.hazelcast.jet.impl.JobRepository.FilterExecutionIdByJobIdPredicate;
 import com.hazelcast.jet.impl.JobRepository.FilterJobIdPredicate;
@@ -88,6 +89,7 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
     public static final int NOTIFY_MEMBER_SHUTDOWN_OP = 31;
     public static final int GET_JOB_SUMMARY_LIST_OP = 32;
     public static final int JOB_SUMMARY = 33;
+    public static final int SNAPSHOT_STATS = 34;
 
     public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(JET_IMPL_DS_FACTORY, JET_IMPL_DS_FACTORY_ID);
 
@@ -173,6 +175,8 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
                     return new JobSummary();
                 case GET_JOB_SUMMARY_LIST_OP:
                     return new GetJobSummaryListOperation();
+                case SNAPSHOT_STATS:
+                    return new SnapshotStats();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriter.java
@@ -26,7 +26,8 @@ public interface AsyncSnapshotWriter {
     boolean offer(Entry<? extends Data, ? extends Data> entry);
 
     @CheckReturnValue
-    boolean flushAndReset();
+    boolean flushAndResetMap();
+    void resetStats();
 
     boolean hasPendingAsyncOps();
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -301,7 +301,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
             assertNotNull("null JobExecutionRecord", record);
             assertTrue("No snapshot produced",
                     record.dataMapIndex() >= 0 && record.snapshotId() >= 0);
-            assertTrue("stats are 0", record.numBytes() > 0);
+            assertTrue("stats are 0", record.snapshotStats().numBytes() > 0);
             snapshotId[0] = record.snapshotId();
         }, timeout);
         logger.info("First snapshot found (id=" + snapshotId[0] + ")");
@@ -318,7 +318,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
             snapshotId[0] = record.snapshotId();
             assertTrue("No more snapshots produced after restart in " + timeoutSeconds + " seconds",
                     snapshotId[0] > originalSnapshotId);
-            assertTrue("stats are 0", record.numBytes() > 0);
+            assertTrue("stats are 0", record.snapshotStats().numBytes() > 0);
         }, timeoutSeconds);
         logger.info("Next snapshot found (id=" + snapshotId[0] + ", previous id=" + originalSnapshotId + ")");
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -301,6 +301,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
             assertNotNull("null JobExecutionRecord", record);
             assertTrue("No snapshot produced",
                     record.dataMapIndex() >= 0 && record.snapshotId() >= 0);
+            assertTrue("stats are 0", record.numBytes() > 0);
             snapshotId[0] = record.snapshotId();
         }, timeout);
         logger.info("First snapshot found (id=" + snapshotId[0] + ")");
@@ -317,6 +318,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
             snapshotId[0] = record.snapshotId();
             assertTrue("No more snapshots produced after restart in " + timeoutSeconds + " seconds",
                     snapshotId[0] > originalSnapshotId);
+            assertTrue("stats are 0", record.numBytes() > 0);
         }, timeoutSeconds);
         logger.info("Next snapshot found (id=" + snapshotId[0] + ", previous id=" + originalSnapshotId + ")");
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
@@ -70,16 +70,27 @@ public class JetInitDataSerializerHookTest {
                         singleton("config")},
 
                 new Object[]{
-                        "JobExecutionRecord",
-                        sampleJobExecutionRecord(),
+                        "sampleJobExecutionRecord_whenSuccessfulSnapshot",
+                        sampleJobExecutionRecord_whenSuccessfulSnapshot(),
+                        emptyList()},
+                new Object[]{
+                        "sampleJobExecutionRecord_whenFailedSnapshot",
+                        sampleJobExecutionRecord_whenFailedSnapshot(),
                         emptyList()}
         );
     }
 
-    private static JobExecutionRecord sampleJobExecutionRecord() {
+    private static JobExecutionRecord sampleJobExecutionRecord_whenSuccessfulSnapshot() {
         JobExecutionRecord r = new JobExecutionRecord(1, 2, true);
         r.startNewSnapshot();
-        r.ongoingSnapshotDone(10, 11, 12, "failure");
+        r.ongoingSnapshotDone(10, 11, 12, null);
+        return r;
+    }
+
+    private static JobExecutionRecord sampleJobExecutionRecord_whenFailedSnapshot() {
+        JobExecutionRecord r = new JobExecutionRecord(1, 2, true);
+        r.startNewSnapshot();
+        r.ongoingSnapshotDone(10, 11, 12, "Failed");
         return r;
     }
 
@@ -116,9 +127,9 @@ public class JetInitDataSerializerHookTest {
 
     private static void customAssertEquals(String msg, Object expected, Object actual) {
         if (expected instanceof AtomicLong) {
-            assertEquals(((AtomicLong) expected).get(), ((AtomicLong) actual).get());
+            assertEquals(msg, ((AtomicLong) expected).get(), ((AtomicLong) actual).get());
         } else if (expected instanceof AtomicInteger) {
-            assertEquals(((AtomicInteger) expected).get(), ((AtomicInteger) actual).get());
+            assertEquals(msg, ((AtomicInteger) expected).get(), ((AtomicInteger) actual).get());
         } else {
             assertEquals(msg, expected, actual);
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/AsyncSnapshotWriterImplTest.java
@@ -98,7 +98,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
 
     @After
     public void after() {
-        assertTrue(writer.flushAndReset());
+        assertTrue(writer.flushAndResetMap());
         assertTrueEventually(() -> assertFalse(uncheckCall(() -> writer.hasPendingAsyncOps())));
         assertTrue(writer.isEmpty());
 
@@ -112,7 +112,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         assertTrue(writer.offer(entry));
         assertTrueAllTheTime(() -> assertTrue(map.isEmpty()), 1);
         assertFalse(writer.isEmpty());
-        assertTrue(writer.flushAndReset());
+        assertTrue(writer.flushAndResetMap());
 
         // Then
         assertTargetMapEntry("k", 0, serializedLength(entry));
@@ -161,7 +161,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         Entry<Data, Data> entry2 = entry(serialize("kk"), serialize("vv"));
         assertTrue(writer.offer(entry1));
         assertTrue(writer.offer(entry2));
-        assertTrue(writer.flushAndReset());
+        assertTrue(writer.flushAndResetMap());
 
         // Then
         assertTargetMapEntry("k", 0, serializedLength(entry1));
@@ -211,7 +211,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
 
         // Then
         assertTrueAllTheTime(() -> {
-            assertFalse(writer.flushAndReset());
+            assertFalse(writer.flushAndResetMap());
             assertTrue(map.isEmpty());
         }, 3);
 
@@ -219,7 +219,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         writer.numConcurrentAsyncOps.decrementAndGet();
 
         // Then
-        assertTrueEventually(() -> assertTrue(writer.flushAndReset()));
+        assertTrueEventually(() -> assertTrue(writer.flushAndResetMap()));
         assertTargetMapEntry("k", 0, serializedLength(entry1));
         assertTargetMapEntry("kk", 1, serializedLength(entry2));
     }
@@ -230,7 +230,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
         when(snapshotContext.currentMapName()).thenReturn(ALWAYS_FAILING_MAP);
         Entry<Data, Data> entry = entry(serialize("k"), serialize("v"));
         assertTrue(writer.offer(entry));
-        assertTrue(writer.flushAndReset());
+        assertTrue(writer.flushAndResetMap());
 
         // Then
         assertTrueEventually(() ->
@@ -262,7 +262,7 @@ public class AsyncSnapshotWriterImplTest extends JetTestSupport {
     @Test
     public void when_noItemsAndNoCurrentMap_then_flushAndResetReturnsFalse() {
         when(snapshotContext.currentMapName()).thenReturn(null);
-        assertFalse(writer.flushAndReset());
+        assertFalse(writer.flushAndResetMap());
         when(snapshotContext.currentMapName()).thenReturn("map1");
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/MockAsyncSnapshotWriter.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/MockAsyncSnapshotWriter.java
@@ -43,12 +43,16 @@ public class MockAsyncSnapshotWriter implements AsyncSnapshotWriter {
     }
 
     @Override
-    public boolean flushAndReset() {
+    public boolean flushAndResetMap() {
         if (ableToFlushRemaining) {
             hasPendingFlushes = !isFlushed;
             isFlushed = true;
         }
         return ableToFlushRemaining;
+    }
+
+    @Override
+    public void resetStats() {
     }
 
     @Override


### PR DESCRIPTION
The number of bytes, chunks and keys for snapshot was always reported as
0. Also improves JobExecutionRecord to see if there's an ongoing snapshot.
