### PR TITLE
Simplify unbounded stream tests

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineStreamTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineStreamTestSupport.java
@@ -49,7 +49,7 @@ public abstract class PipelineStreamTestSupport extends PipelineTestSupport {
      * entire Jet job to complete.
      *
      */
-    StreamStage<Integer> sourceStageFromList(List<Integer> input) {
+    StreamStage<Integer> streamStageFromList(List<Integer> input) {
         StreamSource<Integer> source = SourceBuilder
                 .timestampedStream("sequence", x -> null)
                 .<Integer>fillBufferFn((x, buf) -> {
@@ -67,7 +67,7 @@ public abstract class PipelineStreamTestSupport extends PipelineTestSupport {
      * The stage emits (1e9 / {@value SOURCE_EVENT_PERIOD_NANOS}) items per
      * second. After it exhausts the input, it remains idle forever.
      */
-    StreamStage<Integer> sourceStageFromList(List<Integer> input, long earlyResultsPeriod) {
+    StreamStage<Integer> streamStageFromList(List<Integer> input, long earlyResultsPeriod) {
         Preconditions.checkPositive(earlyResultsPeriod, "earlyResultsPeriod must greater than zero");
         StreamSource<Integer> source = SourceBuilder
                 .timestampedStream("sequence", x -> new LongLongAccumulator(System.nanoTime(), 0))

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineStreamTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineStreamTestSupport.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.pipeline;
 import com.hazelcast.jet.accumulator.LongLongAccumulator;
 import com.hazelcast.jet.datamodel.TimestampedEntry;
 import com.hazelcast.jet.datamodel.TimestampedItem;
+import com.hazelcast.util.Preconditions;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,8 +41,23 @@ public abstract class PipelineStreamTestSupport extends PipelineTestSupport {
     static final long EARLY_RESULTS_PERIOD = 200L;
     private static final int SOURCE_EVENT_PERIOD_NANOS = 100_000;
 
+    /**
+     * The returned stream stage emits all the items from the supplied list
+     * of integers. It uses the integer as both timestamp and data.
+     * <p>
+     * When it exhausts the input, the source completes. This allows the
+     * entire Jet job to complete.
+     *
+     */
     StreamStage<Integer> sourceStageFromList(List<Integer> input) {
-        return sourceStageFromList(input, 0);
+        StreamSource<Integer> source = SourceBuilder
+                .timestampedStream("sequence", x -> null)
+                .<Integer>fillBufferFn((x, buf) -> {
+                    input.forEach(i -> buf.add(i, i));
+                    buf.close();
+                })
+                .build();
+        return p.drawFrom(source).withNativeTimestamps(0);
     }
 
     /**
@@ -49,25 +65,15 @@ public abstract class PipelineStreamTestSupport extends PipelineTestSupport {
      * integers. It uses the integer as both timestamp and data.
      * <p>
      * The stage emits (1e9 / {@value SOURCE_EVENT_PERIOD_NANOS}) items per
-     * second.
-     * <p>
-     * If not emitting early results (earlyResultsPeriod == 0), the source
-     * stage will complete when it exhausts the input. This allows the
-     * entire Jet job to complete.
+     * second. After it exhausts the input, it remains idle forever.
      */
     StreamStage<Integer> sourceStageFromList(List<Integer> input, long earlyResultsPeriod) {
-        boolean emittingEarlyResults = earlyResultsPeriod != 0;
+        Preconditions.checkPositive(earlyResultsPeriod, "earlyResultsPeriod must greater than zero");
         StreamSource<Integer> source = SourceBuilder
                 .timestampedStream("sequence", x -> new LongLongAccumulator(System.nanoTime(), 0))
                 .<Integer>fillBufferFn((deadline_emittedCount, buf) -> {
                     int emittedCount = (int) deadline_emittedCount.get2();
-                    if (emittedCount == input.size()) {
-                        if (!emittingEarlyResults) {
-                            buf.close();
-                        }
-                        return;
-                    }
-                    if (System.nanoTime() < deadline_emittedCount.get1()) {
+                    if (emittedCount == input.size() || System.nanoTime() < deadline_emittedCount.get1()) {
                         return;
                     }
                     int item = input.get(emittedCount);
@@ -76,7 +82,7 @@ public abstract class PipelineStreamTestSupport extends PipelineTestSupport {
                     deadline_emittedCount.add2(1);
                 })
                 .build();
-        return p.drawFrom(source).withNativeTimestamps(emittingEarlyResults ? 2 * itemCount : 0);
+        return p.drawFrom(source).withNativeTimestamps(2 * itemCount);
     }
 
     Stream<Integer> sinkStreamOfInt() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -58,7 +57,6 @@ import static com.hazelcast.jet.pipeline.WindowDefinition.tumbling;
 import static java.util.Collections.emptyList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 public class StreamStageTest extends PipelineStreamTestSupport {
@@ -103,11 +101,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().map(mapFn), identity());
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), Object::toString)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().map(mapFn), identity()),
+                streamToString(sinkList.stream(), Object::toString));
     }
 
     @Test
@@ -122,11 +119,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         filtered.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().filter(filterFn), formatFn);
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkStreamOfInt(), formatFn)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().filter(filterFn), formatFn),
+                streamToString(sinkStreamOfInt(), formatFn));
     }
 
     @Test
@@ -142,11 +138,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         flatMapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().flatMap(flatMapFn), identity());
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), Object::toString)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().flatMap(flatMapFn), identity()),
+                streamToString(sinkList.stream(), Object::toString));
     }
 
     @Test
@@ -163,12 +158,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-
-        String expectedString = streamToString(input.stream().map(i -> formatFn.apply(suffix, i)), identity());
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), Object::toString)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().map(i -> formatFn.apply(suffix, i)), identity()),
+                streamToString(sinkList.stream(), Object::toString));
     }
 
     @Test
@@ -185,11 +178,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().map(i -> formatFn.apply(suffix, i)), identity());
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), Object::toString)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().map(i -> formatFn.apply(suffix, i)), identity()),
+                streamToString(sinkList.stream(), Object::toString));
     }
 
     @Test
@@ -205,14 +197,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-
-        String expectedString = streamToString(
-                input.stream().filter(i -> i % 2 == acceptedRemainder),
-                formatFn);
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkStreamOfInt(), formatFn)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().filter(i -> i % 2 == acceptedRemainder), formatFn),
+                streamToString(sinkStreamOfInt(), formatFn));
     }
 
     @Test
@@ -231,13 +219,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(
-                input.stream().filter(r -> r % 2 == acceptedRemainder),
-                formatFn);
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkStreamOfInt(), formatFn)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().filter(r -> r % 2 == acceptedRemainder), formatFn),
+                streamToString(sinkStreamOfInt(), formatFn));
     }
 
     @Test
@@ -256,11 +241,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         flatMapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().flatMap(flatMapFn), identity());
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), Object::toString)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().flatMap(flatMapFn), identity()),
+                streamToString(sinkList.stream(), Object::toString));
     }
 
     @Test
