### PR TITLE
Don't merge touching sessions in SessWP

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SessionWindowPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/SessionWindowPTest.java
@@ -137,6 +137,19 @@ public class SessionWindowPTest {
                 ));
     }
 
+    @Test
+    public void when_sessionsTouch_then_shouldNotBeMerged() {
+        verifyProcessor(supplier)
+                .input(asList(
+                        entry("key", 0L),
+                        entry("key", 10L)
+                ))
+                .expectOutput(asList(
+                        new WindowResult(0, 10, "key", 1L),
+                        new WindowResult(10, 20, "key", 1L)
+                ));
+    }
+
     private void assertCorrectness(List<Object> events) {
         List<Object> expectedOutput = events.stream()
                                                .map(e -> ((Entry<String, Long>) e).getKey())


### PR DESCRIPTION
If two sessions "touch", we currently merge them. Two sessions are 
touching, if when `window1.end == window2.start`. This PR changes the 
behavior to not merge them. Reason: otherwise we'd depend on the order 
of input in edge case.

Example: timeout=2. If input is: `1, wm(3), 3`, the output will be two
sessions: the event 1 creates a session (1, 3) which can be emitted at
wm(3). But if input is: `1, 3, wm(3)`, output would be 1 session (1, 5),
if we merge "touching" sessions. In neither case item 3 is late. The
wm(3) can come at any time depending on exact order in which other
partitions are processed and when the wm is coalesced.

This PR also fixes the case when `saveToSnapshot` is called while in 
`complete` where we didn't prevent creating snapshot while there could 
have been a half-emitted item.