### PR TITLE
Cluster Restart support: graceful cluster state change to PASSIVE

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -25,12 +25,14 @@ import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.MetricsConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
+import com.hazelcast.jet.impl.JetNodeContext;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.metrics.JetMetricsService;
 import com.hazelcast.map.merge.IgnoreMergingEntryMapMergePolicy;
@@ -63,7 +65,8 @@ public final class Jet {
      * Creates a member of the Jet cluster with the given configuration.
      */
     public static JetInstance newJetInstance(JetConfig config) {
-        return newJetInstanceImpl(config, Hazelcast::newHazelcastInstance);
+        return newJetInstanceImpl(config, cfg ->
+                HazelcastInstanceFactory.newHazelcastInstance(cfg, cfg.getInstanceName(), new JetNodeContext()));
     }
 
     /**
@@ -105,7 +108,6 @@ public final class Jet {
         HazelcastInstanceImpl hzImpl = ((HazelcastInstanceProxy) newHzFn.apply(config.getHazelcastConfig()))
                 .getOriginal();
         JetService jetService = hzImpl.node.nodeEngine.getService(JetService.SERVICE_NAME);
-        jetService.getJobCoordinationService().startScanningForJobs();
         return jetService.getJetInstance();
     }
 
@@ -142,12 +144,12 @@ public final class Jet {
                         .setClassName(JetMetricsService.class.getName())
                         .setConfigObject(jetConfig.getMetricsConfig()));
 
-        boolean hotRestartEnabled = hzConfig.getHotRestartPersistenceConfig().isEnabled();
         MapConfig metadataMapConfig = new MapConfig(INTERNAL_JET_OBJECTS_PREFIX + '*')
                 .setBackupCount(jetConfig.getInstanceConfig().getBackupCount())
                 .setStatisticsEnabled(false);
         metadataMapConfig.getMergePolicyConfig().setPolicy(IgnoreMergingEntryMapMergePolicy.class.getName());
-        metadataMapConfig.getHotRestartConfig().setEnabled(hotRestartEnabled);
+        boolean enabled = hzConfig.getHotRestartPersistenceConfig().isEnabled();
+        metadataMapConfig.getHotRestartConfig().setEnabled(enabled);
 
         MapConfig resultsMapConfig = new MapConfig(metadataMapConfig)
                 .setName(JOB_RESULTS_MAP_NAME)

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -113,7 +113,7 @@ public final class Jet {
         return new JetClientInstanceImpl(((HazelcastClientProxy) client).client);
     }
 
-    static void configureJetService(JetConfig jetConfig) {
+    private static void configureJetService(JetConfig jetConfig) {
         Config hzConfig = jetConfig.getHazelcastConfig();
         if (!(hzConfig.getConfigPatternMatcher() instanceof MatchingPointConfigPatternMatcher)) {
             throw new UnsupportedOperationException("Custom config pattern matcher is not supported in Jet");
@@ -152,7 +152,6 @@ public final class Jet {
         MapConfig resultsMapConfig = new MapConfig(metadataMapConfig)
                 .setName(JOB_RESULTS_MAP_NAME)
                 .setTimeToLiveSeconds(properties.getSeconds(JOB_RESULTS_TTL_SECONDS));
-        resultsMapConfig.getHotRestartConfig().setEnabled(hotRestartEnabled);
 
         hzConfig.addMapConfig(metadataMapConfig)
                 .addMapConfig(resultsMapConfig);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetInstanceImpl.java
@@ -44,7 +44,7 @@ public class JetInstanceImpl extends AbstractJetInstance {
     private final NodeEngine nodeEngine;
     private final JetConfig config;
 
-    public JetInstanceImpl(HazelcastInstanceImpl hazelcastInstance, JetConfig config) {
+    JetInstanceImpl(HazelcastInstanceImpl hazelcastInstance, JetConfig config) {
         super(hazelcastInstance);
         this.nodeEngine = hazelcastInstance.node.getNodeEngine();
         this.config = config;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeContext.java
@@ -27,12 +27,12 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 public class JetNodeContext extends DefaultNodeContext {
-    private static final String NODE_EXTENSION_FACTORY_ID = "com.hazelcast.instance.NodeExtension";
-
-    private static final List<String> JET_EXTENSION_PRIORITY_LIST = unmodifiableList(asList(
+    public static final List<String> JET_EXTENSION_PRIORITY_LIST = unmodifiableList(asList(
             "com.hazelcast.jet.impl.JetEnterpriseNodeExtension",
             "com.hazelcast.jet.impl.JetNodeExtension"
     ));
+
+    private static final String NODE_EXTENSION_FACTORY_ID = "com.hazelcast.instance.NodeExtension";
 
     @Override
     public NodeExtension createNodeExtension(Node node) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.instance.DefaultNodeContext;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.instance.NodeExtensionFactory;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+public class JetNodeContext extends DefaultNodeContext {
+    private static final String NODE_EXTENSION_FACTORY_ID = "com.hazelcast.instance.NodeExtension";
+
+    private static final List<String> JET_EXTENSION_PRIORITY_LIST = unmodifiableList(asList(
+            "com.hazelcast.jet.impl.JetEnterpriseNodeExtension",
+            "com.hazelcast.jet.impl.JetNodeExtension"
+    ));
+
+    @Override
+    public NodeExtension createNodeExtension(Node node) {
+        return NodeExtensionFactory.create(node, JET_EXTENSION_PRIORITY_LIST);
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeContext.java
@@ -32,8 +32,6 @@ public class JetNodeContext extends DefaultNodeContext {
             "com.hazelcast.jet.impl.JetNodeExtension"
     ));
 
-    private static final String NODE_EXTENSION_FACTORY_ID = "com.hazelcast.instance.NodeExtension";
-
     @Override
     public NodeExtension createNodeExtension(Node node) {
         return NodeExtensionFactory.create(node, JET_EXTENSION_PRIORITY_LIST);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeExtension.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeExtension.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.DefaultNodeExtension;
+import com.hazelcast.instance.Node;
+
+public class JetNodeExtension extends DefaultNodeExtension {
+    private final NodeExtensionCommon extCommon;
+
+    public JetNodeExtension(Node node) {
+        super(node);
+        extCommon = new NodeExtensionCommon(node);
+    }
+
+    @Override
+    public void afterStart() {
+        super.afterStart();
+        extCommon.afterStart();
+    }
+
+    @Override
+    public void beforeClusterStateChange(ClusterState currState, ClusterState requestedState, boolean isTransient) {
+        super.beforeClusterStateChange(currState, requestedState, isTransient);
+        extCommon.beforeClusterStateChange(requestedState);
+    }
+
+    @Override
+    public void printNodeInfo() {
+        extCommon.printNodeInfo(systemLogger, "");
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeExtension.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetNodeExtension.java
@@ -41,6 +41,12 @@ public class JetNodeExtension extends DefaultNodeExtension {
     }
 
     @Override
+    public void onClusterStateChange(ClusterState newState, boolean isTransient) {
+        super.onClusterStateChange(newState, isTransient);
+        extCommon.onClusterStateChange(newState);
+    }
+
+    @Override
     public void printNodeInfo() {
         extCommon.printNodeInfo(systemLogger, "");
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -158,8 +158,8 @@ public class JetService
 
                       @Override
                       public void onFailure(Throwable t) {
-                          logger.warning("Failed to notify master member that this member is shutting down, will retry in "
-                                  + NOTIFY_MEMBER_SHUTDOWN_DELAY + " seconds", t);
+                          logger.warning("Failed to notify master member that this member is shutting down," +
+                                  " will retry in " + NOTIFY_MEMBER_SHUTDOWN_DELAY + " seconds", t);
                           // recursive call
                           nodeEngine.getExecutionService().schedule(
                                   () -> notifyMasterWeAreShuttingDown(result), NOTIFY_MEMBER_SHUTDOWN_DELAY, SECONDS);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -18,9 +18,7 @@ package com.hazelcast.jet.impl;
 
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.core.ExecutionCallback;
-import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.HazelcastInstanceImpl;
-import com.hazelcast.instance.JetBuildInfo;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.JetConfig;
@@ -121,19 +119,10 @@ public class JetService
             Runtime.getRuntime().addShutdownHook(shutdownHookThread);
         }
 
-        JetBuildInfo jetBuildInfo = BuildInfoProvider.getBuildInfo().getJetBuildInfo();
-        logger.info(String.format("Starting Jet %s (%s - %s)",
-                jetBuildInfo.getVersion(), jetBuildInfo.getBuild(), jetBuildInfo.getRevision()));
         logger.info("Setting number of cooperative threads and default parallelism to "
                 + config.getInstanceConfig().getCooperativeThreadCount());
 
-        logger.info('\n' +
-                "\to   o   o   o---o o---o o     o---o   o   o---o o-o-o        o o---o o-o-o\n" +
-                "\t|   |  / \\     /  |     |     |      / \\  |       |          | |       |  \n" +
-                "\to---o o---o   o   o-o   |     o     o---o o---o   |          | o-o     |  \n" +
-                "\t|   | |   |  /    |     |     |     |   |     |   |      \\   | |       |  \n" +
-                "\to   o o   o o---o o---o o---o o---o o   o o---o   o       o--o o---o   o   ");
-        logger.info("Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.");
+
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -433,7 +433,7 @@ public class JobCoordinationService {
         }
         InternalPartitionServiceImpl partitionService = getInternalPartitionService();
         return partitionService.getPartitionStateManager().isInitialized()
-                && partitionService.isMigrationAllowed()
+                && partitionService.areMigrationTasksAllowed()
                 && !partitionService.hasOnGoingMigrationLocal();
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -179,7 +179,7 @@ public class JobCoordinationService {
     }
 
     public CompletableFuture<Void> prepareForPassiveClusterState() {
-        assertIsMaster("Cannot prepare for passive cluster state from a non-master node");
+        assertIsMaster("Cannot prepare for passive cluster state on a non-master node");
         synchronized (lock) {
             isClusterEnteringPassiveState = true;
             CompletableFuture[] futures = masterContexts

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -445,7 +445,7 @@ public class JobCoordinationService {
     }
 
     boolean shouldStartJobs() {
-        if (!isMaster() || !nodeEngine.isRunning()) {
+        if (!(isMaster() && nodeEngine.isRunning() && !isClusterEnteringPassiveState)) {
             return false;
         }
         // if any of the members is in shutdown process, don't start jobs

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -48,7 +48,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
@@ -65,7 +64,6 @@ import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static com.hazelcast.jet.impl.TerminationMode.CANCEL;
-import static com.hazelcast.jet.impl.TerminationMode.RESTART_GRACEFUL;
 import static com.hazelcast.jet.impl.execution.init.CustomClassLoadedObject.deserializeWithCustomClassLoader;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.JetGroupProperty.JOB_SCAN_PERIOD;
@@ -557,7 +555,7 @@ public class JobCoordinationService {
             return;
         }
 
-        masterContext.ensureSnapshotStarted(executionId);
+        masterContext.beginSnapshot(executionId);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -254,7 +254,7 @@ public class JobCoordinationService {
                     + ", should be " + RUNNING);
         }
 
-        String terminationResult = masterContext.requestTermination(terminationMode).f2();
+        String terminationResult = masterContext.requestTermination(terminationMode).f1();
         if (terminationResult != null) {
             throw new IllegalStateException("Cannot " + terminationMode + ": " + terminationResult);
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -178,12 +178,12 @@ public class JobCoordinationService {
         assertIsMaster("Cannot prepare for passive cluster state on a non-master node");
         synchronized (lock) {
             isClusterEnteringPassiveState = true;
-            CompletableFuture[] futures = masterContexts
-                    .values().stream()
-                    .map(MasterContext::gracefullyTerminate)
-                    .toArray(CompletableFuture[]::new);
-            return CompletableFuture.allOf(futures);
         }
+        CompletableFuture[] futures = masterContexts
+                .values().stream()
+                .map(MasterContext::gracefullyTerminate)
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(futures);
     }
 
     void clusterChangeDone() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -508,7 +508,7 @@ public class JobCoordinationService {
             logger.warning("MasterContext not found to schedule snapshot of " + idToString(jobId));
             return;
         }
-        if (masterContext.completionFuture().isDone() || masterContext.isCancelled()
+        if (masterContext.jobCompletionFuture().isDone() || masterContext.isCancelled()
                 || masterContext.jobStatus() != RUNNING) {
             logger.fine("Not starting snapshot since " + masterContext.jobIdString() + " is done.");
             return;
@@ -645,20 +645,20 @@ public class JobCoordinationService {
         }
 
         if (oldMasterContext != null) {
-            return oldMasterContext.completionFuture();
+            return oldMasterContext.jobCompletionFuture();
         }
 
         // If job is not currently running, it might be that it just completed.
         // Since we've put the MasterContext into the masterContexts map, someone else could
         // have joined to the job in the meantime so we should notify its future.
         if (completeMasterContextIfJobAlreadyCompleted(masterContext)) {
-            return masterContext.completionFuture();
+            return masterContext.jobCompletionFuture();
         }
 
         logger.info("Starting job " + idToString(masterContext.jobId()) + ": " + reason);
         tryStartJob(masterContext);
 
-        return masterContext.completionFuture();
+        return masterContext.jobCompletionFuture();
     }
 
     // If a job result is present, it completes the master context using the job result

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -252,8 +252,10 @@ public class MasterContext {
 
         if (localStatus == SUSPENDED) {
             coordinationService.completeJob(this, System.currentTimeMillis(), new CancellationException());
-        } else if (localStatus == RUNNING || localStatus == STARTING) {
-            handleTermination(mode);
+        } else {
+            if (localStatus == RUNNING || localStatus == STARTING) {
+                handleTermination(mode);
+            }
         }
 
         return true;
@@ -289,7 +291,9 @@ public class MasterContext {
                 break synchronized_block;
             }
 
-            if (!setJobStatusToStarting() || scheduleRestartIfQuorumAbsent() || scheduleRestartIfClusterIsNotSafe()) {
+            if (!setJobStatusToStarting()
+                    || scheduleRestartIfQuorumAbsent()
+                    || scheduleRestartIfClusterIsNotSafe()) {
                 return;
             }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -221,7 +221,7 @@ public class MasterContext {
         return jobExecutionRecord;
     }
 
-    public CompletableFuture<Void> completionFuture() {
+    public CompletableFuture<Void> jobCompletionFuture() {
         return jobCompletionFuture;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -241,10 +241,8 @@ public class MasterContext {
 
         if (localStatus == SUSPENDED) {
             coordinationService.completeJob(this, System.currentTimeMillis(), new CancellationException());
-        } else {
-            if (localStatus == RUNNING || localStatus == STARTING) {
-                handleTermination(mode);
-            }
+        } else if (localStatus == RUNNING || localStatus == STARTING) {
+            handleTermination(mode);
         }
 
         return true;
@@ -505,11 +503,9 @@ public class MasterContext {
         // be safe against it (idempotent).
         if (mode.isWithTerminalSnapshot()) {
             nextSnapshotIsTerminal = true;
-            beginSnapshot(executionId);
-        } else {
-            if (executionInvocationCallback != null) {
-                executionInvocationCallback.cancelInvocations(mode);
-            }
+            ensureSnapshotStarted(executionId);
+        } else if (executionInvocationCallback != null) {
+            executionInvocationCallback.cancelInvocations(mode);
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/NodeExtensionCommon.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/NodeExtensionCommon.java
@@ -66,7 +66,7 @@ class NodeExtensionCommon {
         }
     }
 
-    void onClusterStateChange(ClusterState newState) {
+    void onClusterStateChange(ClusterState ignored) {
         if (jetService != null) {
             jetService.getJobCoordinationService().clusterChangeDone();
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/NodeExtensionCommon.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/NodeExtensionCommon.java
@@ -1,13 +1,34 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.impl;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.instance.JetBuildInfo;
 import com.hazelcast.instance.Node;
+import com.hazelcast.jet.impl.operation.PrepareForPassiveClusterOperation;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import javax.annotation.Nonnull;
 
+import java.util.concurrent.ExecutionException;
+
 import static com.hazelcast.cluster.ClusterState.PASSIVE;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
 
 class NodeExtensionCommon {
     private static final String JET_LOGO =
@@ -31,8 +52,23 @@ class NodeExtensionCommon {
     }
 
     void beforeClusterStateChange(ClusterState requestedState) {
-        if (requestedState == PASSIVE) {
-            jetService.shutDownJobs();
+        if (requestedState != PASSIVE) {
+            return;
+        }
+        jetService.getJobCoordinationService().shutdown();
+        NodeEngineImpl ne = node.nodeEngine;
+        try {
+            ne.getOperationService().createInvocationBuilder(JetService.SERVICE_NAME,
+                    new PrepareForPassiveClusterOperation(), ne.getMasterAddress())
+              .invoke().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw rethrow(e);
+        }
+    }
+
+    void onClusterStateChange(ClusterState newState) {
+        if (jetService != null) {
+            jetService.getJobCoordinationService().clusterChangeDone();
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/NodeExtensionCommon.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/NodeExtensionCommon.java
@@ -1,0 +1,60 @@
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.instance.JetBuildInfo;
+import com.hazelcast.instance.Node;
+import com.hazelcast.logging.ILogger;
+
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.cluster.ClusterState.PASSIVE;
+
+class NodeExtensionCommon {
+    private static final String JET_LOGO =
+            "\to   o   o   o---o o---o o     o---o   o   o---o o-o-o        o o---o o-o-o\n" +
+            "\t|   |  / \\     /  |     |     |      / \\  |       |          | |       |\n" +
+            "\to---o o---o   o   o-o   |     o     o---o o---o   |          | o-o     |\n" +
+            "\t|   | |   |  /    |     |     |     |   |     |   |      \\   | |       |\n" +
+            "\to   o o   o o---o o---o o---o o---o o   o o---o   o       o--o o---o   o";
+    private static final String COPYRIGHT_LINE = "Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.";
+
+    private final Node node;
+    private JetService jetService;
+
+    NodeExtensionCommon(Node node) {
+        this.node = node;
+    }
+
+    void afterStart() {
+        jetService = node.nodeEngine.getService(JetService.SERVICE_NAME);
+        jetService.getJobCoordinationService().startScanningForJobs();
+    }
+
+    void beforeClusterStateChange(ClusterState requestedState) {
+        if (requestedState == PASSIVE) {
+            jetService.shutDownJobs();
+        }
+    }
+
+    void printNodeInfo(ILogger log, String addToProductName) {
+        log.info(versionAndAddressMessage(addToProductName));
+        log.fine(serializationVersionMessage());
+        log.info('\n' + JET_LOGO);
+        log.info(COPYRIGHT_LINE);
+    }
+
+    private String versionAndAddressMessage(@Nonnull String addToName) {
+        JetBuildInfo jetBuildInfo = node.getBuildInfo().getJetBuildInfo();
+        String build = jetBuildInfo.getBuild();
+        String revision = jetBuildInfo.getRevision();
+        if (!revision.isEmpty()) {
+            build += " - " + revision;
+        }
+        return "Hazelcast Jet" + addToName + ' ' + jetBuildInfo.getVersion() +
+                " (" + build + ") starting at " + node.getThisAddress();
+    }
+
+    private String serializationVersionMessage() {
+        return "Configured Hazelcast Serialization version: " + node.getBuildInfo().getSerializationVersion();
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/exception/EnteringPassiveClusterStateException.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/exception/EnteringPassiveClusterStateException.java
@@ -22,8 +22,8 @@ import com.hazelcast.jet.impl.operation.StartExecutionOperation;
 
 /**
  * An exception thrown internally for {@link InitExecutionOperation} and
- * {@link StartExecutionOperation} to indicate that the member is shutting
- * down.
+ * {@link StartExecutionOperation} to indicate that the cluster is entering
+ * passive state.
  */
-public class ShutdownInProgressException extends JetException {
+public class EnteringPassiveClusterStateException extends JetException {
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
@@ -38,6 +38,7 @@ import com.hazelcast.jet.impl.operation.GetJobSummaryListOperation;
 import com.hazelcast.jet.impl.operation.InitExecutionOperation;
 import com.hazelcast.jet.impl.operation.JoinSubmittedJobOperation;
 import com.hazelcast.jet.impl.operation.NotifyMemberShutdownOperation;
+import com.hazelcast.jet.impl.operation.PrepareForPassiveClusterOperation;
 import com.hazelcast.jet.impl.operation.ResumeJobOperation;
 import com.hazelcast.jet.impl.operation.SnapshotOperation;
 import com.hazelcast.jet.impl.operation.SnapshotOperation.SnapshotOperationResult;
@@ -90,6 +91,7 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
     public static final int GET_JOB_SUMMARY_LIST_OP = 32;
     public static final int JOB_SUMMARY = 33;
     public static final int SNAPSHOT_STATS = 34;
+    public static final int PREPARE_FOR_PASSIVE_CLUSTER_OP = 35;
 
     public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(JET_IMPL_DS_FACTORY, JET_IMPL_DS_FACTORY_ID);
 
@@ -177,6 +179,8 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
                     return new GetJobSummaryListOperation();
                 case SNAPSHOT_STATS:
                     return new SnapshotStats();
+                case PREPARE_FOR_PASSIVE_CLUSTER_OP:
+                    return new PrepareForPassiveClusterOperation();
                 default:
                     throw new IllegalArgumentException("Unknown type id " + typeId);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobConfigOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobConfigOperation.java
@@ -19,8 +19,9 @@ package com.hazelcast.jet.impl.operation;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-public class GetJobConfigOperation extends AbstractJobOperation {
+public class GetJobConfigOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
 
     private JobConfig response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
@@ -23,11 +23,14 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
 import java.util.List;
 
-public class GetJobIdsByNameOperation extends Operation implements IdentifiedDataSerializable {
+public class GetJobIdsByNameOperation
+        extends Operation
+        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private String name;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
@@ -21,10 +21,13 @@ import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.util.Set;
 
-public class GetJobIdsOperation extends Operation implements IdentifiedDataSerializable {
+public class GetJobIdsOperation
+        extends Operation
+        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private Set<Long> response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -19,8 +19,9 @@ package com.hazelcast.jet.impl.operation;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-public class GetJobStatusOperation extends AbstractJobOperation {
+public class GetJobStatusOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
 
     private JobStatus response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -18,8 +18,9 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-public class GetJobSubmissionTimeOperation extends AbstractJobOperation {
+public class GetJobSubmissionTimeOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
 
     private long response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
@@ -22,10 +22,13 @@ import com.hazelcast.jet.impl.JobSummary;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.util.List;
 
-public class GetJobSummaryListOperation extends Operation implements IdentifiedDataSerializable {
+public class GetJobSummaryListOperation
+        extends Operation
+        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private List<JobSummary> response;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -28,7 +29,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
  * caller is about to shut down. The master should request termination of all
  * jobs running on caller and then the caller will actually shut down.
  */
-public class NotifyMemberShutdownOperation extends AsyncOperation {
+public class NotifyMemberShutdownOperation extends AsyncOperation implements AllowedDuringPassiveState {
 
     public NotifyMemberShutdownOperation() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.spi.exception.WrongTargetException;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
@@ -34,7 +35,7 @@ public class PrepareForPassiveClusterOperation extends AsyncOperation {
     @Override
     protected void doRun() {
         if (!getNodeEngine().getClusterService().isMaster()) {
-            return;
+            throw new WrongTargetException("I am not the master");
         }
         this.<JetService>getService()
                 .getJobCoordinationService()

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.spi.exception.WrongTargetException;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
@@ -34,9 +33,6 @@ public class PrepareForPassiveClusterOperation extends AsyncOperation {
 
     @Override
     protected void doRun() {
-        if (!getNodeEngine().getClusterService().isMaster()) {
-            throw new WrongTargetException("I am not the master");
-        }
         this.<JetService>getService()
                 .getJobCoordinationService()
                 .prepareForPassiveClusterState()

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
@@ -18,9 +18,6 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.spi.Operation;
-
-import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.operation;
+
+import com.hazelcast.jet.impl.JetService;
+import com.hazelcast.spi.Operation;
+
+/**
+ * Sent from the member that initiates a cluster state change to the master.
+ * When the operation completes, all jobs have been terminated.
+ */
+public class PrepareForPassiveClusterOperation extends Operation {
+
+    public PrepareForPassiveClusterOperation() {
+    }
+
+    @Override
+    public void run() {
+        if (!getNodeEngine().getClusterService().isMaster()) {
+            return;
+        }
+        this.<JetService>getService().getJobCoordinationService().prepareForPassiveClusterState();
+    }
+
+    @Override
+    public Object getResponse() {
+        return "Ready for passive cluster state";
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -27,6 +27,7 @@ import com.hazelcast.jet.RestartableException;
 import com.hazelcast.jet.core.JobNotFoundException;
 import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.datamodel.Tuple3;
+import com.hazelcast.jet.impl.exception.EnteringPassiveClusterStateException;
 import com.hazelcast.jet.impl.exception.ShutdownInProgressException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.exception.CallerNotMemberException;
@@ -72,7 +73,8 @@ public final class ExceptionUtil {
                 || t instanceof TargetNotMemberException
                 || t instanceof CallerNotMemberException
                 || t instanceof HazelcastInstanceNotActiveException
-                || t instanceof ShutdownInProgressException;
+                || t instanceof ShutdownInProgressException
+                || t instanceof EnteringPassiveClusterStateException;
     }
 
     /**

--- a/hazelcast-jet-core/src/main/resources/META-INF/services/com.hazelcast.instance.NodeExtension
+++ b/hazelcast-jet-core/src/main/resources/META-INF/services/com.hazelcast.instance.NodeExtension
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.hazelcast.jet.impl.JetNodeExtension

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
@@ -44,11 +44,7 @@ public class JetTestInstanceFactory {
     }
 
     public JetInstance newMember(JetConfig config, Address[] blockedAddresses) {
-        Jet.configureJetService(config);
-        HazelcastInstanceImpl hazelcastInstance =
-                ((HazelcastInstanceProxy) (factory.newHazelcastInstance(config.getHazelcastConfig(), blockedAddresses)))
-                        .getOriginal();
-        return new JetInstanceImpl(hazelcastInstance, config);
+        return Jet.newJetInstanceImpl(config, hzCfg -> factory.newHazelcastInstance(hzCfg, blockedAddresses));
     }
 
     public JetInstance[] newMembers(JetConfig config, int nodeCount) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
@@ -19,11 +19,8 @@ package com.hazelcast.jet;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.HazelcastInstanceImpl;
-import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
-import com.hazelcast.jet.impl.JetInstanceImpl;
 import com.hazelcast.nio.Address;
 
 import java.util.Arrays;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/JetTestInstanceFactory.java
@@ -22,15 +22,24 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.test.mocknetwork.TestNodeRegistry;
 
 import java.util.Arrays;
 
 import static com.hazelcast.jet.Jet.getJetClientInstance;
+import static com.hazelcast.jet.impl.JetNodeContext.JET_EXTENSION_PRIORITY_LIST;
 import static com.hazelcast.jet.impl.config.XmlJetConfigBuilder.getClientConfig;
 
 public class JetTestInstanceFactory {
 
-    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+    private final TestHazelcastFactory factory = new TestHazelcastFactoryForJet();
+
+    private static class TestHazelcastFactoryForJet extends TestHazelcastFactory {
+        @Override
+        protected TestNodeRegistry createRegistry() {
+            return new TestNodeRegistry(getKnownAddresses(), JET_EXTENSION_PRIORITY_LIST);
+        }
+    }
 
     public JetInstance newMember() {
         return newMember(JetConfig.loadDefault());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.core.Cluster;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.core.TestProcessors.MockPMS;
+import com.hazelcast.jet.core.TestProcessors.MockPS;
+import com.hazelcast.jet.core.TestProcessors.StuckProcessor;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.cluster.ClusterState.ACTIVE;
+import static com.hazelcast.cluster.ClusterState.PASSIVE;
+import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class ClusterStateChangeTest extends JetTestSupport {
+
+    private static final int NODE_COUNT = 3;
+    private static final int LOCAL_PARALLELISM = 4;
+    private static final int TOTAL_PARALLELISM = NODE_COUNT * LOCAL_PARALLELISM;
+
+    private JetInstance[] members;
+    private JetInstance jet;
+    private Cluster cluster;
+    private DAG dag;
+
+    @Before
+    public void before() {
+        TestProcessors.reset(TOTAL_PARALLELISM);
+        JetConfig config = new JetConfig();
+        config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        members = createJetMembers(config, NODE_COUNT);
+        for (JetInstance member : members) {
+            if (!getNodeEngineImpl(member).getClusterService().isMaster()) {
+                jet = member;
+                break;
+            }
+        }
+        cluster = jet.getCluster();
+        dag = new DAG().vertex(new Vertex("test",
+                new MockPMS(() -> new MockPS(StuckProcessor::new, NODE_COUNT))));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void when_clusterPassive_then_jobSubmissionFails() {
+        cluster.changeClusterState(PASSIVE);
+        jet.newJob(dag);
+    }
+
+    @Test
+    public void when_enterPassiveState_then_jobTerminated() throws Exception {
+        // Given
+        Job job = jet.newJob(dag);
+        StuckProcessor.executionStarted.await();
+
+        // When
+        cluster.changeClusterState(PASSIVE);
+
+        // Then
+        assertEquals("Cluster state", PASSIVE, cluster.getClusterState());
+        assertTrue("Processors should get closed", MockPMS.closeCalled.get());
+        assertEquals("Job status", NOT_RUNNING, job.getStatus());
+    }
+
+    @Test
+    public void when_goPassiveAndBack_then_jobResumes() throws Exception {
+        // Given
+        jet.newJob(dag);
+        StuckProcessor.executionStarted.await();
+
+        // When
+        cluster.changeClusterState(PASSIVE);
+        TestProcessors.reset(TOTAL_PARALLELISM);
+        cluster.changeClusterState(ACTIVE);
+
+        // Then
+        assertEquals("Cluster state", ACTIVE, cluster.getClusterState());
+        StuckProcessor.executionStarted.await();
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ClusterStateChangeTest.java
@@ -66,6 +66,7 @@ public class ClusterStateChangeTest extends JetTestSupport {
     @Test(expected = IllegalStateException.class)
     public void when_clusterPassive_then_jobSubmissionFails() {
         cluster.changeClusterState(PASSIVE);
+        assertEquals("Cluster state", PASSIVE, cluster.getClusterState());
         jet.newJob(dag);
     }
 
@@ -80,7 +81,8 @@ public class ClusterStateChangeTest extends JetTestSupport {
 
         // Then
         assertEquals("Cluster state", PASSIVE, cluster.getClusterState());
-        assertTrue("Processors should get closed", MockPMS.closeCalled.get());
+        assertTrue("ProcessorMetaSupplier should get closed", MockPMS.closeCalled.get());
+        assertEquals("ProcessorSupplier should get closed on each member", NODE_COUNT, MockPS.closeCount.get());
         assertEquals("Job status", NOT_RUNNING, job.getStatus());
     }
 
@@ -92,6 +94,7 @@ public class ClusterStateChangeTest extends JetTestSupport {
 
         // When
         cluster.changeClusterState(PASSIVE);
+        assertEquals("Cluster state", PASSIVE, cluster.getClusterState());
         TestProcessors.reset(TOTAL_PARALLELISM);
         cluster.changeClusterState(ACTIVE);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -102,7 +102,7 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
             assertTrueEventually(() -> {
                 MasterContext masterContext = service2.getJobCoordinationService().getMasterContext(jobId);
                 assertNotNull(masterContext);
-                minorityJobFutureRef[0] = masterContext.completionFuture();
+                minorityJobFutureRef[0] = masterContext.jobCompletionFuture();
             });
 
             assertTrueAllTheTime(() -> {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -470,19 +470,15 @@ public class TopologyChangeTest extends JetTestSupport {
         for (JetInstance instance : instances) {
             warmUpPartitions(instance.getHazelcastInstance());
         }
-
         rejectOperationsBetween(instances[0].getHazelcastInstance(), instances[2].getHazelcastInstance(),
                 JetInitDataSerializerHook.FACTORY_ID, singletonList(START_EXECUTION_OP));
 
         DAG dag = new DAG().vertex(new Vertex("test", new MockPS(TestProcessors.Identity::new, nodeCount - 1)));
-
         Job job = instances[0].newJob(dag);
-
         assertJobStatusEventually(job, RUNNING);
 
         // When a participant shuts down during execution
-        instances[2].shutdown();
-
+        instances[2].getHazelcastInstance().getLifecycleService().shutdown();
 
         // Then, the job restarts and successfully completes
         job.join();


### PR DESCRIPTION
In order to gracefully restart a Hazelcast cluster, it must first enter the PASSIVE state. Jet must prepare to enter this state by terminating all the running jobs.

This PR introduces the ability of Jet to prepare for the PASSIVE cluster state.