### PR TITLE
Fix when_shutDownInProgressFromInit_then_restarts

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
@@ -50,9 +50,7 @@ import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
 import static com.hazelcast.jet.core.BroadcastKey.broadcastKey;
 import static com.hazelcast.jet.core.Edge.between;
-import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
-import static com.hazelcast.jet.core.JobStatus.STARTING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.test.PacketFiltersUtil.delayOperationsFrom;
 import static java.util.Collections.singletonList;
@@ -180,24 +178,13 @@ public class GracefulShutdownTest extends JetTestSupport {
                 singletonList(JetInitDataSerializerHook.NOTIFY_MEMBER_SHUTDOWN_OP));
 
         // initiate a shutdown in the background
-        Future future = spawn(() -> instances[1].shutdown());
+        spawn(() -> instances[1].shutdown());
 
         // submit a job, the init operation should fail with a ShutdownInProgressOperation.
         // Unfortunately, we can't assert that.
         DAG dag = new DAG();
         dag.newVertex("v", (DistributedSupplier<Processor>) StuckProcessor::new);
         Job job = instances[0].newJob(dag);
-
-        while (true) {
-            JobStatus status = job.getStatus();
-            // While the future is not done, the job should remain in NOT_RUNNING or STARTING state.
-            if (future.isDone()) {
-                break;
-            } else {
-                assertTrue("status=" + status, status == NOT_RUNNING || status == STARTING);
-            }
-            sleepMillis(200);
-        }
 
         // after that, the job should become RUNNING
         assertJobStatusEventually(job, JobStatus.RUNNING, 5);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
@@ -187,7 +187,7 @@ public class GracefulShutdownTest extends JetTestSupport {
         Job job = instances[0].newJob(dag);
 
         // after that, the job should become RUNNING
-        assertJobStatusEventually(job, JobStatus.RUNNING, 5);
+        assertJobStatusEventually(job, JobStatus.RUNNING);
     }
 
     @Test


### PR DESCRIPTION
The removed part was racy: it could happen that job status was RUNNING
and the shutdown() call didn't yet return.

Fixes #1118