### PR TITLE
Hash Join support for non-distinct keys #1326

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
@@ -21,53 +21,56 @@ import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.impl.pipeline.transform.HashJoinTransform;
+import com.hazelcast.jet.impl.processor.HashJoinCollectP.HashJoinArrayList;
 import com.hazelcast.jet.pipeline.BatchStage;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static com.hazelcast.jet.Traversers.traverseIterable;
 import static com.hazelcast.jet.Traversers.traverseStream;
-import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
-import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
-import static java.util.Collections.emptyList;
+import static com.hazelcast.util.Preconditions.checkTrue;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 /**
- * Implements the {@linkplain HashJoinTransform
- * hash-join transform}. On all edges except 0 it will receive a single
- * item &mdash; the lookup table for that edge (a {@code Map}) and then it
- * will process edge 0 by joining to each item the data from lookup tables.
- * It will extract a separate key for each of the lookup tables using the
- * functions supplied in the {@code keyFns} argument. Element 0 in that list
- * corresponds to the lookup table received at ordinal 1 and so on.
+ * Implements the {@linkplain HashJoinTransform hash-join transform}. On
+ * all edges except 0 it receives a single item &mdash; the lookup table
+ * for that edge (a {@code Map}) and then it processes edge 0 by joining
+ * to each item the data from the lookup tables.
  * <p>
- * The {@code tags} is used to populate the output items. It can be {@code
- * null}, in which case {@code keyFns} must have either one or two elements,
- * corresponding to the two supported special cases in {@link BatchStage}.
+ * It extracts a separate key for each of the lookup tables using the
+ * functions supplied in the {@code keyFns} argument. Element 0 in that
+ * list corresponds to the lookup table received at ordinal 1 and so on.
+ * <p>
+ * It uses the {@code tags} list to populate the output items. It can be
+ * {@code null}, in which case {@code keyFns} must have either one or two
+ * elements, corresponding to the two supported special cases in {@link
+ * BatchStage} (hash-joining with one or two enriching streams).
  * <p>
  * After looking up all the joined items the processor calls the supplied
  * {@code mapToOutput*Fn} to get the final output item. It uses {@code
  * mapToOutputBiFn} both for the single-arity case ({@code tags == null &&
  * keyFns.size() == 1}) and the variable-arity case ({@code tags != null}).
  * In the latter case the function must expect {@code ItemsByTag} as the
- * second argument.
- * <p>
- * Note that internally the processor stores the lists with a {@code null}
- * element prepended to remove the mismatch between list index and ordinal.
+ * second argument. It uses {@code mapToOutputTriFn} for the two-arity
+ * case ({@code tags == null && keyFns.size() == 2}).
  */
