### PR TITLE
Pipe operator to make pipelines more customizable (#1310)

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -56,6 +56,11 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
         this(transform, pipeline);
     }
 
+    @Override
+    public <R> BatchStage<R> pipe(FunctionEx<BatchStage<T>, BatchStage<R>> pipedTransformation) {
+        return pipedTransformation.apply(this);
+    }
+
     @Nonnull @Override
     public <K> BatchStageWithKey<T, K> groupingKey(@Nonnull FunctionEx<? super T, ? extends K> keyFn) {
         checkSerializable(keyFn, "keyFn");

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -26,10 +26,7 @@ import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.datamodel.Tuple3;
-import com.hazelcast.jet.function.BiFunctionEx;
-import com.hazelcast.jet.function.SupplierEx;
-import com.hazelcast.jet.function.TriFunction;
-import com.hazelcast.jet.function.TriPredicate;
+import com.hazelcast.jet.function.*;
 
 import javax.annotation.Nonnull;
 import java.util.Map.Entry;
@@ -411,6 +408,11 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     @Nonnull
     default GroupAggregateBuilder1<T, K> aggregateBuilder() {
         return new GroupAggregateBuilder1<>(this);
+    }
+
+    @Nonnull
+    default <R, RK> BatchStageWithKey<R, RK> pipe(@Nonnull FunctionEx<BatchStageWithKey<T, K>, BatchStageWithKey<R, RK>> transformationFunction) {
+        return transformationFunction.apply(this);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -186,6 +186,11 @@ public interface StreamStage<T> extends GeneralStage<T> {
         return (StreamStage<T>) GeneralStage.super.peek(toStringFn);
     }
 
+    @Nonnull
+    default <R> StreamStage<R> pipe(@Nonnull FunctionEx<StreamStage<T>, StreamStage<R>> transformationFunction) {
+        return transformationFunction.apply(this);
+    }
+
     @Nonnull @Override
     default <R> StreamStage<R> customTransform(@Nonnull String stageName,
                                                @Nonnull SupplierEx<Processor> procSupplier) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
@@ -22,10 +22,7 @@ import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
-import com.hazelcast.jet.function.BiFunctionEx;
-import com.hazelcast.jet.function.SupplierEx;
-import com.hazelcast.jet.function.TriFunction;
-import com.hazelcast.jet.function.TriPredicate;
+import com.hazelcast.jet.function.*;
 
 import javax.annotation.Nonnull;
 import java.util.Map.Entry;
@@ -106,6 +103,11 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     <R> StreamStage<Entry<K, R>> rollingAggregate(
             @Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp
     );
+
+    @Nonnull
+    default <R, RK> StreamStageWithKey<R, RK> pipe(@Nonnull FunctionEx<StreamStageWithKey<T, K>, StreamStageWithKey<R, RK>> transformationFunction) {
+        return transformationFunction.apply(this);
+    }
 
     @Nonnull @Override
     default <R> StreamStage<R> customTransform(@Nonnull String stageName,


### PR DESCRIPTION
Introduced `pipe` operator to allow more customizable Pipeline code, i.e. extracting common logic.

Currently it's a draft PR, just to show concept