### PR TITLE
Simplify watermark max gap

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -158,7 +158,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         Vertex generator = dag.newVertex("generator", throttle(sup, 30))
                               .localParallelism(1);
         Vertex insWm = dag.newVertex("insWm", insertWatermarksP(eventTimePolicy(
-                o -> ((Entry<Integer, Integer>) o).getValue(), limitingLag(0), emitByFrame(wDef, Long.MAX_VALUE), -1)))
+                o -> ((Entry<Integer, Integer>) o).getValue(), limitingLag(0), emitByFrame(wDef), -1)))
                           .localParallelism(1);
         Vertex map = dag.newVertex("map",
                 mapP((TimestampedEntry e) -> entry(asList(e.getTimestamp(), (long) (int) e.getKey()), e.getValue())));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Processors_slidingWindowingIntegrationTest.java
@@ -103,7 +103,7 @@ public class Processors_slidingWindowingIntegrationTest extends JetTestSupport {
 
         Vertex source = dag.newVertex("source", () -> new EmitListP(sourceEvents, isBatchLocal)).localParallelism(1);
         Vertex insertPP = dag.newVertex("insertWmP", insertWatermarksP(eventTimePolicy(
-                timestampFn, limitingLagAndLull(500, 1000), emitByFrame(wDef, Long.MAX_VALUE), -1
+                timestampFn, limitingLagAndLull(500, 1000), emitByFrame(wDef), -1
         ))).localParallelism(1);
         Vertex sink = dag.newVertex("sink", SinkProcessors.writeListP("sink"));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkEmissionPolicyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkEmissionPolicyTest.java
@@ -33,7 +33,7 @@ public class WatermarkEmissionPolicyTest {
     private long lastEmittedWm = Long.MIN_VALUE;
 
     @Test
-    public void test_throttleByMinStep() {
+    public void when_wmIncreasing_then_throttleByMinStep() {
         p = emitByMinStep(MIN_STEP);
         assertWm(2, 2);
         assertWm(3, 2);
@@ -45,9 +45,9 @@ public class WatermarkEmissionPolicyTest {
     }
 
     @Test
-    public void test_throttleByFrame_maxStepCloseToMax() {
-        // this tests the possible overflow when calculating with maxStep
+    public void when_wmIncreasing_then_throttleByFrame() {
         p = emitByFrame(tumblingWinPolicy(3));
+        assertWm(Long.MIN_VALUE, Long.MIN_VALUE);
         assertWm(2, 0);
         assertWm(3, 3);
         assertWm(4, 3);
@@ -58,23 +58,8 @@ public class WatermarkEmissionPolicyTest {
         assertWm(15, 15);
     }
 
-    @Test
-    public void test_throttleByFrame_withMaxStep() {
-        // this tests the possible overflow when calculating with maxStep
-        p = emitByFrame(tumblingWinPolicy(5));
-        assertWm(2, 2);
-        assertWm(3, 2);
-        assertWm(4, 4);
-        assertWm(5, 5);
-        assertWm(6, 6);
-        assertWm(13, 12);
-        assertWm(14, 14);
-        assertWm(15, 15);
-    }
-
     private void assertWm(long currentWm, long expectedToEmit) {
-        long newWm = p.throttleWm(currentWm, lastEmittedWm);
-        lastEmittedWm = Math.max(lastEmittedWm, newWm);
+        lastEmittedWm = p.throttleWm(currentWm, lastEmittedWm);
         assertEquals(expectedToEmit, lastEmittedWm);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkEmissionPolicyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkEmissionPolicyTest.java
@@ -46,7 +46,7 @@ public class WatermarkEmissionPolicyTest {
 
     @Test
     public void test_throttleByFrame_noMaxStep() {
-        p = emitByFrame(tumblingWinPolicy(3), Long.MAX_VALUE);
+        p = emitByFrame(tumblingWinPolicy(3));
         assertWm(2, 0);
         assertWm(3, 3);
         assertWm(4, 3);
@@ -60,7 +60,7 @@ public class WatermarkEmissionPolicyTest {
     @Test
     public void test_throttleByFrame_maxStepCloseToMax() {
         // this tests the possible overflow when calculating with maxStep
-        p = emitByFrame(tumblingWinPolicy(3), Long.MAX_VALUE);
+        p = emitByFrame(tumblingWinPolicy(3));
         assertWm(2, 0);
         assertWm(3, 3);
         assertWm(4, 3);
@@ -74,7 +74,7 @@ public class WatermarkEmissionPolicyTest {
     @Test
     public void test_throttleByFrame_withMaxStep() {
         // this tests the possible overflow when calculating with maxStep
-        p = emitByFrame(tumblingWinPolicy(5), 2);
+        p = emitByFrame(tumblingWinPolicy(5));
         assertWm(2, 2);
         assertWm(3, 2);
         assertWm(4, 4);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkEmissionPolicyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/WatermarkEmissionPolicyTest.java
@@ -45,19 +45,6 @@ public class WatermarkEmissionPolicyTest {
     }
 
     @Test
-    public void test_throttleByFrame_noMaxStep() {
-        p = emitByFrame(tumblingWinPolicy(3));
-        assertWm(2, 0);
-        assertWm(3, 3);
-        assertWm(4, 3);
-        assertWm(5, 3);
-        assertWm(6, 6);
-        assertWm(13, 12);
-        assertWm(14, 12);
-        assertWm(15, 15);
-    }
-
-    @Test
     public void test_throttleByFrame_maxStepCloseToMax() {
         // this tests the possible overflow when calculating with maxStep
         p = emitByFrame(tumblingWinPolicy(3));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksPTest.java
@@ -176,7 +176,7 @@ public class InsertWatermarksPTest {
 
     @Test
     public void emitByFrame_when_eventsIncrease_then_wmIncreases() throws Exception {
-        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(2), Long.MAX_VALUE);
+        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(2));
         doTest(
                 asList(
                         item(10),
@@ -198,7 +198,7 @@ public class InsertWatermarksPTest {
 
     @Test
     public void emitByFrame_when_eventsIncreaseAndStartAtVergeOfFrame_then_wmIncreases() throws Exception {
-        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(2), Long.MAX_VALUE);
+        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(2));
         doTest(
                 asList(
                         item(11),
@@ -219,7 +219,7 @@ public class InsertWatermarksPTest {
 
     @Test
     public void emitByFrame_when_eventsNotAtTheVergeOfFrame_then_wmEmittedCorrectly() throws Exception {
-        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(10), Long.MAX_VALUE);
+        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(10));
         doTest(
                 asList(
                         item(14),
@@ -238,7 +238,7 @@ public class InsertWatermarksPTest {
 
     @Test
     public void emitByFrame_when_gapBetweenEvents_then_gapInWms() throws Exception {
-        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(2), Long.MAX_VALUE);
+        wmEmissionPolicy = emitByFrame(tumblingWinPolicy(2));
         doTest(
                 asList(
                         item(11),

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/InsertWatermarksP_IntegrationTest.java
@@ -51,7 +51,7 @@ public class InsertWatermarksP_IntegrationTest extends JetTestSupport {
         DAG dag = new DAG();
         Vertex source = dag.newVertex("source", ListSource.supplier(asList(111L, 222L, 333L)));
         Vertex iwm = dag.newVertex("iwm", Processors.insertWatermarksP(eventTimePolicy(
-                (Long x) -> x, limitingLag(100), emitByFrame(tumblingWinPolicy(100), Long.MAX_VALUE), -1)))
+                (Long x) -> x, limitingLag(100), emitByFrame(tumblingWinPolicy(100)), -1)))
                 .localParallelism(1);
         Vertex mapWmToStr = dag.newVertex("mapWmToStr", MapWatermarksToString::new)
                 .localParallelism(1);


### PR DESCRIPTION
We'll include the maxGap in the gcd calculation. This might be slightly
less efficient with frame sizes that are not multiples of 1000 (1
second), but this is not common and it's not that much worse.