+@SuppressWarnings("unchecked")
 public class HashJoinP<E0> extends AbstractProcessor {
 
+    private static final List<Object> LIST_WITH_NULL = singletonList(null);
+
     private final List<Function<E0, Object>> keyFns;
-    private final List<Map<Object, List<Object>>> lookupTables;
-    private final List<Tag> tags;
-    private final BiFunction mapToOutputBiFn;
+    private final List<Map<Object, Object>> lookupTables;
 
     private final FlatMapper<E0, Object> flatMapper;
 
@@ -79,70 +82,86 @@ public class HashJoinP<E0> extends AbstractProcessor {
             @Nullable BiFunction mapToOutputBiFn,
             @Nullable TriFunction mapToOutputTriFn
     ) {
-        this.keyFns = prependNull(keyFns);
-        this.lookupTables = prependNull(Collections.nCopies(keyFns.size(), null));
-        this.tags = tags.isEmpty() ? emptyList() : prependNull(tags);
-        this.mapToOutputBiFn = mapToOutputBiFn;
-
-        if (tags.isEmpty()) {
-            if (this.keyFns.size() == 2) {
-                BiFunction mapToOutput = requireNonNull(mapToOutputBiFn, "mapToOutputBiFn function should be provided");
-                this.flatMapper = flatMapper(object -> traverseStream(
-                        lookupJoined(1, object).stream()
-                                .map(joinedObject -> tuple2(object, joinedObject))
-                ).map(joinedTuple -> mapToOutput.apply(joinedTuple.f0(), joinedTuple.f1())));
-            } else {
-                TriFunction mapToOutput = requireNonNull(mapToOutputTriFn, "mapToOutputTriFn function should be provided");
-                this.flatMapper = flatMapper(object -> traverseStream(
-                        lookupJoined(1, object).stream().flatMap(firstJoined ->
-                                lookupJoined(2, object).stream().map(secondJoined ->
-                                        tuple3(object, firstJoined, secondJoined)
-                                )
-                        )
-                ).map(joinedTuple ->  mapToOutput.apply(joinedTuple.f0(), joinedTuple.f1(), joinedTuple.f2())));
-            }
-        } else {
-            this.flatMapper = null;
+        this.keyFns = keyFns;
+        this.lookupTables = new ArrayList<>(Collections.nCopies(keyFns.size(), null));
+        if (!tags.isEmpty()) {
+            this.flatMapper = itemsByTagFlatMapper(tags, mapToOutputBiFn);
+            return;
         }
+        if (keyFns.size() == 1) {
+            BiFunction mapToOutput = requireNonNull(mapToOutputBiFn,
+                    "tags.isEmpty() && keyFns.size() == 1, but mapToOutputBiFn == null");
+            this.flatMapper = flatMapper(item -> traverseStream(lookupJoined(0, item).stream()
+                    .map(joinedObject -> mapToOutput.apply(item, joinedObject))
+                    .filter(Objects::nonNull)));
+            return;
+        }
+        checkTrue(keyFns.size() == 2, "tags.isEmpty(), but keyFns.size() is neither 1 nor 2");
+        TriFunction mapToOutput = requireNonNull(mapToOutputTriFn,
+                "tags.isEmpty() && keyFns.size() == 2, but mapToOutputTriFn == null");
+        this.flatMapper = flatMapper(object -> {
+            List<Object> joined0 = lookupJoined(0, object);
+            List<Object> joined1 = lookupJoined(1, object);
+            return traverseStream(joined0.stream()
+                    .flatMap(firstJoined -> joined1.stream()
+                            .map(secondJoined -> mapToOutput.apply(object, firstJoined, secondJoined)))
+                    .filter(Objects::nonNull));
+        });
+    }
+
+    private FlatMapper<E0, Object> itemsByTagFlatMapper(@Nonnull List<Tag> tags, @Nullable BiFunction mapToOutputBiFn) {
+        assert mapToOutputBiFn != null : "mapToOutputBiFn required";
+        List<Object>[] lookedUpValues = new List[keyFns.size()];
+        List<ItemsByTag> values = new ArrayList<>();
+        int[] indices = new int[keyFns.size()];
+        return flatMapper(primaryItem -> {
+            for (int i = 0; i < keyFns.size(); i++) {
+                lookedUpValues[i] = lookupJoined(i, primaryItem);
+            }
+            Arrays.fill(indices, 0);
+            values.clear();
+            while (indices[0] < lookedUpValues[0].size()) {
+                ItemsByTag val = new ItemsByTag();
+                for (int j = 0; j < lookedUpValues.length; j++) {
+                    val.put(tags.get(j), lookedUpValues[j].get(indices[j]));
+                }
+                values.add(val);
+                for (int j = indices.length - 1; j >= 0; j--) {
+                    indices[j]++;
+                    if (j == 0 || indices[j] < lookedUpValues[j].size()) {
+                        break;
+                    }
+                    indices[j] = 0;
+                }
+            }
+            return traverseIterable(values)
+                    .map(map -> mapToOutputBiFn.apply(primaryItem, map));
+        });
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected boolean tryProcess(int ordinal, @Nonnull Object item) {
         assert !ordinal0consumed : "Edge 0 must have a lower priority than all other edges";
-        lookupTables.set(ordinal, (Map) item);
+        lookupTables.set(ordinal - 1, (Map) item);
         return true;
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected boolean tryProcess0(@Nonnull Object item) {
         E0 e0 = (E0) item;
         ordinal0consumed = true;
-        if (tags.isEmpty()) {
-            return flatMapper.tryProcess(e0);
-        }
-        ItemsByTag map = new ItemsByTag();
-        for (int i = 1; i < keyFns.size(); i++) {
-            map.put(tags.get(i), lookupJoined(i, e0).get(0));
-        }
-        Object result = mapToOutputBiFn.apply(e0, map);
-        return result == null || tryEmit(result);
+        return flatMapper.tryProcess(e0);
     }
 
     @Nonnull
-    private List<Object> lookupJoined(int ordinal, E0 item) {
-        Map<Object, List<Object>> lookupTableForOrdinal = lookupTables.get(ordinal);
+    private List<Object> lookupJoined(int index, E0 item) {
+        Map<Object, Object> lookupTableForOrdinal = lookupTables.get(index);
 
-        Object lookupTableKey = keyFns.get(ordinal).apply(item);
-        List<Object> objects = lookupTableForOrdinal.get(lookupTableKey);
+        Object lookupTableKey = keyFns.get(index).apply(item);
+        Object objects = lookupTableForOrdinal.get(lookupTableKey);
 
-        return objects == null ? new ArrayList<>() : objects;
-    }
-
-    private static <E> List<E> prependNull(List<E> in) {
-        List<E> result = new ArrayList<>(singletonList(null));
-        result.addAll(in);
-        return result;
+        return objects == null ? LIST_WITH_NULL
+                : objects instanceof HashJoinArrayList ? (List<Object>) objects
+                : singletonList(objects);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
@@ -16,28 +16,33 @@
 
 package com.hazelcast.jet.impl.processor;
 
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.datamodel.Tuple3;
 import com.hazelcast.jet.function.SupplierEx;
 import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.impl.processor.HashJoinCollectP.HashJoinArrayList;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.core.test.TestSupport.verifyProcessor;
+import static com.hazelcast.jet.datamodel.ItemsByTag.itemsByTag;
+import static com.hazelcast.jet.datamodel.Tag.tag0;
+import static com.hazelcast.jet.datamodel.Tag.tag1;
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
 import static java.util.Arrays.asList;
@@ -48,96 +53,307 @@ import static java.util.Collections.singletonList;
 @RunWith(HazelcastParallelClassRunner.class)
 public class HashJoinPTest extends JetTestSupport {
 
-    private final BiFunction mapToOutputBi = Tuple2::tuple2;
-    private final TriFunction mapToOutputTri = Tuple3::tuple3;
-    private JetInstance instance;
+    private static final BiFunction mapToOutputBiFn = Tuple2::tuple2;
+    private static final TriFunction mapToOutputTriFn = Tuple3::tuple3;
 
-    @Before
-    public void setUp() {
-        instance = this.createJetMember();
+    @Test
+    public void test_oneToOneJoin_biJoin() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                singletonList(e -> e),
+                emptyList(),
+                mapToOutputBiFn,
+                mapToOutputTriFn
+        );
+
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(0, 1, 2),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(2, "b")
+                        ))
+                ), new int[]{ 10, 1 })
+                .expectOutput(asList(
+                        tuple2(0, null),
+                        tuple2(1, "a"),
+                        tuple2(2, "b")
+                ));
     }
 
     @Test
-    public void when_oneToOneJoinBiJoin_then_producesCorrectOutput() {
-        Function<Integer, Object> enrichingSideKeyFn = e -> e;
-        List<List<?>> inputs = asList(
-                asList(1, 2, 3),
-                hashJoinCollected(e -> e, 1, 3)
-        );
-        List<Tuple2<Integer, Integer>> expectedOutput = asList(
-                tuple2(1, 1),
-                tuple2(3, 3)
-        );
-
-        testJoin(asList(e -> e, enrichingSideKeyFn), inputs, expectedOutput);
-    }
-    @Test
-    public void when_oneToManyJoinBiJoin_then_producesCorrectOutput() {
+    public void test_oneToNJoin_biJoin() {
         Function<Integer, Object> enrichingSideKeyFn = e -> e % 10;
 
-        List<List<?>> inputs = asList(
-                asList(1, 2, 3), //
-                hashJoinCollected(enrichingSideKeyFn, 1, 3, 11, 12)
-        );
-        List<Tuple2<Integer, Integer>> expectedOutput = asList(
-                tuple2(1, 1),
-                tuple2(1, 11),
-                tuple2(2, 12),
-                tuple2(3, 3)
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                singletonList(enrichingSideKeyFn),
+                emptyList(),
+                mapToOutputBiFn,
+                mapToOutputTriFn
         );
 
-        testJoin(asList(e -> e, enrichingSideKeyFn), inputs, expectedOutput);
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(0, 1, 2),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(2, asCustomList("b", "c"))
+                        ))
+
+                ), new int[]{ 10, 1 })
+                .expectOutput(asList(
+                        tuple2(0, null),
+                        tuple2(1, "a"),
+                        tuple2(2, "b"),
+                        tuple2(2, "c")
+                ));
     }
 
     @Test
