### PR TITLE
Fix migration taking place before test job starts

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -291,6 +291,10 @@ public class Edge implements IdentifiedDataSerializable {
      * routing policy where all items will be routed to the same partition ID,
      * determined from the given {@code key}. It means that all items will be
      * directed to the same processor and other processors will be idle.
+     * <p>
+     * It is equivalent to using {@code partitioned(t -> key)}, but it a
+     * has small optimization that the partition ID is not recalculated
+     * for each stream item.
      */
     @Nonnull
     public Edge allToOne(Object key) {


### PR DESCRIPTION
In the test we submitted the job and immediately proceeded to add a
member to cause migration, there was no synchronization. It could happen
that the member was added before the job started, which caused the test
to fail.

This commit also uses random group name for the remote members so that
they don't inadvertently form a cluster with test running in another JVM
on the same network.

Fixes #1108
