### PR TITLE
Improve constantKey perf, fix global aggregation

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -288,9 +288,9 @@ public class Edge implements IdentifiedDataSerializable {
 
     /**
      * Activates a special-cased {@link RoutingPolicy#PARTITIONED PARTITIONED}
-     * routing policy where all items will be assigned the same, randomly
-     * chosen partition ID. Therefore all items will be directed to the same
-     * processor.
+     * routing policy where all items will be routed to the same partition ID,
+     * determined from the given {@code key}. It means that all items will be
+     * directed to the same processor and other processors will be idle.
      */
     @Nonnull
     public Edge allToOne(Object key) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -58,7 +58,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.core.TimestampKind.EVENT;
 import static com.hazelcast.jet.function.DistributedFunction.identity;
-import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static java.util.Collections.nCopies;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -233,7 +232,7 @@ public final class Processors {
     ) {
         // We should use the same constant key as the input edges do, but since
         // the processor doesn't save the state, there's no need to.
-        return () -> new GroupP<>(nCopies(aggrOp.arity(), constantKey("ALL")), aggrOp, (k, r) -> r);
+        return () -> new GroupP<>(nCopies(aggrOp.arity(), t -> "ALL"), aggrOp, (k, r) -> r);
     }
 
     /**
@@ -258,7 +257,7 @@ public final class Processors {
         return () -> new GroupP<>(
                 // We should use the same constant key as the input edges do, but since
                 // the processor doesn't save the state, there's no need to.
-                nCopies(aggrOp.arity(), constantKey("ALL")),
+                nCopies(aggrOp.arity(), t -> "ALL"),
                 aggrOp.withIdentityFinish(),
                 (k, r) -> r);
     }
@@ -287,7 +286,7 @@ public final class Processors {
         return () -> new GroupP<>(
                 // We should use the same constant key as the input edges do, but since
                 // the processor doesn't save the state, there's no need to.
-                constantKey("ALL"),
+                t -> "ALL",
                 aggrOp.withCombiningAccumulateFn(identity()),
                 (k, r) -> r);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -231,7 +231,9 @@ public final class Processors {
     public static <A, R> DistributedSupplier<Processor> aggregateP(
             @Nonnull AggregateOperation<A, R> aggrOp
     ) {
-        return () -> new GroupP<>(nCopies(aggrOp.arity(), constantKey()), aggrOp, (k, r) -> r);
+        // We should use the same constant key as the input edges do, but since
+        // the processor doesn't save the state, there's no need to.
+        return () -> new GroupP<>(nCopies(aggrOp.arity(), constantKey("ALL")), aggrOp, (k, r) -> r);
     }
 
     /**
@@ -254,7 +256,9 @@ public final class Processors {
     @Nonnull
     public static <A, R> DistributedSupplier<Processor> accumulateP(@Nonnull AggregateOperation<A, R> aggrOp) {
         return () -> new GroupP<>(
-                nCopies(aggrOp.arity(), constantKey()),
+                // We should use the same constant key as the input edges do, but since
+                // the processor doesn't save the state, there's no need to.
+                nCopies(aggrOp.arity(), constantKey("ALL")),
                 aggrOp.withIdentityFinish(),
                 (k, r) -> r);
     }
@@ -281,7 +285,9 @@ public final class Processors {
             @Nonnull AggregateOperation<A, R> aggrOp
     ) {
         return () -> new GroupP<>(
-                constantKey(),
+                // We should use the same constant key as the input edges do, but since
+                // the processor doesn't save the state, there's no need to.
+                constantKey("ALL"),
                 aggrOp.withCombiningAccumulateFn(identity()),
                 (k, r) -> r);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.jet.function;
 
+import com.hazelcast.jet.impl.util.ConstantFunction;
+
 import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -24,11 +26,6 @@ import java.util.Map.Entry;
  * Factory methods for several common distributed functions.
  */
 public final class DistributedFunctions {
-
-    /**
-     * The string key returned by {@link #constantKey()}.
-     */
-    public static final String CONSTANT_KEY = "ALL";
 
     private DistributedFunctions() {
     }
@@ -63,15 +60,14 @@ public final class DistributedFunctions {
     }
 
     /**
-     * Returns a function that always evaluates to {@value #CONSTANT_KEY}. This
+     * Returns a function that always evaluates to the given {@code key}. This
      * is useful as a key extractor in group-by operations where no
-     * classification by key is desired. Note, however, that all such
-     * aggregations will run on the same member because they are routed using
-     * the same key. To likely avoid that, use different key for each such step
-     * using {@code t -> "foo"}.
+     * classification by key is desired; in other words, a global group is
+     * used. Choose a random {@code key} so that each global group is handled
+     * by a random member.
      */
     @Nonnull
-    public static <T> DistributedFunction<T, String> constantKey() {
-        return t -> CONSTANT_KEY;
+    public static <T, K> DistributedFunction<T, K> constantKey(K key) {
+        return new ConstantFunction<>(key);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.function;
 
-import com.hazelcast.jet.impl.util.ConstantFunction;
-
 import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -57,17 +55,5 @@ public final class DistributedFunctions {
     @Nonnull
     public static <K, V> DistributedFunction<Entry<K, V>, V> entryValue() {
         return Map.Entry::getValue;
-    }
-
-    /**
-     * Returns a function that always evaluates to the given {@code key}. This
-     * is useful as a key extractor in group-by operations where no
-     * classification by key is desired; in other words, a global group is
-     * used. Choose a random {@code key} so that each global group is handled
-     * by a random member.
-     */
-    @Nonnull
-    public static <T, K> DistributedFunction<T, K> constantKey(K key) {
-        return new ConstantFunction<>(key);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
@@ -19,15 +19,16 @@ package com.hazelcast.jet.function;
 import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.joining;
 
 /**
  * Factory methods for several common distributed functions.
  */
 public final class DistributedFunctions {
+
+    /**
+     * The string key returned by {@link #constantKey()}.
+     */
+    public static final String CONSTANT_KEY = "ALL";
 
     private DistributedFunctions() {
     }
@@ -62,21 +63,12 @@ public final class DistributedFunctions {
     }
 
     /**
-     * Returns a function that always evaluates to the same value. This is
-     * useful as a key extractor in group-by operations where classification
-     * into a single group is desired.
-     * <p>
-     * Each invocation of this method will return a new function that will
-     * return a constant, randomly generated key to improve partition balance.
-     * The key has the form {@code "KEY:<3 random characters>"}
+     * Returns a function that always evaluates to the {@link #CONSTANT_KEY}.
+     * This is useful as a key extractor in group-by operations where no
+     * classification by key is desired.
      */
     @Nonnull
     public static <T> DistributedFunction<T, String> constantKey() {
-        // we use a string of 3 random characters from the range '0' .. 'z'
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        String key = "KEY:" + Stream.generate(() -> String.valueOf((char) ('0' + random.nextInt('z' - '0'))))
-                               .limit(3)
-                               .collect(joining());
-        return t -> key;
+        return t -> CONSTANT_KEY;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
@@ -19,16 +19,15 @@ package com.hazelcast.jet.function;
 import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.joining;
 
 /**
  * Factory methods for several common distributed functions.
  */
 public final class DistributedFunctions {
-
-    /**
-     * The string key returned by {@link #constantKey()}.
-     */
-    public static final String CONSTANT_KEY = "ALL";
 
     private DistributedFunctions() {
     }
@@ -63,12 +62,21 @@ public final class DistributedFunctions {
     }
 
     /**
-     * Returns a function that always evaluates to the {@link #CONSTANT_KEY}.
-     * This is useful as a key extractor in group-by operations where no
-     * classification by key is desired.
+     * Returns a function that always evaluates to the same value. This is
+     * useful as a key extractor in group-by operations where classification
+     * into a single group is desired.
+     * <p>
+     * Each invocation of this method will return a new function that will
+     * return a constant, randomly generated key to improve partition balance.
+     * The key has the form {@code "KEY:<3 random characters>"}
      */
     @Nonnull
     public static <T> DistributedFunction<T, String> constantKey() {
-        return t -> CONSTANT_KEY;
+        // we use a string of 3 random characters from the range '0' .. 'z'
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        String key = "KEY:" + Stream.generate(() -> String.valueOf((char) ('0' + random.nextInt('z' - '0'))))
+                               .limit(3)
+                               .collect(joining());
+        return t -> key;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/function/DistributedFunctions.java
@@ -63,9 +63,12 @@ public final class DistributedFunctions {
     }
 
     /**
-     * Returns a function that always evaluates to the {@link #CONSTANT_KEY}.
-     * This is useful as a key extractor in group-by operations where no
-     * classification by key is desired.
+     * Returns a function that always evaluates to {@value #CONSTANT_KEY}. This
+     * is useful as a key extractor in group-by operations where no
+     * classification by key is desired. Note, however, that all such
+     * aggregations will run on the same member because they are routed using
+     * the same key. To likely avoid that, use different key for each such step
+     * using {@code t -> "foo"}.
      */
     @Nonnull
     public static <T> DistributedFunction<T, String> constantKey() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/TopologicalSorter.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/TopologicalSorter.java
@@ -19,9 +19,11 @@ package com.hazelcast.jet.impl;
 import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Function;
 
 import static com.hazelcast.jet.Util.entry;
@@ -80,6 +82,24 @@ public final class TopologicalSorter<V> {
                                                  .map(tarjanVertices::get)
                                                  .collect(toList())));
         return new TopologicalSorter<>(tarjanAdjacencyMap, vertexNameFn).go();
+    }
+
+    /**
+     * Checks that a collection we assume is topologically sorted actually is
+     * sorted.
+     *
+     * @throws RuntimeException if it's not sorted
+     */
+    public static <V> void checkTopologicalSort(Iterable<Entry<V, List<V>>> adjacencyMap) {
+        Set<V> seen = new HashSet<>();
+        for (Entry<V, List<V>> parentAndChildren : adjacencyMap) {
+            for (V child : parentAndChildren.getValue()) {
+                if (seen.contains(child)) {
+                    throw new RuntimeException("A child seen before its parent");
+                }
+            }
+            seen.add(parentAndChildren.getKey());
+        }
     }
 
     // Partial implementation of Tarjan's algorithm:

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -106,7 +106,7 @@ public class ExecutionContext {
         // available to be completed in the case of init failure
         procSuppliers = unmodifiableList(plan.getProcessorSuppliers());
         processors = plan.getProcessors();
-        snapshotContext = new SnapshotContext(nodeEngine.getLogger(SnapshotContext.class), jobId, jobNameAndExecutionId(),
+        snapshotContext = new SnapshotContext(nodeEngine.getLogger(SnapshotContext.class), jobNameAndExecutionId(),
                 plan.lastSnapshotId(), jobConfig.getProcessingGuarantee());
         plan.initialize(nodeEngine, jobId, executionId, snapshotContext);
         snapshotContext.initTaskletCount(plan.getStoreSnapshotTaskletCount(), plan.getHigherPriorityVertexCount());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -33,7 +33,6 @@ public class SnapshotContext {
 
     private final ILogger logger;
 
-    private final long jobId;
     private final String jobNameAndExecutionId;
     private final ProcessingGuarantee guarantee;
 
@@ -103,10 +102,9 @@ public class SnapshotContext {
     private final AtomicLong totalChunks = new AtomicLong();
     private boolean isCancelled;
 
-    public SnapshotContext(ILogger logger, long jobId, String jobNameAndExecutionId, long activeSnapshotId,
+    public SnapshotContext(ILogger logger, String jobNameAndExecutionId, long activeSnapshotId,
                            ProcessingGuarantee guarantee
     ) {
-        this.jobId = jobId;
         this.jobNameAndExecutionId = jobNameAndExecutionId;
         this.activeSnapshotId = currentSnapshotId = activeSnapshotId;
         this.guarantee = guarantee;
@@ -274,7 +272,7 @@ public class SnapshotContext {
     }
 
     // public-visible for tests
-    public AtomicInteger getNumRemainingTasklets() {
+    AtomicInteger getNumRemainingTasklets() {
         return numRemainingTasklets;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -38,7 +38,6 @@ import com.hazelcast.jet.pipeline.JoinClause;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -132,7 +131,7 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
 
     @Nonnull @Override
     public <R> BatchStage<R> rollingAggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
-        return groupingKey(constantKey(name().hashCode())).rollingAggregate(aggrOp, (k, v) -> v);
+        return attachGlobalRollingAggregate(aggrOp);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -39,6 +39,7 @@ import com.hazelcast.jet.pipeline.JoinClause;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
+import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -132,8 +133,7 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
 
     @Nonnull @Override
     public <R> BatchStage<R> rollingAggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
-        Integer vertexNameHashCode = name().hashCode();
-        return groupingKey(t -> vertexNameHashCode).rollingAggregate(aggrOp, (k, v) -> v);
+        return groupingKey(constantKey(name().hashCode())).rollingAggregate(aggrOp, (k, v) -> v);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -39,7 +39,6 @@ import com.hazelcast.jet.pipeline.JoinClause;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -133,7 +132,8 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
 
     @Nonnull @Override
     public <R> BatchStage<R> rollingAggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
-        return groupingKey(constantKey()).rollingAggregate(aggrOp, (k, v) -> v);
+        Integer vertexNameHashCode = name().hashCode();
+        return groupingKey(t -> vertexNameHashCode).rollingAggregate(aggrOp, (k, v) -> v);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -32,6 +32,7 @@ import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.jet.impl.pipeline.transform.AbstractTransform;
 import com.hazelcast.jet.impl.pipeline.transform.FilterTransform;
 import com.hazelcast.jet.impl.pipeline.transform.FlatMapTransform;
+import com.hazelcast.jet.impl.pipeline.transform.GlobalRollingAggregateTransform;
 import com.hazelcast.jet.impl.pipeline.transform.HashJoinTransform;
 import com.hazelcast.jet.impl.pipeline.transform.MapTransform;
 import com.hazelcast.jet.impl.pipeline.transform.MergeTransform;
@@ -279,6 +280,17 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
                         fnAdapter.adaptKeyFn(keyFn),
                         fnAdapter.adaptAggregateOperation1(aggrOp),
                         fnAdapter.adaptRollingAggregateOutputFn(mapToOutputFn)),
+                fnAdapter);
+    }
+
+    @Nonnull
+    @SuppressWarnings("unchecked")
+    <R, RET> RET attachGlobalRollingAggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
+        GlobalRollingAggregateTransform transform = new GlobalRollingAggregateTransform(
+                this.transform,
+                fnAdapter.adaptAggregateOperation1(aggrOp),
+                fnAdapter.adaptRollingAggregateOutputFn((key, result) -> result));
+        return (RET) attach(transform,
                 fnAdapter);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -38,7 +38,6 @@ import com.hazelcast.jet.pipeline.WindowDefinition;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements StreamStage<T> {
@@ -131,7 +130,7 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
 
     @Nonnull @Override
     public <R> StreamStage<R> rollingAggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
-        return groupingKey(constantKey(name().hashCode())).rollingAggregate(aggrOp, (k, v) -> v);
+        return attachGlobalRollingAggregate(aggrOp);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -39,7 +39,6 @@ import com.hazelcast.jet.pipeline.WindowDefinition;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements StreamStage<T> {
@@ -132,7 +131,8 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
 
     @Nonnull @Override
     public <R> StreamStage<R> rollingAggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
-        return groupingKey(constantKey()).rollingAggregate(aggrOp, (k, v) -> v);
+        Integer vertexNameHashCode = name().hashCode();
+        return groupingKey(t -> vertexNameHashCode).rollingAggregate(aggrOp, (k, v) -> v);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -39,6 +39,7 @@ import com.hazelcast.jet.pipeline.WindowDefinition;
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
+import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
 public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements StreamStage<T> {
@@ -131,8 +132,7 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
 
     @Nonnull @Override
     public <R> StreamStage<R> rollingAggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
-        Integer vertexNameHashCode = name().hashCode();
-        return groupingKey(t -> vertexNameHashCode).rollingAggregate(aggrOp, (k, v) -> v);
+        return groupingKey(constantKey(name().hashCode())).rollingAggregate(aggrOp, (k, v) -> v);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
@@ -73,7 +73,7 @@ public class AggregateTransform<A, R> extends AbstractTransform {
     //                  |   aggregateP   | local parallelism = 1
     //                   ----------------
     private void addToDagSingleStage(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), 1, aggregateP(aggrOp));
+        PlannerVertex pv = p.addVertex(this, name(), 1, aggregateP(aggrOp));
         p.addEdges(this, pv.v, edge -> edge.distributed().allToOne());
     }
 
@@ -95,7 +95,7 @@ public class AggregateTransform<A, R> extends AbstractTransform {
     //                  |    combineP    | local parallelism = 1
     //                   ----------------
     private void addToDagTwoStage(Planner p) {
-        String vertexName = p.uniqueVertexName(name());
+        String vertexName = name();
         Vertex v1 = p.dag.newVertex(vertexName + FIRST_STAGE_VERTEX_NAME_SUFFIX, accumulateP(aggrOp))
                          .localParallelism(localParallelism());
         PlannerVertex pv2 = p.addVertex(this, vertexName, 1, combineP(aggrOp));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
@@ -74,7 +74,7 @@ public class AggregateTransform<A, R> extends AbstractTransform {
     //                   ----------------
     private void addToDagSingleStage(Planner p) {
         PlannerVertex pv = p.addVertex(this, name(), 1, aggregateP(aggrOp));
-        p.addEdges(this, pv.v, edge -> edge.distributed().allToOne());
+        p.addEdges(this, pv.v, edge -> edge.distributed().allToOne(name().hashCode()));
     }
 
     //               ---------       ---------
@@ -100,6 +100,6 @@ public class AggregateTransform<A, R> extends AbstractTransform {
                          .localParallelism(localParallelism());
         PlannerVertex pv2 = p.addVertex(this, vertexName, 1, combineP(aggrOp));
         p.addEdges(this, v1);
-        p.dag.edge(between(v1, pv2.v).distributed().allToOne());
+        p.dag.edge(between(v1, pv2.v).distributed().allToOne(name().hashCode()));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/BatchSourceTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/BatchSourceTransform.java
@@ -46,6 +46,6 @@ public class BatchSourceTransform<T> extends AbstractTransform implements BatchS
 
     @Override
     public void addToDag(Planner p) {
-        p.addVertex(this, p.uniqueVertexName(name()), localParallelism(), metaSupplier);
+        p.addVertex(this, name(), localParallelism(), metaSupplier);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/DistinctTransform.java
@@ -40,7 +40,7 @@ public class DistinctTransform<T, K> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        String vertexName = p.uniqueVertexName(this.name());
+        String vertexName = name();
         Vertex v1 = p.dag.newVertex(vertexName + FIRST_STAGE_VERTEX_NAME_SUFFIX, distinctP(keyFn))
                          .localParallelism(localParallelism());
         PlannerVertex pv2 = p.addVertex(this, vertexName, localParallelism(), distinctP(keyFn));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FilterTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FilterTransform.java
@@ -42,7 +42,7 @@ public class FilterTransform<T> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(), filterP(filterFn()));
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(), filterP(filterFn()));
         p.addEdges(this, pv.v);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/FlatMapTransform.java
@@ -44,7 +44,7 @@ public class FlatMapTransform<T, R> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(), flatMapP(flatMapFn()));
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(), flatMapP(flatMapFn()));
         p.addEdges(this, pv.v);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalRollingAggregateTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalRollingAggregateTransform.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.pipeline.transform;
+
+import com.hazelcast.jet.aggregate.AggregateOperation1;
+import com.hazelcast.jet.function.DistributedTriFunction;
+import com.hazelcast.jet.impl.pipeline.Planner;
+import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
+import com.hazelcast.jet.impl.util.ConstantFunction;
+
+import javax.annotation.Nonnull;
+
+import static com.hazelcast.jet.core.processor.Processors.rollingAggregateP;
+
+public class GlobalRollingAggregateTransform<T, R> extends AbstractTransform {
+    @Nonnull private final AggregateOperation1<? super T, ?, ? extends R> aggrOp;
+    @Nonnull private final DistributedTriFunction<? super T, Integer, ? super R, ? extends R> mapToOutputFn;
+
+    public GlobalRollingAggregateTransform(
+            @Nonnull Transform upstream,
+            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp,
+            @Nonnull DistributedTriFunction<? super T, Integer, ? super R, ? extends R> mapToOutputFn
+    ) {
+        super("rolling-aggregate", upstream);
+        this.aggrOp = aggrOp;
+        this.mapToOutputFn = mapToOutputFn;
+    }
+
+    @Override
+    public void addToDag(Planner p) {
+        ConstantFunction<T, Integer> keyFn = new ConstantFunction<>(name().hashCode());
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(),
+                rollingAggregateP(keyFn, aggrOp, mapToOutputFn));
+        p.addEdges(this, pv.v, edge -> edge.partitioned(keyFn).distributed());
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GroupTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GroupTransform.java
@@ -84,7 +84,7 @@ public class GroupTransform<K, A, R, OUT> extends AbstractTransform {
     //                        | aggregateByKeyP |
     //                         -----------------
     private void addToDagSingleStage(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(),
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(),
                 aggregateByKeyP(groupKeyFns, aggrOp, mapToOutputFn));
         p.addEdges(this, pv.v, (e, ord) -> e.distributed().partitioned(groupKeyFns.get(ord)));
     }
@@ -108,10 +108,9 @@ public class GroupTransform<K, A, R, OUT> extends AbstractTransform {
     //                         ---------------
     private void addToDagTwoStage(Planner p) {
         List<DistributedFunction<?, ? extends K>> groupKeyFns = this.groupKeyFns;
-        String vertexName = p.uniqueVertexName(this.name());
-        Vertex v1 = p.dag.newVertex(vertexName + FIRST_STAGE_VERTEX_NAME_SUFFIX, accumulateByKeyP(groupKeyFns, aggrOp))
+        Vertex v1 = p.dag.newVertex(name() + FIRST_STAGE_VERTEX_NAME_SUFFIX, accumulateByKeyP(groupKeyFns, aggrOp))
                 .localParallelism(localParallelism());
-        PlannerVertex pv2 = p.addVertex(this, vertexName, localParallelism(),
+        PlannerVertex pv2 = p.addVertex(this, name(), localParallelism(),
                 combineByKeyP(aggrOp, mapToOutputFn));
         p.addEdges(this, v1, (e, ord) -> e.partitioned(groupKeyFns.get(ord), HASH_CODE));
         p.dag.edge(between(v1, pv2.v).distributed().partitioned(entryKey()));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
@@ -95,7 +95,6 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
     @Override
     @SuppressWarnings("unchecked")
     public void addToDag(Planner p) {
-        String namePrefix = p.uniqueVertexName(this.name());
         PlannerVertex primary = p.xform2vertex.get(this.upstream().get(0));
         List keyFns = this.clauses.stream()
                                   .map(JoinClause::leftKeyFn)
@@ -104,11 +103,11 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
         List<Tag> tags = this.tags;
         DistributedBiFunction mapToOutputBiFn = this.mapToOutputBiFn;
         DistributedTriFunction mapToOutputTriFn = this.mapToOutputTriFn;
-        Vertex joiner = p.addVertex(this, namePrefix + "-joiner", localParallelism(),
+        Vertex joiner = p.addVertex(this, name() + "-joiner", localParallelism(),
                 () -> new HashJoinP<>(keyFns, tags, mapToOutputBiFn, mapToOutputTriFn)).v;
         p.dag.edge(from(primary.v, primary.nextAvailableOrdinal()).to(joiner, 0));
 
-        String collectorName = namePrefix + "-collector";
+        String collectorName = name() + "-collector";
         int collectorOrdinal = 1;
         for (Transform fromTransform : tailList(this.upstream())) {
             PlannerVertex fromPv = p.xform2vertex.get(fromTransform);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MapTransform.java
@@ -42,7 +42,7 @@ public class MapTransform<T, R> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(), mapP(mapFn()));
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(), mapP(mapFn()));
         p.addEdges(this, pv.v);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MergeTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/MergeTransform.java
@@ -33,7 +33,7 @@ public class MergeTransform<T> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(), mapP(identity()));
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(), mapP(identity()));
         p.addEdges(this, pv.v);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -100,7 +100,7 @@ public final class PartitionedProcessorTransform<T, K> extends ProcessorTransfor
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(), processorSupplier);
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(), processorSupplier);
         p.addEdges(this, pv.v, e -> e.partitioned(partitionKeyFn).distributed());
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
@@ -95,7 +95,7 @@ public class ProcessorTransform extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(), processorSupplier);
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(), processorSupplier);
         p.addEdges(this, pv.v);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/RollingAggregateTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/RollingAggregateTransform.java
@@ -45,7 +45,7 @@ public class RollingAggregateTransform<T, K, R, OUT> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(),
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(),
                 rollingAggregateP(keyFn, aggrOp, mapToOutputFn));
         p.addEdges(this, pv.v, edge -> edge.partitioned(keyFn).distributed());
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SinkTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SinkTransform.java
@@ -49,12 +49,8 @@ public class SinkTransform<T> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        PlannerVertex pv = p.addVertex(
-                this,
-                p.uniqueVertexName(name()),
-                localParallelism(),
-                adaptingMetaSupplier(metaSupplier, ordinalsToAdapt)
-        );
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(),
+                adaptingMetaSupplier(metaSupplier, ordinalsToAdapt));
         p.addEdges(this, pv.v);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/StreamSourceTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/StreamSourceTransform.java
@@ -67,7 +67,7 @@ public class StreamSourceTransform<T> extends AbstractTransform implements Strea
         if (emitsWatermarks || eventTimePolicy == null) {
             // Reached when the source either emits both JetEvents and watermarks
             // or neither. In these cases we don't have to insert watermarks.
-            p.addVertex(this, p.uniqueVertexName(name()), localParallelism(),
+            p.addVertex(this, name(), localParallelism(),
                     metaSupplierFn.apply(eventTimePolicy != null ? eventTimePolicy : noEventTime())
             );
         } else {
@@ -80,7 +80,7 @@ public class StreamSourceTransform<T> extends AbstractTransform implements Strea
             //                  -------------
             //                 |  insertWmP  |
             //                  -------------
-            String v1name = p.uniqueVertexName(name());
+            String v1name = name();
             Vertex v1 = p.dag.newVertex(v1name, metaSupplierFn.apply(eventTimePolicy))
                              .localParallelism(localParallelism());
             PlannerVertex pv2 = p.addVertex(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/TimestampTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/TimestampTransform.java
@@ -43,7 +43,7 @@ public class TimestampTransform<T> extends AbstractTransform {
     public void addToDag(Planner p) {
         @SuppressWarnings("unchecked")
         PlannerVertex pv = p.addVertex(
-                this, p.uniqueVertexName(name()), localParallelism(), insertWatermarksP(eventTimePolicy)
+                this, name(), localParallelism(), insertWatermarksP(eventTimePolicy)
         );
         p.addEdges(this, pv.v);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowAggregateTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowAggregateTransform.java
@@ -97,7 +97,7 @@ public class WindowAggregateTransform<A, R, OUT> extends AbstractTransform {
     //            | aggregateToSlidingWindowP | local parallelism = 1
     //             ---------------------------
     private void addSlidingWindowSingleStage(Planner p, SlidingWindowDef wDef) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), 1,
+        PlannerVertex pv = p.addVertex(this, name(), 1,
                 aggregateToSlidingWindowP(
                         nCopies(aggrOp.arity(), constantKey()),
                         nCopies(aggrOp.arity(), (DistributedToLongFunction<JetEvent>) JetEvent::timestamp),
@@ -127,9 +127,8 @@ public class WindowAggregateTransform<A, R, OUT> extends AbstractTransform {
     //              | combineToSlidingWindowP | local parallelism = 1
     //               -------------------------
     private void addSlidingWindowTwoStage(Planner p, SlidingWindowDef wDef) {
-        String vertexName = p.uniqueVertexName(name());
         SlidingWindowPolicy winPolicy = wDef.toSlidingWindowPolicy();
-        Vertex v1 = p.dag.newVertex(vertexName + FIRST_STAGE_VERTEX_NAME_SUFFIX, accumulateByFrameP(
+        Vertex v1 = p.dag.newVertex(name() + FIRST_STAGE_VERTEX_NAME_SUFFIX, accumulateByFrameP(
                 nCopies(aggrOp.arity(), constantKey()),
                 nCopies(aggrOp.arity(), (DistributedToLongFunction<JetEvent>) JetEvent::timestamp),
                 TimestampKind.EVENT,
@@ -137,7 +136,7 @@ public class WindowAggregateTransform<A, R, OUT> extends AbstractTransform {
                 aggrOp
         ));
         v1.localParallelism(localParallelism());
-        PlannerVertex pv2 = p.addVertex(this, vertexName, 1,
+        PlannerVertex pv2 = p.addVertex(this, name(), 1,
                 combineToSlidingWindowP(winPolicy, aggrOp, mapToOutputFn.toKeyedWindowResultFn()));
         p.addEdges(this, v1);
         p.dag.edge(between(v1, pv2.v).distributed().allToOne());
@@ -156,7 +155,7 @@ public class WindowAggregateTransform<A, R, OUT> extends AbstractTransform {
     //            | aggregateToSessionWindowP | local parallelism = 1
     //             ---------------------------
     private void addSessionWindow(Planner p, SessionWindowDef wDef) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(),
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(),
                 aggregateToSessionWindowP(
                         wDef.sessionTimeout(),
                         nCopies(aggrOp.arity(), (DistributedToLongFunction<JetEvent>) JetEvent::timestamp),

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowGroupTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/WindowGroupTransform.java
@@ -102,7 +102,7 @@ public class WindowGroupTransform<K, R, OUT> extends AbstractTransform {
     //            | aggregateToSlidingWindowP |
     //             ---------------------------
     private void addSlidingWindowSingleStage(Planner p, SlidingWindowDef wDef) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(),
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(),
                 aggregateToSlidingWindowP(
                         keyFns,
                         nCopies(keyFns.size(), (DistributedToLongFunction<JetEvent>) JetEvent::timestamp),
@@ -132,16 +132,15 @@ public class WindowGroupTransform<K, R, OUT> extends AbstractTransform {
     //             | combineToSlidingWindowP |
     //              -------------------------
     private void addSlidingWindowTwoStage(Planner p, SlidingWindowDef wDef) {
-        String vertexName = p.uniqueVertexName(name());
         SlidingWindowPolicy winPolicy = wDef.toSlidingWindowPolicy();
-        Vertex v1 = p.dag.newVertex(vertexName + FIRST_STAGE_VERTEX_NAME_SUFFIX, accumulateByFrameP(
+        Vertex v1 = p.dag.newVertex(name() + FIRST_STAGE_VERTEX_NAME_SUFFIX, accumulateByFrameP(
                 keyFns,
                 nCopies(keyFns.size(), (DistributedToLongFunction<JetEvent>) JetEvent::timestamp),
                 TimestampKind.EVENT,
                 winPolicy,
                 aggrOp));
         v1.localParallelism(localParallelism());
-        PlannerVertex pv2 = p.addVertex(this, vertexName, localParallelism(),
+        PlannerVertex pv2 = p.addVertex(this, name(), localParallelism(),
                 combineToSlidingWindowP(winPolicy, aggrOp, mapToOutputFn));
         p.addEdges(this, v1, (e, ord) -> e.partitioned(keyFns.get(ord), HASH_CODE));
         p.dag.edge(between(v1, pv2.v).distributed().partitioned(entryKey()));
@@ -160,7 +159,7 @@ public class WindowGroupTransform<K, R, OUT> extends AbstractTransform {
     //            | aggregateToSessionWindowP |
     //             ---------------------------
     private void addSessionWindow(Planner p, SessionWindowDef wDef) {
-        PlannerVertex pv = p.addVertex(this, p.uniqueVertexName(name()), localParallelism(),
+        PlannerVertex pv = p.addVertex(this, name(), localParallelism(),
                 aggregateToSessionWindowP(
                         wDef.sessionTimeout(),
                         nCopies(keyFns.size(), (DistributedToLongFunction<JetEvent>) JetEvent::timestamp),

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ConstantFunction.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ConstantFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ConstantFunction.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ConstantFunction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.jet.function.DistributedFunction;
+
+/**
+ * A function returning a constant.
+ * <p>
+ * This is a trivial lambda, but we want to be able to do instanceof check on
+ * it to be able to do some optimizations.
+ */
+public class ConstantFunction<T, R> implements DistributedFunction<T, R> {
+    private final R key;
+
+    public ConstantFunction(R key) {
+        this.key = key;
+    }
+
+    @Override
+    public R applyEx(T t) {
+        return key;
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.aggregate.AggregateOperation2;
 import com.hazelcast.jet.aggregate.AggregateOperation3;
+import com.hazelcast.jet.aggregate.AggregateOperations;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.datamodel.Tuple3;
@@ -122,7 +123,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
             @Nonnull String mapName,
             @Nonnull DistributedBiFunction<? super IMap<K, V>, ? super T, ? extends CompletableFuture<R>> mapFn
     ) {
-        return (BatchStage<R>) GeneralStage.super.<K, V, R>mapUsingIMapAsync(mapName, mapFn);
+        return (BatchStage<R>) GeneralStage.super.mapUsingIMapAsync(mapName, mapFn);
     }
 
     @Override @Nonnull
@@ -130,7 +131,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
             @Nonnull IMap<K, V> iMap,
             @Nonnull DistributedBiFunction<? super IMap<K, V>, ? super T, ? extends CompletableFuture<R>> mapFn
     ) {
-        return (BatchStage<R>) GeneralStage.super.<K, V, R>mapUsingIMapAsync(iMap, mapFn);
+        return (BatchStage<R>) GeneralStage.super.mapUsingIMapAsync(iMap, mapFn);
     }
 
     @Nonnull @Override
@@ -184,7 +185,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * Attaches a stage that performs the given aggregate operation over all
      * the items it receives. The aggregating stage emits a single item.
      *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
+     * @see AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
      * @param <R> the type of the result
      */
@@ -209,7 +210,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * <p>
      * The returned stage emits a single item.
      *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
+     * @see AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
      * @param <T1> type of items in {@code stage1}
      * @param <R> type of the result
@@ -286,7 +287,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * <p>
      * The aggregating stage emits a single item.
      *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
+     * @see AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
      * @param <T1> type of items in {@code stage1}
      * @param <T2> type of items in {@code stage2}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
@@ -147,9 +147,8 @@ public class WordCountTest extends HazelcastTestSupport implements Serializable 
     @Ignore
     public void testAggregations() {
         final Map<String, Long>[] counts = new Map[1];
-        benchmark("aggregations", () -> {
-            counts[0] = instance.<Integer, String>getMap("words").aggregate(new WordCountAggregator());
-        });
+        benchmark("aggregations", () ->
+                counts[0] = instance.<Integer, String>getMap("words").aggregate(new WordCountAggregator()));
         assertCounts(counts[0]);
     }
 
@@ -202,7 +201,7 @@ public class WordCountTest extends HazelcastTestSupport implements Serializable 
 
         dag.edge(between(source, mapReduce))
            .edge(between(mapReduce, combineLocal))
-           .edge(between(combineLocal, combineGlobal).distributed().allToOne())
+           .edge(between(combineLocal, combineGlobal).distributed().allToOne("ALL"))
            .edge(between(combineGlobal, sink));
 
         benchmark("jet", () -> instance.newJob(dag).join());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/EdgeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/EdgeTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.core.Edge.RoutingPolicy;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 public class EdgeTest {
     private static final String A = "a";
     private static final String B = "b";
@@ -155,7 +155,7 @@ public class EdgeTest {
         final int mockPartitionCount = 100;
 
         // When
-        e.allToOne();
+        e.allToOne("key");
         final Partitioner partitioner = e.getPartitioner();
         assertNotNull(partitioner);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
@@ -16,22 +16,21 @@
 
 package com.hazelcast.jet.function;
 
-import com.google.common.base.Objects;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.function.DistributedFunctions.CONSTANT_KEY;
+import static com.hazelcast.jet.function.DistributedPredicate.alwaysFalse;
+import static com.hazelcast.jet.function.DistributedPredicate.alwaysTrue;
 import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryValue;
 import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
-import static com.hazelcast.jet.function.DistributedPredicate.alwaysFalse;
-import static com.hazelcast.jet.function.DistributedPredicate.alwaysTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class DistributedFunctionsTest extends HazelcastTestSupport {
@@ -59,19 +58,7 @@ public class DistributedFunctionsTest extends HazelcastTestSupport {
 
     @Test
     public void when_constantKey() {
-        DistributedFunction<Object, String> f = constantKey();
-        assertEquals(f.apply(1), f.apply(2));
-        assertEquals(f.apply(1), f.apply(3));
-    }
-
-    @Test
-    public void when_constantKeyCalledTwice_then_constantKeyLikelyDifferent() {
-        for (int i = 0; i < 10; i++) {
-            if (!Objects.equal(constantKey().apply(1), constantKey().apply(1))) {
-                return;
-            }
-        }
-        fail("10 calls generated the same key, this is extremely unlikely");
+        assertEquals(CONSTANT_KEY, constantKey().apply(1));
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
@@ -22,7 +22,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.Util.entry;
-import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryValue;
 import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
@@ -53,12 +52,6 @@ public class DistributedFunctionsTest extends HazelcastTestSupport {
     @Test
     public void when_entryValue() {
         assertEquals(2, entryValue().apply(entry(1, 2)));
-    }
-
-    @Test
-    public void when_constantKey() {
-        String key = "ALL";
-        assertEquals(key, constantKey(key).apply(1));
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
@@ -16,23 +16,22 @@
 
 package com.hazelcast.jet.function;
 
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.Util.entry;
-import static com.hazelcast.jet.function.DistributedFunctions.CONSTANT_KEY;
-import static com.hazelcast.jet.function.DistributedPredicate.alwaysFalse;
-import static com.hazelcast.jet.function.DistributedPredicate.alwaysTrue;
 import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryValue;
 import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
+import static com.hazelcast.jet.function.DistributedPredicate.alwaysFalse;
+import static com.hazelcast.jet.function.DistributedPredicate.alwaysTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 public class DistributedFunctionsTest extends HazelcastTestSupport {
 
     @Test
@@ -58,7 +57,8 @@ public class DistributedFunctionsTest extends HazelcastTestSupport {
 
     @Test
     public void when_constantKey() {
-        assertEquals(CONSTANT_KEY, constantKey().apply(1));
+        String key = "ALL";
+        assertEquals(key, constantKey(key).apply(1));
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/function/DistributedFunctionsTest.java
@@ -16,21 +16,22 @@
 
 package com.hazelcast.jet.function;
 
+import com.google.common.base.Objects;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.Util.entry;
-import static com.hazelcast.jet.function.DistributedFunctions.CONSTANT_KEY;
-import static com.hazelcast.jet.function.DistributedPredicate.alwaysFalse;
-import static com.hazelcast.jet.function.DistributedPredicate.alwaysTrue;
 import static com.hazelcast.jet.function.DistributedFunctions.constantKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryKey;
 import static com.hazelcast.jet.function.DistributedFunctions.entryValue;
 import static com.hazelcast.jet.function.DistributedFunctions.wholeItem;
+import static com.hazelcast.jet.function.DistributedPredicate.alwaysFalse;
+import static com.hazelcast.jet.function.DistributedPredicate.alwaysTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class DistributedFunctionsTest extends HazelcastTestSupport {
@@ -58,7 +59,19 @@ public class DistributedFunctionsTest extends HazelcastTestSupport {
 
     @Test
     public void when_constantKey() {
-        assertEquals(CONSTANT_KEY, constantKey().apply(1));
+        DistributedFunction<Object, String> f = constantKey();
+        assertEquals(f.apply(1), f.apply(2));
+        assertEquals(f.apply(1), f.apply(3));
+    }
+
+    @Test
+    public void when_constantKeyCalledTwice_then_constantKeyLikelyDifferent() {
+        for (int i = 0; i < 10; i++) {
+            if (!Objects.equal(constantKey().apply(1), constantKey().apply(1))) {
+                return;
+            }
+        }
+        fail("10 calls generated the same key, this is extremely unlikely");
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -195,7 +195,7 @@ public class ProcessorTaskletTest_Snapshots {
         for (int i = 0; i < instreams.size(); i++) {
             instreams.get(i).setOrdinal(i);
         }
-        snapshotContext = new SnapshotContext(mock(ILogger.class), 1, "test job", -1, guarantee);
+        snapshotContext = new SnapshotContext(mock(ILogger.class), "test job", -1, guarantee);
         snapshotContext.initTaskletCount(1, 0);
         final ProcessorTasklet t = new ProcessorTasklet(context, serializationService, processor, instreams, outstreams,
                 snapshotContext, snapshotCollector, null);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Watermarks.java
@@ -265,7 +265,7 @@ public class ProcessorTaskletTest_Watermarks {
         for (int i = 0; i < instreams.size(); i++) {
             instreams.get(i).setOrdinal(i);
         }
-        SnapshotContext snapshotContext = new SnapshotContext(mock(ILogger.class), 1, "test job", -1, EXACTLY_ONCE);
+        SnapshotContext snapshotContext = new SnapshotContext(mock(ILogger.class), "test job", -1, EXACTLY_ONCE);
         snapshotContext.initTaskletCount(1, 0);
         final ProcessorTasklet t = new ProcessorTasklet(context, new DefaultSerializationServiceBuilder().build(),
                 processor, instreams, outstreams, snapshotContext, snapshotCollector, null);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextSimpleTest.java
@@ -40,7 +40,7 @@ public class SnapshotContextSimpleTest {
     public ExpectedException exception = ExpectedException.none();
 
     private SnapshotContext ssContext =
-            new SnapshotContext(mock(ILogger.class), 1, "test job", 9, ProcessingGuarantee.EXACTLY_ONCE);
+            new SnapshotContext(mock(ILogger.class), "test job", 9, ProcessingGuarantee.EXACTLY_ONCE);
 
     @Test
     public void when_cancelledInitially_then_cannotStartNewSnapshot() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/SnapshotContextTest.java
@@ -76,7 +76,7 @@ public class SnapshotContextTest {
     @Test
     public void test_snapshotStartedAndDone() {
         SnapshotContext ssContext =
-                new SnapshotContext(mock(ILogger.class), 1, "test job", 9, ProcessingGuarantee.EXACTLY_ONCE);
+                new SnapshotContext(mock(ILogger.class), "test job", 9, ProcessingGuarantee.EXACTLY_ONCE);
 
         ssContext.initTaskletCount(taskletCount, numHigherPriority);
         CompletableFuture<SnapshotOperationResult> future = null;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
@@ -61,7 +61,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
     private MockAsyncSnapshotWriter mockSsWriter;
 
     private void init(List<Object> inputData) {
-        ssContext = new SnapshotContext(Logger.getLogger(SnapshotContext.class), 1, "test job", 1,
+        ssContext = new SnapshotContext(Logger.getLogger(SnapshotContext.class), "test job", 1,
                 ProcessingGuarantee.EXACTLY_ONCE);
         ssContext.initTaskletCount(1, 0);
         inputData = new ArrayList<>(inputData);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/Processors_globalAggregationIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/Processors_globalAggregationIntegrationTest.java
@@ -25,9 +25,7 @@ import com.hazelcast.jet.core.TestProcessors.ListSource;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelTest;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -46,7 +44,6 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
-@Category(ParallelTest.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 public class Processors_globalAggregationIntegrationTest extends JetTestSupport {
 
@@ -77,7 +74,7 @@ public class Processors_globalAggregationIntegrationTest extends JetTestSupport 
             Vertex aggregate = dag.newVertex("aggregate", Processors.aggregateP(summingOp))
                     .localParallelism(1);
             dag
-                    .edge(between(source, aggregate).distributed().allToOne())
+                    .edge(between(source, aggregate).distributed().allToOne("foo"))
                     .edge(between(aggregate, sink).isolated());
 
         } else {
@@ -85,7 +82,7 @@ public class Processors_globalAggregationIntegrationTest extends JetTestSupport 
             Vertex combine = dag.newVertex("combine", combineP(summingOp)).localParallelism(1);
             dag
                     .edge(between(source, accumulate))
-                    .edge(between(accumulate, combine).distributed().allToOne())
+                    .edge(between(accumulate, combine).distributed().allToOne("foo"))
                     .edge(between(combine, sink).isolated());
         }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
@@ -34,6 +34,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.impl.util.Util.addClamped;
+import static com.hazelcast.jet.impl.util.Util.addOrIncrementIndexInName;
 import static com.hazelcast.jet.impl.util.Util.gcd;
 import static com.hazelcast.jet.impl.util.Util.memoizeConcurrent;
 import static com.hazelcast.jet.impl.util.Util.subtractClamped;
@@ -140,5 +141,19 @@ public class UtilTest extends JetTestSupport {
         logger.info("Done copying");
 
         assertEquals(testData, new HashMap<>(instances[0].getMap("target")));
+    }
+
+    @Test
+    public void test_addIndexToName() {
+        assertEquals("a-2", addOrIncrementIndexInName("a"));
+        assertEquals("a-3", addOrIncrementIndexInName("a-2"));
+        assertEquals("a-26", addOrIncrementIndexInName("a-25"));
+        assertEquals("a-25x-2", addOrIncrementIndexInName("a-25x"));
+        assertEquals("a-1351318168168168168168-2", addOrIncrementIndexInName("a-1351318168168168168168"));
+        assertEquals("a-" + Integer.MAX_VALUE + "-2", addOrIncrementIndexInName("a-" + Integer.MAX_VALUE));
+        assertEquals("a-0-2", addOrIncrementIndexInName("a-0"));
+        assertEquals("a-1-2", addOrIncrementIndexInName("a-1"));
+        assertEquals("a-1-3", addOrIncrementIndexInName("a-1-2"));
+        assertEquals("a--1-2", addOrIncrementIndexInName("a--1"));
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
@@ -346,7 +346,7 @@ public class BatchStageTest extends PipelineTestSupport {
     }
 
     @Test
-    public void rollingAggregate() {
+    public void rollingAggregate_global() {
         // Given
         List<Integer> input = sequence(itemCount);
         putToBatchSrcMap(input);


### PR DESCRIPTION
Each invocation of constantKey() will return a different function
instance, that constantly returns a random key.

Fixes #1240