-    public void when_oneToOneJoinTriJoin_then_producesCorrectOutput() {
-        Function<Integer, Object> keyFn = e -> e;
-        List<List<?>> inputs = asList(
-                asList(1, 2, 3), //
-                hashJoinCollected(e -> e, 1, 3), //
-                hashJoinCollected(e -> e, 1, 3)
-        );
-        List<Tuple3<Integer, Integer, Integer>> expectedOutput = asList(
-                tuple3(1, 1, 1), //
-                tuple3(3, 3, 3)
-        );
-
-        testJoin(asList(keyFn, keyFn, keyFn), inputs, expectedOutput);
-    }
-
-    private void testJoin(
-            List<Function<Integer, Object>> keyFunctions,
-            List<List<?>> inputs,
-            List<?> expectedOutput
-    ) {
+    public void test_oneToOneJoin_triJoin() {
         SupplierEx<Processor> supplier = () -> new HashJoinP<>(
-                keyFunctions,
+                asList(e -> e, e -> e),
                 emptyList(),
-                mapToOutputBi,
-                mapToOutputTri
+                mapToOutputBiFn,
+                mapToOutputTriFn
         );
 
-        int[] priorities = inputs.size() == 2 ? new int[]{ 10, 1 } : new int[]{ 10, 1, 1 };
         verifyProcessor(supplier)
-                .jetInstance(instance)
                 .disableSnapshots()
-                .disableLogging()
-                .inputs(inputs, priorities)
-                .expectOutput(expectedOutput);
+                .inputs(asList(
+                        asList(1, 2, 3),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(3, "c")
+                        )),
+                        singletonList(toMap(
+                                tuple2(1, "A"),
+                                tuple2(2, "B")
+                        ))
+                ), new int[]{ 10, 1, 1 })
+                .expectOutput(asList(
+                        tuple3(1, "a", "A"),
+                        tuple3(2, null, "B"),
+                        tuple3(3, "c", null)
+                ));
     }
 
