### PR TITLE
Remove deprecated password from Jet

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetClientConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetClientConfig.java
@@ -27,10 +27,9 @@ import com.hazelcast.client.config.ClientConfig;
 public class JetClientConfig extends ClientConfig {
 
     /**
-     * Creates a new config instance with default group name and password for Jet
+     * Creates a new config instance with default group name for Jet
      */
     public JetClientConfig() {
         getGroupConfig().setName(JetConfig.DEFAULT_GROUP_NAME);
-        getGroupConfig().setPassword(JetConfig.DEFAULT_GROUP_PASSWORD);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
@@ -44,13 +44,6 @@ public class JetConfig {
      */
     public static final String DEFAULT_GROUP_NAME = "jet";
 
-    /**
-     * The default group password for a Jet cluster.
-     *
-     * See {@link com.hazelcast.config.GroupConfig}
-     */
-    public static final String DEFAULT_GROUP_PASSWORD = "jet-pass";
-
     private static final ILogger LOGGER = Logger.getLogger(JetConfig.class);
 
     private Config hazelcastConfig = defaultHazelcastConfig();
@@ -303,7 +296,6 @@ public class JetConfig {
         Config config = new Config();
         config.getNetworkConfig().getJoin().getMulticastConfig().setMulticastPort(DEFAULT_JET_MULTICAST_PORT);
         config.getGroupConfig().setName(DEFAULT_GROUP_NAME);
-        config.getGroupConfig().setPassword(DEFAULT_GROUP_PASSWORD);
         return config;
     }
 }

--- a/hazelcast-jet-core/src/main/resources/hazelcast-jet-client-default.xml
+++ b/hazelcast-jet-core/src/main/resources/hazelcast-jet-client-default.xml
@@ -20,6 +20,5 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>
         <name>jet</name>
-        <password>jet-pass</password>
     </group>
 </hazelcast-client>

--- a/hazelcast-jet-core/src/main/resources/hazelcast-jet-member-default.xml
+++ b/hazelcast-jet-core/src/main/resources/hazelcast-jet-member-default.xml
@@ -20,7 +20,6 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <group>
         <name>jet</name>
-        <password>jet-pass</password>
     </group>
     <network>
         <port auto-increment="true" port-count="100">5701</port>


### PR DESCRIPTION
Fixes #734 

After https://github.com/hazelcast/hazelcast/pull/14603 is merged, the password warning should also not be printed. Password option will be kept only in the enterprise version as it is only used there.