### PR TITLE
Override initialSnapshotName and jobName only if they are passed as an argument to the cli

### DIFF
--- a/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetBootstrap.java
+++ b/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetBootstrap.java
@@ -212,8 +212,12 @@ public final class JetBootstrap {
             if (jarName != null) {
                 config.addJar(jarName);
             }
-            config.setInitialSnapshotName(snapshotName);
-            config.setName(jobName);
+            if (snapshotName != null) {
+                config.setInitialSnapshotName(snapshotName);
+            }
+            if (jobName != null) {
+                config.setName(jobName);
+            }
             return config;
         }
 


### PR DESCRIPTION
fixes #1245 