@@ -280,11 +264,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         flatMapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().flatMap(flatMapFn), identity());
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), Object::toString)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().flatMap(flatMapFn), identity()),
+                streamToString(sinkList.stream(), Object::toString));
     }
 
     @Test
@@ -304,17 +287,15 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(
-                input.stream().map(i -> String.format("(%04d, %s%04d)", i, valuePrefix, i)),
-                identity());
+        jet().newJob(p).join();
         // sinkList: entry(0, "value-0000"), entry(1, "value-0001"), ...
-        assertTrueEventually(
-                () -> assertEquals(expectedString,
-                        streamToString(
-                                this.<Integer, String>sinkStreamOfEntry(),
-                                e -> String.format("(%04d, %s)", e.getKey(), e.getValue()))),
-                ASSERT_TIMEOUT_SECONDS);
+        assertEquals(
+                streamToString(
+                        input.stream().map(i -> String.format("(%04d, %s%04d)", i, valuePrefix, i)),
+                        identity()),
+                streamToString(
+                        this.<Integer, String>sinkStreamOfEntry(),
+                        e -> String.format("(%04d, %s)", e.getKey(), e.getValue())));
     }
 
     @Test
@@ -335,17 +316,15 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(
-                input.stream().map(i -> String.format("(%04d, %s%04d)", i, valuePrefix, i)),
-                identity());
+        jet().newJob(p).join();
         // sinkList: entry(0, "value-0000"), entry(1, "value-0001"), ...
-        assertTrueEventually(
-                () -> assertEquals(expectedString,
-                        streamToString(
-                                this.<Integer, String>sinkStreamOfEntry(),
-                                e -> String.format("(%04d, %s)", e.getKey(), e.getValue()))),
-                ASSERT_TIMEOUT_SECONDS);
+        assertEquals(
+                streamToString(
+                        input.stream().map(i -> String.format("(%04d, %s%04d)", i, valuePrefix, i)),
+                        identity()),
+                streamToString(
+                        this.<Integer, String>sinkStreamOfEntry(),
+                        e -> String.format("(%04d, %s)", e.getKey(), e.getValue())));
     }
 
     @Test
@@ -366,17 +345,15 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(
-                input.stream().map(i -> String.format("(%04d, %s%04d)", i, valuePrefix, i)),
-                identity());
+        jet().newJob(p).join();
         // sinkList: entry(0, "value-0000"), entry(1, "value-0001"), ...
-        assertTrueEventually(
-                () -> assertEquals(expectedString,
-                        streamToString(
-                                this.<Integer, String>sinkStreamOfEntry(),
-                                e -> String.format("(%04d, %s)", e.getKey(), e.getValue()))),
-                ASSERT_TIMEOUT_SECONDS);
+        assertEquals(
+                streamToString(
+                        input.stream().map(i -> String.format("(%04d, %s%04d)", i, valuePrefix, i)),
+                        identity()),
+                streamToString(
+                        this.<Integer, String>sinkStreamOfEntry(),
+                        e -> String.format("(%04d, %s)", e.getKey(), e.getValue())));
     }
 
     @Test
@@ -390,12 +367,11 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         rolled.drainTo(sink);
-        jet().newJob(p);
+        jet().newJob(p).join();
         Function<Object, String> formatFn = i -> String.format("%04d", (Long) i);
-        String expectedString = streamToString(LongStream.rangeClosed(1, itemCount).boxed(), formatFn);
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), formatFn)),
-                ASSERT_TIMEOUT_SECONDS);
+        assertEquals(
+                streamToString(LongStream.rangeClosed(1, itemCount).boxed(), formatFn),
+                streamToString(sinkList.stream(), formatFn));
     }
 
     @Test
@@ -410,15 +386,13 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
+        jet().newJob(p).join();
         Function<Entry<Integer, Long>, String> formatFn = e -> String.format("(%d, %04d)", e.getKey(), e.getValue());
-        String expectedString = streamToString(
-                IntStream.range(2, itemCount + 2).mapToObj(i -> entry(i % 2, (long) i / 2)),
-                formatFn
-        );
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkStreamOfEntry(), formatFn)),
-                ASSERT_TIMEOUT_SECONDS);
+        assertEquals(
+                streamToString(
+                        IntStream.range(2, itemCount + 2).mapToObj(i -> entry(i % 2, (long) i / 2)),
+                        formatFn),
+                streamToString(sinkStreamOfEntry(), formatFn));
     }
 
     @Test
@@ -435,15 +409,13 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(
-                IntStream.range(2, itemCount + 2).mapToObj(i -> entry(i % 2, (long) i / 2)),
-                e -> formatFn.apply(e.getKey(), e.getValue())
-        );
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(
+                        IntStream.range(2, itemCount + 2).mapToObj(i -> entry(i % 2, (long) i / 2)),
+                        e -> formatFn.apply(e.getKey(), e.getValue())),
                 streamToString(sinkList.stream().map(String.class::cast), identity())
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -458,8 +430,8 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p);
-        assertTrueFiveSeconds(() -> assertEquals(0, sinkList.size()));
+        jet().newJob(p).join();
+        assertEquals(0, sinkList.size());
     }
 
     @Test
@@ -478,16 +450,15 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         rolling.window(tumbling(1))
                .aggregate(identity)
                .drainTo(sink);
-        jet().newJob(p);
-        String expectedString = LongStream.range(0, itemCount)
-                                          .mapToObj(i -> String.format("(%04d %04d)", i + 1, i))
-                                          .collect(joining("\n"));
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        jet().newJob(p).join();
+        assertEquals(
+                LongStream.range(0, itemCount)
+                          .mapToObj(i -> String.format("(%04d %04d)", i + 1, i))
+                          .collect(joining("\n")),
                 streamToString(
                         this.<Long>sinkStreamOfTsItem(),
                         tsItem -> String.format("(%04d %04d)", tsItem.timestamp(), tsItem.item()))
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -503,11 +474,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         merged.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().flatMap(i -> Stream.of(i, i)), formatFn);
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkStreamOfInt(), formatFn)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().flatMap(i -> Stream.of(i, i)), formatFn),
+                streamToString(sinkStreamOfInt(), formatFn));
     }
 
     @Test
@@ -530,18 +500,17 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         hashJoined.drainTo(sink);
-        jet().newJob(p);
+        jet().newJob(p).join();
         BiFunction<Integer, String, String> formatFn = (i, value) -> String.format("(%04d, %s)", i, value);
