### PR TITLE
Add sample snippets to Javadoc

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.pipeline;
 
 import com.hazelcast.jet.Traverser;
+import com.hazelcast.jet.Util;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.function.BiFunctionEx;
@@ -248,17 +249,15 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     @SuppressWarnings("unchecked")
     <K, R, OUT, RET> RET attachRollingAggregate(
             FunctionEx<? super T, ? extends K> keyFn,
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp,
-            @Nonnull BiFunctionEx<? super K, ? super R, ? extends OUT> mapToOutputFn
+            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp
 
     ) {
         checkSerializable(keyFn, "keyFn");
-        checkSerializable(mapToOutputFn, "mapToOutputFn");
         return (RET) attach(new RollingAggregateTransform(
                         transform,
                         fnAdapter.adaptKeyFn(keyFn),
                         fnAdapter.adaptAggregateOperation1(aggrOp),
-                        fnAdapter.adaptRollingAggregateOutputFn(mapToOutputFn)
+                        fnAdapter.adaptRollingAggregateOutputFn(Util::entry)
         ), fnAdapter);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
@@ -20,7 +20,6 @@ import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
-import com.hazelcast.jet.function.BiFunctionEx;
 import com.hazelcast.jet.function.FunctionEx;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.function.TriPredicate;
@@ -30,6 +29,7 @@ import com.hazelcast.jet.pipeline.StreamStageWithKey;
 import com.hazelcast.jet.pipeline.WindowDefinition;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class StreamStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> implements StreamStageWithKey<T, K> {
@@ -98,11 +98,10 @@ public class StreamStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> im
     }
 
     @Nonnull @Override
-    public <R, OUT> StreamStage<OUT> rollingAggregate(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp,
-            @Nonnull BiFunctionEx<? super K, ? super R, ? extends OUT> mapToOutputFn
+    public <R> StreamStage<Map.Entry<K, R>> rollingAggregate(
+            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp
     ) {
-        return computeStage.attachRollingAggregate(keyFn(), aggrOp, mapToOutputFn);
+        return computeStage.attachRollingAggregate(keyFn(), aggrOp);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -190,6 +190,11 @@ public interface BatchStage<T> extends GeneralStage<T> {
     /**
      * Attaches a stage that performs the given aggregate operation over all
      * the items it receives. The aggregating stage emits a single item.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * stage.aggregate(AggregateOperations.counting())
+     * }</pre>
      *
      * @see AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
@@ -215,6 +220,15 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * accumulator.
      * <p>
      * The returned stage emits a single item.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * BatchStage<Tuple2<Long, Long>> counts = pageVisits.aggregate2(addToCarts,
+     *         AggregateOperations.aggregateOperation2(
+     *                 AggregateOperations.counting(),
+     *                 AggregateOperations.counting())
+     *         );
+     * }</pre>
      *
      * @see AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
@@ -232,6 +246,14 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * a {@link Tuple2} with their results.
      * <p>
      * The returned stage emits a single item.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * BatchStage<Tuple2<Long, Long>> counts = pageVisits.aggregate2(
+     *         AggregateOperations.counting(),
+     *         addToCarts, AggregateOperations.counting()
+     * );
+     * }</pre>
      *
      * @param aggrOp0 aggregate operation to perform on this stage
      * @param stage1 the other stage
@@ -264,7 +286,18 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * aggregate operation that combines the input streams into the same
      * accumulator.
      * <p>
-     * The aggregating stage emits a single item.
+     * The returned stage emits a single item.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * BatchStage<Tuple3<Long, Long, Long>> counts = pageVisits.aggregate3(
+     *         addToCarts,
+     *         payments,
+     *         AggregateOperations.aggregateOperation3(
+     *                 AggregateOperations.counting(),
+     *                 AggregateOperations.counting(),
+     *                 AggregateOperations.counting()));
+     * }</pre>
      *
      * @see AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
@@ -285,6 +318,15 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * emitting a {@link Tuple3} with their results.
      * <p>
      * The returned stage emits a single item.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * BatchStage<Tuple3<Long, Long, Long>> counts = pageVisits.aggregate3(
+     *         AggregateOperations.counting(),
+     *         addToCarts, AggregateOperations.counting(),
+     *         payments, AggregateOperations.counting()
+     * );
+     * }</pre>
      *
      * @param aggrOp0 aggregate operation to perform on this stage
      * @param stage1 the first additional stage

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -228,33 +228,6 @@ public interface BatchStage<T> extends GeneralStage<T> {
 
     /**
      * Attaches a stage that co-aggregates the data from this and the supplied
-     * stage by performing a separate aggregate operation on each and then
-     * passing both results to {@code mapToOutputFn}, which transforms them
-     * into the final output.
-     * <p>
-     * The returned stage emits a single item.
-     *
-     * @param aggrOp0 aggregate operation to perform on this stage
-     * @param stage1 the other stage
-     * @param aggrOp1 aggregate operation to perform on the other stage
-     * @param mapToOutputFn function to apply to the aggregated results
-     * @param <T1> type of the items in the other stage
-     * @param <R0> type of the aggregated result for this stage
-     * @param <R1> type of the aggregated result for the other stage
-     * @param <OUT> the output item type
-     */
-    @Nonnull
-    default <T1, R0, R1, OUT> BatchStage<OUT> aggregate2(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R0> aggrOp0,
-            @Nonnull BatchStage<T1> stage1,
-            @Nonnull AggregateOperation1<? super T1, ?, ? extends R1> aggrOp1,
-            @Nonnull BiFunctionEx<? super R0, ? super R1, ? extends OUT> mapToOutputFn
-    ) {
-        return aggregate2(stage1, aggregateOperation2(aggrOp0, aggrOp1, mapToOutputFn));
-    }
-
-    /**
-     * Attaches a stage that co-aggregates the data from this and the supplied
      * stage by performing a separate aggregate operation on each and emitting
      * a {@link Tuple2} with their results.
      * <p>
@@ -273,7 +246,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
             @Nonnull BatchStage<T1> stage1,
             @Nonnull AggregateOperation1<? super T1, ?, ? extends R1> aggrOp1
     ) {
-        return aggregate2(stage1, aggregateOperation2(aggrOp0, aggrOp1, Tuple2::tuple2));
+        return aggregate2(stage1, aggregateOperation2(aggrOp0, aggrOp1));
     }
 
     /**
@@ -305,38 +278,6 @@ public interface BatchStage<T> extends GeneralStage<T> {
             @Nonnull BatchStage<T2> stage2,
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, ?, ? extends R> aggrOp);
 
-    /**
-     * Attaches a stage that co-aggregates the data from this and the two
-     * supplied stages by performing a separate aggregate operation on each and
-     * then passing all three results to {@code mapToOutputFn}, which
-     * transforms them into the final output.
-     * <p>
-     * The returned stage emits a single item.
-     *
-     * @param aggrOp0 aggregate operation to perform on this stage
-     * @param stage1 the first additional stage
-     * @param aggrOp1 aggregate operation to perform on {@code stage1}
-     * @param stage2 the second additional stage
-     * @param aggrOp2 aggregate operation to perform on {@code stage2}
-     * @param mapToOutputFn function to apply to the aggregated results
-     * @param <T1> type of the items in {@code stage1}
-     * @param <T2> type of the items in {@code stage2}
-     * @param <R0> type of the aggregated result for this stage
-     * @param <R1> type of the aggregated result for {@code stage1}
-     * @param <R2> type of the aggregated result for {@code stage2}
-     * @param <OUT> the output item type
-     */
-    @Nonnull
-    default <T1, T2, R0, R1, R2, OUT> BatchStage<OUT> aggregate3(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R0> aggrOp0,
-            @Nonnull BatchStage<T1> stage1,
-            @Nonnull AggregateOperation1<? super T1, ?, ? extends R1> aggrOp1,
-            @Nonnull BatchStage<T2> stage2,
-            @Nonnull AggregateOperation1<? super T2, ?, ? extends R2> aggrOp2,
-            @Nonnull TriFunction<? super R0, ? super R1, ? super R2, ? extends OUT> mapToOutputFn
-    ) {
-        return aggregate3(stage1, stage2, aggregateOperation3(aggrOp0, aggrOp1, aggrOp2, mapToOutputFn));
-    }
 
     /**
      * Attaches a stage that co-aggregates the data from this and the two

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -117,85 +117,25 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     );
 
     @Nonnull @Override
-    <R, OUT> BatchStage<OUT> rollingAggregate(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp,
-            @Nonnull BiFunctionEx<? super K, ? super R, ? extends OUT> mapToOutputFn
-    );
-
-    @Nonnull @Override
-    default <R> BatchStage<Entry<K, R>> rollingAggregate(
+    <R> BatchStage<Entry<K, R>> rollingAggregate(
             @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp
-    ) {
-        return (BatchStage<Entry<K, R>>) GeneralStageWithKey.super.<R>rollingAggregate(aggrOp);
-    }
-
-    /**
-     * Attaches a stage that performs the given group-and-aggregate operation.
-     * For each distinct grouping key it observes in the input, it performs the
-     * supplied aggregate operation across all the items sharing that key. Once
-     * it has received all the items, it calls the supplied {@code mapToOutputFn}
-     * with each key and the associated aggregation result to create the items
-     * to emit.
-     *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
-     * @param aggrOp the aggregate operation to perform
-     * @param mapToOutputFn the function that creates the output item
-     * @param <R> type of the aggregation result
-     * @param <OUT> type of the output item
-     */
-    @Nonnull
-    <R, OUT> BatchStage<OUT> aggregate(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp,
-            @Nonnull BiFunctionEx<? super K, ? super R, ? extends OUT> mapToOutputFn);
+    );
 
     /**
      * Attaches a stage that performs the given group-and-aggregate operation.
      * It emits one key-value pair (in a {@code Map.Entry}) for each distinct
      * key it observes in its input. The value is the result of the aggregate
      * operation across all the items with the given grouping key.
-     *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
-     * @param aggrOp the aggregate operation to perform
-     * @param <R> type of the aggregation result
-     */
-    @Nonnull
-    default <R> BatchStage<Entry<K, R>> aggregate(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp
-    ) {
-        return aggregate(aggrOp, Util::entry);
-    }
-
-    /**
-     * Attaches a stage that performs the given cogroup-and-aggregate operation
-     * over the items from both this stage and {@code stage1} you supply. For
-     * each distinct grouping key it observes in the input, it performs the
-     * supplied aggregate operation across all the items sharing that key. Once
-     * it has received all the items, it calls the supplied {@code mapToOutputFn}
-     * with each key and the associated aggregation result to create the items
-     * to emit.
      * <p>
-     * This variant requires you to provide a two-input aggregate operation
-     * (refer to its {@linkplain AggregateOperation2 Javadoc} for a simple
-     * example). If you can express your logic in terms of two single-input
-     * aggregate operations, one for each input stream, then you should use
-     * {@link #aggregate2(AggregateOperation1, BatchStageWithKey, AggregateOperation1)
-     * stage0.aggregate2(aggrOp0, stage1, aggrOp1)} because it offers a simpler
-     * API and you can use the already defined single-input operations. Use
-     * this variant only when you have the need to implement an aggregate
-     * operation that combines the input streams into the same accumulator.
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
-     * @param mapToOutputFn the function that creates the output item
-     * @param <T1> type of items in {@code stage1}
      * @param <R> type of the aggregation result
-     * @param <OUT> type of the output item
      */
     @Nonnull
-    <T1, R, OUT> BatchStage<OUT> aggregate2(
-            @Nonnull BatchStageWithKey<T1, ? extends K> stage1,
-            @Nonnull AggregateOperation2<? super T, ? super T1, ?, ? extends R> aggrOp,
-            @Nonnull BiFunctionEx<? super K, ? super R, ? extends OUT> mapToOutputFn);
+    <R> BatchStage<Entry<K, R>> aggregate(
+            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp
+    );
 
     /**
      * Attaches a stage that performs the given cogroup-and-aggregate operation
@@ -220,44 +160,10 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * @param <R> type of the aggregation result
      */
     @Nonnull
-    default <T1, R> BatchStage<Entry<K, R>> aggregate2(
+    <T1, R> BatchStage<Entry<K, R>> aggregate2(
             @Nonnull BatchStageWithKey<T1, ? extends K> stage1,
             @Nonnull AggregateOperation2<? super T, ? super T1, ?, R> aggrOp
-    ) {
-        return aggregate2(stage1, aggrOp, Util::entry);
-    }
-
-    /**
-     * Attaches a stage that performs the given cogroup-and-aggregate
-     * transformation of the items from both this stage and {@code stage1} you
-     * supply. For each distinct grouping key it observes in the input, it
-     * performs the supplied aggregate operation across all the items sharing
-     * that key. It performs the aggregation separately for each input stage:
-     * {@code aggrOp0} on this stage and {@code aggrOp1} on {@code stage1}.
-     * Once it has received all the items, it calls the supplied {@code
-     * mapToOutputFn} with each key and the associated aggregation results to
-     * create the items to emit.
-     *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
-     *@param <R0> type of the aggregation result for stream-0
-     * @param <T1> type of items in {@code stage1}
-     * @param <R1> type of the aggregation result for stream-1
-     * @param <OUT> type of the output item
-     * @param aggrOp0 aggregate operation to perform on this stage
-     * @param stage1 the other stage
-     * @param aggrOp1 aggregate operation to perform on the other stage
-     * @param mapToOutputFn the function that creates the output item
-     */
-    @Nonnull
-    default <T1, R0, R1, OUT> BatchStage<OUT> aggregate2(
-            @Nonnull AggregateOperation1<? super T, ?, R0> aggrOp0,
-            @Nonnull BatchStageWithKey<T1, ? extends K> stage1,
-            @Nonnull AggregateOperation1<? super T1, ?, R1> aggrOp1,
-            @Nonnull TriFunction<? super K, ? super R0, ? super R1, OUT> mapToOutputFn
-    ) {
-        return aggregate2(stage1, aggregateOperation2(aggrOp0, aggrOp1, Tuple2::tuple2),
-                (key, tuple) -> mapToOutputFn.apply(key, tuple.f0(), tuple.f1()));
-    }
+    );
 
     /**
      * Attaches a stage that performs the given cogroup-and-aggregate
@@ -286,45 +192,8 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     ) {
         AggregateOperation2<? super T, ? super T1, ?, Tuple2<R0, R1>> aggrOp =
                 aggregateOperation2(aggrOp0, aggrOp1, Tuple2::tuple2);
-        return aggregate2(stage1, aggrOp, Util::entry);
+        return aggregate2(stage1, aggrOp);
     }
-
-    /**
-     * Attaches a stage that performs the given cogroup-and-aggregate operation
-     * over the items from this stage as well as {@code stage1} and {@code
-     * stage2} you supply. For each distinct grouping key it observes in the
-     * input, it performs the supplied aggregate operation across all the items
-     * sharing that key. Once it has received all the items, it calls the
-     * supplied {@code mapToOutputFn} with each key and the associated
-     * aggregation result to create the items to
-     * emit.
-     * <p>
-     * This variant requires you to provide a three-input aggregate operation
-     * (refer to its {@linkplain AggregateOperation3 Javadoc} for a simple
-     * example). If you can express your logic in terms of three single-input
-     * aggregate operations, one for each input stream, then you should use
-     * {@link #aggregate3(AggregateOperation1, BatchStageWithKey,
-     *      AggregateOperation1, BatchStageWithKey, AggregateOperation1)
-     * stage0.aggregate2(aggrOp0, stage1, aggrOp1, stage2, aggrOp2)} because it
-     * offers a simpler API and you can use the already defined single-input
-     * operations. Use this variant only when you have the need to implement an
-     * aggregate operation that combines the input streams into the same
-     * accumulator.
-     *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
-     * @param aggrOp the aggregate operation to perform
-     * @param mapToOutputFn the function that creates the output item
-     * @param <T1> type of items in {@code stage1}
-     * @param <T2> type of items in {@code stage2}
-     * @param <R> type of the aggregation result
-     * @param <OUT> type of the output item
-     */
-    @Nonnull
-    <T1, T2, R, OUT> BatchStage<OUT> aggregate3(
-            @Nonnull BatchStageWithKey<T1, ? extends K> stage1,
-            @Nonnull BatchStageWithKey<T2, ? extends K> stage2,
-            @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, ?, R> aggrOp,
-            @Nonnull BiFunctionEx<? super K, ? super R, ? extends OUT> mapToOutputFn);
 
     /**
      * Attaches a stage that performs the given cogroup-and-aggregate operation
@@ -353,54 +222,11 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
      * @param <R> type of the aggregation result
      */
     @Nonnull
-    default <T1, T2, R> BatchStage<Entry<K, R>> aggregate3(
+    <T1, T2, R> BatchStage<Entry<K, R>> aggregate3(
             @Nonnull BatchStageWithKey<T1, ? extends K> stage1,
             @Nonnull BatchStageWithKey<T2, ? extends K> stage2,
             @Nonnull AggregateOperation3<? super T, ? super T1, ? super T2, ?, ? extends R> aggrOp
-    ) {
-        return aggregate3(stage1, stage2, aggrOp, Util::entry);
-    }
-
-    /**
-     * Attaches a stage that performs the given cogroup-and-aggregate
-     * transformation of the items from this stage as well as {@code stage1}
-     * and {@code stage2} you supply. For each distinct grouping key it
-     * observes in the input, it performs the supplied aggregate operation
-     * across all the items sharing that key. It performs the aggregation
-     * separately for each input stage: {@code aggrOp0} on this stage, {@code
-     * aggrOp1} on {@code stage1} and {@code aggrOp2} on {@code stage2}. Once
-     * it has received all the items, it calls the supplied {@code
-     * mapToOutputFn} with each key and the associated aggregation results to
-     * create the items to emit.
-     *
-     * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
-     *
-     * @param aggrOp0 aggregate operation to perform on this stage
-     * @param stage1 the first additional stage
-     * @param aggrOp1 aggregate operation to perform on {@code stage1}
-     * @param stage2 the second additional stage
-     * @param aggrOp2 aggregate operation to perform on {@code stage2}
-     * @param mapToOutputFn the function that creates the output item
-     * @param <T1> type of items in {@code stage1}
-     * @param <T2> type of items in {@code stage2}
-     * @param <R0> type of the aggregation result for stream-0
-     * @param <R1> type of the aggregation result for stream-1
-     * @param <R2> type of the aggregation result for stream-2
-     * @param <OUT> type of the output item
-     */
-    @Nonnull
-    default <T1, T2, R0, R1, R2, OUT> BatchStage<OUT> aggregate3(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R0> aggrOp0,
-            @Nonnull BatchStageWithKey<T1, ? extends K> stage1,
-            @Nonnull AggregateOperation1<? super T1, ?, ? extends R1> aggrOp1,
-            @Nonnull BatchStageWithKey<T2, ? extends K> stage2,
-            @Nonnull AggregateOperation1<? super T2, ?, ? extends R2> aggrOp2,
-            @Nonnull QuadFunction<? super K, ? super R0, ? super R1, ? super R2, ? extends OUT> mapToOutputFn
-    ) {
-        return aggregate3(stage1, stage2,
-                aggregateOperation3(aggrOp0, aggrOp1, aggrOp2, Tuple3::tuple3),
-                (key, tuple) -> mapToOutputFn.apply(key, tuple.f0(), tuple.f1(), tuple.f2()));
-    }
+    );
 
     /**
      * Attaches a stage that performs the given cogroup-and-aggregate
@@ -436,7 +262,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     ) {
         AggregateOperation3<T, T1, T2, ?, Tuple3<R0, R1, R2>> aggrOp =
                 aggregateOperation3(aggrOp0, aggrOp1, aggrOp2, Tuple3::tuple3);
-        return aggregate3(stage1, stage2, aggrOp, Util::entry);
+        return aggregate3(stage1, stage2, aggrOp);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GroupAggregateBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GroupAggregateBuilder.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.aggregate.CoAggregateOperationBuilder;
 import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tag;
-import com.hazelcast.jet.function.BiFunctionEx;
 import com.hazelcast.jet.impl.pipeline.GrAggBuilder;
 
 import javax.annotation.Nonnull;
@@ -83,26 +82,6 @@ public class GroupAggregateBuilder<K, R0> {
 
     /**
      * Creates and returns a pipeline stage that performs the co-aggregation
-     * of the stages registered with this builder object. The composite
-     * aggregate operation places the results of the individual aggregate
-     * operations in an {@code ItemsByTag} and the {@code mapToOutputFn} you
-     * supply transforms it to the final result to emit. Use the tags you got
-     * from this builder in the implementation of {@code mapToOutputFn} to
-     * access the results.
-     *
-     * @param mapToOutputFn function that transforms the aggregation result into the output item
-     * @param <OUT> the output item type
-     */
-    @Nonnull
-    public <OUT> BatchStage<OUT> build(
-            @Nonnull BiFunctionEx<? super K, ItemsByTag, OUT> mapToOutputFn
-    ) {
-        AggregateOperation<Object[], ItemsByTag> aggrOp = aggrOpBuilder.build();
-        return grAggBuilder.buildBatch(aggrOp, mapToOutputFn);
-    }
-
-    /**
-     * Creates and returns a pipeline stage that performs the co-aggregation
      * of the stages registered with this builder object and emits a {@code
      * Map.Entry(key, resultsByTag)} for each distinct key. The composite
      * aggregate operation places the results of the individual aggregate
@@ -113,6 +92,7 @@ public class GroupAggregateBuilder<K, R0> {
      */
     @Nonnull
     public BatchStage<Entry<K, ItemsByTag>> build() {
-        return build(Util::entry);
+        AggregateOperation<Object[], ItemsByTag> aggrOp = aggrOpBuilder.build();
+        return grAggBuilder.buildBatch(aggrOp, Util::entry);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithKeyAndWindow.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithKeyAndWindow.java
@@ -76,6 +76,14 @@ public interface StageWithKeyAndWindow<T, K> {
      * distinct key it observes in its input belonging to a given window. The
      * value is the result of the aggregate operation across all the items with
      * the given grouping key.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<KeyedWindowResult<Long, Long>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .groupingKey(PageVisit::getUserId)
+     *     .aggregate(AggregateOperations.counting());
+     * }</pre>
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
@@ -94,6 +102,18 @@ public interface StageWithKeyAndWindow<T, K> {
      * value is the result of the aggregate operation across all the items with
      * the given grouping key.
      * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<KeyedWindowResult<Long, Tuple2<Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .groupingKey(PageVisit::getUserId)
+     *     .aggregate2(
+     *         addToCarts.groupingKey(AddToCart::getUserId),
+     *         AggregateOperations.aggregateOperation2(
+     *                 AggregateOperations.counting(),
+     *                 AggregateOperations.counting())
+     *     );
+     * }</pre>
      * This variant requires you to provide a two-input aggregate operation
      * (refer to its {@linkplain AggregateOperation2 Javadoc} for a simple
      * example). If you can express your logic in terms of two single-input
@@ -126,6 +146,18 @@ public interface StageWithKeyAndWindow<T, K> {
      * stage1}. Once it has received all the items belonging to a window, it
      * emits for each distinct key a {@code KeyedWindowResult(key, Tuple2(result0,
      * result1))}.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<KeyedWindowResult<Long, Tuple2<Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .groupingKey(PageVisit::getUserId)
+     *     .aggregate2(
+     *             AggregateOperations.counting(),
+     *             addToCarts.groupingKey(AddToCart::getUserId),
+     *             AggregateOperations.counting()
+     *     );
+     * }</pre>
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
      * @param aggrOp0 aggregate operation to perform on this stage
@@ -153,6 +185,21 @@ public interface StageWithKeyAndWindow<T, K> {
      * all the items belonging to a window, it emits for each distinct key a
      * {@code KeyedWindowResult(key, Tuple3(result0, result1, result2))}.
      * <p>
+     * Sample usage:
+     * StreamStage<KeyedWindowResult<Long, Tuple3<Long, Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .groupingKey(PageVisit::getUserId)
+     *     .aggregate3(
+     *         addToCarts.groupingKey(AddToCart::getUserId),
+     *         payments.groupingKey(Payment::getUserId),
+     *         AggregateOperations.aggregateOperation3(
+     *             AggregateOperations.counting(),
+     *             AggregateOperations.counting(),
+     *             AggregateOperations.counting())
+     *     );
+     * <pre>{@code
+     *
+     * }</pre>
      * This variant requires you to provide a three-input aggregate operation
      * (refer to its {@linkplain AggregateOperation3 Javadoc} for a simple
      * example). If you can express your logic in terms of three single-input
@@ -190,6 +237,20 @@ public interface StageWithKeyAndWindow<T, K> {
      * stage1} and {@code aggrOp2} on {@code stage2}. Once it has received all
      * the items, it calls the supplied {@code mapToOutputFn} with each key and
      * the associated aggregation result to create the items to emit.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<KeyedWindowResult<Long, Tuple3<Long, Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .groupingKey(PageVisit::getUserId)
+     *     .aggregate3(
+     *         AggregateOperations.counting(),
+     *         addToCarts.groupingKey(AddToCart::getUserId),
+     *         AggregateOperations.counting(),
+     *         payments.groupingKey(Payment::getUserId),
+     *         AggregateOperations.counting()
+     *     );
+     * }</pre>
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
      * @param aggrOp0 aggregate operation to perform on this stage

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithWindow.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StageWithWindow.java
@@ -92,7 +92,13 @@ public interface StageWithWindow<T> {
      * the items that belong to a given window. Once the window is complete, it
      * emits a {@code WindowResult} with the result of the aggregate
      * operation and the timestamp denoting the window's ending time.
-     *
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<WindowResult<Long>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .aggregate(AggregateOperations.counting());
+     * }</pre>
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
      * @param aggrOp the aggregate operation to perform
      * @param <R> the type of the result
@@ -109,6 +115,17 @@ public interface StageWithWindow<T> {
      * invokes {@code mapToOutputFn} with the result of the aggregate
      * operation and emits its return value as the window result.
      * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<WindowResult<Tuple2<Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .aggregate2(
+     *         addToCarts,
+     *         AggregateOperations.aggregateOperation2(
+     *             AggregateOperations.counting(),
+     *             AggregateOperations.counting())
+     *     );
+     * }</pre>
      * This variant requires you to provide a two-input aggregate operation
      * (refer to its {@linkplain AggregateOperation2 Javadoc} for a simple
      * example). If you can express your logic in terms of two single-input
@@ -141,6 +158,17 @@ public interface StageWithWindow<T> {
      * WindowResult(Tuple2(result0, result1))}.
      * <p>
      * The aggregating stage emits a single item for each completed window.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<WindowResult<Tuple2<Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .aggregate2(
+     *         AggregateOperations.counting(),
+     *         addToCarts,
+     *         AggregateOperations.counting()
+     *     );
+     * }</pre>
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
      * @param aggrOp0 aggregate operation to perform on this stage
@@ -166,6 +194,19 @@ public interface StageWithWindow<T> {
      * WindowResult} with the result of the aggregate operation and the
      * timestamp denoting the window's ending time.
      * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<WindowResult<Tuple3<Long, Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .aggregate3(
+     *         addToCarts,
+     *         payments,
+     *         AggregateOperations.aggregateOperation3(
+     *             AggregateOperations.counting(),
+     *             AggregateOperations.counting(),
+     *             AggregateOperations.counting())
+     *     );
+     * }</pre>
      * This variant requires you to provide a three-input aggregate operation
      * (refer to its {@linkplain AggregateOperation3 Javadoc} for a simple
      * example). If you can express your logic in terms of three single-input
@@ -203,6 +244,19 @@ public interface StageWithWindow<T> {
      * WindowResult(Tuple3(result0, result1, result2))}.
      * <p>
      * The aggregating stage emits a single item for each completed window.
+     * <p>
+     * Sample usage:
+     * <pre>{@code
+     * StreamStage<WindowResult<Tuple3<Long, Long, Long>>> aggregated = pageVisits
+     *     .window(SlidingWindowDefinition.sliding(MINUTES.toMillis(1), SECONDS.toMillis(1)))
+     *     .aggregate3(
+     *         AggregateOperations.counting(),
+     *         addToCarts,
+     *         AggregateOperations.counting(),
+     *         payments,
+     *         AggregateOperations.counting()
+     *     );
+     * }</pre>
      *
      * @see com.hazelcast.jet.aggregate.AggregateOperations AggregateOperations
      *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
@@ -57,6 +57,7 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     }
 
     @Nonnull @Override
