### PR TITLE
Bump-up the surefire plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
         <maven.enforcer.plugin.version>3.0.0-M1</maven.enforcer.plugin.version>
-        <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
+        <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
         <maven.spotbugs.plugin.version>3.1.11</maven.spotbugs.plugin.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>


### PR DESCRIPTION
To resolve: `java.lang.NumberFormatException` while running tests.
Example of the exception:
```
Caused by: java.lang.NumberFormatException: For input string: " output=[]](com.hazelcast.jet.impl.connector.StreamSocketPTest)"
    at java.lang.NumberFormatException.forInputString (NumberFormatException.java:65)
    at java.lang.Integer.parseInt (Integer.java:569)
    at java.lang.Integer.parseInt (Integer.java:615)
    at org.apache.maven.plugin.surefire.runorder.RunEntryStatistics.fromString (RunEntryStatistics.java:82)
    at org.apache.maven.plugin.surefire.runorder.RunEntryStatisticsMap.fromReader (RunEntryStatisticsMap.java:96)
    at org.apache.maven.plugin.surefire.runorder.RunEntryStatisticsMap.fromFile (RunEntryStatisticsMap.java:69)
    at org.apache.maven.surefire.util.DefaultRunOrderCalculator.orderTestClasses (DefaultRunOrderCalculator.java:79)
    at org.apache.maven.surefire.util.DefaultRunOrderCalculator.orderTestClasses (DefaultRunOrderCalculator.java:67)
    ```