### PR TITLE
Make minimum idle time configurable

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -172,5 +172,4 @@ public final class Jet {
         MetricsConfig metricsConfig = jetConfig.getMetricsConfig();
         applyMetricsConfig(hzConfig, metricsConfig);
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -103,7 +103,7 @@ public class JetService
         HazelcastProperties jetProperties = new HazelcastProperties(config.getProperties());
         taskletExecutionService = new TaskletExecutionService(nodeEngine,
                 config.getInstanceConfig().getCooperativeThreadCount(),
-                jetProperties.getNanos(JetGroupProperty.JET_MINIMUM_IDLE_TIME));
+                jetProperties.getNanos(JetGroupProperty.JET_MINIMUM_IDLE_MICROSECONDS));
         jobRepository = new JobRepository(jetInstance);
         jobExecutionService = new JobExecutionService(nodeEngine, taskletExecutionService, jobRepository);
         jobCoordinationService = createJobCoordinationService();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.core.JobNotFoundException;
 import com.hazelcast.jet.impl.execution.TaskletExecutionService;
 import com.hazelcast.jet.impl.operation.NotifyMemberShutdownOperation;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
+import com.hazelcast.jet.impl.util.JetGroupProperty;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.LiveOperations;
@@ -40,6 +41,7 @@ import com.hazelcast.spi.MembershipServiceEvent;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -93,13 +95,15 @@ public class JetService
 
     // ManagedService
     @Override
-    public void init(NodeEngine engine, Properties properties) {
+    public void init(NodeEngine engine, Properties hzProperties) {
         this.nodeEngine = (NodeEngineImpl) engine;
         this.config = findJetServiceConfig(engine.getConfig());
         this.sharedMigrationWatcher = new MigrationWatcher(engine.getHazelcastInstance());
         jetInstance = new JetInstanceImpl((HazelcastInstanceImpl) engine.getHazelcastInstance(), config);
+        HazelcastProperties properties = new HazelcastProperties(hzProperties);
         taskletExecutionService = new TaskletExecutionService(nodeEngine,
-                config.getInstanceConfig().getCooperativeThreadCount());
+                config.getInstanceConfig().getCooperativeThreadCount(),
+                properties.getNanos(JetGroupProperty.JET_MINIMUM_IDLE_TIME));
         jobRepository = new JobRepository(jetInstance);
         jobExecutionService = new JobExecutionService(nodeEngine, taskletExecutionService, jobRepository);
         jobCoordinationService = createJobCoordinationService();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetService.java
@@ -100,10 +100,10 @@ public class JetService
         this.config = findJetServiceConfig(engine.getConfig());
         this.sharedMigrationWatcher = new MigrationWatcher(engine.getHazelcastInstance());
         jetInstance = new JetInstanceImpl((HazelcastInstanceImpl) engine.getHazelcastInstance(), config);
-        HazelcastProperties properties = new HazelcastProperties(hzProperties);
+        HazelcastProperties jetProperties = new HazelcastProperties(config.getProperties());
         taskletExecutionService = new TaskletExecutionService(nodeEngine,
                 config.getInstanceConfig().getCooperativeThreadCount(),
-                properties.getNanos(JetGroupProperty.JET_MINIMUM_IDLE_TIME));
+                jetProperties.getNanos(JetGroupProperty.JET_MINIMUM_IDLE_TIME));
         jobRepository = new JobRepository(jetInstance);
         jobExecutionService = new JobExecutionService(nodeEngine, taskletExecutionService, jobRepository);
         jobCoordinationService = createJobCoordinationService();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -52,7 +52,6 @@ import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptyList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
