### PR TITLE
Fix StreamKafkaP_TimestampModesTest failure

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTest.java
@@ -39,7 +39,7 @@ public class StreamSourceStageTest extends StreamSourceStageTestBase {
 
     @BeforeClass
     public static void beforeClass1() {
-        IMap<Integer, Integer> sourceMap = instances[0].getMap(JOURNALED_MAP_NAME);
+        IMap<Integer, Integer> sourceMap = instance.getMap(JOURNALED_MAP_NAME);
         sourceMap.put(1, 1);
         sourceMap.put(2, 2);
     }
@@ -122,14 +122,14 @@ public class StreamSourceStageTest extends StreamSourceStageTestBase {
 
     @Test
     public void test_withTimestampsButTimestampsNotUsed() {
-        IList sinkList = instances[0].getList("sinkList");
+        IList sinkList = instance.getList("sinkList");
 
         Pipeline p = Pipeline.create();
         p.drawFrom(createSourceJournal())
          .withIngestionTimestamps()
          .drainTo(Sinks.list(sinkList));
 
-        instances[0].newJob(p);
+        instance.newJob(p);
         assertTrueEventually(() -> assertEquals(Arrays.asList(1, 2), new ArrayList<>(sinkList)), 5);
     }
 


### PR DESCRIPTION
The issue was that the kafka source total parallelism was 4, but there
was only 1 partition in the test. So 3 processors were idle. Most of the
time, the idle processors immediately emitted IDLE_MESSAGE. But in the
failed run, IDLE_MESSAGE was emitted after the active processor emitted
the items and watermarks. This caused that wm(1) was suppressed at the
coalescer and only wm(2) was forwarded after the idle message was
received.

It's resolved by using total parallelism=1 everywhere, the test isn't
influenced by the parallelism.

Fixes #1294