-    /**
-     * Second and third ordinal has one element list of Map as an input.
-     * This function simulates output of {@link HashJoinCollectP}
-     */
+    @Test
+    public void test_oneToNJoin_triJoin() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                asList(e -> e, e -> e),
+                emptyList(),
+                mapToOutputBiFn,
+                mapToOutputTriFn
+        );
+
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(0, 1, 2, 3, 4),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(2, asCustomList("b", "c")),
+                                tuple2(4, asCustomList("d", "e"))
+                        )),
+                        singletonList(toMap(
+                                tuple2(2, "A"),
+                                tuple2(3, asCustomList("B", "C")),
+                                tuple2(4, asCustomList("D", "E"))
+                        ))
+                ), new int[]{ 10, 1, 1 })
+                .expectOutput(asList(
+                        tuple3(0, null, null),
+                        tuple3(1, "a", null),
+                        tuple3(2, "b", "A"),
+                        tuple3(2, "c", "A"),
+                        tuple3(3, null, "B"),
+                        tuple3(3, null, "C"),
+                        tuple3(4, "d", "D"),
+                        tuple3(4, "d", "E"),
+                        tuple3(4, "e", "D"),
+                        tuple3(4, "e", "E")
+                ));
+    }
+
+    @Test
+    public void test_oneToOneJoin_withTags() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                asList(e -> e, e -> e),
+                asList(tag0(), tag1()),
+                mapToOutputBiFn,
+                mapToOutputTriFn
+        );
+
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(1, 2, 3),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(3, "c")
+                        )),
+                        singletonList(toMap(
+                                tuple2(1, "A"),
+                                tuple2(2, "B")
+                        ))
+                ), new int[]{ 10, 1, 1 })
+                .expectOutput(asList(
+                        tuple2(1, itemsByTag(tag0(), "a", tag1(), "A")),
+                        tuple2(2, itemsByTag(tag0(), null, tag1(), "B")),
+                        tuple2(3, itemsByTag(tag0(), "c", tag1(), null))
+                ));
+    }
+
+    @Test
+    public void test_oneToNJoin_withTags() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                asList(e -> e, e -> e),
+                asList(tag0(), tag1()),
+                mapToOutputBiFn,
+                mapToOutputTriFn
+        );
+
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(0, 1, 2, 3, 4),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(2, asCustomList("b", "c")),
+                                tuple2(4, asCustomList("d", "e"))
+                        )),
+                        singletonList(toMap(
+                                tuple2(2, "A"),
+                                tuple2(3, asCustomList("B", "C")),
+                                tuple2(4, asCustomList("D", "E"))
+                        ))
+                ), new int[]{ 10, 1, 1 })
+                .expectOutput(asList(
+                        tuple2(0, itemsByTag(tag0(), null, tag1(), null)),
+                        tuple2(1, itemsByTag(tag0(), "a", tag1(), null)),
+                        tuple2(2, itemsByTag(tag0(), "b", tag1(), "A")),
+                        tuple2(2, itemsByTag(tag0(), "c", tag1(), "A")),
+                        tuple2(3, itemsByTag(tag0(), null, tag1(), "B")),
+                        tuple2(3, itemsByTag(tag0(), null, tag1(), "C")),
+                        tuple2(4, itemsByTag(tag0(), "d", tag1(), "D")),
+                        tuple2(4, itemsByTag(tag0(), "d", tag1(), "E")),
+                        tuple2(4, itemsByTag(tag0(), "e", tag1(), "D")),
+                        tuple2(4, itemsByTag(tag0(), "e", tag1(), "E"))
+                ));
+    }
+
+    @Test
+    public void test_biJoin_mapToNull() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                singletonList(e -> e),
+                emptyList(),
+                (l, r) -> r == null ? null : tuple2(l, r),
+                null
+        );
+
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(0, 1),
+                        singletonList(toMap(
+                                tuple2(1, "a")
+                        ))
+                ), new int[]{ 10, 1 })
+                .expectOutput(singletonList(
+                        tuple2(1, "a")));
+    }
+
+    @Test
+    public void test_triJoin_mapToNull() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                asList(e -> e, e -> e),
+                emptyList(),
+                null,
+                (l, r1, r2) -> r1 == null || r2 == null ? null : tuple3(l, r1, r2)
+        );
+
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(0, 1, 2, 3),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(2, "b")
+                        )),
+                        singletonList(toMap(
+                                tuple2(1, "A"),
+                                tuple2(3, "C")
+                        ))
+                ), new int[]{ 10, 1, 1 })
+                .expectOutput(singletonList(
+                        tuple3(1, "a", "A")));
+    }
+
+    @Test
+    public void test_withTags_mapToNull() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                asList(e -> e, e -> e),
+                asList(tag0(), tag1()),
+                (item, map) -> ((ItemsByTag) map).get(tag0()) == null ? null : tuple2(item, map),
+                null
+        );
+
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        asList(1, 2, 3),
+                        singletonList(toMap(
+                                tuple2(1, "a"),
+                                tuple2(3, "c")
+                        )),
+                        singletonList(toMap(
+                                tuple2(1, "A"),
+                                tuple2(2, "B")
+                        ))
+                ), new int[]{ 10, 1, 1 })
+                .expectOutput(asList(
+                        tuple2(1, itemsByTag(tag0(), "a", tag1(), "A")),
+                        tuple2(3, itemsByTag(tag0(), "c", tag1(), null))
+                ));
+
+    }
+
+    @Test
+    public void when_arrayListInItems_then_treatedAsAnItem() {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                singletonList(e -> e),
+                emptyList(),
+                mapToOutputBiFn,
+                mapToOutputTriFn
+        );
+
+        List<String> listItem = new ArrayList<>();
+        listItem.add("a");
+        listItem.add("b");
+        verifyProcessor(supplier)
+                .disableSnapshots()
+                .inputs(asList(
+                        singletonList(0),
+                        singletonList(toMap(
+                                tuple2(0, listItem)
+                        ))
+                ), new int[]{ 10, 1 })
+                .expectOutput(singletonList(
+                        tuple2(0, listItem)
+                ));
+    }
+
     @SafeVarargs
