### PR TITLE
Add run-until-output-matches mode to TestSupport

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MigrationWatcher.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MigrationWatcher.java
@@ -44,7 +44,7 @@ public class MigrationWatcher {
      */
     public BooleanSupplier createWatcher() {
         int startChangeCount = changeCount.get();
-        return () -> changeCount.get() - startChangeCount > 0; // this is overflow-safe
+        return () -> changeCount.get() != startChangeCount;
     }
 
     public void deregister() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -269,6 +269,14 @@ public final class Util {
                 : sum;
     }
 
+    /**
+     * Calculates {@code a - b}, returns {@code Long.MAX_VALUE} if the result
+     * would overflow
+     *
+     * @param a the amount
+     * @param b the value to subtract
+     * @return {@code a - b}, clamped
+     */
     public static long subtractClamped(long a, long b) {
         long diff = a - b;
         return diffHadOverflow(a, b, diff)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalPTest.java
@@ -102,7 +102,7 @@ public class StreamEventJournalPTest extends JetTestSupport {
 
         TestSupport.verifyProcessor(supplier)
                    .disableProgressAssertion() // no progress assertion because of async calls
-                   .disableRunUntilCompleted(1000) // processor would never complete otherwise
+                   .runUntilOutputMatches(60_000, 100)
                    .outputChecker(SAME_ITEMS_ANY_ORDER) // ordering is only per partition
                    .expectOutput(Arrays.asList(0, 1, 2, 3));
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalP_WmCoalescingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamEventJournalP_WmCoalescingTest.java
@@ -89,7 +89,7 @@ public class StreamEventJournalP_WmCoalescingTest extends JetTestSupport {
 
         TestSupport.verifyProcessor(createSupplier(asList(0, 1), 2000))
                    .disableProgressAssertion()
-                   .disableRunUntilCompleted(1000)
+                   .runUntilOutputMatches(60_000, 100)
                    .disableSnapshots()
                    .expectOutput(asList(wm(10), 10, 10));
     }
@@ -114,7 +114,7 @@ public class StreamEventJournalP_WmCoalescingTest extends JetTestSupport {
 
         TestSupport.verifyProcessor(createSupplier(asList(0, 1), 4000))
                    .disableProgressAssertion()
-                   .disableRunUntilCompleted(4000)
+                   .runUntilOutputMatches(60_000, 100)
                    .disableSnapshots()
                    .outputChecker((e, a) -> new HashSet<>(e).equals(new HashSet<>(a)))
                    .expectOutput(asList(11, wm(11)));
@@ -126,7 +126,7 @@ public class StreamEventJournalP_WmCoalescingTest extends JetTestSupport {
     public void when_allPartitionsIdle_then_idleMessageOutput() {
         TestSupport.verifyProcessor(createSupplier(asList(0, 1), 500))
                    .disableProgressAssertion()
-                   .disableRunUntilCompleted(1500)
+                   .runUntilOutputMatches(60_000, 100)
                    .disableSnapshots()
                    .expectOutput(singletonList(IDLE_MESSAGE));
     }
@@ -170,7 +170,7 @@ public class StreamEventJournalP_WmCoalescingTest extends JetTestSupport {
 
         TestSupport.verifyProcessor(createSupplier(singletonList(1), 2000))
                    .disableProgressAssertion()
-                   .disableRunUntilCompleted(4000)
+                   .runUntilOutputMatches(60_000, 100)
                    .disableSnapshots()
                    .expectOutput(asList(wm(13), 13, IDLE_MESSAGE));
     }


### PR DESCRIPTION
Removes the `disableRunUntilCompleted()` method. The method was meant to
test streaming sources, but the timeout needs to be pretty high to
account for test environment hiccups which makes the test slow even in
cases when the output is produced very shortly after run. This commit
introduces `runUntilOutputMatches()` which runs `complete()` until the
output matches and for little extra time to check that there's no more
output.

Fixes #1261