### PR TITLE
Fixed nightly profile

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
@@ -23,18 +23,15 @@ import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.TestProcessors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
-@Category(NightlyTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
 public class MulticastDiscoveryTest extends JetTestSupport {
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/BackpressureTest.java
@@ -30,10 +30,8 @@ import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -41,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ThreadLocalRandom;
+import org.junit.Ignore;
 
 import static com.hazelcast.jet.Traversers.lazy;
 import static com.hazelcast.jet.Traversers.traverseIterable;
@@ -53,8 +52,8 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Category(NightlyTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
+@Ignore("https://github.com/hazelcast/hazelcast-jet/issues/1357")
 public class BackpressureTest extends JetTestSupport {
 
     private static final int CLUSTER_SIZE = 2;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/benchmark/WordCountTest.java
@@ -35,12 +35,10 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -68,7 +66,6 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@Category(NightlyTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
 public class WordCountTest extends HazelcastTestSupport implements Serializable {
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,8 @@
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.language>java</sonar.language>
         <sonar.verbose>true</sonar.verbose>
+
+        <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     </properties>
 
     <licenses>
@@ -336,10 +338,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <runOrder>failedfirst</runOrder>
                     <forkCount>4</forkCount>
-                    <failIfNoTests>false</failIfNoTests>
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>
                         ${argLine}
@@ -459,8 +459,12 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <forkCount>1</forkCount>
-                            <excludedGroups></excludedGroups>
+                            <forkCount combine.self="override">1</forkCount>
+                            <groups combine.self="override">
+                                com.hazelcast.test.annotation.NightlyTest,
+                                com.hazelcast.test.annotation.SlowTest
+                            </groups>
+                            <excludedGroups combine.self="override" />
                         </configuration>
                     </plugin>
                 </plugins>
@@ -486,11 +490,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <testFailureIgnore>true</testFailureIgnore>
-                            <argLine>@{argLine}</argLine>
-                            <excludedGroups>
-                                com.hazelcast.test.annotation.SlowTest,
-                                com.hazelcast.test.annotation.NightlyTest,
+                            <excludedGroups combine.self="override">
                                 com.hazelcast.jet.test.IgnoredForCoverage
                             </excludedGroups>
                         </configuration>


### PR DESCRIPTION
It fixes or adjusts following:
* categories `NightlyTest` and `SlowTest` were not executed in `nightly` profile
* run only categories `NightlyTest` and `SlowTest` in nightly profile (i.e. not run common tests in this profile)
* `test-coverage` used for Sonar should include also `NightlyTest` and `SlowTest` categories since they are also related to test coverage
* `redirectTestOutputToFile` is moved to property to have it configured automatically for all test-related profiles
* removed `failIfNoTests=false` from surefire plugin configuration - it can cause that no tests were run and it looks like everything finished ok. In case when anybody needs it for locally testing etc., then `-DfailIfNoTests=false` can be used in maven command 
* moved tests `MulticastDiscoveryTest`, `BackpressureTest` and `WordCountTest` from nightly profile to common tests