-    private static <E0> List<Map<Object, List<E0>>> hashJoinCollected(Function<E0, Object> keyFn, E0... items) {
-        Map<Object, List<E0>> map = new HashMap<>();
-        for (E0 item : items) {
-            map.computeIfAbsent(keyFn.apply(item), k -> new ArrayList<>())
-                    .add(item);
-        }
-        return singletonList(map);
+    private static <T> HashJoinArrayList asCustomList(T ... values) {
+        HashJoinArrayList res = new HashJoinArrayList();
+        Collections.addAll(res, values);
+        return res;
     }
 
+    @SafeVarargs
+    private static <K, V> Map<K, V> toMap(Tuple2<K, V>... entries) {
+        return Stream.of(entries).collect(Collectors.toMap(Tuple2::f0, Tuple2::f1));
+    }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.core.Processor;
+import com.hazelcast.jet.datamodel.Tuple2;
+import com.hazelcast.jet.datamodel.Tuple3;
+import com.hazelcast.jet.function.SupplierEx;
+import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static com.hazelcast.jet.core.test.TestSupport.verifyProcessor;
+import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
+import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+@Category(ParallelTest.class)
+@RunWith(HazelcastParallelClassRunner.class)
+public class HashJoinPTest extends JetTestSupport {
+
+    private final BiFunction mapToOutputBi = Tuple2::tuple2;
+    private final TriFunction mapToOutputTri = Tuple3::tuple3;
+    private JetInstance instance;
+
+    @Before
+    public void setUp() {
+        instance = this.createJetMember();
+    }
+
+    @Test
+    public void when_oneToOneJoinBiJoin_then_producesCorrectOutput() {
+        Function<Integer, Object> enrichingSideKeyFn = e -> e;
+        List<List<?>> inputs = asList(
+                asList(1, 2, 3),
+                hashJoinCollected(e -> e, 1, 3)
+        );
+        List<Tuple2<Integer, Integer>> expectedOutput = asList(
+                tuple2(1, 1),
+                tuple2(3, 3)
+        );
+
+        testJoin(asList(e -> e, enrichingSideKeyFn), inputs, expectedOutput);
+    }
+    @Test
+    public void when_oneToManyJoinBiJoin_then_producesCorrectOutput() {
+        Function<Integer, Object> enrichingSideKeyFn = e -> e % 10;
+
+        List<List<?>> inputs = asList(
+                asList(1, 2, 3), //
+                hashJoinCollected(enrichingSideKeyFn, 1, 3, 11, 12)
+        );
+        List<Tuple2<Integer, Integer>> expectedOutput = asList(
+                tuple2(1, 1),
+                tuple2(1, 11),
+                tuple2(2, 12),
+                tuple2(3, 3)
+        );
+
+        testJoin(asList(e -> e, enrichingSideKeyFn), inputs, expectedOutput);
+    }
+
+    @Test
+    public void when_oneToOneJoinTriJoin_then_producesCorrectOutput() {
+        Function<Integer, Object> keyFn = e -> e;
+        List<List<?>> inputs = asList(
+                asList(1, 2, 3), //
+                hashJoinCollected(e -> e, 1, 3), //
+                hashJoinCollected(e -> e, 1, 3)
+        );
+        List<Tuple3<Integer, Integer, Integer>> expectedOutput = asList(
+                tuple3(1, 1, 1), //
+                tuple3(3, 3, 3)
+        );
+
+        testJoin(asList(keyFn, keyFn, keyFn), inputs, expectedOutput);
+    }
+
+    private void testJoin(
+            List<Function<Integer, Object>> keyFunctions,
+            List<List<?>> inputs,
+            List<?> expectedOutput
+    ) {
+        SupplierEx<Processor> supplier = () -> new HashJoinP<>(
+                keyFunctions,
+                emptyList(),
+                mapToOutputBi,
+                mapToOutputTri
+        );
+
+        int[] priorities = inputs.size() == 2 ? new int[]{ 10, 1 } : new int[]{ 10, 1, 1 };
+        verifyProcessor(supplier)
+                .jetInstance(instance)
+                .disableSnapshots()
+                .disableLogging()
+                .inputs(inputs, priorities)
+                .expectOutput(expectedOutput);
+    }
+
+    /**
+     * Second and third ordinal has one element list of Map as an input.
+     * This function simulates output of {@link HashJoinCollectP}
+     */
+    @SafeVarargs
+    private static <E0> List<Map<Object, List<E0>>> hashJoinCollected(Function<E0, Object> keyFn, E0... items) {
+        Map<Object, List<E0>> map = new HashMap<>();
+        for (E0 item : items) {
+            map.computeIfAbsent(keyFn.apply(item), k -> new ArrayList<>())
+                    .add(item);
+        }
+        return singletonList(map);
+    }
+
+}


### PR DESCRIPTION
As in the title, this PR add Hash Join support for non-distinct keys #1326

Note: it considers only non-tag way. I have to digg more into how Tags works, but this issue is a blocker for my team, that's why I create PR before second part is implemented. It will be implemented in a follow-up