+    @SuppressWarnings("unchecked")
     default <V, R> StreamStage<R> mapUsingIMap(
             @Nonnull IMap<K, V> iMap,
             @Nonnull BiFunctionEx<? super T, ? super V, ? extends R> mapFn
@@ -102,18 +103,9 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     );
 
     @Nonnull @Override
-    @SuppressWarnings("unchecked")
-    <R, OUT> StreamStage<OUT> rollingAggregate(
-            @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp,
-            @Nonnull BiFunctionEx<? super K, ? super R, ? extends OUT> mapToOutputFn
-    );
-
-    @Nonnull @Override
-    default <R> StreamStage<Entry<K, R>> rollingAggregate(
+    <R> StreamStage<Entry<K, R>> rollingAggregate(
             @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp
-    ) {
-        return (StreamStage<Entry<K, R>>) GeneralStageWithKey.super.<R>rollingAggregate(aggrOp);
-    }
+    );
 
     @Nonnull @Override
     default <R> StreamStage<R> customTransform(@Nonnull String stageName,

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -395,45 +395,6 @@ public class StreamStageTest extends PipelineStreamTestSupport {
     }
 
     @Test
-    public void rollingAggregate_keyed_withOutputFn() {
-        // Given
-        List<Integer> input = sequence(itemCount);
-        BiFunctionEx<Integer, Long, String> formatFn =
-                (key, count) -> String.format("(%d, %04d)", key, count);
-
-        // When
-        StreamStage<String> mapped = streamStageFromList(input)
-                .groupingKey(i -> i % 2)
-                .rollingAggregate(counting(), formatFn);
-
-        // Then
-        mapped.drainTo(sink);
-        execute();
-        assertEquals(
-                streamToString(
-                        IntStream.range(2, itemCount + 2).mapToObj(i -> entry(i % 2, (long) i / 2)),
-                        e -> formatFn.apply(e.getKey(), e.getValue())),
-                streamToString(sinkList.stream().map(String.class::cast), identity())
-        );
-    }
-
-    @Test
-    public void rollingAggregate_when_outputFnReturnsNull_then_filteredOut() {
-        // Given
-        List<Integer> input = sequence(itemCount);
-
-        // When
-        StreamStage<String> mapped = streamStageFromList(input)
-                .groupingKey(i -> i % 2)
-                .rollingAggregate(counting(), (x, y) -> null);
-
-        // Then
-        mapped.drainTo(sink);
-        execute();
-        assertEquals(0, sinkList.size());
-    }
-
-    @Test
     public void when_rollingAggregateWithTimestamps_then_timestampsPropagated() {
         // Given
         List<Integer> input = sequence(itemCount);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -530,7 +530,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         Tag<String> tagB = builder.add(enrichingStage2, joinMapEntries(wholeItem()));
         @SuppressWarnings("Convert2MethodRef")
         // there's a method ref bug in JDK
-        GeneralStage<Tuple2<Integer, ItemsByTag>> joined = builder.build((a, b) -> tuple2(a, b));
+        StreamStage<Tuple2<Integer, ItemsByTag>> joined = builder.build((a, b) -> tuple2(a, b));
 
         // Then
         joined.drainTo(sink);


### PR DESCRIPTION
Also remove the `mapToOutputFn` parameter from batch `aggregateN` methods.

Removed from `BatchStage`:

- `aggregate2(aggrOp0, stage1, aggrOp1, mapToOutputFn)`
- `aggregate3(aggrOp0, stage1, aggrOp1, stage2, aggrOp2, mapToOutputFn)`

Removed from `BatchStageWithKey`:

- `aggregate(aggrOp, mapToOutputFn)`
- `aggregate2(stage1, aggrOp, mapToOutputFn)`
- `aggregate2(aggrOp0, stage1, aggrOp1, mapToOutputFn)`
- `aggregate3(stage1, stage2, aggrOp, mapToOutputFn)`
- `aggregate3(aggrOp0, stage1, aggrOp1, stage2, aggrOp2, mapToOutputFn)`

Removed `GroupAggregateBuilder.build(mapToOutputFn)`
