### PR TITLE
Simplify saveToSnapshot contract

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -192,20 +192,15 @@ public interface Processor {
 
     /**
      * Stores its snapshotted state by adding items to the outbox's {@linkplain
-     * Outbox#offerToSnapshot(Object, Object) snapshot bucket}. If it returns
-     * {@code false}, it will be called again before proceeding to call any
-     * other method.
+     * Outbox#offerToSnapshot(Object, Object) snapshot bucket}. If this method
+     * returns {@code false}, it will be called again before proceeding to call
+     * any other method.
      * <p>
      * This method will only be called after a call to {@link #process(int,
-     * Inbox) process()} returns and the inbox is empty. After all the input is
-     * exhausted, it may also be called between {@link #complete()} calls. Once
+     * Inbox) process()} returns with an empty inbox. After all the input is
+     * exhausted, it is also called between {@link #complete()} calls. Once
      * {@code complete()} returns {@code true}, this method won't be called
      * anymore.
-     * <p>
-     * <b>Note:</b> if you returned from {@link #complete()} because some of
-     * the {@code Outbox.offer()} method returned false, you need to make sure
-     * to re-offer the pending item in this method before offering any items to
-     * {@link Outbox#offerToSnapshot}.
      * <p>
      * The default implementation takes no action and returns {@code true}.
      */

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/GracefulShutdownTest.java
@@ -288,7 +288,6 @@ public class GracefulShutdownTest extends JetTestSupport {
         private int counter;
         private int globalIndex;
         private int numItems;
-        private boolean emitSucceeded;
 
         EmitIntegersP(int numItems) {
             this.numItems = numItems;
@@ -301,8 +300,7 @@ public class GracefulShutdownTest extends JetTestSupport {
 
         @Override
         public boolean complete() {
-            emitSucceeded = tryEmit(counter);
-            if (emitSucceeded) {
+            if (tryEmit(counter)) {
                 counter++;
             }
             return counter == numItems;
@@ -310,12 +308,6 @@ public class GracefulShutdownTest extends JetTestSupport {
 
         @Override
         public boolean saveToSnapshot() {
-            if (!emitSucceeded) {
-                complete();
-                if (!emitSucceeded) {
-                    return false;
-                }
-            }
             savedCounters.put(globalIndex, counter);
             return tryEmitToSnapshot(broadcastKey(globalIndex), counter);
         }


### PR DESCRIPTION
The contract of `saveToSnapshot` required to first offer the possibly
half-emitted item to the outbox and only then proceed to emitting to
snapshot. This was a major complication and a gotcha. Also, in case of
batch sources such as `readFileP` if, for whatever reason snapshots are
enabled, it could happen that the outbox rejected the snapshot barrier
offered by the ProcessorTasklet due to an unfinished half-emitted item
(or worse, if assertions were disabled and some output queues won't have
the barrier).

This commit fixes it by adding `OutboxImpl.block()` that would only
allow to offer the unfinished item to the outbox and `ProcessorTasklet`
calls `complete()` until there's no unfinished item in the outbox. This
allows us to remove the requirement from `saveToSnapshot`'s contract.