-        String expectedString = streamToString(
-                input.stream().map(i -> formatFn.apply(i, ENRICHING_FORMAT_FN.apply(prefixA, i))),
-                identity());
         // sinkList: tuple2(0, "A-0000"), tuple2(1, "A-0001"), ...
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        assertEquals(
+                streamToString(
+                        input.stream().map(i -> formatFn.apply(i, ENRICHING_FORMAT_FN.apply(prefixA, i))),
+                        identity()),
                 streamToString(
                         sinkList.stream().map(t2 -> (Tuple2<Integer, String>) t2),
                         t2 -> formatFn.apply(t2.f0(), t2.f1()))
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -567,22 +536,20 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         hashJoined.drainTo(sink);
-        jet().newJob(p);
+        jet().newJob(p).join();
 
         TriFunction<Integer, String, String, String> formatFn =
                 (i, valueA, valueB) -> String.format("(%04d, %s, %s)", i, valueA, valueB);
-        String expectedString = streamToString(
-                input.stream().map(i -> formatFn.apply(i,
-                        ENRICHING_FORMAT_FN.apply(prefixA, i),
-                        ENRICHING_FORMAT_FN.apply(prefixB, i)
-                )),
-                identity());
         // sinkList: tuple3(0, "A-0000", "B-0000"), tuple3(1, "A-0001", "B-0001"), ...
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        assertEquals(
+                streamToString(
+                        input.stream().map(i -> formatFn.apply(i,
+                                ENRICHING_FORMAT_FN.apply(prefixA, i),
+                                ENRICHING_FORMAT_FN.apply(prefixB, i))),
+                        identity()),
                 streamToString(sinkList.stream().map(t3 -> (Tuple3<Integer, String, String>) t3),
                         t3 -> formatFn.apply(t3.f0(), t3.f1(), t3.f2()))
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -607,22 +574,20 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         joined.drainTo(sink);
-        jet().newJob(p);
+        jet().newJob(p).join();
 
         TriFunction<Integer, String, String, String> formatFn =
                 (i, valueA, valueB) -> String.format("(%04d, %s, %s)", i, valueA, valueB);
-        String expectedString = streamToString(
-                input.stream().map(i -> formatFn.apply(i,
-                        ENRICHING_FORMAT_FN.apply(prefixA, i),
-                        ENRICHING_FORMAT_FN.apply(prefixB, i)
-                )),
-                identity());
         // sinkList: tuple2(0, ibt(tagA: "A-0000", tagB: "B-0000")), tuple2(1, ibt(tagA: "A-0001", tagB: "B-0001"))
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        assertEquals(
+                streamToString(
+                        input.stream().map(i -> formatFn.apply(i,
+                                ENRICHING_FORMAT_FN.apply(prefixA, i),
+                                ENRICHING_FORMAT_FN.apply(prefixB, i))),
+                        identity()),
                 streamToString(sinkList.stream().map(t2 -> (Tuple2<Integer, ItemsByTag>) t2),
                         t2 -> formatFn.apply(t2.f0(), t2.f1().get(tagA), t2.f1().get(tagB)))
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     private BatchStage<Entry<Integer, String>> enrichingStage(List<Integer> input, String prefix) {
@@ -649,11 +614,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         custom.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = streamToString(input.stream().map(mapFn), identity());
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkList.stream(), Object::toString)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().map(mapFn), identity()),
+                streamToString(sinkList.stream(), Object::toString));
     }
 
 
@@ -675,14 +639,11 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         custom.drainTo(sink);
-        jet().newJob(p);
+        jet().newJob(p).join();
 
         // Each processor emitted distinct keys it observed. If groupingKey isn't
         // correctly partitioning, multiple processors will observe the same keys.
-        assertTrueEventually(() -> assertEquals(
-                "0\n1",
-                streamToString(sinkList.stream().map(Object::toString), identity())
-        ), ASSERT_TIMEOUT_SECONDS);
+        assertEquals("0\n1", streamToString(sinkList.stream().map(Object::toString), identity()));
     }
 
     @Test
@@ -695,12 +656,11 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         peeked.drainTo(sink);
-        jet().newJob(p);
+        jet().newJob(p).join();
         Function<Integer, String> formatFn = i -> String.format("%04d", i);
-        String expectedString = streamToString(input.stream(), formatFn);
-        assertTrueEventually(
-                () -> assertEquals(expectedString, streamToString(sinkStreamOfInt(), formatFn)),
-                ASSERT_TIMEOUT_SECONDS);
+        assertEquals(
+                streamToString(input.stream(), formatFn),
+                streamToString(sinkStreamOfInt(), formatFn));
     }
 
     @Test
@@ -708,6 +668,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         // Given
         List<Integer> input = sequence(itemCount);
         DistributedPredicate<Integer> filterFn = i -> i % 2 == 1;
+        Function<Integer, String> formatFn = i -> String.format("%04d", i);
 
         // When
         sourceStageFromList(input)
@@ -716,9 +677,9 @@ public class StreamStageTest extends PipelineStreamTestSupport {
          .drainTo(sink);
 
         // Then
-        jet().newJob(p);
-
-        Map<Integer, Integer> expected = toBag(input.stream().filter(filterFn).collect(toList()));
-        assertTrueEventually(() -> assertEquals(expected, sinkToBag()), ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                streamToString(input.stream().filter(filterFn), formatFn),
+                streamToString(sinkStreamOfInt(), formatFn));
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -101,7 +101,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().map(mapFn), identity()),
                 streamToString(sinkList.stream(), Object::toString));
@@ -119,7 +119,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         filtered.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().filter(filterFn), formatFn),
                 streamToString(sinkStreamOfInt(), formatFn));
@@ -138,7 +138,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         flatMapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().flatMap(flatMapFn), identity()),
                 streamToString(sinkList.stream(), Object::toString));
@@ -158,7 +158,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().map(i -> formatFn.apply(suffix, i)), identity()),
                 streamToString(sinkList.stream(), Object::toString));
@@ -178,7 +178,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().map(i -> formatFn.apply(suffix, i)), identity()),
                 streamToString(sinkList.stream(), Object::toString));
@@ -197,7 +197,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().filter(i -> i % 2 == acceptedRemainder), formatFn),
                 streamToString(sinkStreamOfInt(), formatFn));
@@ -219,7 +219,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().filter(r -> r % 2 == acceptedRemainder), formatFn),
                 streamToString(sinkStreamOfInt(), formatFn));
@@ -241,7 +241,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         flatMapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().flatMap(flatMapFn), identity()),
                 streamToString(sinkList.stream(), Object::toString));
@@ -264,7 +264,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         flatMapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().flatMap(flatMapFn), identity()),
                 streamToString(sinkList.stream(), Object::toString));
