### PR TITLE
Fix compilation error in config

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetConfigBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetConfigBuilder.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.config.AbstractConfigBuilder;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.DomConfigHelper;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.instance.BuildInfo;
@@ -43,6 +44,8 @@ import java.io.InputStream;
 import java.util.Optional;
 import java.util.Properties;
 
+import static com.hazelcast.config.DomConfigHelper.childElements;
+import static com.hazelcast.config.DomConfigHelper.cleanNodeName;
 import static com.hazelcast.jet.impl.config.XmlJetConfigLocator.getClientConfigStream;
 import static com.hazelcast.jet.impl.config.XmlJetConfigLocator.getJetConfigStream;
 import static com.hazelcast.jet.impl.config.XmlJetConfigLocator.getMemberConfigStream;
@@ -265,5 +268,13 @@ public final class XmlJetConfigBuilder extends AbstractConfigBuilder {
 
     private Optional<Boolean> getBooleanAttribute(Node node, String name) {
         return Optional.ofNullable(node.getAttributes().getNamedItem(name)).map(this::booleanValue);
+    }
+
+    private String getTextContent(Node node) {
+        return DomConfigHelper.getTextContent(node, domLevel3);
+    }
+
+    public void fillProperties(Node node, Properties properties) {
+        DomConfigHelper.fillProperties(node, properties, domLevel3);
     }
 }

--- a/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetInstanceBeanDefinitionParser.java
+++ b/hazelcast-jet-spring/src/main/java/com/hazelcast/jet/spring/JetInstanceBeanDefinitionParser.java
@@ -29,6 +29,8 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
+import static com.hazelcast.config.DomConfigHelper.childElements;
+import static com.hazelcast.config.DomConfigHelper.cleanNodeName;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
 
 /**


### PR DESCRIPTION
Code related to W3C DOM processing has been extracted from the XML
config builder classes in IMDG that, which led to compilation errors in Jet.

This commit fixes these errors by using the extracted methods from the
new DomConfigHelper class.

Depends on https://github.com/hazelcast/hazelcast/pull/14368