-import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.regex.Matcher.quoteReplacement;
@@ -62,10 +61,8 @@ import static java.util.stream.Collectors.toList;
 
 public class TaskletExecutionService {
 
-    private static final IdleStrategy IDLER_COOPERATIVE =
-            new BackoffIdleStrategy(0, 0, MICROSECONDS.toNanos(1), MILLISECONDS.toNanos(1));
-    private static final IdleStrategy IDLER_NON_COOPERATIVE =
-            new BackoffIdleStrategy(0, 0, MICROSECONDS.toNanos(1), MILLISECONDS.toNanos(5));
+    private static final long MAXIMUM_IDLE_COOPERATIVE = MILLISECONDS.toNanos(1);
+    private static final long MAXIMUM_IDLE_NON_COOPERATIVE = MILLISECONDS.toNanos(5);
 
     private final ExecutorService blockingTaskletExecutor = newCachedThreadPool(new BlockingTaskThreadFactory());
     private final CooperativeWorker[] cooperativeWorkers;
@@ -77,12 +74,17 @@ public class TaskletExecutionService {
     private final AtomicInteger blockingWorkerCount = new AtomicInteger();
     private volatile boolean isShutdown;
     private final Object lock = new Object();
+    private volatile IdleStrategy idlerCooperative;
+    private volatile IdleStrategy idlerNonCooperative;
 
-    public TaskletExecutionService(NodeEngineImpl nodeEngine, int threadCount) {
+    public TaskletExecutionService(NodeEngineImpl nodeEngine, int threadCount, long minimumIdleTime) {
         this.hzInstanceName = nodeEngine.getHazelcastInstance().getName();
         this.cooperativeWorkers = new CooperativeWorker[threadCount];
         this.cooperativeThreadPool = new Thread[threadCount];
         this.logger = nodeEngine.getLoggingService().getLogger(TaskletExecutionService.class);
+
+        idlerCooperative = new BackoffIdleStrategy(0, 0, minimumIdleTime, MAXIMUM_IDLE_COOPERATIVE);
+        idlerNonCooperative = new BackoffIdleStrategy(0, 0, minimumIdleTime, MAXIMUM_IDLE_NON_COOPERATIVE);
 
         nodeEngine.getMetricsRegistry().newProbeBuilder()
                        .withTag("module", "jet")
@@ -217,6 +219,7 @@ public class TaskletExecutionService {
             final Tasklet t = tracker.tasklet;
             final String oldName = currentThread().getName();
             currentThread().setContextClassLoader(tracker.jobClassLoader);
+            IdleStrategy idlerLocal = idlerNonCooperative;
 
             // swap the thread name by replacing the ".thread-NN" part at the end
             try {
@@ -233,7 +236,7 @@ public class TaskletExecutionService {
                     if (result.isMadeProgress()) {
                         idleCount = 0;
                     } else {
-                        IDLER_NON_COOPERATIVE.idle(++idleCount);
+                        idlerLocal.idle(++idleCount);
                     }
                 } while (!result.isDone()
                         && !tracker.executionTracker.executionCompletedExceptionally()
@@ -265,6 +268,7 @@ public class TaskletExecutionService {
 
         @Override
         public void run() {
+            IdleStrategy idlerLocal = idlerCooperative;
             long idleCount = 0;
             // capture thread once and prevent lambda allocation on each iteration
             Consumer<TaskletTracker> runTasklet = t -> runTasklet(Thread.currentThread(), t);
@@ -277,7 +281,7 @@ public class TaskletExecutionService {
                 if (progressTracker.isMadeProgress()) {
                     idleCount = 0;
                 } else {
-                    IDLER_COOPERATIVE.idle(++idleCount);
+                    idlerLocal.idle(++idleCount);
                 }
             }
             trackers.forEach(t -> t.executionTracker.taskletDone());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
@@ -48,7 +48,7 @@ public final class JetGroupProperty {
      * very high value (>10000µs) limits the throughput.
      */
     public static final HazelcastProperty JET_MINIMUM_IDLE_TIME
-            = new HazelcastProperty("jet.minimum.idle.time", 25, MICROSECONDS);
+            = new HazelcastProperty("jet.minimum.idle.microseconds", 25, MICROSECONDS);
 
     private JetGroupProperty() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
@@ -37,9 +37,9 @@ public final class JetGroupProperty {
             = new HazelcastProperty("jet.job.results.ttl.seconds", DAYS.toSeconds(7), SECONDS);
 
     /**
-     * The minimum time in microseconds the worker thread will sleep if none of
-     * the tasklets made any progress. If you see high cpu usage for jobs with
-     * otherwise low traffic, you can try increasing the value.
+     * The minimum time in microseconds the worker threads will sleep if none
+     * of the tasklets made any progress. If you see high cpu usage for jobs
+     * with otherwise low traffic, you can try increasing the value.
      * <p>
      * The default value is 25µs, but the {@code parkNano} call actually sleeps
      * longer, by default 50µs on Linux and up to 15000µs on Windows. See
@@ -47,7 +47,7 @@ public final class JetGroupProperty {
      * for more information. Higher value also slightly increases latency and a
      * very high value (>10000µs) limits the throughput.
      */
-    public static final HazelcastProperty JET_MINIMUM_IDLE_TIME
+    public static final HazelcastProperty JET_MINIMUM_IDLE_MICROSECONDS
             = new HazelcastProperty("jet.minimum.idle.microseconds", 25, MICROSECONDS);
 
     private JetGroupProperty() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
@@ -20,6 +20,7 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -34,8 +35,9 @@ public final class JetGroupProperty {
             = new HazelcastProperty("jet.shutdownhook.enabled", SHUTDOWNHOOK_ENABLED.getDefaultValue());
     public static final HazelcastProperty JOB_RESULTS_TTL_SECONDS
             = new HazelcastProperty("jet.job.results.ttl.seconds", DAYS.toSeconds(7), SECONDS);
+    public static final HazelcastProperty JET_MINIMUM_IDLE_TIME
+            = new HazelcastProperty("jet.minimum.idle.time", 25, MICROSECONDS);
 
     private JetGroupProperty() {
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetGroupProperty.java
@@ -35,6 +35,18 @@ public final class JetGroupProperty {
             = new HazelcastProperty("jet.shutdownhook.enabled", SHUTDOWNHOOK_ENABLED.getDefaultValue());
     public static final HazelcastProperty JOB_RESULTS_TTL_SECONDS
             = new HazelcastProperty("jet.job.results.ttl.seconds", DAYS.toSeconds(7), SECONDS);
+
+    /**
+     * The minimum time in microseconds the worker thread will sleep if none of
+     * the tasklets made any progress. If you see high cpu usage for jobs with
+     * otherwise low traffic, you can try increasing the value.
+     * <p>
+     * The default value is 25µs, but the {@code parkNano} call actually sleeps
+     * longer, by default 50µs on Linux and up to 15000µs on Windows. See
+     * https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/
+     * for more information. Higher value also slightly increases latency and a
+     * very high value (>10000µs) limits the throughput.
+     */
     public static final HazelcastProperty JET_MINIMUM_IDLE_TIME
             = new HazelcastProperty("jet.minimum.idle.time", 25, MICROSECONDS);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/TaskletExecutionServiceTest.java
@@ -83,7 +83,7 @@ public class TaskletExecutionServiceTest extends JetTestSupport {
         Mockito.when(neMock.getMetricsRegistry()).thenReturn(metricsRegistry);
         Mockito.when(loggingService.getLogger(TaskletExecutionService.class))
                .thenReturn(Logger.getLogger(TaskletExecutionService.class));
-        es = new TaskletExecutionService(neMock, THREAD_COUNT);
+        es = new TaskletExecutionService(neMock, THREAD_COUNT, 10_000);
         classLoaderMock = mock(ClassLoader.class);
     }
 


### PR DESCRIPTION
Also increases the default minimum from 1µs to 25µs - the real minimum
on linux actually was 50µs and 15000µs on Windows.