### PR TITLE
Introduced getDistributedObjects on JetClientInstanceImpl

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetClientInstanceImpl.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.jet.impl;
 
+import com.hazelcast.client.impl.client.DistributedObjectInfo;
 import com.hazelcast.client.impl.clientside.ClientMessageDecoder;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.ClientGetDistributedObjectsCodec;
 import com.hazelcast.client.impl.protocol.codec.JetExistsDistributedObjectCodec;
 import com.hazelcast.client.impl.protocol.codec.JetGetClusterMetadataCodec;
 import com.hazelcast.client.impl.protocol.codec.JetGetClusterMetadataCodec.ResponseParameters;
@@ -156,6 +158,13 @@ public class JetClientInstanceImpl extends AbstractJetInstance {
         return invokeRequestOnAnyMemberAndDecodeResponse(
                 JetExistsDistributedObjectCodec.encodeRequest(serviceName, objectName),
                 response -> JetExistsDistributedObjectCodec.decodeResponse(response).response
+        );
+    }
+
+    public List<DistributedObjectInfo> getDistributedObjects() {
+        return invokeRequestOnAnyMemberAndDecodeResponse(
+                ClientGetDistributedObjectsCodec.encodeRequest(),
+                response -> ClientGetDistributedObjectsCodec.decodeResponse(response).response
         );
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JetClientInstanceImplTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JetClientInstanceImplTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.client.impl.client.DistributedObjectInfo;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+public class JetClientInstanceImplTest extends JetTestSupport {
+
+    @Test
+    public void given_singleMapOnMember_when_getDistributedObjectsCalled_then_ReturnedObjectInfo() {
+        // Given
+        JetInstance member = createJetMember();
+        JetClientInstanceImpl client = (JetClientInstanceImpl) createJetClient();
+        String mapName = randomMapName();
+        member.getMap(mapName);
+
+        // When
+        List<DistributedObjectInfo> objects = client.getDistributedObjects();
+
+
+        // Then
+        assertFalse(objects.isEmpty());
+        DistributedObjectInfo info = objects.stream()
+                                            .filter(i -> mapName.equals(i.getName()))
+                                            .findFirst()
+                                            .orElseThrow(AssertionError::new);
+        assertEquals(MapService.SERVICE_NAME, info.getServiceName());
+    }
+
+
+}


### PR DESCRIPTION
Introduced getDistributedObjects method in the JetClientInstanceImpl which only returns list of objects instead of actual/usable proxies

Workaround for https://github.com/hazelcast/hazelcast/issues/14571