### PR TITLE
Move processingGuarantee up from Processor.Context

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetException;
-import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
@@ -297,17 +296,5 @@ public interface Processor {
          * The value is in the range {@code [0...totalParallelism-1]}.
          */
         int globalProcessorIndex();
-
-        /**
-         * Returns true, if snapshots will be saved for this job.
-         */
-        default boolean snapshottingEnabled() {
-            return processingGuarantee() != ProcessingGuarantee.NONE;
-        }
-
-        /**
-         * Returns the guarantee for current job.
-         */
-        ProcessingGuarantee processingGuarantee();
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorMetaSupplier.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.function.DistributedFunction;
 import com.hazelcast.jet.function.DistributedSupplier;
 import com.hazelcast.logging.ILogger;
@@ -372,6 +373,17 @@ public interface ProcessorMetaSupplier extends Serializable {
          */
         @Nonnull
         ILogger logger();
-    }
 
+        /**
+         * Returns true, if snapshots will be saved for this job.
+         */
+        default boolean snapshottingEnabled() {
+            return processingGuarantee() != ProcessingGuarantee.NONE;
+        }
+
+        /**
+         * Returns the guarantee for current job.
+         */
+        ProcessingGuarantee processingGuarantee();
+    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorContext.java
@@ -30,7 +30,6 @@ public class TestProcessorContext extends TestProcessorSupplierContext implement
 
     private int localProcessorIndex;
     private int globalProcessorIndex;
-    private ProcessingGuarantee processingGuarantee = ProcessingGuarantee.NONE;
 
     /**
      * Constructor with default values.
@@ -70,20 +69,6 @@ public class TestProcessorContext extends TestProcessorSupplierContext implement
         return this;
     }
 
-    @Override
-    public ProcessingGuarantee processingGuarantee() {
-        return processingGuarantee;
-    }
-
-    /**
-     * Sets the processing guarantee.
-     */
-    @Nonnull
-    public TestProcessorContext setProcessingGuarantee(ProcessingGuarantee processingGuarantee) {
-        this.processingGuarantee = processingGuarantee;
-        return this;
-    }
-
     @Nonnull @Override
     public TestProcessorContext setLogger(@Nonnull ILogger logger) {
         return (TestProcessorContext) super.setLogger(logger);
@@ -107,6 +92,11 @@ public class TestProcessorContext extends TestProcessorSupplierContext implement
     @Nonnull @Override
     public TestProcessorContext setVertexName(@Nonnull String vertexName) {
         return (TestProcessorContext) super.setVertexName(vertexName);
+    }
+
+    @Nonnull @Override
+    public TestProcessorContext setProcessingGuarantee(ProcessingGuarantee processingGuarantee) {
+        return (TestProcessorContext) super.setProcessingGuarantee(processingGuarantee);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorMetaSupplierContext.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.core.test;
 
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -39,6 +40,7 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
     private int totalParallelism = 1;
     private int localParallelism = 1;
     private String vertexName = "testVertex";
+    private ProcessingGuarantee processingGuarantee;
 
     @Nonnull @Override
     public JetInstance jetInstance() {
@@ -160,5 +162,19 @@ public class TestProcessorMetaSupplierContext implements ProcessorMetaSupplier.C
 
     protected String loggerName() {
         return vertexName() + "#PMS";
+    }
+
+    @Override
+    public ProcessingGuarantee processingGuarantee() {
+        return processingGuarantee;
+    }
+
+    /**
+     * Sets the processing guarantee.
+     */
+    @Nonnull
+    public TestProcessorMetaSupplierContext setProcessingGuarantee(ProcessingGuarantee processingGuarantee) {
+        this.processingGuarantee = processingGuarantee;
+        return this;
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.core.test;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.logging.ILogger;
 
@@ -54,6 +55,11 @@ public class TestProcessorSupplierContext
     @Nonnull @Override
     public TestProcessorSupplierContext setLocalParallelism(int localParallelism) {
         return (TestProcessorSupplierContext) super.setLocalParallelism(localParallelism);
+    }
+
+    @Nonnull @Override
+    public TestProcessorSupplierContext setProcessingGuarantee(ProcessingGuarantee processingGuarantee) {
+        return (TestProcessorSupplierContext) super.setProcessingGuarantee(processingGuarantee);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -41,9 +41,11 @@ public final class Contexts {
         private final int localParallelism;
         private final int totalParallelism;
         private final int memberCount;
+        private final ProcessingGuarantee processingGuarantee;
 
         MetaSupplierCtx(JetInstance jetInstance, long jobId, long executionId, JobConfig jobConfig, ILogger logger,
-                        String vertexName, int localParallelism, int totalParallelism, int memberCount) {
+                        String vertexName, int localParallelism, int totalParallelism, int memberCount,
+                        ProcessingGuarantee processingGuarantee) {
             this.jetInstance = jetInstance;
             this.jobId = jobId;
             this.executionId = executionId;
@@ -53,6 +55,7 @@ public final class Contexts {
             this.totalParallelism = totalParallelism;
             this.localParallelism = localParallelism;
             this.memberCount = memberCount;
+            this.processingGuarantee = processingGuarantee;
         }
 
         @Nonnull
@@ -100,17 +103,24 @@ public final class Contexts {
         public ILogger logger() {
             return logger;
         }
+
+        @Override
+        public ProcessingGuarantee processingGuarantee() {
+            return processingGuarantee;
+        }
     }
 
     static class ProcSupplierCtx extends MetaSupplierCtx implements ProcessorSupplier.Context {
 
         private final int memberIndex;
 
+        @SuppressWarnings("checkstyle:ParameterNumber")
         ProcSupplierCtx(
                 JetInstance jetInstance, long jobId, long executionId, JobConfig jobConfig, ILogger logger,
-                String vertexName, int localParallelism, int totalParallelism, int memberIndex, int memberCount) {
+                String vertexName, int localParallelism, int totalParallelism, int memberIndex, int memberCount,
+                ProcessingGuarantee processingGuarantee) {
             super(jetInstance, jobId, executionId, jobConfig, logger, vertexName, localParallelism, totalParallelism,
-                    memberCount);
+                    memberCount, processingGuarantee);
             this.memberIndex = memberIndex;
         }
 
@@ -124,7 +134,6 @@ public final class Contexts {
 
         private final int localProcessorIndex;
         private final int globalProcessorIndex;
-        private final ProcessingGuarantee processingGuarantee;
 
         @SuppressWarnings("checkstyle:ParameterNumber")
         public ProcCtx(JetInstance instance, long jobId, long executionId, JobConfig jobConfig,
@@ -132,10 +141,9 @@ public final class Contexts {
                        int globalProcessorIndex, ProcessingGuarantee processingGuarantee, int localParallelism,
                        int memberIndex, int memberCount) {
             super(instance, jobId, executionId, jobConfig, logger, vertexName, localParallelism,
-                    memberCount * localParallelism, memberIndex, memberCount);
+                    memberCount * localParallelism, memberIndex, memberCount, processingGuarantee);
             this.localProcessorIndex = localProcessorIndex;
             this.globalProcessorIndex = globalProcessorIndex;
-            this.processingGuarantee = processingGuarantee;
         }
 
         @Override
@@ -146,11 +154,6 @@ public final class Contexts {
         @Override
         public int globalProcessorIndex() {
             return globalProcessorIndex;
-        }
-
-        @Override
-        public ProcessingGuarantee processingGuarantee() {
-            return processingGuarantee;
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -321,7 +321,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                         vertex.localParallelism(),
                         vertex.localParallelism() * memberCount,
                         memberIndex,
-                        memberCount
+                        memberCount,
+                        jobConfig.getProcessingGuarantee()
                 ));
             } catch (Exception e) {
                 throw sneakyThrow(e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlanBuilder.java
@@ -89,7 +89,8 @@ public final class ExecutionPlanBuilder {
                     metaSupplier.getClass().getName(), vertex.getName()));
             try {
                 metaSupplier.init(new MetaSupplierCtx(instance, jobId, executionId, jobConfig, logger,
-                        vertex.getName(), localParallelism, totalParallelism, clusterSize));
+                        vertex.getName(), localParallelism, totalParallelism, clusterSize,
+                        jobConfig.getProcessingGuarantee()));
             } catch (Exception e) {
                 throw sneakyThrow(e);
             }


### PR DESCRIPTION
Method `processingGuarantee()` was available only in `Processor.Context`,
but this information is available up in `ProcessorMetaSupplier.Context`,
it should be there.