### PR TITLE
Fix issues related to operation packet loss

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterContext.java
@@ -16,12 +16,13 @@
 
 package com.hazelcast.jet.impl;
 
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlan;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -29,6 +30,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
@@ -215,38 +218,60 @@ public class MasterContext {
      * @param completionCallback a consumer that will receive a map of responses, one for each member,
      *                           after all have been received. The value will be either the response or
      *                           an exception thrown from the operation
-     * @param callback A callback that will be called after each individual operation for each
-     *                 member completes
+     * @param throwableCallback A callback that will be called after each individual operation
+     *                          when it fails
+     * @param retryTimedOut if true, operations that throw {@link
+     *      com.hazelcast.core.OperationTimeoutException} will be retried.
      */
     void invokeOnParticipants(
             Function<ExecutionPlan, Operation> operationCtor,
-            @Nullable Consumer<Map<MemberInfo, Object>> completionCallback,
-            @Nullable ExecutionCallback<Object> callback
+            @Nullable Consumer<Collection<Object>> completionCallback,
+            @Nullable Consumer<Throwable> throwableCallback,
+            boolean retryTimedOut
     ) {
-        ConcurrentMap<MemberInfo, Object> responses = new ConcurrentHashMap<>();
+        ConcurrentMap<Address, Object> responses = new ConcurrentHashMap<>();
         AtomicInteger remainingCount = new AtomicInteger(executionPlanMap.size());
         for (Entry<MemberInfo, ExecutionPlan> entry : executionPlanMap.entrySet()) {
-            MemberInfo member = entry.getKey();
+            Address address = entry.getKey().getAddress();
             Operation op = operationCtor.apply(entry.getValue());
-            InternalCompletableFuture<Object> future = nodeEngine.getOperationService()
-                    .createInvocationBuilder(JetService.SERVICE_NAME, op, member.getAddress())
-                    .invoke();
-
-            if (completionCallback != null) {
-                future.andThen(callbackOf((r, throwable) -> {
-                    Object response = r != null ? r : throwable != null ? peel(throwable) : NULL_OBJECT;
-                    Object oldResponse = responses.put(member, response);
-                    assert oldResponse == null :
-                            "Duplicate response for " + member + ". Old=" + oldResponse + ", new=" + response;
-                    if (remainingCount.decrementAndGet() == 0) {
-                        completionCallback.accept(responses);
-                    }
-                }));
-            }
-
-            if (callback != null) {
-                future.andThen(callback);
-            }
+            invokeOnParticipant(address, op, completionCallback, throwableCallback, retryTimedOut, responses,
+                    remainingCount);
         }
+    }
+
+    private void invokeOnParticipant(
+            Address address,
+            Operation op,
+            @Nullable Consumer<Collection<Object>> completionCallback,
+            @Nullable Consumer<Throwable> throwableCallback,
+            boolean retryTimedOut,
+            ConcurrentMap<Address, Object> collectedResponses,
+            AtomicInteger remainingCount
+    ) {
+        InternalCompletableFuture<Object> future = nodeEngine.getOperationService()
+                                                             .createInvocationBuilder(JetService.SERVICE_NAME, op, address)
+                                                             .invoke();
+
+        future.andThen(callbackOf((r, throwable) -> {
+            Object response = r != null ? r : throwable != null ? peel(throwable) : NULL_OBJECT;
+            if (retryTimedOut && throwable instanceof OperationTimeoutException) {
+                logger.warning("Retrying " + op.getClass().getSimpleName() + " that failed with "
+                        + OperationTimeoutException.class.getSimpleName() + " in " + jobIdString());
+                invokeOnParticipant(address, op, completionCallback, throwableCallback, retryTimedOut, collectedResponses,
+                        remainingCount);
+                return;
+            }
+            if (throwableCallback != null && throwable != null) {
+                throwableCallback.accept(throwable);
+            }
+            Object oldResponse = collectedResponses.put(address, response);
+            assert oldResponse == null :
+                    "Duplicate response for " + address + ". Old=" + oldResponse + ", new=" + response;
+            if (remainingCount.decrementAndGet() == 0 && completionCallback != null) {
+                completionCallback.accept(collectedResponses.values().stream()
+                                                            .map(o -> o == NULL_OBJECT ? null : o)
+                                                            .collect(Collectors.toList()));
+            }
+        }));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl;
 
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LocalMemberResetException;
 import com.hazelcast.internal.cluster.MemberInfo;
@@ -52,7 +51,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -90,7 +89,6 @@ import static java.util.Collections.emptyList;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.stream.Collectors.partitioningBy;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Part of {@link MasterContext} that deals with execution starting and
@@ -105,7 +103,7 @@ public class MasterJobContext {
     private final ILogger logger;
 
     private volatile long executionStartTime;
-    private volatile ExecutionInvocationCallback executionInvocationCallback;
+    private volatile ExecutionFailureCallback executionFailureCallback;
     private volatile Set<Vertex> vertices;
 
     /**
@@ -273,7 +271,7 @@ public class MasterJobContext {
         Function<ExecutionPlan, Operation> operationCtor = plan ->
                 new InitExecutionOperation(mc.jobId(), mc.executionId(), membersView.getVersion(), participants,
                         mc.nodeEngine().getSerializationService().toData(plan));
-        mc.invokeOnParticipants(operationCtor, this::onInitStepCompleted, null);
+        mc.invokeOnParticipants(operationCtor, this::onInitStepCompleted, null, false);
     }
 
     /**
@@ -407,7 +405,7 @@ public class MasterJobContext {
     }
 
     // Called as callback when all InitOperation invocations are done
-    private void onInitStepCompleted(Map<MemberInfo, Object> responses) {
+    private void onInitStepCompleted(Collection<Object> responses) {
         Throwable error = getResult("Init", responses);
 
         if (error == null) {
@@ -432,17 +430,17 @@ public class MasterJobContext {
 
         long executionId = mc.executionId();
 
-        executionInvocationCallback = new ExecutionInvocationCallback(executionId);
+        executionFailureCallback = new ExecutionFailureCallback(executionId);
         if (requestedTerminationMode != null) {
             handleTermination(requestedTerminationMode);
         }
 
         Function<ExecutionPlan, Operation> operationCtor = plan -> new StartExecutionOperation(mc.jobId(), executionId);
-        Consumer<Map<MemberInfo, Object>> completionCallback = this::onExecuteStepCompleted;
+        Consumer<Collection<Object>> completionCallback = this::onExecuteStepCompleted;
 
         mc.setJobStatus(RUNNING);
 
-        mc.invokeOnParticipants(operationCtor, completionCallback, executionInvocationCallback);
+        mc.invokeOnParticipants(operationCtor, completionCallback, executionFailureCallback, false);
 
         if (mc.jobConfig().getProcessingGuarantee() != NONE) {
             mc.coordinationService().scheduleSnapshot(mc, executionId);
@@ -454,13 +452,13 @@ public class MasterJobContext {
         // be safe against it (idempotent).
         if (mode.isWithTerminalSnapshot()) {
             mc.snapshotContext().tryBeginSnapshot();
-        } else if (executionInvocationCallback != null) {
-            executionInvocationCallback.cancelInvocations(mode);
+        } else if (executionFailureCallback != null) {
+            executionFailureCallback.cancelInvocations(mode);
         }
     }
 
     // Called as callback when all ExecuteOperation invocations are done
-    private void onExecuteStepCompleted(Map<MemberInfo, Object> responses) {
+    private void onExecuteStepCompleted(Collection<Object> responses) {
         invokeCompleteExecution(getResult("Execution", responses));
     }
 
@@ -487,21 +485,21 @@ public class MasterJobContext {
      *     that the job will be restarted
      * </ul>
      */
-    private Throwable getResult(String opName, Map<MemberInfo, Object> responses) {
+    private Throwable getResult(String opName, Collection<Object> responses) {
         if (isCancelled()) {
             logger.fine(mc.jobIdString() + " to be cancelled after " + opName);
             return new CancellationException();
         }
 
-        Map<Boolean, List<Entry<MemberInfo, Object>>> grouped = groupResponses(responses);
-        Collection<MemberInfo> successfulMembers = grouped.get(false).stream().map(Entry::getKey).collect(toList());
+        Map<Boolean, List<Object>> grouped = groupResponses(responses);
+        int successfulCountMembers = grouped.get(false).size();
 
-        List<Entry<MemberInfo, Object>> failures = grouped.get(true);
+        List<Object> failures = grouped.get(true);
         if (!failures.isEmpty()) {
             logger.fine(opName + " of " + mc.jobIdString() + " has failures: " + failures);
         }
 
-        if (successfulMembers.size() == mc.executionPlanMap().size()) {
+        if (successfulCountMembers == mc.executionPlanMap().size()) {
             logger.fine(opName + " of " + mc.jobIdString() + " was successful");
             return null;
         }
@@ -510,7 +508,7 @@ public class MasterJobContext {
         // threw it and others completed normally, the terminal snapshot will fail,
         // but we still handle it as if terminal snapshot was done. If there are
         // other exceptions, ignore this and handle the other exception.
-        if (failures.stream().allMatch(entry -> entry.getValue() instanceof TerminatedWithSnapshotException)) {
+        if (failures.stream().allMatch(entry -> entry instanceof TerminatedWithSnapshotException)) {
             assert opName.equals("Execution") : "opName is '" + opName + "', expected 'Execution'";
             logger.fine(opName + " of " + mc.jobIdString() + " terminated after a terminal snapshot");
             TerminationMode mode = requestedTerminationMode;
@@ -523,7 +521,7 @@ public class MasterJobContext {
         // participants return a TopologyChangedException.
         return failures
                 .stream()
-                .map(entry -> (Throwable) entry.getValue())
+                .map(entry -> (Throwable) entry)
                 .filter(e -> !(e instanceof CancellationException
                         || e instanceof TerminatedWithSnapshotException
                         || isTopologyException(e)))
@@ -546,7 +544,7 @@ public class MasterJobContext {
 
         Function<ExecutionPlan, Operation> operationCtor = plan ->
                 new CompleteExecutionOperation(mc.executionId(), finalError);
-        mc.invokeOnParticipants(operationCtor, responses -> onCompleteExecutionCompleted(error), null);
+        mc.invokeOnParticipants(operationCtor, responses -> onCompleteExecutionCompleted(error), null, true);
     }
 
     private void logCannotComplete(Throwable error) {
@@ -570,9 +568,16 @@ public class MasterJobContext {
         }
     }
 
-    private void cancelExecutionInvocations(long jobId, long executionId, TerminationMode mode) {
+    void cancelExecutionInvocations(long jobId, long executionId, TerminationMode mode) {
         mc.nodeEngine().getExecutionService().execute(ExecutionService.ASYNC_EXECUTOR, () ->
-                mc.invokeOnParticipants(plan -> new TerminateExecutionOperation(jobId, executionId, mode), null, null));
+                mc.invokeOnParticipants(plan -> new TerminateExecutionOperation(jobId, executionId, mode),
+                        responses -> {
+                            if (responses.stream().anyMatch(Objects::nonNull)) {
+                                // log errors
+                                logger.severe("Some TerminateExecutionOperation invocations failed, execution will " +
+                                        "likely get stuck: " + responses);
+                            }
+                        }, null, true));
     }
 
     // Called as callback when all CompleteOperation invocations are done
@@ -591,7 +596,7 @@ public class MasterJobContext {
 
             // reset state for the next execution
             requestedTerminationMode = null;
-            executionInvocationCallback = null;
+            executionFailureCallback = null;
             ActionAfterTerminate terminationModeAction = failure instanceof JobTerminateRequestedException
                     ? ((JobTerminateRequestedException) failure).mode().actionAfterTerminate() : null;
             mc.snapshotContext().onExecutionTerminated();
@@ -757,11 +762,10 @@ public class MasterJobContext {
     }
 
     // true -> failures, false -> success responses
-    private Map<Boolean, List<Entry<MemberInfo, Object>>> groupResponses(Map<MemberInfo, Object> responses) {
-        Map<Boolean, List<Entry<MemberInfo, Object>>> grouped = responses
-                .entrySet()
+    private Map<Boolean, List<Object>> groupResponses(Collection<Object> responses) {
+        Map<Boolean, List<Object>> grouped = responses
                 .stream()
-                .collect(partitioningBy(e -> e.getValue() instanceof Throwable));
+                .collect(partitioningBy(e -> e instanceof Throwable));
 
         grouped.putIfAbsent(true, emptyList());
         grouped.putIfAbsent(false, emptyList());
@@ -787,24 +791,20 @@ public class MasterJobContext {
     }
 
     /**
-     * Registered to {@link StartExecutionOperation} invocations to cancel invocations in case of a failure or restart
+     * Registered to {@link StartExecutionOperation} invocations to cancel
+     * invocations in case of a failure or restart.
      */
-    private class ExecutionInvocationCallback implements ExecutionCallback<Object> {
+    private class ExecutionFailureCallback implements Consumer<Throwable> {
 
         private final AtomicBoolean invocationsCancelled = new AtomicBoolean();
         private final long executionId;
 
-        ExecutionInvocationCallback(long executionId) {
+        ExecutionFailureCallback(long executionId) {
             this.executionId = executionId;
         }
 
         @Override
-        public void onResponse(Object response) {
-
-        }
-
-        @Override
-        public void onFailure(Throwable t) {
+        public void accept(Throwable t) {
             if (!(peel(t) instanceof TerminatedWithSnapshotException)) {
                 cancelInvocations(null);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -492,14 +492,14 @@ public class MasterJobContext {
         }
 
         Map<Boolean, List<Object>> grouped = groupResponses(responses);
-        int successfulCountMembers = grouped.get(false).size();
+        int successfulMembersCount = grouped.get(false).size();
 
         List<Object> failures = grouped.get(true);
         if (!failures.isEmpty()) {
             logger.fine(opName + " of " + mc.jobIdString() + " has failures: " + failures);
         }
 
-        if (successfulCountMembers == mc.executionPlanMap().size()) {
+        if (successfulMembersCount == mc.executionPlanMap().size()) {
             logger.fine(opName + " of " + mc.jobIdString() + " was successful");
             return null;
         }
@@ -791,8 +791,8 @@ public class MasterJobContext {
     }
 
     /**
-     * Registered to {@link StartExecutionOperation} invocations to cancel
-     * invocations in case of a failure or restart.
+     * Attached to {@link StartExecutionOperation} invocations to cancel
+     * invocations in case of a failure.
      */
     private class ExecutionFailureCallback implements Consumer<Throwable> {
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.impl;
 
 import com.hazelcast.core.IMap;
-import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.datamodel.Tuple3;
 import com.hazelcast.jet.impl.JobExecutionRecord.SnapshotStats;
@@ -29,8 +28,8 @@ import com.hazelcast.spi.Operation;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Collection;
 import java.util.LinkedList;
-import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -167,11 +166,11 @@ class MasterSnapshotContext {
                 responses -> mc.coordinationService().submitToCoordinatorThread(() ->
                         onSnapshotCompleted(responses, localExecutionId, newSnapshotId, finalMapName, isExport, isTerminal,
                                 future)),
-                null);
+                null, false);
     }
 
     private void onSnapshotCompleted(
-            Map<MemberInfo, Object> responses,
+            Collection<Object> responses,
             long executionId,
             long snapshotId,
             String snapshotMapName,
@@ -183,7 +182,7 @@ class MasterSnapshotContext {
         // We only wait for snapshot completion if the job completed with a terminal snapshot and the job
         // was successful.
         SnapshotOperationResult mergedResult = new SnapshotOperationResult();
-        for (Object response : responses.values()) {
+        for (Object response : responses) {
             // the response is either SnapshotOperationResult or an exception, see #invokeOnParticipants() method
             if (response instanceof Throwable) {
                 response = new SnapshotOperationResult(0, 0, 0, (Throwable) response);
@@ -252,9 +251,14 @@ class MasterSnapshotContext {
             assert snapshotInProgress : "snapshot not in progress";
             snapshotInProgress = false;
             if (wasTerminal) {
-                // after a terminal snapshot, no more snapshots are scheduled in this execution
+                // after a successful terminal snapshot, no more snapshots are scheduled in this execution
                 boolean completedNow = terminalSnapshotFuture.complete(null);
                 assert completedNow : "terminalSnapshotFuture was already completed";
+                if (!isSuccess) {
+                    // If the terminal snapshot failed, the executions might not terminate on some members.
+                    // Let's execute the CompleteExecutionOperation to terminate them.
+                    mc.jobContext().cancelExecutionInvocations(mc.jobId(), mc.executionId(), null);
+                }
             } else if (!wasExport) {
                 // if this snapshot was an automatic snapshot, schedule the next one
                 mc.coordinationService().scheduleSnapshot(mc, executionId);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -251,11 +251,13 @@ class MasterSnapshotContext {
             assert snapshotInProgress : "snapshot not in progress";
             snapshotInProgress = false;
             if (wasTerminal) {
-                // after a successful terminal snapshot, no more snapshots are scheduled in this execution
+                // after a terminal snapshot, no more snapshots are scheduled in this execution
                 boolean completedNow = terminalSnapshotFuture.complete(null);
                 assert completedNow : "terminalSnapshotFuture was already completed";
                 if (!isSuccess) {
-                    // If the terminal snapshot failed, the executions might not terminate on some members.
+                    // If the terminal snapshot failed, the executions might not terminate on some members
+                    // normally and we don't care if it does - the snapshot is done, though unsuccessfully, and
+                    // we have to bring the execution down.
                     // Let's execute the CompleteExecutionOperation to terminate them.
                     mc.jobContext().cancelExecutionInvocations(mc.jobId(), mc.executionId(), null);
                 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -350,8 +350,8 @@ public class ProcessorTasklet implements Tasklet {
                 progTracker.notDone();
                 // check ssContext to see if a barrier should be emitted
                 long currSnapshotId = ssContext.activeSnapshotId();
-                assert currSnapshotId >= pendingSnapshotId - 1 : "Unexpected new snapshot id " + currSnapshotId
-                        + ", current was" + pendingSnapshotId;
+                assert currSnapshotId >= pendingSnapshotId - 1 : "Unexpected new snapshot id: " + currSnapshotId
+                        + ", expected was " + (pendingSnapshotId - 1) + " or more";
                 if (currSnapshotId >= pendingSnapshotId) {
                     pendingSnapshotId = currSnapshotId;
                     if (outbox.hasUnfinishedItem()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -155,11 +155,13 @@ public class SnapshotContext {
      */
     synchronized CompletableFuture<SnapshotOperationResult> startNewSnapshot(
             long snapshotId, String mapName, boolean isTerminal) {
+        assert snapshotId > currentSnapshotId
+                : "new snapshotId not larger than previous. Previous=" + currentSnapshotId + ", new=" + snapshotId;
         if (snapshotId != currentSnapshotId + 1) {
             // this can be a result of a lost SnapshotOperation,
             // see OperationLossTest.when_snapshotOperationLost_then_ignored()
-            logger.warning("New snapshotId for job " + jobNameAndExecutionId + " not incremented by 1. " +
-                    "Previous=" + currentSnapshotId + ", new=" + snapshotId + "; ignoring it");
+            logger.warning("New snapshotId for " + jobNameAndExecutionId + " not incremented by 1. " +
+                    "Previous=" + currentSnapshotId + ", new=" + snapshotId + "; this is just a warning");
         }
         assert currentSnapshotId == activeSnapshotId : "last snapshot was postponed but not started";
         assert numTasklets >= 0 : "numTasklets=" + numTasklets;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -155,8 +155,12 @@ public class SnapshotContext {
      */
     synchronized CompletableFuture<SnapshotOperationResult> startNewSnapshot(
             long snapshotId, String mapName, boolean isTerminal) {
-        assert snapshotId == currentSnapshotId + 1
-                : "new snapshotId not incremented by 1. Previous=" + currentSnapshotId + ", new=" + snapshotId;
+        if (snapshotId != currentSnapshotId + 1) {
+            // this can be a result of a lost SnapshotOperation,
+            // see OperationLossTest.when_snapshotOperationLost_then_ignored()
+            logger.warning("New snapshotId for job " + jobNameAndExecutionId + " not incremented by 1. " +
+                    "Previous=" + currentSnapshotId + ", new=" + snapshotId + "; ignoring it");
+        }
         assert currentSnapshotId == activeSnapshotId : "last snapshot was postponed but not started";
         assert numTasklets >= 0 : "numTasklets=" + numTasklets;
         if (isCancelled) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -82,8 +82,7 @@ public final class ExceptionUtil {
                 || t instanceof EnteringPassiveClusterStateException
                 || t instanceof OperationTimeoutException
                     && (t.getMessage().contains(InitExecutionOperation.class.getSimpleName())
-                        || t.getMessage().contains(StartExecutionOperation.class.getSimpleName())
-                        /*|| t.getMessage().contains(CompleteExecutionOperation.class.getSimpleName())*/);
+                        || t.getMessage().contains(StartExecutionOperation.class.getSimpleName()));
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -21,14 +21,17 @@ import com.hazelcast.client.impl.clientside.ClientExceptionFactory.ExceptionFact
 import com.hazelcast.client.impl.protocol.ClientExceptions;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.jet.JetException;
-import com.hazelcast.jet.RestartableException;
 import com.hazelcast.jet.JobAlreadyExistsException;
+import com.hazelcast.jet.RestartableException;
 import com.hazelcast.jet.core.JobNotFoundException;
 import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.datamodel.Tuple3;
 import com.hazelcast.jet.impl.exception.EnteringPassiveClusterStateException;
+import com.hazelcast.jet.impl.operation.InitExecutionOperation;
+import com.hazelcast.jet.impl.operation.StartExecutionOperation;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.exception.CallerNotMemberException;
@@ -76,7 +79,11 @@ public final class ExceptionUtil {
                 || t instanceof TargetNotMemberException
                 || t instanceof CallerNotMemberException
                 || t instanceof HazelcastInstanceNotActiveException
-                || t instanceof EnteringPassiveClusterStateException;
+                || t instanceof EnteringPassiveClusterStateException
+                || t instanceof OperationTimeoutException
+                    && (t.getMessage().contains(InitExecutionOperation.class.getSimpleName())
+                        || t.getMessage().contains(StartExecutionOperation.class.getSimpleName())
+                        /*|| t.getMessage().contains(CompleteExecutionOperation.class.getSimpleName())*/);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -139,7 +139,8 @@ public final class Util {
      * @param <T> type of the response
      * @return {@link ExecutionCallback}
      */
-    public static <T> ExecutionCallback<T> callbackOf(Consumer<T> onResponse, Consumer<Throwable> onError) {
+    public static <T> ExecutionCallback<T> callbackOf(@Nonnull Consumer<T> onResponse,
+                                                      @Nonnull Consumer<Throwable> onError) {
         return new ExecutionCallback<T>() {
             @Override
             public void onResponse(T o) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.core.TestProcessors.DummyStatefulP;
+import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
+import com.hazelcast.jet.core.processor.DiagnosticProcessors;
+import com.hazelcast.jet.impl.JobExecutionRecord;
+import com.hazelcast.jet.impl.JobRepository;
+import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.PacketFiltersUtil;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CancellationException;
+
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
+import static com.hazelcast.jet.core.Edge.between;
+import static com.hazelcast.jet.core.JobStatus.COMPLETING;
+import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
+import static com.hazelcast.jet.core.JobStatus.RUNNING;
+import static com.hazelcast.jet.core.JobStatus.STARTING;
+import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class OperationLossTest extends JetTestSupport {
+
+    private static JetTestInstanceFactory factory = new JetTestInstanceFactory();
+    private static JetInstance instance1;
+    private static JetInstance instance2;
+
+    @BeforeClass
+    public static void beforeClass() {
+        JetConfig config = new JetConfig();
+        config.getHazelcastConfig().setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "1000");
+        instance1 = factory.newMember(config);
+        instance2 = factory.newMember(config);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        factory.terminateAll();
+    }
+
+    @Before
+    public void before() {
+        TestProcessors.reset(1);
+        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        PacketFiltersUtil.resetPacketFiltersFrom(instance2.getHazelcastInstance());
+    }
+
+    @Test
+    public void when_initExecutionOperationLost_then_jobRestarts() {
+        when_operationLost_then_jobRestarts(JetInitDataSerializerHook.INIT_EXECUTION_OP, STARTING);
+    }
+
+    @Test
+    public void when_startExecutionOperationLost_then_jobRestarts() {
+        when_operationLost_then_jobRestarts(JetInitDataSerializerHook.START_EXECUTION_OP, RUNNING);
+    }
+
+    private void when_operationLost_then_jobRestarts(int operationId, JobStatus expectedStatus) {
+        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+                singletonList(operationId));
+        DAG dag = new DAG().vertex(new Vertex("v", () -> new NoOutputSourceP()).localParallelism(1));
+        Job job = instance1.newJob(dag);
+        assertJobStatusEventually(job, expectedStatus);
+        // NOT_RUNNING will occur briefly, we might miss to observe it. But restart occurs every
+        // second (that's the operation heartbeat timeout) so hopefully we'll eventually succeed.
+        assertJobStatusEventually(job, NOT_RUNNING);
+
+        // now allow the job to complete normally
+        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        NoOutputSourceP.proceedLatch.countDown();
+        job.join();
+    }
+
+    @Test
+    public void when_completeExecutionOperationLost_then_jobCompletes() {
+        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+                singletonList(JetInitDataSerializerHook.COMPLETE_EXECUTION_OP));
+        DAG dag = new DAG().vertex(new Vertex("v", () -> new DummyStatefulP()).localParallelism(1));
+        Job job = instance1.newJob(dag);
+        assertJobStatusEventually(job, RUNNING);
+        job.suspend();
+        assertJobStatusEventually(job, COMPLETING);
+        assertTrueAllTheTime(() -> assertEquals(COMPLETING, job.getStatus()), 1);
+        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        assertJobStatusEventually(job, SUSPENDED);
+        job.resume();
+        assertJobStatusEventually(job, RUNNING);
+        job.cancel();
+        try {
+            job.join();
+        } catch (CancellationException ignored) { }
+    }
+
+    @Test
+    public void when_snapshotOperationLost_then_ignored() {
+        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+                singletonList(JetInitDataSerializerHook.SNAPSHOT_OPERATION));
+        DAG dag = new DAG().vertex(new Vertex("v", () -> new DummyStatefulP()).localParallelism(1));
+        Job job = instance1.newJob(dag, new JobConfig()
+                .setProcessingGuarantee(EXACTLY_ONCE)
+                .setSnapshotIntervalMillis(100));
+        assertJobStatusEventually(job, RUNNING);
+        JobRepository jobRepository = new JobRepository(instance1);
+        assertTrueEventually(() -> {
+            JobExecutionRecord record = jobRepository.getJobExecutionRecord(job.getId());
+            assertNotNull("null JobExecutionRecord", record);
+            assertTrue("ongoingSnapshotId not incremented: " + record.ongoingSnapshotId(),
+                    record.ongoingSnapshotId() >= 2);
+        });
+        // now lift the filter and check that a snapshot is done
+        logger.info("Lifting the packet filter...");
+        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        waitForFirstSnapshot(jobRepository, job.getId(), 10);
+        job.cancel();
+        try {
+            job.join();
+        } catch (CancellationException ignored) { }
+    }
+
+    @Test
+    public void when_connectionDroppedWithoutMemberLeaving_then_jobRestarts() {
+        DAG dag = new DAG();
+        Vertex source = dag.newVertex("source", () -> new NoOutputSourceP()).localParallelism(1);
+        Vertex sink = dag.newVertex("sink", DiagnosticProcessors.writeLoggerP());
+        dag.edge(between(source, sink).distributed());
+        Job job = instance1.newJob(dag);
+        assertJobStatusEventually(job, RUNNING);
+        assertEquals(2, NoOutputSourceP.initCount.get());
+
+        Connection connection = Util.getMemberConnection(getNodeEngineImpl(instance1),
+                instance2.getHazelcastInstance().getCluster().getLocalMember().getAddress());
+        // When
+        connection.close(null, null);
+        System.out.println("connection closed");
+        sleepSeconds(1);
+
+        // Then
+        NoOutputSourceP.proceedLatch.countDown();
+        job.join();
+
+        assertEquals(4, NoOutputSourceP.initCount.get());
+    }
+
+    @Test
+    public void when_terminateExecutionOperationLost_then_jobTerminates() {
+        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+                singletonList(JetInitDataSerializerHook.TERMINATE_EXECUTION_OP));
+        DAG dag = new DAG().vertex(new Vertex("v", () -> new NoOutputSourceP()).localParallelism(1));
+        Job job = instance1.newJob(dag);
+        assertJobStatusEventually(job, RUNNING);
+        job.cancel();
+        // sleep so that the TerminateExecutionOperation is sent out, but lost
+        sleepSeconds(1);
+        // reset filters so that the situation can resolve
+        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+
+        try {
+            // Then
+            job.join();
+        } catch (CancellationException ignored) { }
+    }
+
+    @Test
+    public void when_terminalSnapshotOperationLost_then_jobSuspends() {
+        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+                singletonList(JetInitDataSerializerHook.SNAPSHOT_OPERATION));
+        DAG dag = new DAG().vertex(new Vertex("v", () -> new NoOutputSourceP()).localParallelism(1));
+        Job job = instance1.newJob(dag, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
+        assertJobStatusEventually(job, RUNNING);
+        job.suspend();
+        // sleep so that the SnapshotOperation is sent out, but lost
+        sleepSeconds(1);
+        // reset filters so that the situation can resolve
+        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+
+        // Then
+        assertJobStatusEventually(job, SUSPENDED);
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ProcessorTaskletTest_Snapshots.java
@@ -182,6 +182,7 @@ public class ProcessorTaskletTest_Snapshots {
         outstreams.add(outstream1);
 
         Tasklet tasklet = createTasklet(EXACTLY_ONCE);
+        snapshotContext.startNewSnapshot(0, null, false);
 
         // When
         callUntil(tasklet, DONE);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
@@ -124,7 +124,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         assertEquals(MADE_PROGRESS, sst.call());
 
         // Then
-        assertEquals(3, sst.pendingSnapshotId);
+        assertEquals(2, sst.lastSnapshotId);
     }
 
     @Test
@@ -133,13 +133,13 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         Entry<String, String> entry = entry("k", "v");
         init(asList(entry, new SnapshotBarrier(2, false)));
         ssContext.startNewSnapshot(2, "map", false);
-        assertEquals(2, sst.pendingSnapshotId);
+        assertEquals(1, sst.lastSnapshotId);
         assertEquals(MADE_PROGRESS, sst.call());
         mockSsWriter.hasPendingFlushes = false;
         assertEquals(MADE_PROGRESS, sst.call());
 
         // Then
-        assertEquals(3, sst.pendingSnapshotId);
+        assertEquals(2, sst.lastSnapshotId);
         assertEquals(entry(serialize("k"), serialize("v")), mockSsWriter.poll());
     }
 
@@ -158,7 +158,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         assertEquals(MADE_PROGRESS, sst.call());
         assertEquals(MADE_PROGRESS, sst.call());
         assertEquals(NO_PROGRESS, sst.call());
-        assertEquals(3, sst.pendingSnapshotId);
+        assertEquals(2, sst.lastSnapshotId);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         mockSsWriter.hasPendingFlushes = false;
         assertEquals(MADE_PROGRESS, sst.call());
         assertEquals(NO_PROGRESS, sst.call());
-        assertEquals(3, sst.pendingSnapshotId);
+        assertEquals(2, sst.lastSnapshotId);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         // Then
         assertTrue(future.isDone());
         assertEquals(mockFailure.toString(), future.get().getError());
-        assertEquals(3, sst.pendingSnapshotId);
+        assertEquals(2, sst.lastSnapshotId);
     }
 
     private HeapData serialize(String o) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/StoreSnapshotTaskletTest.java
@@ -124,7 +124,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         assertEquals(MADE_PROGRESS, sst.call());
 
         // Then
-        assertEquals(2, sst.lastSnapshotId);
+        assertEquals(3, sst.pendingSnapshotId);
     }
 
     @Test
@@ -133,13 +133,13 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         Entry<String, String> entry = entry("k", "v");
         init(asList(entry, new SnapshotBarrier(2, false)));
         ssContext.startNewSnapshot(2, "map", false);
-        assertEquals(1, sst.lastSnapshotId);
+        assertEquals(2, sst.pendingSnapshotId);
         assertEquals(MADE_PROGRESS, sst.call());
         mockSsWriter.hasPendingFlushes = false;
         assertEquals(MADE_PROGRESS, sst.call());
 
         // Then
-        assertEquals(2, sst.lastSnapshotId);
+        assertEquals(3, sst.pendingSnapshotId);
         assertEquals(entry(serialize("k"), serialize("v")), mockSsWriter.poll());
     }
 
@@ -158,7 +158,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         assertEquals(MADE_PROGRESS, sst.call());
         assertEquals(MADE_PROGRESS, sst.call());
         assertEquals(NO_PROGRESS, sst.call());
-        assertEquals(2, sst.lastSnapshotId);
+        assertEquals(3, sst.pendingSnapshotId);
     }
 
     @Test
@@ -175,7 +175,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         mockSsWriter.hasPendingFlushes = false;
         assertEquals(MADE_PROGRESS, sst.call());
         assertEquals(NO_PROGRESS, sst.call());
-        assertEquals(2, sst.lastSnapshotId);
+        assertEquals(3, sst.pendingSnapshotId);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class StoreSnapshotTaskletTest extends JetTestSupport {
         // Then
         assertTrue(future.isDone());
         assertEquals(mockFailure.toString(), future.get().getError());
-        assertEquals(2, sst.lastSnapshotId);
+        assertEquals(3, sst.pendingSnapshotId);
     }
 
     private HeapData serialize(String o) {


### PR DESCRIPTION
Any operation or response to operation can be lost due to network reconnection. If it happens, we'll get an `OperationTimeoutException`. That operation might or might not have been executed on the remote member. This commit fixes issues around that for Jet operations:

- if we get it for `InitExecutionOp` or `StartExecutionOp`, treat it as a restartable exception and restart the job (implemented in `ExceptionUtil.isTopologyException`)

- for `CompleteExecutionOp` the operation is simply retried, assuming the operation is idempotent. I also added logging of other errors because they were ignored.

- for `TerminateExecutionOp` the termination is retried. The operation was already idempotent so it was fairly easy. Again, logging of other errors was added.

- for non-terminal `SnapshotOperation` the snapshot is completed with failure and the next one can succeed. I had to lift the requirement that `snapshotId` must be sequential because some members can just miss some snapshots. Failure of user-requested snapshots will be reported to the user.

- for terminal `SnapshotOperation`, some members can terminate the execution after the terminal snapshot while others didn't know that there was a snapshot at all. There's no way to resolve it other than restarting the job from previous good snapshot. If a terminal snapshot fails, we cancel the execution and don't wait for it to terminate normally.

Other operations are user-triggered so the exception will just be reported to the user (job submission, status query...), I haven't done anything about it.

The original issue (#1375) was that there were 3 members on 2 machines and he turned off wifi on one of them. What probably happened is that the connection wasn't closed, but data stopped getting through. The default member and operation heartbeat timeouts are both 60 seconds and the heartbeats are pretty infrequent, so if the operation heartbeat failure was detected first, the `StartExecutionOp` failed which was handled as a job failure and the job didn't restart.

Other changes in the PR:
- simplify `invokeOnParticipants`: responses are just `List<Object>` instead of `Map<MemberInfo, Object>` - the key was unused. Also the list doesn't contain `NULL_OBJECT`s, but `null`s.
- the two callbacks in `invokeOnParticipants` were simplified and documented. They can be further simplified though..
- negative return value from `Connection.write` in `SenderTasklet` is handled. Before if a member was reconnected, we won't notice that.

Fixes #1375.