@@ -287,7 +287,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         // sinkList: entry(0, "value-0000"), entry(1, "value-0001"), ...
         assertEquals(
                 streamToString(
@@ -316,7 +316,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         // sinkList: entry(0, "value-0000"), entry(1, "value-0001"), ...
         assertEquals(
                 streamToString(
@@ -345,7 +345,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         // sinkList: entry(0, "value-0000"), entry(1, "value-0001"), ...
         assertEquals(
                 streamToString(
@@ -367,7 +367,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         rolled.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         Function<Object, String> formatFn = i -> String.format("%04d", (Long) i);
         assertEquals(
                 streamToString(LongStream.rangeClosed(1, itemCount).boxed(), formatFn),
@@ -386,7 +386,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         Function<Entry<Integer, Long>, String> formatFn = e -> String.format("(%d, %04d)", e.getKey(), e.getValue());
         assertEquals(
                 streamToString(
@@ -409,7 +409,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(
                         IntStream.range(2, itemCount + 2).mapToObj(i -> entry(i % 2, (long) i / 2)),
@@ -430,7 +430,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         mapped.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(0, sinkList.size());
     }
 
@@ -450,7 +450,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         rolling.window(tumbling(1))
                .aggregate(identity)
                .drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 LongStream.range(0, itemCount)
                           .mapToObj(i -> String.format("(%04d %04d)", i + 1, i))
@@ -474,7 +474,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         merged.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().flatMap(i -> Stream.of(i, i)), formatFn),
                 streamToString(sinkStreamOfInt(), formatFn));
@@ -500,7 +500,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         hashJoined.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         BiFunction<Integer, String, String> formatFn = (i, value) -> String.format("(%04d, %s)", i, value);
         // sinkList: tuple2(0, "A-0000"), tuple2(1, "A-0001"), ...
         assertEquals(
@@ -536,7 +536,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         hashJoined.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
 
         TriFunction<Integer, String, String, String> formatFn =
                 (i, valueA, valueB) -> String.format("(%04d, %s, %s)", i, valueA, valueB);
@@ -574,7 +574,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         joined.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
 
         TriFunction<Integer, String, String, String> formatFn =
                 (i, valueA, valueB) -> String.format("(%04d, %s, %s)", i, valueA, valueB);
@@ -614,7 +614,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         custom.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().map(mapFn), identity()),
                 streamToString(sinkList.stream(), Object::toString));
@@ -639,7 +639,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         custom.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
 
         // Each processor emitted distinct keys it observed. If groupingKey isn't
         // correctly partitioning, multiple processors will observe the same keys.
@@ -656,7 +656,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
         // Then
         peeked.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         Function<Integer, String> formatFn = i -> String.format("%04d", i);
         assertEquals(
                 streamToString(input.stream(), formatFn),
@@ -677,7 +677,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
          .drainTo(sink);
 
         // Then
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 streamToString(input.stream().filter(filterFn), formatFn),
                 streamToString(sinkStreamOfInt(), formatFn));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -70,7 +70,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         String stageName = randomName();
 
         // When
-        StreamStage<Integer> stage = sourceStageFromList(emptyList());
+        StreamStage<Integer> stage = streamStageFromList(emptyList());
         stage.setName(stageName);
 
         // Then
@@ -83,7 +83,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         int localParallelism = 10;
 
         // When
-        StreamStage<Integer> stage = sourceStageFromList(emptyList());
+        StreamStage<Integer> stage = streamStageFromList(emptyList());
         stage.setLocalParallelism(localParallelism);
 
         // Then
@@ -97,7 +97,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         DistributedFunction<Integer, String> mapFn = item -> String.format("%04d-x", item);
 
         // When
-        StreamStage<String> mapped = sourceStageFromList(input).map(mapFn);
+        StreamStage<String> mapped = streamStageFromList(input).map(mapFn);
 
         // Then
         mapped.drainTo(sink);
@@ -115,7 +115,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         Function<Integer, String> formatFn = i -> String.format("%04d", i);
 
         // When
-        StreamStage<Integer> filtered = sourceStageFromList(input).filter(filterFn);
+        StreamStage<Integer> filtered = streamStageFromList(input).filter(filterFn);
 
         // Then
         filtered.drainTo(sink);
@@ -133,7 +133,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
                 i -> Stream.of("A", "B").map(s -> String.format("%04d-%s", i, s));
 
         // When
-        StreamStage<String> flatMapped = sourceStageFromList(input)
+        StreamStage<String> flatMapped = streamStageFromList(input)
                 .flatMap(o -> traverseStream(flatMapFn.apply(o)));
 
         // Then
@@ -152,7 +152,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         String suffix = "-context";
 
         // When
-        StreamStage<String> mapped = sourceStageFromList(input).mapUsingContext(
+        StreamStage<String> mapped = streamStageFromList(input).mapUsingContext(
                 ContextFactory.withCreateFn(x -> suffix),
                 formatFn);
 
@@ -172,7 +172,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         String suffix = "-keyed-context";
 
         // When
-        StreamStage<String> mapped = sourceStageFromList(input)
+        StreamStage<String> mapped = streamStageFromList(input)
                 .groupingKey(i -> i)
                 .mapUsingContext(ContextFactory.withCreateFn(i -> suffix), (suff, k, i) -> formatFn.apply(suff, i));
 
@@ -192,7 +192,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         Function<Integer, String> formatFn = i -> String.format("%04d", i);
 
         // When
-        StreamStage<Integer> mapped = sourceStageFromList(input)
+        StreamStage<Integer> mapped = streamStageFromList(input)
                 .filterUsingContext(ContextFactory.withCreateFn(i -> acceptedRemainder), (rem, i) -> i % 2 == rem);
 
         // Then
@@ -211,7 +211,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         int acceptedRemainder = 1;
 
         // When
-        StreamStage<Integer> mapped = sourceStageFromList(input)
+        StreamStage<Integer> mapped = streamStageFromList(input)
                 .groupingKey(i -> i)
                 .filterUsingContext(
                         ContextFactory.withCreateFn(i -> acceptedRemainder),
@@ -233,7 +233,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
                 i -> Stream.of("A", "B").map(s -> String.format("%04d-%s", i, s));
 
         // When
-        StreamStage<String> flatMapped = sourceStageFromList(input)
+        StreamStage<String> flatMapped = streamStageFromList(input)
                 .flatMapUsingContext(
                         ContextFactory.withCreateFn(x -> flatMapFn),
                         (fn, i) -> traverseStream(fn.apply(i))
@@ -255,7 +255,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
                 i -> Stream.of("A", "B").map(s -> String.format("%04d-%s", i, s));
 
         // When
-        StreamStage<String> flatMapped = sourceStageFromList(input)
+        StreamStage<String> flatMapped = streamStageFromList(input)
                 .groupingKey(i -> i)
                 .flatMapUsingContext(
                         ContextFactory.withCreateFn(x -> flatMapFn),
@@ -282,7 +282,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         }
 
         // When
-        StreamStage<Entry<Integer, String>> mapped = sourceStageFromList(input)
+        StreamStage<Entry<Integer, String>> mapped = streamStageFromList(input)
                 .mapUsingReplicatedMap(map, (m, i) -> entry(i, m.get(i)));
 
         // Then
@@ -310,7 +310,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         }
 
         // When
-        StreamStage<Entry<Integer, String>> mapped = sourceStageFromList(input)
+        StreamStage<Entry<Integer, String>> mapped = streamStageFromList(input)
                 .mapUsingIMapAsync(map, (m, i) -> Util.toCompletableFuture(m.getAsync(i))
                                                       .thenApply(v -> entry(i, v)));
 
@@ -339,7 +339,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         }
 
         // When
-        StreamStage<Entry<Integer, String>> mapped = sourceStageFromList(input)
+        StreamStage<Entry<Integer, String>> mapped = streamStageFromList(input)
                 .groupingKey(i -> i)
                 .mapUsingIMapAsync(map, Util::entry);
 
@@ -362,7 +362,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         List<Integer> input = sequence(itemCount);
 
         // When
-        StreamStage<Long> rolled = sourceStageFromList(input)
+        StreamStage<Long> rolled = streamStageFromList(input)
                 .rollingAggregate(counting());
 
         // Then
@@ -380,7 +380,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         List<Integer> input = sequence(itemCount);
 
         // When
-        StreamStage<Entry<Integer, Long>> mapped = sourceStageFromList(input)
+        StreamStage<Entry<Integer, Long>> mapped = streamStageFromList(input)
                 .groupingKey(i -> i % 2)
                 .rollingAggregate(counting());
 
@@ -403,7 +403,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
                 (key, count) -> String.format("(%d, %04d)", key, count);
 
         // When
-        StreamStage<String> mapped = sourceStageFromList(input)
+        StreamStage<String> mapped = streamStageFromList(input)
                 .groupingKey(i -> i % 2)
                 .rollingAggregate(counting(), formatFn);
 
@@ -424,7 +424,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         List<Integer> input = sequence(itemCount);
 
         // When
-        StreamStage<String> mapped = sourceStageFromList(input)
+        StreamStage<String> mapped = streamStageFromList(input)
                 .groupingKey(i -> i % 2)
                 .rollingAggregate(counting(), (x, y) -> null);
 
@@ -444,7 +444,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
                 .andExportFinish(acc -> (int) acc.get());
 
         // When
-        StreamStage<Integer> rolling = sourceStageFromList(input).rollingAggregate(identity);
+        StreamStage<Integer> rolling = streamStageFromList(input).rollingAggregate(identity);
 
         // Then
         rolling.window(tumbling(1))
@@ -466,8 +466,8 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         // Given
         List<Integer> input = sequence(itemCount);
         Function<Integer, String> formatFn = i -> String.format("%04d", i);
-        StreamStage<Integer> srcStage0 = sourceStageFromList(input);
-        StreamStage<Integer> srcStage1 = sourceStageFromList(input);
+        StreamStage<Integer> srcStage0 = streamStageFromList(input);
+        StreamStage<Integer> srcStage1 = streamStageFromList(input);
 
         // When
         StreamStage<Integer> merged = srcStage0.merge(srcStage1);
@@ -492,7 +492,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         // When
         @SuppressWarnings("Convert2MethodRef")
         // there's a method ref bug in JDK
-        StreamStage<Tuple2<Integer, String>> hashJoined = sourceStageFromList(input).hashJoin(
+        StreamStage<Tuple2<Integer, String>> hashJoined = streamStageFromList(input).hashJoin(
                 enrichingStage,
                 joinMapEntries(wholeItem()),
                 (i, valueA) -> tuple2(i, valueA)
@@ -528,7 +528,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         // When
         @SuppressWarnings("Convert2MethodRef")
         // there's a method ref bug in JDK
-        StreamStage<Tuple3<Integer, String, String>> hashJoined = sourceStageFromList(input).hashJoin2(
+        StreamStage<Tuple3<Integer, String, String>> hashJoined = streamStageFromList(input).hashJoin2(
                 enrichingStage1, joinMapEntries(wholeItem()),
                 enrichingStage2, joinMapEntries(wholeItem()),
                 (i, valueA, valueB) -> tuple3(i, valueA, valueB)
@@ -565,7 +565,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         BatchStage<Entry<Integer, String>> enrichingStage2 = enrichingStage(input, prefixB);
 
         // When
-        StreamHashJoinBuilder<Integer> builder = sourceStageFromList(input).hashJoinBuilder();
+        StreamHashJoinBuilder<Integer> builder = streamStageFromList(input).hashJoinBuilder();
         Tag<String> tagA = builder.add(enrichingStage1, joinMapEntries(wholeItem()));
         Tag<String> tagB = builder.add(enrichingStage2, joinMapEntries(wholeItem()));
         @SuppressWarnings("Convert2MethodRef")
@@ -605,7 +605,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         DistributedFunction<Integer, String> mapFn = item -> String.format("%04d-x", item);
 
         // When
-        StreamStage<String> custom = sourceStageFromList(input).customTransform("map",
+        StreamStage<String> custom = streamStageFromList(input).customTransform("map",
                 Processors.mapP(o -> {
                     @SuppressWarnings("unchecked")
                     JetEvent<Integer> jetEvent = (JetEvent<Integer>) o;
@@ -628,7 +628,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         DistributedFunction<Integer, Integer> extractKeyFn = i -> i % 2;
 
         // When
-        StreamStage<Object> custom = sourceStageFromList(input)
+        StreamStage<Object> custom = streamStageFromList(input)
                 .groupingKey(extractKeyFn)
                 .customTransform("map", Processors.mapUsingContextP(
                         ContextFactory.withCreateFn(jet -> new HashSet<>()),
@@ -652,7 +652,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         List<Integer> input = sequence(itemCount);
 
         // When
-        StreamStage<Integer> peeked = sourceStageFromList(input).peek();
+        StreamStage<Integer> peeked = streamStageFromList(input).peek();
 
         // Then
         peeked.drainTo(sink);
@@ -671,7 +671,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         Function<Integer, String> formatFn = i -> String.format("%04d", i);
 
         // When
-        sourceStageFromList(input)
+        streamStageFromList(input)
          .filter(filterFn)
          .peek(Object::toString)
          .drainTo(sink);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowAggregateTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowAggregateTest.java
@@ -64,7 +64,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
         SlidingWindowDefinition tumbling = tumbling(2);
 
         // When
-        StageWithWindow<Integer> stage = sourceStageFromList(emptyList()).window(tumbling);
+        StageWithWindow<Integer> stage = streamStageFromList(emptyList()).window(tumbling);
 
         // Then
         assertEquals(tumbling, stage.windowDefinition());
@@ -79,7 +79,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
                                             .flatMap(i -> IntStream.of(i, i))
                                             .boxed()
                                             .collect(toList());
-        StageWithWindow<Integer> windowed = sourceStageFromList(timestamps)
+        StageWithWindow<Integer> windowed = streamStageFromList(timestamps)
                 .window(tumbling(winSize));
 
         // When
@@ -107,7 +107,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
                 (timestamp, item) -> String.format("(%04d, %04d)", timestamp, item);
 
         List<Integer> input = sequence(itemCount);
-        StreamStage<Integer> stage = sourceStageFromList(input);
+        StreamStage<Integer> stage = streamStageFromList(input);
 
         // When
         SlidingWindowDefinition wDef = tumbling(winSize);
@@ -134,7 +134,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
                 (timestamp, item) -> String.format("(%04d, %04d)", timestamp, item);
 
         List<Integer> input = sequence(itemCount);
-        StreamStage<Integer> stage = sourceStageFromList(input, EARLY_RESULTS_PERIOD);
+        StreamStage<Integer> stage = streamStageFromList(input, EARLY_RESULTS_PERIOD);
 
         // When
         SlidingWindowDefinition wDef = tumbling(winSize).setEarlyResultsPeriod(EARLY_RESULTS_PERIOD);
@@ -165,7 +165,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
         BiFunction<Long, Long, String> formatFn =
                 (timestamp, item) -> String.format("(%04d, %04d)", timestamp, item);
         // If emitting early results, keep the watermark behind all input
-        StreamStage<Integer> stage = sourceStageFromList(input);
+        StreamStage<Integer> stage = streamStageFromList(input);
 
         // When
         SlidingWindowDefinition wDef = sliding(winSize, slideBy);
@@ -193,7 +193,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
         BiFunction<Long, Long, String> formatFn =
                 (timestamp, item) -> String.format("(%04d, %04d)", timestamp, item);
         // If emitting early results, keep the watermark behind all input
-        StreamStage<Integer> stage = sourceStageFromList(input, EARLY_RESULTS_PERIOD);
+        StreamStage<Integer> stage = streamStageFromList(input, EARLY_RESULTS_PERIOD);
 
         // When
         SlidingWindowDefinition wDef = sliding(winSize, slideBy).setEarlyResultsPeriod(EARLY_RESULTS_PERIOD);
@@ -228,7 +228,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // When
         SessionWindowDefinition wDef = session(sessionTimeout);
-        StageWithWindow<Integer> windowed = sourceStageFromList(input).window(wDef);
+        StageWithWindow<Integer> windowed = streamStageFromList(input).window(wDef);
 
         // Then
         windowed.aggregate(summingLong(i -> i),
@@ -257,7 +257,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
                                                  .collect(toList());
         BiFunction<Long, Long, String> formatFn = (timestamp, sum) -> String.format("(%04d, %04d)", timestamp, sum);
         // Keep the watermark behind all input
-        StreamStage<Integer> stage = sourceStageFromList(input, EARLY_RESULTS_PERIOD);
+        StreamStage<Integer> stage = streamStageFromList(input, EARLY_RESULTS_PERIOD);
 
         // When
         SessionWindowDefinition wDef = session(sessionTimeout).setEarlyResultsPeriod(EARLY_RESULTS_PERIOD);
@@ -298,7 +298,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
     private void assertEarlyResultsEmittedRepeatedly(WindowDefinition wDef) {
         // Given
         long earlyResultPeriod = 50;
-        StreamStage<Integer> srcStage = sourceStageFromList(singletonList(1), earlyResultPeriod);
+        StreamStage<Integer> srcStage = streamStageFromList(singletonList(1), earlyResultPeriod);
 
         // When
         StageWithWindow<Integer> stage = srcStage.window(wDef.setEarlyResultsPeriod(earlyResultPeriod));
@@ -314,7 +314,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
     @Test
     public void when_slidingWindow_outputFnReturnsNull_then_filteredOut() {
         // Given
-        StreamStage<Integer> stage = sourceStageFromList(sequence(itemCount));
+        StreamStage<Integer> stage = streamStageFromList(sequence(itemCount));
 
         // When
         StreamStage<Object> aggregated = stage.window(sliding(2, 1))
@@ -329,7 +329,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
     @Test
     public void when_sessionWindow_outputFnReturnsNull_then_filteredOut() {
         // Given
-        StreamStage<Integer> stage = sourceStageFromList(sequence(itemCount));
+        StreamStage<Integer> stage = streamStageFromList(sequence(itemCount));
 
         // When
         StreamStage<Object> aggregated = stage.window(session(1))
@@ -357,7 +357,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
                 .stringResults(e -> FORMAT_FN_3.apply(e.getKey(), tuple3(e.getValue(), e.getValue(), e.getValue())));
 
         StreamStage<Integer> newStage() {
-            return sourceStageFromList(input);
+            return streamStageFromList(input);
         }
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowAggregateTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowAggregateTest.java
@@ -87,7 +87,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         distinct.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 IntStream.range(0, itemCount)
                          .mapToObj(i -> String.format("(%04d, %04d)", roundUp(i + 1, winSize), i))
@@ -116,7 +116,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
         // Then
         windowed.aggregate(summingLong(i -> i))
                 .drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 new SlidingWindowSimulator(wDef)
                         .acceptStream(input.stream())
@@ -174,7 +174,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 new SlidingWindowSimulator(wDef)
                         .acceptStream(input.stream())
@@ -234,7 +234,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
         windowed.aggregate(summingLong(i -> i),
                 (start, end, sum) -> new TimestampedItem<>(start, sum))
                 .drainTo(sink);
-        jet().newJob(p).join();
+        execute();
 
         assertEquals(
                 new SessionWindowSimulator(wDef, sessionLength + sessionTimeout)
@@ -372,7 +372,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         //Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(
                         this.<Tuple2<Long, Long>>sinkStreamOfTsItem(),
@@ -391,7 +391,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         //Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(
                         this.<Tuple2<Long, Long>>sinkStreamOfTsItem(),
@@ -410,7 +410,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -428,7 +428,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -444,7 +444,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(this.<Tuple3<Long, Long, Long>>sinkStreamOfTsItem(),
                         tsItem -> FORMAT_FN_3.apply(tsItem.timestamp(), tsItem.item())
@@ -463,7 +463,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         //Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(this.<Tuple3<Long, Long, Long>>sinkStreamOfTsItem(),
                         tsItem -> FORMAT_FN_3.apply(tsItem.timestamp(), tsItem.item())
@@ -483,7 +483,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -501,7 +501,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -520,7 +520,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -544,7 +544,7 @@ public class WindowAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity())
         );

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowGroupAggregateTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowGroupAggregateTest.java
@@ -90,7 +90,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
     public void windowDefinition() {
         SlidingWindowDefinition tumbling = tumbling(2);
         StageWithKeyAndWindow<Integer, Integer> stage =
-                sourceStageFromList(emptyList()).groupingKey(wholeItem()).window(tumbling);
+                streamStageFromList(emptyList()).groupingKey(wholeItem()).window(tumbling);
         assertEquals(tumbling, stage.windowDefinition());
     }
 
@@ -115,8 +115,8 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         StreamStageWithKey<Entry<String, Integer>, String> newSourceStage() {
             StreamStage<Integer> sourceStage = emittingEarlyResults
-                    ? sourceStageFromList(input, EARLY_RESULTS_PERIOD)
-                    : sourceStageFromList(input);
+                    ? streamStageFromList(input, EARLY_RESULTS_PERIOD)
+                    : streamStageFromList(input);
             return sourceStage.flatMap(i -> traverseItems(entry("a", i), entry("b", i)))
                               .groupingKey(Entry::getKey);
         }
@@ -128,7 +128,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
         itemCount = (int) roundUp(itemCount, 2);
         int winSize = itemCount / 2;
         List<Integer> timestamps = sequence(itemCount);
-        StageWithKeyAndWindow<Integer, Integer> windowed = sourceStageFromList(timestamps)
+        StageWithKeyAndWindow<Integer, Integer> windowed = streamStageFromList(timestamps)
                 .groupingKey(i -> i / 2)
                 .window(tumbling(winSize));
 
@@ -157,7 +157,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
         int winSize = itemCount / 2;
         List<Integer> timestamps = sequence(itemCount);
 
-        StageWithKeyAndWindow<Integer, Integer> windowed = sourceStageFromList(timestamps)
+        StageWithKeyAndWindow<Integer, Integer> windowed = streamStageFromList(timestamps)
                 .groupingKey(i -> i / 2)
                 .window(tumbling(winSize));
 
@@ -276,7 +276,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
         // Given
         List<Integer> input = asList(0, 1, 2);
         StreamStage<Entry<String, String>> srcStage =
-                sourceStageFromList(input)
+                streamStageFromList(input)
                         .flatMap(i -> traverseItems(entry("a", "a" + i), entry("b", "b" + i)));
 
         // When

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowGroupAggregateTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowGroupAggregateTest.java
@@ -114,9 +114,11 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
         }
 
         StreamStageWithKey<Entry<String, Integer>, String> newSourceStage() {
-            return sourceStageFromList(input, emittingEarlyResults ? EARLY_RESULTS_PERIOD : 0)
-                    .flatMap(i -> traverseItems(entry("a", i), entry("b", i)))
-                    .groupingKey(Entry::getKey);
+            StreamStage<Integer> sourceStage = emittingEarlyResults
+                    ? sourceStageFromList(input, EARLY_RESULTS_PERIOD)
+                    : sourceStageFromList(input);
+            return sourceStage.flatMap(i -> traverseItems(entry("a", i), entry("b", i)))
+                              .groupingKey(Entry::getKey);
         }
     }
 
@@ -135,19 +137,17 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         distinct.drainTo(sink);
-        String expectedString = IntStream
-                .range(0, itemCount)
-                .mapToObj(i -> String.format("(%04d, %04d)", roundUp(i + 1, winSize), i / 2))
-                .distinct()
-                .sorted()
-                .collect(joining("\n"));
-        jet().newJob(p);
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        jet().newJob(p).join();
+        assertEquals(
+                IntStream.range(0, itemCount)
+                         .mapToObj(i -> String.format("(%04d, %04d)", roundUp(i + 1, winSize), i / 2))
+                         .distinct()
+                         .sorted()
+                         .collect(joining("\n")),
                 streamToString(
                         this.<Integer>sinkStreamOfTsItem(),
                         tsItem -> String.format("(%04d, %04d)", tsItem.timestamp(), tsItem.item() / 2))
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -168,47 +168,56 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         distinct.drainTo(sink);
-        jet().newJob(p);
-        String expectedString = IntStream
-                .range(0, itemCount)
-                .mapToObj(i -> String.format("(%04d, %04d)", roundUp(i + 1, winSize), i / 2))
-                .distinct()
-                .sorted()
-                .collect(joining("\n"));
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        jet().newJob(p).join();
+        assertEquals(
+                IntStream.range(0, itemCount)
+                         .mapToObj(i -> String.format("(%04d, %04d)", roundUp(i + 1, winSize), i / 2))
+                         .distinct()
+                         .sorted()
+                         .collect(joining("\n")),
                 streamToString(sinkList.stream().map(String.class::cast), identity())
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
     public void tumblingWindow() {
-        testTumblingWindow(0L);
+        // Given
+        final int winSize = 4;
+        WindowTestFixture fx = new WindowTestFixture(false);
+
+        // When
+        SlidingWindowDefinition wDef = tumbling(winSize);
+        StageWithKeyAndWindow<Entry<String, Integer>, String> windowed = fx.newSourceStage().window(wDef);
+
+        // Then
+        windowed.aggregate(SUMMING)
+                .drainTo(sink);
+        jet().newJob(p).join();
+        assertEquals(
+                new SlidingWindowSimulator(wDef)
+                        .acceptStream(fx.input.stream())
+                        .stringResults(MOCK_FORMAT_FN),
+                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN, TS_ENTRY_DISTINCT_FN)
+        );
     }
 
     @Test
     public void tumblingWindow_withEarlyResults() {
-        testTumblingWindow(EARLY_RESULTS_PERIOD);
-    }
-
-    private void testTumblingWindow(long earlyResultsPeriod) {
         // Given
         final int winSize = 4;
-        WindowTestFixture fx = new WindowTestFixture(earlyResultsPeriod != 0);
+        WindowTestFixture fx = new WindowTestFixture(true);
 
         // When
-        SlidingWindowDefinition wDef = tumbling(winSize).setEarlyResultsPeriod(earlyResultsPeriod);
+        SlidingWindowDefinition wDef = tumbling(winSize).setEarlyResultsPeriod(EARLY_RESULTS_PERIOD);
         StageWithKeyAndWindow<Entry<String, Integer>, String> windowed = fx.newSourceStage().window(wDef);
 
         // Then
         windowed.aggregate(SUMMING)
                 .drainTo(sink);
         jet().newJob(p);
-
         String expectedString = new SlidingWindowSimulator(wDef)
                 .acceptStream(fx.input.stream())
                 .stringResults(MOCK_FORMAT_FN);
-
         assertTrueEventually(() -> assertEquals(
                 expectedString,
                 streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN, TS_ENTRY_DISTINCT_FN)
@@ -217,29 +226,42 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
     @Test
     public void slidingWindow() {
-        testSlidingWindow(0L);
+        // Given
+        final int winSize = 4;
+        final int slideBy = 2;
+        WindowTestFixture fx = new WindowTestFixture(false);
+
+        // When
+        SlidingWindowDefinition wDef = sliding(winSize, slideBy);
+        StageWithKeyAndWindow<Entry<String, Integer>, String> windowed = fx.newSourceStage().window(wDef);
+
+        // Then
+        windowed.aggregate(SUMMING)
+                .drainTo(sink);
+        jet().newJob(p).join();
+        assertEquals(
+                new SlidingWindowSimulator(wDef)
+                        .acceptStream(fx.input.stream())
+                        .stringResults(MOCK_FORMAT_FN),
+                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN, TS_ENTRY_DISTINCT_FN)
+        );
     }
 
     @Test
     public void slidingWindow_withEarlyResults() {
-        testSlidingWindow(EARLY_RESULTS_PERIOD);
-    }
-
-    private void testSlidingWindow(long earlyResultsPeriod) {
         // Given
         final int winSize = 4;
         final int slideBy = 2;
-        WindowTestFixture fx = new WindowTestFixture(earlyResultsPeriod != 0);
+        WindowTestFixture fx = new WindowTestFixture(true);
 
         // When
-        SlidingWindowDefinition wDef = sliding(winSize, slideBy).setEarlyResultsPeriod(earlyResultsPeriod);
+        SlidingWindowDefinition wDef = sliding(winSize, slideBy).setEarlyResultsPeriod(EARLY_RESULTS_PERIOD);
         StageWithKeyAndWindow<Entry<String, Integer>, String> windowed = fx.newSourceStage().window(wDef);
 
         // Then
         windowed.aggregate(SUMMING)
                 .drainTo(sink);
         jet().newJob(p);
-
         String expectedString = new SlidingWindowSimulator(wDef)
                 .acceptStream(fx.input.stream())
                 .stringResults(MOCK_FORMAT_FN);
@@ -271,17 +293,15 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
                 .drainTo(sink);
 
         // Then
-        jet().newJob(p);
-        String expectedString = String.join("\n",
-                formatTsItem(1, singletonList("a0"), singletonList("b0")),
-                formatTsItem(2, asList("a0", "a1"), asList("b0", "b1")),
-                formatTsItem(3, asList("a1", "a2"), asList("b1", "b2")),
-                formatTsItem(4, singletonList("a2"), singletonList("b2"))
-        );
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
-                streamToString(sinkList.stream().map(String.class::cast), identity())),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(
+                String.join("\n",
+                        formatTsItem(1, singletonList("a0"), singletonList("b0")),
+                        formatTsItem(2, asList("a0", "a1"), asList("b0", "b1")),
+                        formatTsItem(3, asList("a1", "a2"), asList("b1", "b2")),
+                        formatTsItem(4, singletonList("a2"), singletonList("b2"))
+                ),
+                streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
 
     private static String formatTsItem(long timestamp, List<String> l1, List<String> l2) {
@@ -300,22 +320,20 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
                 .collect(toList());
 
         // When
-        SessionWindowDefinition wDef = session(sessionTimeout).setEarlyResultsPeriod(0L);
+        SessionWindowDefinition wDef = session(sessionTimeout);
         StageWithKeyAndWindow<Entry<String, Integer>, String> windowed = fx.newSourceStage().window(wDef);
 
         // Then
         windowed.aggregate(SUMMING,
                 (start, end, key, sum) -> new TimestampedEntry<>(start, key, sum))
                 .drainTo(sink);
-        jet().newJob(p);
-
-        String expectedString = new SessionWindowSimulator(wDef, sessionLength + sessionTimeout)
-                .acceptStream(fx.input.stream())
-                .stringResults(MOCK_FORMAT_FN);
-        assertTrueEventually(() -> assertEquals(
-                expectedString,
+        jet().newJob(p).join();
+        assertEquals(
+                new SessionWindowSimulator(wDef, sessionLength + sessionTimeout)
+                        .acceptStream(fx.input.stream())
+                        .stringResults(MOCK_FORMAT_FN),
                 streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN, TS_ENTRY_DISTINCT_FN)
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -342,7 +360,6 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
                                 : new TimestampedEntry<>(start, key, sum))
                 .drainTo(sink);
         jet().newJob(p);
-
         String expectedString = new SessionWindowSimulator(wDef, sessionLength + sessionTimeout)
                 .acceptStream(fx.input.stream())
                 .stringResults(MOCK_FORMAT_FN);
@@ -366,11 +383,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString2,
-                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_2)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString2,
+                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_2));
     }
 
     @Test
@@ -385,11 +400,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString2,
-                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_2)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString2,
+                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_2));
     }
 
     @Test
@@ -405,12 +418,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString2,
-                streamToString(sinkList.stream().map(String.class::cast), identity())),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString2,
+                streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
 
     @Test
@@ -426,12 +436,10 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString2,
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity())
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -446,11 +454,10 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString3,
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString3,
                 streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_3)
-        ), ASSERT_TIMEOUT_SECONDS);
+        );
     }
 
     @Test
@@ -466,11 +473,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString3,
-                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_3)),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString3,
+                streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_3));
     }
 
     @Test
@@ -488,12 +493,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString3,
-                streamToString(sinkList.stream().map(String.class::cast), identity())),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString3,
+                streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
 
     @Test
@@ -510,12 +512,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString3,
-                streamToString(sinkList.stream().map(String.class::cast), identity())),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString3,
+                streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
 
     @Test
@@ -534,12 +533,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString2,
-                streamToString(sinkList.stream().map(String.class::cast), identity())),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString2,
+                streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
 
     @Test
@@ -568,12 +564,9 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p);
-
-        assertTrueEventually(() -> assertEquals(
-                fx.expectedString2,
-                streamToString(sinkList.stream().map(String.class::cast), identity())),
-                ASSERT_TIMEOUT_SECONDS);
+        jet().newJob(p).join();
+        assertEquals(fx.expectedString2,
+                streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
 
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowGroupAggregateTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/WindowGroupAggregateTest.java
@@ -137,7 +137,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         distinct.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 IntStream.range(0, itemCount)
                          .mapToObj(i -> String.format("(%04d, %04d)", roundUp(i + 1, winSize), i / 2))
@@ -168,7 +168,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         distinct.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 IntStream.range(0, itemCount)
                          .mapToObj(i -> String.format("(%04d, %04d)", roundUp(i + 1, winSize), i / 2))
@@ -192,7 +192,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
         // Then
         windowed.aggregate(SUMMING)
                 .drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 new SlidingWindowSimulator(wDef)
                         .acceptStream(fx.input.stream())
@@ -238,7 +238,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
         // Then
         windowed.aggregate(SUMMING)
                 .drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 new SlidingWindowSimulator(wDef)
                         .acceptStream(fx.input.stream())
@@ -293,7 +293,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
                 .drainTo(sink);
 
         // Then
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 String.join("\n",
                         formatTsItem(1, singletonList("a0"), singletonList("b0")),
@@ -327,7 +327,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
         windowed.aggregate(SUMMING,
                 (start, end, key, sum) -> new TimestampedEntry<>(start, key, sum))
                 .drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(
                 new SessionWindowSimulator(wDef, sessionLength + sessionTimeout)
                         .acceptStream(fx.input.stream())
@@ -383,7 +383,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_2));
     }
@@ -400,7 +400,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_2));
     }
@@ -418,7 +418,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -436,7 +436,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity())
         );
@@ -454,7 +454,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_3)
         );
@@ -473,7 +473,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(sinkStreamOfTsEntry(), TS_ENTRY_FORMAT_FN_3));
     }
@@ -493,7 +493,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -512,7 +512,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString3,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -533,7 +533,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }
@@ -564,7 +564,7 @@ public class WindowGroupAggregateTest extends PipelineStreamTestSupport {
 
         // Then
         aggregated.drainTo(sink);
-        jet().newJob(p).join();
+        execute();
         assertEquals(fx.expectedString2,
                 streamToString(sinkList.stream().map(String.class::cast), identity()));
     }


### PR DESCRIPTION
Use a bounded streaming source so we can join() the job and 
deterministically assert the output.