### PR TITLE
Start job scan after HZ init is done

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -20,10 +20,10 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.ServiceConfig;
-import com.hazelcast.config.ServicesConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
@@ -35,7 +35,6 @@ import com.hazelcast.jet.config.MetricsConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
-import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
@@ -68,7 +67,9 @@ public final class Jet {
         configureJetService(config);
         HazelcastInstanceImpl hazelcastInstance = ((HazelcastInstanceProxy)
                 Hazelcast.newHazelcastInstance(config.getHazelcastConfig())).getOriginal();
-        return Util.getJetInstance(hazelcastInstance.node.nodeEngine);
+        JetService jetService = hazelcastInstance.node.nodeEngine.getService(JetService.SERVICE_NAME);
+        jetService.getJobCoordinationService().startScanningForJobs();
+        return jetService.getJetInstance();
     }
 
     /**
@@ -125,33 +126,32 @@ public final class Jet {
 
         HazelcastProperties properties = new HazelcastProperties(hzProperties);
 
-        ServicesConfig servicesConfig = hzConfig.getServicesConfig();
-        servicesConfig
-                .addServiceConfig(new ServiceConfig().setEnabled(true)
+        hzConfig.getServicesConfig()
+                .addServiceConfig(new ServiceConfig()
+                        .setEnabled(true)
                         .setName(JetService.SERVICE_NAME)
                         .setClassName(JetService.class.getName())
                         .setProperties(jetServiceProperties(properties))
-                        .setConfigObject(jetConfig));
-
-        servicesConfig
-                .addServiceConfig(new ServiceConfig().setEnabled(true)
+                        .setConfigObject(jetConfig))
+                .addServiceConfig(new ServiceConfig()
+                        .setEnabled(true)
                         .setName(JetMetricsService.SERVICE_NAME)
                         .setClassName(JetMetricsService.class.getName())
                         .setConfigObject(jetConfig.getMetricsConfig()));
 
-
-        MapConfig metadataMapConfig = new MapConfig(INTERNAL_JET_OBJECTS_PREFIX + "*")
+        MapConfig metadataMapConfig = new MapConfig(INTERNAL_JET_OBJECTS_PREFIX + '*')
                 .setBackupCount(jetConfig.getInstanceConfig().getBackupCount())
                 .setStatisticsEnabled(false)
                 .setMergePolicyConfig(
-                        new MergePolicyConfig().setPolicy(IgnoreMergingEntryMapMergePolicy.class.getName()));
+                        new MergePolicyConfig().setPolicy(IgnoreMergingEntryMapMergePolicy.class.getName()))
+                .setHotRestartConfig(new HotRestartConfig().setEnabled(true));
 
         MapConfig resultsMapConfig = new MapConfig(metadataMapConfig)
                 .setName(JOB_RESULTS_MAP_NAME)
                 .setTimeToLiveSeconds(properties.getSeconds(JOB_RESULTS_TTL_SECONDS));
+        resultsMapConfig.getHotRestartConfig().setEnabled(true);
 
-        hzConfig
-                .addMapConfig(metadataMapConfig)
+        hzConfig.addMapConfig(metadataMapConfig)
                 .addMapConfig(resultsMapConfig);
 
         MetricsConfig metricsConfig = jetConfig.getMetricsConfig();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -116,8 +116,6 @@ public class JetService
         ClientEngineImpl clientEngine = engine.getService(ClientEngineImpl.SERVICE_NAME);
         ExceptionUtil.registerJetExceptions(clientEngine.getClientExceptions());
 
-        jobCoordinationService.init();
-
         if (Boolean.parseBoolean(properties.getProperty(SHUTDOWNHOOK_ENABLED.getName()))) {
             logger.finest("Adding Jet shutdown hook");
             Runtime.getRuntime().addShutdownHook(shutdownHookThread);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -287,7 +287,7 @@ public final class Util {
             return;
         }
         if (!(object instanceof Serializable)) {
-            throw new IllegalArgumentException("\"" + objectName + "\" must implement Serializable");
+            throw new IllegalArgumentException('"' + objectName + "\" must implement Serializable");
         }
         try (ObjectOutputStream os = new ObjectOutputStream(new NullOutputStream())) {
             os.writeObject(object);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
@@ -24,7 +24,6 @@ import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JetInstanceImpl;
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.nio.Address;
 
 import java.util.Arrays;
@@ -41,12 +40,7 @@ public class JetTestInstanceFactory {
     }
 
     public JetInstance newMember(JetConfig config) {
-        Jet.configureJetService(config);
-        HazelcastInstanceImpl hazelcastInstance =
-                ((HazelcastInstanceProxy) (factory.newHazelcastInstance(config.getHazelcastConfig()))).getOriginal();
-        JetService jetService = hazelcastInstance.node.nodeEngine.getService(JetService.SERVICE_NAME);
-        jetService.getJobCoordinationService().startScanningForJobs();
-        return new JetInstanceImpl(hazelcastInstance, config);
+        return Jet.newJetInstanceImpl(config, factory::newHazelcastInstance);
     }
 
     public JetInstance newMember(JetConfig config, Address[] blockedAddresses) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
@@ -24,6 +24,7 @@ import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JetInstanceImpl;
+import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.nio.Address;
 
 import java.util.Arrays;
@@ -43,6 +44,8 @@ public class JetTestInstanceFactory {
         Jet.configureJetService(config);
         HazelcastInstanceImpl hazelcastInstance =
                 ((HazelcastInstanceProxy) (factory.newHazelcastInstance(config.getHazelcastConfig()))).getOriginal();
+        JetService jetService = hazelcastInstance.node.nodeEngine.getService(JetService.SERVICE_NAME);
+        jetService.getJobCoordinationService().startScanningForJobs();
         return new JetInstanceImpl(hazelcastInstance, config);
     }
 


### PR DESCRIPTION
JobCoordinationService scans for jobs that aren't running and runs them. Currently the scanning starts in the middle of the Hazelcast service initialization phase, so a job may encounter a partially initialized Hazelcast instance.