### PR TITLE
Offload blocking tasks from async thread

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
@@ -205,6 +205,8 @@ public interface Job {
      *
      * @param name name of the snapshot. If name is already used, it will be
      *            overwritten
+     * @throws JetException if the job is in an incorrect state: completed,
+     *            cancelled or is in the process of restarting or suspending.
      */
     JobStateSnapshot cancelAndExportSnapshot(String name);
 
@@ -237,12 +239,13 @@ public interface Job {
      * <p>
      * You can access the exported state map using {@link
      * JetInstance#getJobStateSnapshot(String)}.
+     * <p>
+     * The method call will block until it has fully exported the snapshot.
      *
      * @param name name of the snapshot. If name is already used, it will be
      *            overwritten
      * @throws JetException if the job is in an incorrect state: completed,
-     *            cancelled, or also in the process of restarting or
-     *            suspending.
+     *            cancelled or is in the process of restarting or suspending.
      */
     JobStateSnapshot exportSnapshot(String name);
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -203,7 +203,8 @@ public class JobCoordinationService {
         });
     }
 
-    private MasterContext createMasterContext(JobRecord jobRecord, JobExecutionRecord jobExecutionRecord) {
+    @SuppressWarnings("WeakerAccess") // used by jet-enterprise
+    MasterContext createMasterContext(JobRecord jobRecord, JobExecutionRecord jobExecutionRecord) {
         return new MasterContext(nodeEngine, this, jobRecord, jobExecutionRecord);
     }
 
@@ -857,7 +858,8 @@ public class JobCoordinationService {
         return record != null ? record : new JobExecutionRecord(jobId, getQuorumSize(), false);
     }
 
-    private void assertIsMaster(String error) {
+    @SuppressWarnings("WeakerAccess") // used by jet-enterprise
+    void assertIsMaster(String error) {
         if (!isMaster()) {
             throw new JetException(error + ". Master address: " + nodeEngine.getClusterService().getMasterAddress());
         }
@@ -884,10 +886,7 @@ public class JobCoordinationService {
             try {
                 return CompletableFuture.completedFuture(action.call());
             } catch (Throwable e) {
-                // replace with CompletableFuture.failedFuture(e) in java9
-                CompletableFuture<T> future = new CompletableFuture<>();
-                future.completeExceptionally(e);
-                return future;
+                return com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture(e);
             }
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.JobAlreadyExistsException;
+import com.hazelcast.jet.Util;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
@@ -45,6 +46,7 @@ import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Clock;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,6 +57,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -84,6 +87,7 @@ import static java.util.Comparator.comparing;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
@@ -99,6 +103,7 @@ public class JobCoordinationService {
      * The delay before retrying to start/scale up a job.
      */
     private static final long RETRY_DELAY_IN_MILLIS = SECONDS.toMillis(2);
+    private static final ThreadLocal<Boolean> IS_JOB_COORDINATOR_THREAD = ThreadLocal.withInitial(() -> false);
 
     private final NodeEngineImpl nodeEngine;
     private final JetService jetService;
@@ -142,65 +147,63 @@ public class JobCoordinationService {
                 0, jobScanPeriodInMillis, MILLISECONDS);
     }
 
-    /**
-     * Starts the job if it is not already started or completed. Returns a future
-     * which represents the result of the job.
-     */
-    public void submitJob(long jobId, Data dag, Data serializedConfig) {
-        JobConfig config = nodeEngine.getSerializationService().toObject(serializedConfig);
-        assertIsMaster("Cannot submit job " + idToString(jobId) + " from non-master node");
-        checkOperationalState();
-
-        // the order of operations is important.
-
-        // first, check if the job is already completed
-        JobResult jobResult = jobRepository.getJobResult(jobId);
-        if (jobResult != null) {
-            logger.fine("Not starting job " + idToString(jobId) + " since already completed with result: " +
-                    jobResult);
-            return;
-        }
-
-        int quorumSize = config.isSplitBrainProtectionEnabled() ? getQuorumSize() : 0;
-        String dagJson = dagToJson(jobId, config, dag);
-        JobRecord jobRecord = new JobRecord(jobId, Clock.currentTimeMillis(), dag, dagJson, config);
-        JobExecutionRecord jobExecutionRecord = new JobExecutionRecord(jobId, quorumSize, false);
-        MasterContext masterContext = createMasterContext(jobRecord, jobExecutionRecord);
-
-        boolean hasDuplicateJobName;
-        synchronized (lock) {
-            assertIsMaster("Cannot submit job " + idToString(jobId) + " from non-master node");
+    public CompletableFuture<Void> submitJob(long jobId, Data dag, Data serializedConfig) {
+        return submitToCoordinatorThread(() -> {
+            JobConfig config = nodeEngine.getSerializationService().toObject(serializedConfig);
+            assertIsMaster("Cannot submit job " + idToString(jobId) + " to non-master node");
             checkOperationalState();
-            hasDuplicateJobName = config.getName() != null && hasActiveJobWithName(config.getName());
-            if (!hasDuplicateJobName) {
-                // just try to initiate the coordination
-                MasterContext prev = masterContexts.putIfAbsent(jobId, masterContext);
-                if (prev != null) {
-                    logger.fine("Joining to already existing masterContext " + prev.jobIdString());
-                    return;
+
+            // the order of operations is important.
+
+            // first, check if the job is already completed
+            JobResult jobResult = jobRepository.getJobResult(jobId);
+            if (jobResult != null) {
+                logger.fine("Not starting job " + idToString(jobId) + " since already completed with result: "
+                        + jobResult);
+                return;
+            }
+
+            int quorumSize = config.isSplitBrainProtectionEnabled() ? getQuorumSize() : 0;
+            String dagJson = dagToJson(jobId, config, dag);
+            JobRecord jobRecord = new JobRecord(jobId, Clock.currentTimeMillis(), dag, dagJson, config);
+            JobExecutionRecord jobExecutionRecord = new JobExecutionRecord(jobId, quorumSize, false);
+            MasterContext masterContext = createMasterContext(jobRecord, jobExecutionRecord);
+
+            boolean hasDuplicateJobName;
+            synchronized (lock) {
+                assertIsMaster("Cannot submit job " + idToString(jobId) + " to non-master node");
+                checkOperationalState();
+                hasDuplicateJobName = config.getName() != null && hasActiveJobWithName(config.getName());
+                if (!hasDuplicateJobName) {
+                    // just try to initiate the coordination
+                    MasterContext prev = masterContexts.putIfAbsent(jobId, masterContext);
+                    if (prev != null) {
+                        logger.fine("Joining to already existing masterContext " + prev.jobIdString());
+                        return;
+                    }
                 }
             }
-        }
 
-        if (hasDuplicateJobName) {
-            jobRepository.deleteJob(jobId);
-            throw new JobAlreadyExistsException("Another active job with equal name (" + config.getName()
-                    + ") exists: " + idToString(jobId));
-        }
+            if (hasDuplicateJobName) {
+                jobRepository.deleteJob(jobId);
+                throw new JobAlreadyExistsException("Another active job with equal name (" + config.getName()
+                        + ") exists: " + idToString(jobId));
+            }
 
-        // If job is not currently running, it might be that it is just completed
-        if (completeMasterContextIfJobAlreadyCompleted(masterContext)) {
-            return;
-        }
+            // If job is not currently running, it might be that it is just completed
+            if (completeMasterContextIfJobAlreadyCompleted(masterContext)) {
+                return;
+            }
 
-        // If there is no master context and job result at the same time, it means this is the first submission
-        jobRepository.putNewJobRecord(jobRecord);
+            // If there is no master context and job result at the same time, it means this is the first submission
+            jobRepository.putNewJobRecord(jobRecord);
 
-        logger.info("Starting job " + idToString(masterContext.jobId()) + " based on submit request");
-        nodeEngine.getExecutionService().execute(COORDINATOR_EXECUTOR_NAME, () -> tryStartJob(masterContext));
+            logger.info("Starting job " + idToString(masterContext.jobId()) + " based on submit request");
+            nodeEngine.getExecutionService().execute(COORDINATOR_EXECUTOR_NAME, () -> tryStartJob(masterContext));
+        });
     }
 
-    MasterContext createMasterContext(JobRecord jobRecord, JobExecutionRecord jobExecutionRecord) {
+    private MasterContext createMasterContext(JobRecord jobRecord, JobExecutionRecord jobExecutionRecord) {
         return new MasterContext(nodeEngine, this, jobRecord, jobExecutionRecord);
     }
 
@@ -249,156 +252,169 @@ public class JobCoordinationService {
     }
 
     public CompletableFuture<Void> joinSubmittedJob(long jobId) {
-        assertIsMaster("Cannot join job " + idToString(jobId) + " from non-master node");
-
+        assertIsMaster("Cannot join job " + idToString(jobId) + " on non-master node");
         checkOperationalState();
 
-        JobRecord jobRecord = jobRepository.getJobRecord(jobId);
-        if (jobRecord != null) {
-            JobExecutionRecord jobExecutionRecord = ensureExecutionRecord(jobId,
-                    jobRepository.getJobExecutionRecord(jobId));
-            return startJobIfNotStartedOrCompleted(jobRecord, jobExecutionRecord, "join request from client");
-        }
-
-        JobResult jobResult = jobRepository.getJobResult(jobId);
-        if (jobResult != null) {
-            return jobResult.asCompletableFuture();
-        }
-
-        throw new JobNotFoundException(jobId);
-    }
-
-    public void terminateJob(long jobId, TerminationMode terminationMode) {
-        assertIsMaster("Cannot " + terminationMode + " job " + idToString(jobId) + " from non-master node");
-
-        JobResult jobResult = jobRepository.getJobResult(jobId);
-        if (jobResult != null) {
-            if (terminationMode == CANCEL_FORCEFUL) {
-                logger.fine("Ignoring cancellation of a completed job " + idToString(jobId));
-                return;
-            }
-            throw new IllegalStateException("Cannot " + terminationMode + " job " + idToString(jobId)
-                    + " because it already has a result: " + jobResult);
-        }
-
-        MasterContext masterContext = masterContexts.get(jobId);
-        if (masterContext == null) {
+        return submitToCoordinatorThread(() -> {
             JobRecord jobRecord = jobRepository.getJobRecord(jobId);
-            String message = "No MasterContext found for job " + idToString(jobId) + " for " + terminationMode;
             if (jobRecord != null) {
-                // we'll eventually learn of the job through scanning of records or from a join operation
-                throw new RetryableHazelcastException(message);
+                JobExecutionRecord jobExecutionRecord = ensureExecutionRecord(jobId,
+                        jobRepository.getJobExecutionRecord(jobId));
+                return startJobIfNotStartedOrCompleted(jobRecord, jobExecutionRecord, "join request from client");
             }
+
+            JobResult jobResult = jobRepository.getJobResult(jobId);
+            if (jobResult != null) {
+                return jobResult.asCompletableFuture();
+            }
+
             throw new JobNotFoundException(jobId);
-        }
-
-        // User can cancel in any state, other terminations are allowed only when running.
-        // This is not technically required (we can request termination in any state),
-        // but this method is only called from client. It would be weird for the client to
-        // request a restart if the job didn't start yet etc.
-        // Also, it would be weird to restart the job during STARTING: as soon as it will start,
-        // it will restart.
-        // In any case, it doesn't make sense to restart a suspended job.
-        JobStatus jobStatus = masterContext.jobStatus();
-        if (jobStatus != RUNNING && terminationMode != CANCEL_FORCEFUL) {
-            throw new IllegalStateException("Cannot " + terminationMode + ", job status is " + jobStatus
-                    + ", should be " + RUNNING);
-        }
-
-        String terminationResult = masterContext.jobContext().requestTermination(terminationMode, false).f1();
-        if (terminationResult != null) {
-            throw new IllegalStateException("Cannot " + terminationMode + ": " + terminationResult);
-        }
+        }).thenCompose(identity()); // unwrap the inner future
     }
 
-    public Set<Long> getAllJobIds() {
-        assertIsMaster("Cannot query list of job ids from non-master node");
+    public CompletableFuture<Void> terminateJob(long jobId, TerminationMode terminationMode) {
+        assertIsMaster("Cannot " + terminationMode + " job " + idToString(jobId) + " on non-master node");
 
-        Set<Long> jobIds = new HashSet<>(jobRepository.getAllJobIds());
-        jobIds.addAll(masterContexts.keySet());
-        return jobIds;
+        return submitToCoordinatorThread(() -> {
+            JobResult jobResult = jobRepository.getJobResult(jobId);
+            if (jobResult != null) {
+                if (terminationMode == CANCEL_FORCEFUL) {
+                    logger.fine("Ignoring cancellation of a completed job " + idToString(jobId));
+                    return;
+                }
+                throw new IllegalStateException("Cannot " + terminationMode + " job " + idToString(jobId)
+                        + " because it already has a result: " + jobResult);
+            }
+
+            MasterContext masterContext = masterContexts.get(jobId);
+            if (masterContext == null) {
+                JobRecord jobRecord = jobRepository.getJobRecord(jobId);
+                String message = "No MasterContext found for job " + idToString(jobId) + " for " + terminationMode;
+                if (jobRecord != null) {
+                    // we'll eventually learn of the job through scanning of records or from a join operation
+                    throw new RetryableHazelcastException(message);
+                }
+                throw new JobNotFoundException(jobId);
+            }
+
+            // User can cancel in any state, other terminations are allowed only when running.
+            // This is not technically required (we can request termination in any state),
+            // but this method is only called from client. It would be weird for the client to
+            // request a restart if the job didn't start yet etc.
+            // Also, it would be weird to restart the job during STARTING: as soon as it will start,
+            // it will restart.
+            // In any case, it doesn't make sense to restart a suspended job.
+            JobStatus jobStatus = masterContext.jobStatus();
+            if (jobStatus != RUNNING && terminationMode != CANCEL_FORCEFUL) {
+                throw new IllegalStateException("Cannot " + terminationMode + ", job status is " + jobStatus
+                        + ", should be " + RUNNING);
+            }
+
+            String terminationResult = masterContext.jobContext().requestTermination(terminationMode, false).f1();
+            if (terminationResult != null) {
+                throw new IllegalStateException("Cannot " + terminationMode + ": " + terminationResult);
+            }
+        });
+    }
+
+    public CompletableFuture<List<Long>> getAllJobIds() {
+        assertIsMaster("Cannot query list of job ids on non-master node");
+
+        return submitToCoordinatorThread(() -> {
+            Set<Long> jobIds = new HashSet<>(jobRepository.getAllJobIds());
+            jobIds.addAll(masterContexts.keySet());
+            return new ArrayList<>(jobIds);
+        });
     }
 
     /**
-     * Return the job IDs of jobs with given name, sorted by <active/completed, creation time>, active & newest first.
+     * Return the job IDs of jobs with given name, sorted by {active/completed, creation time}, active & newest first.
      */
-    public List<Long> getJobIds(@Nonnull String name) {
-        Map<Long, Long> jobs = jobRepository.getJobResults(name).stream()
-                .collect(toMap(JobResult::getJobId, JobResult::getCreationTime));
+    public CompletableFuture<List<Long>> getJobIds(@Nonnull String name) {
+        assertIsMaster("Cannot query list of job ids on non-master node");
 
-        for (MasterContext ctx : masterContexts.values()) {
-            if (name.equals(ctx.jobConfig().getName())) {
-                jobs.putIfAbsent(ctx.jobId(), Long.MAX_VALUE);
+        return submitToCoordinatorThread(() -> {
+            Map<Long, Long> jobs = jobRepository.getJobResults(name).stream()
+                    .collect(toMap(JobResult::getJobId, JobResult::getCreationTime));
+
+            for (MasterContext ctx : masterContexts.values()) {
+                if (name.equals(ctx.jobConfig().getName())) {
+                    jobs.putIfAbsent(ctx.jobId(), Long.MAX_VALUE);
+                }
             }
-        }
 
-        return jobs.entrySet().stream()
-                   .sorted(comparing(Entry<Long, Long>::getValue).reversed())
-                   .map(Entry::getKey)
-                   .collect(toList());
+            return jobs.entrySet().stream()
+                       .sorted(comparing(Entry<Long, Long>::getValue).reversed())
+                       .map(Entry::getKey)
+                       .collect(toList());
+        });
     }
 
     /**
      * Returns the job status or fails with {@link JobNotFoundException}
      * if the requested job is not found.
      */
-    public JobStatus getJobStatus(long jobId) {
-        assertIsMaster("Cannot query status of job " + idToString(jobId) + " from non-master node");
+    public CompletableFuture<JobStatus> getJobStatus(long jobId) {
+        assertIsMaster("Cannot query status of job " + idToString(jobId) + " on non-master node");
 
-        // first check if there is a job result present.
-        // this map is updated first during completion.
-        JobResult jobResult = jobRepository.getJobResult(jobId);
-        if (jobResult != null) {
-            return jobResult.getJobStatus();
-        }
-
-        // check if there a master context for running job
-        MasterContext currentMasterContext = masterContexts.get(jobId);
-        if (currentMasterContext != null) {
-            JobStatus jobStatus = currentMasterContext.jobStatus();
-            if (jobStatus == RUNNING && currentMasterContext.jobContext().requestedTerminationMode() != null) {
-                return COMPLETING;
-            }
-            return jobStatus;
-        }
-
-        // no master context found, job might be just submitted
-        JobExecutionRecord jobExecutionRecord = jobRepository.getJobExecutionRecord(jobId);
-        if (jobExecutionRecord != null) {
-            return jobExecutionRecord.isSuspended() ? SUSPENDED : NOT_RUNNING;
-        } else {
-            // no job record found, but check job results again
-            // since job might have been completed meanwhile.
-            jobResult = jobRepository.getJobResult(jobId);
+        return submitToCoordinatorThread(() -> {
+            // first check if there is a job result present.
+            // this map is updated first during completion.
+            JobResult jobResult = jobRepository.getJobResult(jobId);
             if (jobResult != null) {
                 return jobResult.getJobStatus();
             }
-            throw new JobNotFoundException(jobId);
-        }
+
+            // check if there a master context for running job
+            MasterContext currentMasterContext = masterContexts.get(jobId);
+            if (currentMasterContext != null) {
+                JobStatus jobStatus = currentMasterContext.jobStatus();
+                if (jobStatus == RUNNING && currentMasterContext.jobContext().requestedTerminationMode() != null) {
+                    return COMPLETING;
+                }
+                return jobStatus;
+            }
+
+            // no master context found, job might be just submitted
+            JobExecutionRecord jobExecutionRecord = jobRepository.getJobExecutionRecord(jobId);
+            if (jobExecutionRecord != null) {
+                return jobExecutionRecord.isSuspended() ? SUSPENDED : NOT_RUNNING;
+            } else {
+                // no job record found, but check job results again
+                // since job might have been completed meanwhile.
+                jobResult = jobRepository.getJobResult(jobId);
+                if (jobResult != null) {
+                    return jobResult.getJobStatus();
+                }
+                throw new JobNotFoundException(jobId);
+            }
+        });
     }
 
     /**
      * Returns the job submission time or fails with {@link JobNotFoundException}
      * if the requested job is not found.
      */
-    public long getJobSubmissionTime(long jobId) {
-        assertIsMaster("Cannot query submission time of job " + idToString(jobId) + " from non-master node");
+    public CompletableFuture<Long> getJobSubmissionTime(long jobId) {
+        assertIsMaster("Cannot query submission time of job " + idToString(jobId) + " on non-master node");
 
-        JobRecord jobRecord = jobRepository.getJobRecord(jobId);
-        if (jobRecord != null) {
-            return jobRecord.getCreationTime();
-        }
+        return submitToCoordinatorThread(() -> {
+            JobRecord jobRecord = jobRepository.getJobRecord(jobId);
+            if (jobRecord != null) {
+                return jobRecord.getCreationTime();
+            }
 
-        JobResult jobResult = jobRepository.getJobResult(jobId);
-        if (jobResult != null) {
-            return jobResult.getCreationTime();
-        }
+            JobResult jobResult = jobRepository.getJobResult(jobId);
+            if (jobResult != null) {
+                return jobResult.getCreationTime();
+            }
 
-        throw new JobNotFoundException(jobId);
+            throw new JobNotFoundException(jobId);
+        });
     }
 
     public void resumeJob(long jobId) {
-        assertIsMaster("Cannot resume job " + idToString(jobId) + " from non-master node");
+        assertIsMaster("Cannot resume job " + idToString(jobId) + " on non-master node");
 
         MasterContext masterContext = masterContexts.get(jobId);
         if (masterContext == null) {
@@ -410,20 +426,22 @@ public class JobCoordinationService {
     /**
      * Return a summary of all jobs
      */
-    public List<JobSummary> getJobSummaryList() {
-        Map<Long, JobSummary> jobs = new HashMap<>();
+    public CompletableFuture<List<JobSummary>> getJobSummaryList() {
+        return submitToCoordinatorThread(() -> {
+            Map<Long, JobSummary> jobs = new HashMap<>();
 
-        // running jobs
-        jobRepository.getJobRecords().stream().map(this::getJobSummary).forEach(s -> jobs.put(s.getJobId(), s));
+            // running jobs
+            jobRepository.getJobRecords().stream().map(this::getJobSummary).forEach(s -> jobs.put(s.getJobId(), s));
 
-        // completed jobs
-        jobRepository.getJobResults().stream()
-                     .map(r -> new JobSummary(
-                             r.getJobId(), r.getJobNameOrId(), r.getJobStatus(), r.getCreationTime(),
-                             r.getCompletionTime(), r.getFailureText())
-                     ).forEach(s -> jobs.put(s.getJobId(), s));
+            // completed jobs
+            jobRepository.getJobResults().stream()
+                         .map(r -> new JobSummary(
+                                 r.getJobId(), r.getJobNameOrId(), r.getJobStatus(), r.getCreationTime(),
+                                 r.getCompletionTime(), r.getFailureText())
+                         ).forEach(s -> jobs.put(s.getJobId(), s));
 
-        return jobs.values().stream().sorted(comparing(JobSummary::getSubmissionTime).reversed()).collect(toList());
+            return jobs.values().stream().sorted(comparing(JobSummary::getSubmissionTime).reversed()).collect(toList());
+        });
     }
 
     /**
@@ -568,23 +586,26 @@ public class JobCoordinationService {
     /**
      * Completes the job which is coordinated with the given master context object.
      */
-    void completeJob(MasterContext masterContext, long completionTime, Throwable error) {
-        // the order of operations is important.
+    @CheckReturnValue
+    CompletableFuture<Void> completeJob(MasterContext masterContext, long completionTime, Throwable error) {
+        return submitToCoordinatorThread(() -> {
+            // the order of operations is important.
 
-        long jobId = masterContext.jobId();
-        String coordinator = nodeEngine.getNode().getThisUuid();
-        jobRepository.completeJob(jobId, coordinator, completionTime, error);
-        if (masterContexts.remove(masterContext.jobId(), masterContext)) {
-            logger.fine(masterContext.jobIdString() + " is completed");
-        } else {
-            MasterContext existing = masterContexts.get(jobId);
-            if (existing != null) {
-                logger.severe("Different master context found to complete " + masterContext.jobIdString()
-                        + ", master context execution " + idToString(existing.executionId()));
+            long jobId = masterContext.jobId();
+            String coordinator = nodeEngine.getNode().getThisUuid();
+            jobRepository.completeJob(jobId, coordinator, completionTime, error);
+            if (masterContexts.remove(masterContext.jobId(), masterContext)) {
+                logger.fine(masterContext.jobIdString() + " is completed");
             } else {
-                logger.severe("No master context found to complete " + masterContext.jobIdString());
+                MasterContext existing = masterContexts.get(jobId);
+                if (existing != null) {
+                    logger.severe("Different master context found to complete " + masterContext.jobIdString()
+                            + ", master context execution " + idToString(existing.executionId()));
+                } else {
+                    logger.severe("No master context found to complete " + masterContext.jobIdString());
+                }
             }
-        }
+        });
     }
 
     /**
@@ -670,32 +691,34 @@ public class JobCoordinationService {
             return;
         }
 
-        try {
-            int currentQuorumSize = getQuorumSize();
-            for (JobRecord jobRecord : jobRepository.getJobRecords()) {
-                try {
-                    if (!jobRecord.getConfig().isSplitBrainProtectionEnabled()) {
-                        continue;
+        submitToCoordinatorThread(() -> {
+            try {
+                int currentQuorumSize = getQuorumSize();
+                for (JobRecord jobRecord : jobRepository.getJobRecords()) {
+                    try {
+                        if (!jobRecord.getConfig().isSplitBrainProtectionEnabled()) {
+                            continue;
+                        }
+                        MasterContext masterContext = masterContexts.get(jobRecord.getJobId());
+                        // if MasterContext doesn't exist, update in the IMap directly, using a sync method
+                        if (masterContext == null) {
+                            jobRepository.updateJobQuorumSizeIfSmaller(jobRecord.getJobId(), currentQuorumSize);
+                            // check the master context again, it might have been just created and have picked
+                            // up the JobRecord before being updated
+                            masterContext = masterContexts.get(jobRecord.getJobId());
+                        }
+                        if (masterContext != null) {
+                            masterContext.updateQuorumSize(currentQuorumSize);
+                        }
+                    } catch (Exception e) {
+                        logger.severe("Quorum of job " + idToString(jobRecord.getJobId())
+                                + " could not be updated to " + currentQuorumSize, e);
                     }
-                    MasterContext masterContext = masterContexts.get(jobRecord.getJobId());
-                    // if MasterContext doesn't exist, update in the IMap directly, using a sync method
-                    if (masterContext == null) {
-                        jobRepository.updateJobQuorumSizeIfSmaller(jobRecord.getJobId(), currentQuorumSize);
-                        // check the master context again, it might have been just created and have picked
-                        // up the JobRecord before being updated
-                        masterContext = masterContexts.get(jobRecord.getJobId());
-                    }
-                    if (masterContext != null) {
-                        masterContext.updateQuorumSize(currentQuorumSize);
-                    }
-                } catch (Exception e) {
-                    logger.severe("Quorum of job " + idToString(jobRecord.getJobId())
-                            + " could not be updated to " + currentQuorumSize, e);
                 }
+            } catch (Exception e) {
+                logger.severe("update quorum values task failed", e);
             }
-        } catch (Exception e) {
-            logger.severe("update quorum values task failed", e);
-        }
+        });
     }
 
     private boolean shouldCheckQuorumValues() {
@@ -834,7 +857,7 @@ public class JobCoordinationService {
         return record != null ? record : new JobExecutionRecord(jobId, getQuorumSize(), false);
     }
 
-    void assertIsMaster(String error) {
+    private void assertIsMaster(String error) {
         if (!isMaster()) {
             throw new JetException(error + ". Master address: " + nodeEngine.getClusterService().getMasterAddress());
         }
@@ -846,5 +869,37 @@ public class JobCoordinationService {
 
     NodeEngineImpl nodeEngine() {
         return nodeEngine;
+    }
+
+    CompletableFuture<Void> submitToCoordinatorThread(Runnable action) {
+        return submitToCoordinatorThread(() -> {
+            action.run();
+            return null;
+        });
+    }
+
+    private <T> CompletableFuture<T> submitToCoordinatorThread(Callable<T> action) {
+        // if we are on our thread already, execute directly in a blocking way
+        if (IS_JOB_COORDINATOR_THREAD.get()) {
+            try {
+                return CompletableFuture.completedFuture(action.call());
+            } catch (Throwable e) {
+                // replace with CompletableFuture.failedFuture(e) in java9
+                CompletableFuture<T> future = new CompletableFuture<>();
+                future.completeExceptionally(e);
+                return future;
+            }
+        }
+
+        Future<T> future = nodeEngine.getExecutionService().submit(COORDINATOR_EXECUTOR_NAME, () -> {
+            assert !IS_JOB_COORDINATOR_THREAD.get() : "flag already raised";
+            IS_JOB_COORDINATOR_THREAD.set(true);
+            try {
+                return action.call();
+            } finally {
+                IS_JOB_COORDINATOR_THREAD.set(false);
+            }
+        });
+        return Util.toCompletableFuture(nodeEngine.getExecutionService().asCompletableFuture(future));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -231,7 +231,9 @@ class MasterSnapshotContext {
                 stats.duration(), stats.numBytes(),
                 stats.numKeys(), stats.numChunks(),
                 snapshotMapName));
-        mc.jobRepository().clearSnapshotData(mc.jobId(), mc.jobExecutionRecord().ongoingDataMapIndex());
+        if (!wasExport) {
+            mc.jobRepository().clearSnapshotData(mc.jobId(), mc.jobExecutionRecord().ongoingDataMapIndex());
+        }
         if (future != null) {
             if (isSuccess) {
                 future.complete(null);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -162,8 +162,11 @@ class MasterSnapshotContext {
         // Need to take a copy of executionId: we don't cancel the scheduled task when the execution
         // finalizes. If a new execution is started in the meantime, we'll use the execution ID to detect it.
         long localExecutionId = mc.executionId();
-        mc.invokeOnParticipants(factory, responses -> onSnapshotCompleted(
-                responses, localExecutionId, newSnapshotId, finalMapName, isExport, isTerminal, future),
+        mc.invokeOnParticipants(
+                factory,
+                responses -> mc.coordinationService().submitToCoordinatorThread(() ->
+                        onSnapshotCompleted(responses, localExecutionId, newSnapshotId, finalMapName, isExport, isTerminal,
+                                future)),
                 null);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobIdsByNameMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobIdsByNameMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.impl.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobIdsByNameCodec;
-import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.jet.impl.operation.GetJobIdsByNameOperation;
 import com.hazelcast.nio.Connection;
@@ -27,9 +26,9 @@ import com.hazelcast.spi.Operation;
 import java.util.List;
 
 public class JetGetJobIdsByNameMessageTask
-        extends AbstractJetMessageTask<JetGetJobIdsByNameCodec.RequestParameters, List<Long>>
-        implements BlockingMessageTask {
-    protected JetGetJobIdsByNameMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        extends AbstractJetMessageTask<JetGetJobIdsByNameCodec.RequestParameters, List<Long>> {
+
+    JetGetJobIdsByNameMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection,
                 JetGetJobIdsByNameCodec::decodeRequest,
                 JetGetJobIdsByNameCodec::encodeResponse);
@@ -39,7 +38,6 @@ public class JetGetJobIdsByNameMessageTask
     protected Operation prepareOperation() {
         return new GetJobIdsByNameOperation(parameters.name);
     }
-
 
     @Override
     public String getMethodName() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobIdsMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobIdsMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.impl.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobIdsCodec;
-import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.jet.impl.operation.GetJobIdsOperation;
 import com.hazelcast.nio.Connection;
@@ -26,9 +25,9 @@ import com.hazelcast.spi.Operation;
 
 import java.util.List;
 
-public class JetGetJobIdsMessageTask extends AbstractJetMessageTask<JetGetJobIdsCodec.RequestParameters, List<Long>>
-        implements BlockingMessageTask {
-    protected JetGetJobIdsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+public class JetGetJobIdsMessageTask extends AbstractJetMessageTask<JetGetJobIdsCodec.RequestParameters, List<Long>> {
+
+    JetGetJobIdsMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection,
                 JetGetJobIdsCodec::decodeRequest,
                 JetGetJobIdsCodec::encodeResponse);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobStatusMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobStatusMessageTask.java
@@ -18,17 +18,15 @@ package com.hazelcast.jet.impl.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobStatusCodec;
-import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.operation.GetJobStatusOperation;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.Operation;
 
-public class JetGetJobStatusMessageTask extends AbstractJetMessageTask<JetGetJobStatusCodec.RequestParameters, JobStatus>
-        implements BlockingMessageTask {
+public class JetGetJobStatusMessageTask extends AbstractJetMessageTask<JetGetJobStatusCodec.RequestParameters, JobStatus> {
 
-    protected JetGetJobStatusMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+    JetGetJobStatusMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection,
                 JetGetJobStatusCodec::decodeRequest,
                 response -> JetGetJobStatusCodec.encodeResponse(response.ordinal()));
@@ -48,5 +46,4 @@ public class JetGetJobStatusMessageTask extends AbstractJetMessageTask<JetGetJob
     public Object[] getParameters() {
         return new Object[0];
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobSubmissionTimeMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobSubmissionTimeMessageTask.java
@@ -18,17 +18,15 @@ package com.hazelcast.jet.impl.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobSubmissionTimeCodec;
-import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.jet.impl.operation.GetJobSubmissionTimeOperation;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.Operation;
 
 public class JetGetJobSubmissionTimeMessageTask
-        extends AbstractJetMessageTask<JetGetJobSubmissionTimeCodec.RequestParameters, Long>
-        implements BlockingMessageTask {
+        extends AbstractJetMessageTask<JetGetJobSubmissionTimeCodec.RequestParameters, Long> {
 
-    protected JetGetJobSubmissionTimeMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+    JetGetJobSubmissionTimeMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection,
                 JetGetJobSubmissionTimeCodec::decodeRequest,
                 JetGetJobSubmissionTimeCodec::encodeResponse);
@@ -48,5 +46,4 @@ public class JetGetJobSubmissionTimeMessageTask
     public Object[] getParameters() {
         return new Object[0];
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobSummaryListMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetGetJobSummaryListMessageTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.impl.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.JetGetJobSummaryListCodec;
-import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.jet.impl.operation.GetJobSummaryListOperation;
 import com.hazelcast.nio.Connection;
@@ -27,8 +26,9 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.serialization.SerializationService;
 
 public class JetGetJobSummaryListMessageTask
-        extends AbstractJetMessageTask<JetGetJobSummaryListCodec.RequestParameters, Data> implements BlockingMessageTask {
-    protected JetGetJobSummaryListMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        extends AbstractJetMessageTask<JetGetJobSummaryListCodec.RequestParameters, Data> {
+
+    JetGetJobSummaryListMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection,
                 JetGetJobSummaryListCodec::decodeRequest,
                 JetGetJobSummaryListCodec::encodeResponse);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetTerminateJobMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/JetTerminateJobMessageTask.java
@@ -18,16 +18,15 @@ package com.hazelcast.jet.impl.client;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.JetTerminateJobCodec;
-import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.jet.impl.TerminationMode;
 import com.hazelcast.jet.impl.operation.TerminateJobOperation;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.Operation;
 
-public class JetTerminateJobMessageTask extends AbstractJetMessageTask<JetTerminateJobCodec.RequestParameters, Void>
-        implements BlockingMessageTask {
-    protected JetTerminateJobMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+public class JetTerminateJobMessageTask extends AbstractJetMessageTask<JetTerminateJobCodec.RequestParameters, Void> {
+
+    JetTerminateJobMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection, JetTerminateJobCodec::decodeRequest,
                 o -> JetTerminateJobCodec.encodeResponse());
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 import static com.hazelcast.jet.Util.idToString;
 import static java.util.Collections.emptyList;
@@ -207,7 +206,7 @@ public class ExecutionContext {
     /**
      * Starts a new snapshot by incrementing the current snapshot id
      */
-    public CompletionStage<SnapshotOperationResult> beginSnapshot(long snapshotId, String mapName,
+    public CompletableFuture<SnapshotOperationResult> beginSnapshot(long snapshotId, String mapName,
                                                                   boolean isTerminal) {
         synchronized (executionLock) {
             if (cancellationFuture.isDone() || executionFuture != null && executionFuture.isDone()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/ReadMetricsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/management/ReadMetricsOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.spi.ReadonlyOperation;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class ReadMetricsOperation extends Operation implements ReadonlyOperation {
@@ -46,7 +47,7 @@ public class ReadMetricsOperation extends Operation implements ReadonlyOperation
         ILogger logger = getNodeEngine().getLogger(getClass());
         JetMetricsService service = getService();
         CompletableFuture<RingbufferSlice<Entry<Long, byte[]>>> future = service.readMetrics(offset);
-        future.whenComplete(withTryCatch(logger, (slice, error) -> doSendResponse(error != null ? error : slice)));
+        future.whenComplete(withTryCatch(logger, (slice, error) -> doSendResponse(error != null ? peel(error) : slice)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
+import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ExceptionAction;
@@ -29,6 +30,11 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 
+/**
+ * Base class for async operations. Handles registration/deregistration of
+ * operations from live registry, exception handling and peeling and
+ * logging of exceptions
+ */
 public abstract class AsyncOperation extends Operation implements IdentifiedDataSerializable {
 
     @Override
@@ -67,6 +73,15 @@ public abstract class AsyncOperation extends Operation implements IdentifiedData
             final JetService service = getService();
             service.getLiveOperationRegistry().deregister(this);
         }
+    }
+
+    protected JetService getJetService() {
+        assert getServiceName().equals(JetService.SERVICE_NAME) : "Service is not Jet Service";
+        return getService();
+    }
+
+    protected JobCoordinationService getJobCoordinationService() {
+        return getJetService().getJobCoordinationService();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
@@ -30,7 +29,7 @@ import java.io.IOException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobIdsByNameOperation
-        extends Operation
+        extends AsyncOperation
         implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     private String name;
@@ -43,21 +42,11 @@ public class GetJobIdsByNameOperation
     }
 
     @Override
-    public void run() {
+    public void doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.getJobIds(name)
                            .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return JetInitDataSerializerHook.FACTORY_ID;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
-import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -43,9 +41,7 @@ public class GetJobIdsByNameOperation
 
     @Override
     public CompletableFuture<List<Long>> doRun() {
-        JetService service = getService();
-        JobCoordinationService coordinationService = service.getJobCoordinationService();
-        return coordinationService.getJobIds(name);
+        return getJobCoordinationService().getJobIds(name);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
@@ -26,6 +26,7 @@ import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobIdsByNameOperation
@@ -46,7 +47,7 @@ public class GetJobIdsByNameOperation
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.getJobIds(name)
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
+                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsByNameOperation.java
@@ -25,9 +25,8 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
-
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public class GetJobIdsByNameOperation
         extends AsyncOperation
@@ -43,11 +42,10 @@ public class GetJobIdsByNameOperation
     }
 
     @Override
-    public void doRun() {
+    public CompletableFuture<List<Long>> doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        coordinationService.getJobIds(name)
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
+        return coordinationService.getJobIds(name);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
@@ -22,8 +22,8 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public class GetJobIdsOperation
         extends AsyncOperation
@@ -33,11 +33,10 @@ public class GetJobIdsOperation
     }
 
     @Override
-    public void doRun() {
+    public CompletableFuture<List<Long>> doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        coordinationService.getAllJobIds()
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
+        return coordinationService.getAllJobIds();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
@@ -23,14 +23,11 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-import java.util.ArrayList;
-import java.util.List;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobIdsOperation
         extends Operation
         implements IdentifiedDataSerializable, AllowedDuringPassiveState {
-
-    private List<Long> response;
 
     public GetJobIdsOperation() {
     }
@@ -39,12 +36,13 @@ public class GetJobIdsOperation
     public void run() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        response = new ArrayList<>(coordinationService.getAllJobIds());
+        coordinationService.getAllJobIds()
+                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
     }
 
     @Override
-    public Object getResponse() {
-        return response;
+    public boolean returnsResponse() {
+        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobIdsOperation
@@ -36,7 +37,7 @@ public class GetJobIdsOperation
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.getAllJobIds()
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
+                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
-import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
@@ -34,9 +32,7 @@ public class GetJobIdsOperation
 
     @Override
     public CompletableFuture<List<Long>> doRun() {
-        JetService service = getService();
-        JobCoordinationService coordinationService = service.getJobCoordinationService();
-        return coordinationService.getAllJobIds();
+        return getJobCoordinationService().getAllJobIds();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
@@ -20,20 +20,19 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobIdsOperation
-        extends Operation
+        extends AsyncOperation
         implements IdentifiedDataSerializable, AllowedDuringPassiveState {
 
     public GetJobIdsOperation() {
     }
 
     @Override
-    public void run() {
+    public void doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.getAllJobIds()
@@ -41,18 +40,7 @@ public class GetJobIdsOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return JetInitDataSerializerHook.FACTORY_ID;
-    }
-
-    @Override
     public int getId() {
         return JetInitDataSerializerHook.GET_JOB_IDS;
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobIdsOperation.java
@@ -17,15 +17,12 @@
 package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-public class GetJobIdsOperation
-        extends AsyncOperation
-        implements IdentifiedDataSerializable, AllowedDuringPassiveState {
+public class GetJobIdsOperation extends AsyncOperation implements AllowedDuringPassiveState {
 
     public GetJobIdsOperation() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -16,14 +16,13 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-public class GetJobStatusOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
-    private JobStatus response;
+public class GetJobStatusOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
 
     public GetJobStatusOperation() {
     }
@@ -35,12 +34,13 @@ public class GetJobStatusOperation extends AbstractJobOperation implements Allow
     @Override
     public void run() {
         JetService service = getService();
-        response = service.getJobCoordinationService().getJobStatus(jobId());
+        service.getJobCoordinationService().getJobStatus(jobId())
+               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
     }
 
     @Override
-    public Object getResponse() {
-        return response;
+    public boolean returnsResponse() {
+        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -23,7 +23,7 @@ import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
-public class GetJobStatusOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
+public class GetJobStatusOperation extends AsyncJobOperation implements AllowedDuringPassiveState {
 
     public GetJobStatusOperation() {
     }
@@ -33,15 +33,10 @@ public class GetJobStatusOperation extends AbstractJobOperation implements Allow
     }
 
     @Override
-    public void run() {
+    public void doRun() {
         JetService service = getService();
         service.getJobCoordinationService().getJobStatus(jobId())
                .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobStatusOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
@@ -35,7 +36,7 @@ public class GetJobStatusOperation extends AbstractJobOperation implements Allow
     public void run() {
         JetService service = getService();
         service.getJobCoordinationService().getJobStatus(jobId())
-               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
+               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -47,5 +47,4 @@ public class GetJobStatusOperation extends AbstractJobOperation implements Allow
     public int getId() {
         return JetInitDataSerializerHook.GET_JOB_STATUS_OP;
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.jet.impl.operation;
 
+import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.concurrent.CompletableFuture;
 
 public class GetJobStatusOperation extends AsyncJobOperation implements AllowedDuringPassiveState {
 
@@ -33,10 +33,9 @@ public class GetJobStatusOperation extends AsyncJobOperation implements AllowedD
     }
 
     @Override
-    public void doRun() {
+    public CompletableFuture<JobStatus> doRun() {
         JetService service = getService();
-        service.getJobCoordinationService().getJobStatus(jobId())
-               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
+        return service.getJobCoordinationService().getJobStatus(jobId());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobStatusOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.core.JobStatus;
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
@@ -34,8 +33,7 @@ public class GetJobStatusOperation extends AsyncJobOperation implements AllowedD
 
     @Override
     public CompletableFuture<JobStatus> doRun() {
-        JetService service = getService();
-        return service.getJobCoordinationService().getJobStatus(jobId());
+        return getJobCoordinationService().getJobStatus(jobId());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -20,8 +20,7 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.concurrent.CompletableFuture;
 
 public class GetJobSubmissionTimeOperation extends AsyncJobOperation implements AllowedDuringPassiveState {
 
@@ -33,10 +32,9 @@ public class GetJobSubmissionTimeOperation extends AsyncJobOperation implements 
     }
 
     @Override
-    public void doRun() {
+    public CompletableFuture<Long> doRun() {
         JetService service = getService();
-        service.getJobCoordinationService().getJobSubmissionTime(jobId())
-               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
+        return service.getJobCoordinationService().getJobSubmissionTime(jobId());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -47,5 +47,4 @@ public class GetJobSubmissionTimeOperation extends AbstractJobOperation implemen
     public int getId() {
         return JetInitDataSerializerHook.GET_JOB_SUBMISSION_TIME_OP;
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobSubmissionTimeOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
@@ -35,7 +36,7 @@ public class GetJobSubmissionTimeOperation extends AbstractJobOperation implemen
     public void run() {
         JetService service = getService();
         service.getJobCoordinationService().getJobSubmissionTime(jobId())
-               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
+               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -20,9 +20,9 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
-public class GetJobSubmissionTimeOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
-    private long response;
+public class GetJobSubmissionTimeOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
 
     public GetJobSubmissionTimeOperation() {
     }
@@ -34,12 +34,13 @@ public class GetJobSubmissionTimeOperation extends AbstractJobOperation implemen
     @Override
     public void run() {
         JetService service = getService();
-        response = service.getJobCoordinationService().getJobSubmissionTime(jobId());
+        service.getJobCoordinationService().getJobSubmissionTime(jobId())
+               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
     }
 
     @Override
-    public Object getResponse() {
-        return response;
+    public boolean returnsResponse() {
+        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
@@ -33,8 +32,7 @@ public class GetJobSubmissionTimeOperation extends AsyncJobOperation implements 
 
     @Override
     public CompletableFuture<Long> doRun() {
-        JetService service = getService();
-        return service.getJobCoordinationService().getJobSubmissionTime(jobId());
+        return getJobCoordinationService().getJobSubmissionTime(jobId());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSubmissionTimeOperation.java
@@ -23,7 +23,7 @@ import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
-public class GetJobSubmissionTimeOperation extends AbstractJobOperation implements AllowedDuringPassiveState {
+public class GetJobSubmissionTimeOperation extends AsyncJobOperation implements AllowedDuringPassiveState {
 
     public GetJobSubmissionTimeOperation() {
     }
@@ -33,15 +33,10 @@ public class GetJobSubmissionTimeOperation extends AbstractJobOperation implemen
     }
 
     @Override
-    public void run() {
+    public void doRun() {
         JetService service = getService();
         service.getJobCoordinationService().getJobSubmissionTime(jobId())
                .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
@@ -18,12 +18,13 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobCoordinationService;
+import com.hazelcast.jet.impl.JobSummary;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ReadonlyOperation;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 public class GetJobSummaryListOperation
         extends AsyncOperation
@@ -33,11 +34,10 @@ public class GetJobSummaryListOperation
     }
 
     @Override
-    public void doRun() {
+    public CompletableFuture<List<JobSummary>> doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        coordinationService.getJobSummaryList()
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
+        return coordinationService.getJobSummaryList();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
@@ -20,20 +20,19 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ReadonlyOperation;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobSummaryListOperation
-        extends Operation
+        extends AsyncOperation
         implements IdentifiedDataSerializable, ReadonlyOperation {
 
     public GetJobSummaryListOperation() {
     }
 
     @Override
-    public void run() {
+    public void doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.getJobSummaryList()
@@ -41,18 +40,7 @@ public class GetJobSummaryListOperation
     }
 
     @Override
-    public boolean returnsResponse() {
-        return false;
-    }
-
-    @Override
-    public int getFactoryId() {
-        return JetInitDataSerializerHook.FACTORY_ID;
-    }
-
-    @Override
     public int getId() {
         return JetInitDataSerializerHook.GET_JOB_SUMMARY_LIST_OP;
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ReadonlyOperation;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobSummaryListOperation
@@ -36,7 +37,7 @@ public class GetJobSummaryListOperation
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.getJobSummaryList()
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
+                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
@@ -18,19 +18,16 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobCoordinationService;
-import com.hazelcast.jet.impl.JobSummary;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ReadonlyOperation;
 
-import java.util.List;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class GetJobSummaryListOperation
         extends Operation
         implements IdentifiedDataSerializable, ReadonlyOperation {
-
-    private List<JobSummary> response;
 
     public GetJobSummaryListOperation() {
     }
@@ -39,12 +36,13 @@ public class GetJobSummaryListOperation
     public void run() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        response = coordinationService.getJobSummaryList();
+        coordinationService.getJobSummaryList()
+                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
     }
 
     @Override
-    public Object getResponse() {
-        return response;
+    public boolean returnsResponse() {
+        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
@@ -18,15 +18,12 @@ package com.hazelcast.jet.impl.operation;
 
 import com.hazelcast.jet.impl.JobSummary;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ReadonlyOperation;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-public class GetJobSummaryListOperation
-        extends AsyncOperation
-        implements IdentifiedDataSerializable, ReadonlyOperation {
+public class GetJobSummaryListOperation extends AsyncOperation implements ReadonlyOperation {
 
     public GetJobSummaryListOperation() {
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSummaryListOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
-import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.JobSummary;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -35,9 +33,7 @@ public class GetJobSummaryListOperation
 
     @Override
     public CompletableFuture<List<JobSummary>> doRun() {
-        JetService service = getService();
-        JobCoordinationService coordinationService = service.getJobCoordinationService();
-        return coordinationService.getJobSummaryList();
+        return getJobCoordinationService().getJobSummaryList();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
@@ -22,9 +22,6 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
-
 public class JoinSubmittedJobOperation extends AsyncJobOperation {
 
     public JoinSubmittedJobOperation() {
@@ -35,11 +32,10 @@ public class JoinSubmittedJobOperation extends AsyncJobOperation {
     }
 
     @Override
-    protected void doRun() {
+    protected CompletableFuture<?> doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        CompletableFuture<Void> executionFuture = coordinationService.joinSubmittedJob(jobId());
-        executionFuture.whenComplete(withTryCatch(getLogger(), (r, t) -> doSendResponse(peel(t))));
+        return coordinationService.joinSubmittedJob(jobId());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/JoinSubmittedJobOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
-import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 
 import java.util.concurrent.CompletableFuture;
@@ -33,9 +31,7 @@ public class JoinSubmittedJobOperation extends AsyncJobOperation {
 
     @Override
     protected CompletableFuture<?> doRun() {
-        JetService service = getService();
-        JobCoordinationService coordinationService = service.getJobCoordinationService();
-        return coordinationService.joinSubmittedJob(jobId());
+        return getJobCoordinationService().joinSubmittedJob(jobId());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
@@ -22,8 +22,6 @@ import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
-
 /**
  * Operation sent from a non-master member to master to notify it that the
  * caller is about to shut down. The master should request termination of all
@@ -35,10 +33,9 @@ public class NotifyMemberShutdownOperation extends AsyncOperation implements All
     }
 
     @Override
-    protected void doRun() {
+    protected CompletableFuture<Void> doRun() {
         JetService service = getService();
-        CompletableFuture<Void> future = service.getJobCoordinationService().addShuttingDownMember(getCallerUuid());
-        future.whenComplete(withTryCatch(getLogger(), (r, e) -> sendResponse(null)));
+        return service.getJobCoordinationService().addShuttingDownMember(getCallerUuid());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/NotifyMemberShutdownOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
@@ -34,8 +33,7 @@ public class NotifyMemberShutdownOperation extends AsyncOperation implements All
 
     @Override
     protected CompletableFuture<Void> doRun() {
-        JetService service = getService();
-        return service.getJobCoordinationService().addShuttingDownMember(getCallerUuid());
+        return getJobCoordinationService().addShuttingDownMember(getCallerUuid());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 
 import java.util.concurrent.CompletableFuture;
@@ -32,9 +31,7 @@ public class PrepareForPassiveClusterOperation extends AsyncOperation {
 
     @Override
     protected CompletableFuture<Void> doRun() {
-        return this.<JetService>getService()
-                .getJobCoordinationService()
-                .prepareForPassiveClusterState();
+        return getJobCoordinationService().prepareForPassiveClusterState();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/PrepareForPassiveClusterOperation.java
@@ -19,8 +19,7 @@ package com.hazelcast.jet.impl.operation;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Sent from the member that initiates a cluster state change to the master.
@@ -32,11 +31,10 @@ public class PrepareForPassiveClusterOperation extends AsyncOperation {
     }
 
     @Override
-    protected void doRun() {
-        this.<JetService>getService()
+    protected CompletableFuture<Void> doRun() {
+        return this.<JetService>getService()
                 .getJobCoordinationService()
-                .prepareForPassiveClusterState()
-                .whenComplete(withTryCatch(getLogger(), (r, t) -> doSendResponse(peel(t))));
+                .prepareForPassiveClusterState();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SnapshotOperation.java
@@ -24,9 +24,9 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.jet.impl.util.LoggingUtil.logFine;
 import static java.util.Objects.requireNonNull;
 
@@ -55,16 +55,14 @@ public class SnapshotOperation extends AsyncJobOperation {
     }
 
     @Override
-    protected void doRun() {
+    protected CompletableFuture<SnapshotOperationResult> doRun() {
         JetService service = getService();
         ExecutionContext ctx = service.getJobExecutionService().assertExecutionContext(
                 getCallerAddress(), jobId(), executionId, getClass().getSimpleName()
         );
-        ctx.beginSnapshot(snapshotId, mapName, isTerminal).whenComplete(withTryCatch(getLogger(),
-                (result, exc) -> {
-                    if (exc != null) {
-                        result = new SnapshotOperationResult(0, 0, 0, exc);
-                    }
+        CompletableFuture<SnapshotOperationResult> future = ctx.beginSnapshot(snapshotId, mapName, isTerminal)
+                .exceptionally(exc -> new SnapshotOperationResult(0, 0, 0, exc))
+                .thenApply(result -> {
                     if (result.getError() == null) {
                         logFine(getLogger(),
                                 "Snapshot %s for %s finished successfully on member",
@@ -73,18 +71,21 @@ public class SnapshotOperation extends AsyncJobOperation {
                         getLogger().warning(String.format("Snapshot %d for %s finished with an error on member: %s",
                                 snapshotId, ctx.jobNameAndExecutionId(), result.getError()));
                     }
-                    maybeSendResponse(result);
-                }));
+                    return result;
+                });
+        CompletableFuture<SnapshotOperationResult> future2 = new CompletableFuture<>();
+        future.thenAccept(result -> maybeCompleteFuture(future2, result));
+        return future2;
     }
 
-    private void maybeSendResponse(SnapshotOperationResult result) {
+    private void maybeCompleteFuture(CompletableFuture<SnapshotOperationResult> future, SnapshotOperationResult result) {
         if (postponeResponses) {
             getNodeEngine().getExecutionService()
-                           .schedule(() -> maybeSendResponse(result), RETRY_MS, TimeUnit.MILLISECONDS);
+                           .schedule(() -> maybeCompleteFuture(future, result), RETRY_MS, TimeUnit.MILLISECONDS);
             return;
         }
 
-        doSendResponse(result);
+        future.complete(result);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
@@ -22,9 +22,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
-
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Operation sent from master to members to start execution of a job. It is
@@ -43,10 +41,9 @@ public class StartExecutionOperation extends AsyncJobOperation {
     }
 
     @Override
-    protected void doRun() {
+    protected CompletableFuture<Void> doRun() {
         JetService service = getService();
-        service.getJobExecutionService().beginExecution(getCallerAddress(), jobId(), executionId)
-                .whenComplete(withTryCatch(getLogger(), (i, e) -> doSendResponse(peel(e))));
+        return service.getJobExecutionService().beginExecution(getCallerAddress(), jobId(), executionId);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 /**
@@ -45,7 +46,7 @@ public class StartExecutionOperation extends AsyncJobOperation {
     protected void doRun() {
         JetService service = getService();
         service.getJobExecutionService().beginExecution(getCallerAddress(), jobId(), executionId)
-                .whenComplete(withTryCatch(getLogger(), (i, e) -> doSendResponse(e)));
+                .whenComplete(withTryCatch(getLogger(), (i, e) -> doSendResponse(peel(e))));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -42,8 +41,7 @@ public class StartExecutionOperation extends AsyncJobOperation {
 
     @Override
     protected CompletableFuture<Void> doRun() {
-        JetService service = getService();
-        return service.getJobExecutionService().beginExecution(getCallerAddress(), jobId(), executionId);
+        return getJetService().getJobExecutionService().beginExecution(getCallerAddress(), jobId(), executionId);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
-import com.hazelcast.jet.impl.JobCoordinationService;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -43,9 +41,7 @@ public class SubmitJobOperation extends AsyncJobOperation {
 
     @Override
     public CompletableFuture<Void> doRun() {
-        JetService service = getService();
-        JobCoordinationService coordinationService = service.getJobCoordinationService();
-        return coordinationService.submitJob(jobId(), dag, config);
+        return getJobCoordinationService().submitJob(jobId(), dag, config);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -44,7 +44,13 @@ public class SubmitJobOperation extends AbstractJobOperation {
     public void run() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        coordinationService.submitJob(jobId(), dag, config);
+        coordinationService.submitJob(jobId(), dag, config)
+                           .whenComplete((r, f) -> sendResponse(f != null ? f : r));
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -25,6 +25,8 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+
 public class SubmitJobOperation extends AbstractJobOperation {
 
     // force serialization of fields to avoid sharing of the mutable instances if submitted to the master member
@@ -45,7 +47,7 @@ public class SubmitJobOperation extends AbstractJobOperation {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.submitJob(jobId(), dag, config)
-                           .whenComplete((r, f) -> sendResponse(f != null ? f : r));
+                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
     }
 
     @Override
@@ -71,5 +73,4 @@ public class SubmitJobOperation extends AbstractJobOperation {
         dag = in.readData();
         config = in.readData();
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
-public class SubmitJobOperation extends AbstractJobOperation {
+public class SubmitJobOperation extends AsyncJobOperation {
 
     // force serialization of fields to avoid sharing of the mutable instances if submitted to the master member
     private Data dag;
@@ -44,16 +44,11 @@ public class SubmitJobOperation extends AbstractJobOperation {
     }
 
     @Override
-    public void run() {
+    public void doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.submitJob(jobId(), dag, config)
                            .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -25,6 +25,7 @@ import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 public class SubmitJobOperation extends AbstractJobOperation {
@@ -47,7 +48,7 @@ public class SubmitJobOperation extends AbstractJobOperation {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
         coordinationService.submitJob(jobId(), dag, config)
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
+                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/SubmitJobOperation.java
@@ -24,9 +24,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.IOException;
-
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.concurrent.CompletableFuture;
 
 public class SubmitJobOperation extends AsyncJobOperation {
 
@@ -44,11 +42,10 @@ public class SubmitJobOperation extends AsyncJobOperation {
     }
 
     @Override
-    public void doRun() {
+    public CompletableFuture<Void> doRun() {
         JetService service = getService();
         JobCoordinationService coordinationService = service.getJobCoordinationService();
-        coordinationService.submitJob(jobId(), dag, config)
-                           .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
+        return coordinationService.submitJob(jobId(), dag, config);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
@@ -23,9 +23,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
-
-import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
-import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Operation sent from client to coordinator member to terminate particular
@@ -45,10 +43,9 @@ public class TerminateJobOperation extends AsyncJobOperation {
     }
 
     @Override
-    public void doRun() {
+    public CompletableFuture<Void> doRun() {
         JetService service = getService();
-        service.getJobCoordinationService().terminateJob(jobId(), terminationMode)
-               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
+        return service.getJobCoordinationService().terminateJob(jobId(), terminationMode);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
@@ -44,7 +44,13 @@ public class TerminateJobOperation extends AbstractJobOperation {
     @Override
     public void run() {
         JetService service = getService();
-        service.getJobCoordinationService().terminateJob(jobId(), terminationMode);
+        service.getJobCoordinationService().terminateJob(jobId(), terminationMode)
+               .whenComplete((r, f) -> sendResponse(f != null ? f : r));
+    }
+
+    @Override
+    public boolean returnsResponse() {
+        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.operation;
 
-import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.TerminationMode;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -44,8 +43,7 @@ public class TerminateJobOperation extends AsyncJobOperation {
 
     @Override
     public CompletableFuture<Void> doRun() {
-        JetService service = getService();
-        return service.getJobCoordinationService().terminateJob(jobId(), terminationMode);
+        return getJobCoordinationService().terminateJob(jobId(), terminationMode);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
@@ -32,7 +32,7 @@ import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
  * job. See also {@link TerminateExecutionOperation}, which is sent from
  * coordinator to members to terminate execution.
  */
-public class TerminateJobOperation extends AbstractJobOperation {
+public class TerminateJobOperation extends AsyncJobOperation {
 
     private TerminationMode terminationMode;
 
@@ -45,15 +45,10 @@ public class TerminateJobOperation extends AbstractJobOperation {
     }
 
     @Override
-    public void run() {
+    public void doRun() {
         JetService service = getService();
         service.getJobCoordinationService().terminateJob(jobId(), terminationMode)
                .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
-    }
-
-    @Override
-    public boolean returnsResponse() {
-        return false;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 
 /**
@@ -47,7 +48,7 @@ public class TerminateJobOperation extends AbstractJobOperation {
     public void run() {
         JetService service = getService();
         service.getJobCoordinationService().terminateJob(jobId(), terminationMode)
-               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
+               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? peel(f) : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/TerminateJobOperation.java
@@ -24,6 +24,8 @@ import com.hazelcast.nio.ObjectDataOutput;
 
 import java.io.IOException;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
+
 /**
  * Operation sent from client to coordinator member to terminate particular
  * job. See also {@link TerminateExecutionOperation}, which is sent from
@@ -45,7 +47,7 @@ public class TerminateJobOperation extends AbstractJobOperation {
     public void run() {
         JetService service = getService();
         service.getJobCoordinationService().terminateJob(jobId(), terminationMode)
-               .whenComplete((r, f) -> sendResponse(f != null ? f : r));
+               .whenComplete(withTryCatch(getLogger(), (r, f) -> sendResponse(f != null ? f : r)));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -415,6 +415,7 @@ public final class Util {
     /**
      * Returns a future which is already completed with the supplied exception.
      */
+    // replace with CompletableFuture.failedFuture(e) once we depend on java9+
     public static <T> CompletableFuture<T> exceptionallyCompletedFuture(@Nonnull Throwable exception) {
         CompletableFuture<T> future = new CompletableFuture<>();
         future.completeExceptionally(exception);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ParallelJobSubmissionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ParallelJobSubmissionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class ParallelJobSubmissionTest extends JetTestSupport {
+    @Test
+    public void test() throws Exception {
+        /*
+        This test tests the issue #1339 (https://github.com/hazelcast/hazelcast-jet/issues/1339)
+        There's no assert in this test. If the problem reproduces, the jobs won't complete and will
+        get stuck.
+         */
+        DAG dag = new DAG();
+        dag.newVertex("p", TestProcessors.ListSource.supplier(Arrays.asList(1, 2, 3)));
+
+        JetInstance instance = createJetMember();
+        ExecutorService executor = Executors.newFixedThreadPool(8);
+        List<Future<Job>> futures = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            futures.add(executor.submit(() -> instance.newJob(dag)));
+        }
+        for (Future<Job> future : futures) {
+            future.get().join();
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SplitBrainTest.java
@@ -94,7 +94,7 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
 
             assertTrueEventually(() -> {
                 JetService service = getJetService(firstSubCluster[0]);
-                assertEquals(COMPLETED, service.getJobCoordinationService().getJobStatus(jobId));
+                assertEquals(COMPLETED, service.getJobCoordinationService().getJobStatus(jobId).get());
             });
 
             JetService service2 = getJetService(secondSubCluster[0]);
@@ -106,7 +106,7 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
             });
 
             assertTrueAllTheTime(() -> {
-                assertStatusNotRunningOrStarting(service2.getJobCoordinationService().getJobStatus(jobId));
+                assertStatusNotRunningOrStarting(service2.getJobCoordinationService().getJobStatus(jobId).get());
             }, 20);
         };
 
@@ -163,8 +163,8 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
             assertTrueAllTheTime(() -> {
                 JetService service1 = getJetService(firstSubCluster[0]);
                 JetService service2 = getJetService(secondSubCluster[0]);
-                JobStatus status1 = service1.getJobCoordinationService().getJobStatus(jobId);
-                JobStatus status2 = service2.getJobCoordinationService().getJobStatus(jobId);
+                JobStatus status1 = service1.getJobCoordinationService().getJobStatus(jobId).get();
+                JobStatus status2 = service2.getJobCoordinationService().getJobStatus(jobId).get();
                 assertStatusNotRunningOrStarting(status1);
                 assertStatusNotRunningOrStarting(status2);
             }, 20);
@@ -206,8 +206,8 @@ public class SplitBrainTest extends JetSplitBrainTestSupport {
             assertTrueEventually(() -> {
                 JetService service1 = getJetService(firstSubCluster[0]);
                 JetService service2 = getJetService(secondSubCluster[0]);
-                assertEquals(COMPLETED, service1.getJobCoordinationService().getJobStatus(jobId));
-                assertEquals(COMPLETED, service2.getJobCoordinationService().getJobStatus(jobId));
+                assertEquals(COMPLETED, service1.getJobCoordinationService().getJobStatus(jobId).get());
+                assertEquals(COMPLETED, service2.getJobCoordinationService().getJobStatus(jobId).get());
             });
         };
 


### PR DESCRIPTION
A deadlock is possible when calling methods that execute operations
backed by `InvokeOnPartitions` from an async thread. This is an issue of
IMDG and it will probably be checked and disallowed in future version
(see hazelcast/hazelcast#14734 for description of the deadlock).

In case of Jet, we call `IMap.clear()` and `IMap.removeAll()` as part of
handling of operation response using `ExecutionCallback`, which is
normally executed on an async thread, which could cause the deadlock
under load.

The fix in this commit is to offload all such handling to own thread, we
use the cached thread pool in `JobCoordinationService`.

Fixes #1339