### PR TITLE
Fix regression in declarative config file resolution

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/ConfigProvider.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/ConfigProvider.java
@@ -41,13 +41,14 @@ public final class ConfigProvider {
         XmlJetConfigLocator xmlConfigLocator = new XmlJetConfigLocator();
         YamlJetConfigLocator yamlConfigLocator = new YamlJetConfigLocator();
         JetConfig config;
-        if (xmlConfigLocator.locateFromSystemProperty()) {
-            // 1. Try loading XML config if provided in system property
-            config = new XmlJetConfigBuilder(xmlConfigLocator).setProperties(properties).build();
 
-        } else if (yamlConfigLocator.locateFromSystemProperty()) {
-            // 2. Try loading YAML config if provided in system property
+        if (yamlConfigLocator.locateFromSystemProperty()) {
+            // 1. Try loading YAML config if provided in system property
             config = new YamlJetConfigBuilder(yamlConfigLocator).setProperties(properties).build();
+
+        } else if (xmlConfigLocator.locateFromSystemProperty()) {
+            // 2. Try loading XML config if provided in system property
+            config = new XmlJetConfigBuilder(xmlConfigLocator).setProperties(properties).build();
 
         } else if (xmlConfigLocator.locateInWorkDirOrOnClasspath()) {
             // 3. Try loading XML config from the working directory or from the classpath
@@ -77,13 +78,13 @@ public final class ConfigProvider {
         XmlJetClientConfigLocator xmlConfigLocator = new XmlJetClientConfigLocator();
         YamlJetClientConfigLocator yamlConfigLocator = new YamlJetClientConfigLocator();
 
-        if (xmlConfigLocator.locateFromSystemProperty()) {
-            // 1. Try loading config if provided in system property and it is an XML file
-            config = new XmlClientConfigBuilder(xmlConfigLocator.getIn()).build();
-
-        } else if (yamlConfigLocator.locateFromSystemProperty()) {
-            // 2. Try loading config if provided in system property and it is an YAML file
+        if (yamlConfigLocator.locateFromSystemProperty()) {
+            // 1. Try loading config if provided in system property and it is an YAML file
             config = new YamlClientConfigBuilder(yamlConfigLocator.getIn()).build();
+
+        } else if (xmlConfigLocator.locateFromSystemProperty()) {
+            // 2. Try loading config if provided in system property and it is an XML file
+            config = new XmlClientConfigBuilder(xmlConfigLocator.getIn()).build();
 
         } else if (xmlConfigLocator.locateInWorkDirOrOnClasspath()) {
             // 3. Try loading XML config from the working directory or from the classpath

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetClientConfigLocator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetClientConfigLocator.java
@@ -28,9 +28,17 @@ public final class XmlJetClientConfigLocator extends AbstractConfigLocator {
     private static final String HAZELCAST_CLIENT_XML = "hazelcast-client.xml";
     private static final String HAZELCAST_CLIENT_DEFAULT_XML = "hazelcast-jet-client-default.xml";
 
+    public XmlJetClientConfigLocator() {
+        this(false);
+    }
+
+    public XmlJetClientConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
-        return loadFromSystemProperty(HAZELCAST_CLIENT_CONFIG_PROPERTY, "xml");
+        return loadFromSystemProperty(HAZELCAST_CLIENT_CONFIG_PROPERTY);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetConfigLocator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetConfigLocator.java
@@ -28,9 +28,13 @@ public final class XmlJetConfigLocator extends AbstractConfigLocator {
     private static final String HAZELCAST_JET_XML = "hazelcast-jet.xml";
     private static final String HAZELCAST_JET_DEFAULT_XML = "hazelcast-jet-default.xml";
 
+    public XmlJetConfigLocator() {
+        super(false);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
-        return loadFromSystemProperty(HAZELCAST_JET_CONFIG_PROPERTY, "xml");
+        return loadFromSystemProperty(HAZELCAST_JET_CONFIG_PROPERTY);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetMemberConfigLocator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/XmlJetMemberConfigLocator.java
@@ -29,9 +29,13 @@ public final class XmlJetMemberConfigLocator extends AbstractConfigLocator {
     private static final String HAZELCAST_MEMBER_DEFAULT_XML = "hazelcast-jet-member-default.xml";
     private static final String HAZELCAST_ENTERPRISE_MEMBER_DEFAULT_XML = "hazelcast-jet-enterprise-member-default.xml";
 
+    public XmlJetMemberConfigLocator() {
+        super(false);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
-        return loadFromSystemProperty(HAZELCAST_MEMBER_CONFIG_PROPERTY, "xml");
+        return loadFromSystemProperty(HAZELCAST_MEMBER_CONFIG_PROPERTY);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetClientConfigLocator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetClientConfigLocator.java
@@ -28,6 +28,14 @@ public final class YamlJetClientConfigLocator extends AbstractConfigLocator {
     private static final String HAZELCAST_CLIENT_YAML = "hazelcast-client.yaml";
     private static final String HAZELCAST_CLIENT_DEFAULT_YAML = "hazelcast-jet-client-default.yaml";
 
+    public YamlJetClientConfigLocator() {
+        this(false);
+    }
+
+    public YamlJetClientConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
         return loadFromSystemProperty(HAZELCAST_CLIENT_CONFIG_PROPERTY, "yaml", "yml");

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetConfigBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetConfigBuilder.java
@@ -45,7 +45,7 @@ public class YamlJetConfigBuilder extends AbstractYamlConfigBuilder {
 
     public YamlJetConfigBuilder(YamlJetConfigLocator locator) {
         if (locator == null) {
-            locator = new YamlJetConfigLocator();
+            locator = new YamlJetConfigLocator(true);
             locator.locateEverywhere();
         }
         this.in = locator.getIn();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetConfigLocator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetConfigLocator.java
@@ -28,6 +28,14 @@ public final class YamlJetConfigLocator extends AbstractConfigLocator {
     private static final String HAZELCAST_JET_YAML = "hazelcast-jet.yaml";
     private static final String HAZELCAST_JET_DEFAULT_YAML = "hazelcast-jet-default.yaml";
 
+    public YamlJetConfigLocator() {
+        this(false);
+    }
+
+    public YamlJetConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
         return loadFromSystemProperty(HAZELCAST_JET_CONFIG_PROPERTY, "yaml", "yml");

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetMemberConfigLocator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetMemberConfigLocator.java
@@ -29,6 +29,9 @@ public final class YamlJetMemberConfigLocator extends AbstractConfigLocator {
     private static final String HAZELCAST_MEMBER_DEFAULT_YAML = "hazelcast-jet-member-default.yaml";
     private static final String HAZELCAST_ENTERPRISE_MEMBER_DEFAULT_YAML = "hazelcast-jet-enterprise-member-default.yaml";
 
+    public YamlJetMemberConfigLocator() {
+        super(true);
+    }
 
     @Override
     public boolean locateFromSystemProperty() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/AbstractJetConfigLoadFromFileSystemOrClasspathTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/AbstractJetConfigLoadFromFileSystemOrClasspathTest.java
@@ -17,8 +17,6 @@
 package com.hazelcast.jet.config;
 
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
@@ -29,17 +27,10 @@ import java.io.IOException;
  * @see XmlJetConfigLoadFromFileSystemOrClasspathTest
  * @see YamlJetConfigLoadFromFileSystemOrClasspathTest
  */
-@RunWith(Enclosed.class)
 public abstract class AbstractJetConfigLoadFromFileSystemOrClasspathTest {
 
     @Test
     public abstract void when_fileSystemFileSpecified_usesSpecifiedFile() throws IOException;
-
-    @Test
-    public abstract void when_fileSystemPathSpecified_usesSpecifiedFile() throws IOException;
-
-    @Test
-    public abstract void when_classpathSpecified_usesSpecifiedResource();
 
     @Test
     public abstract void when_classpathSpecifiedWithClassloader_usesSpecifiedResource();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/AbstractJetConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/AbstractJetConfigWithSystemPropertyTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractJetConfigWithSystemPropertyTest {
         assertEquals("backupCount", 2, jetConfig.getInstanceConfig().getBackupCount());
         assertEquals("flowControlMs", 50, jetConfig.getInstanceConfig().getFlowControlPeriodMs());
         assertEquals("scaleUpDelayMillis", 1234, jetConfig.getInstanceConfig().getScaleUpDelayMillis());
-        assertTrue("losslessRestartEnabled", jetConfig.getInstanceConfig().isLosslessRestartEnabled());
+        assertFalse("losslessRestartEnabled", jetConfig.getInstanceConfig().isLosslessRestartEnabled());
 
         assertEquals("value1", jetConfig.getProperties().getProperty("property1"));
         assertEquals("value2", jetConfig.getProperties().getProperty("property2"));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JetConfigIllegalArgumentsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JetConfigIllegalArgumentsTest.java
@@ -18,12 +18,14 @@ package com.hazelcast.jet.config;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.jet.function.SupplierEx;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -39,6 +41,7 @@ import static com.hazelcast.jet.config.JetConfig.loadYamlFromString;
 import static java.lang.Thread.currentThread;
 
 @RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 public class JetConfigIllegalArgumentsTest {
     @Rule
     public final ExpectedException exception = ExpectedException.none();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlConfigTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlConfigTest.java
@@ -100,7 +100,7 @@ public class XmlConfigTest {
         properties.put("flow.control.period", "50");
         properties.put("backup.count", "2");
         properties.put("scale.up.delay.millis", "1234");
-        properties.put("lossless.restart.enabled", "true");
+        properties.put("lossless.restart.enabled", "false");
         properties.put("metrics.enabled", "false");
         properties.put("metrics.jmxEnabled", "false");
         properties.put("metrics.retention", "124");
@@ -132,7 +132,7 @@ public class XmlConfigTest {
         assertEquals("backupCount", 2, jetConfig.getInstanceConfig().getBackupCount());
         assertEquals("flowControlMs", 50, jetConfig.getInstanceConfig().getFlowControlPeriodMs());
         assertEquals("scaleUpDelayMillis", 1234, jetConfig.getInstanceConfig().getScaleUpDelayMillis());
-        assertTrue("losslessRestartEnabled", jetConfig.getInstanceConfig().isLosslessRestartEnabled());
+        assertFalse("losslessRestartEnabled", jetConfig.getInstanceConfig().isLosslessRestartEnabled());
 
         assertEquals("value1", jetConfig.getProperties().getProperty("property1"));
         assertEquals("value2", jetConfig.getProperties().getProperty("property2"));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigImportVariableReplacementTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigImportVariableReplacementTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.config.replacer.EncryptionReplacer;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 public class XmlJetConfigImportVariableReplacementTest extends AbstractJetConfigImportVariableReplacementTest {
 
     private static final String TEST_XML_JET_WITH_VARIABLES = "hazelcast-jet-with-variables.xml";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigLoadFromFileSystemOrClasspathTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigLoadFromFileSystemOrClasspathTest.java
@@ -17,7 +17,8 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.jet.impl.util.Util;
-import org.junit.Test;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -27,6 +28,7 @@ import java.io.InputStream;
 import static com.hazelcast.jet.config.AbstractJetConfigWithSystemPropertyTest.assertConfig;
 import static com.hazelcast.jet.config.AbstractJetConfigWithSystemPropertyTest.assertDefaultMemberConfig;
 
+@RunWith(HazelcastParallelClassRunner.class)
 public class XmlJetConfigLoadFromFileSystemOrClasspathTest extends AbstractJetConfigLoadFromFileSystemOrClasspathTest {
 
     private static final String TEST_XML_JET = "hazelcast-jet-test.xml";
@@ -49,35 +51,6 @@ public class XmlJetConfigLoadFromFileSystemOrClasspathTest extends AbstractJetCo
     }
 
     @Override
-    @Test
-    public void when_fileSystemPathSpecified_usesSpecifiedFile() throws IOException {
-        // Given
-        File tempFile = File.createTempFile("jet", ".xml");
-        try (FileOutputStream os = new FileOutputStream(tempFile)) {
-            InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(TEST_XML_JET);
-            os.write(Util.readFully(resourceAsStream));
-        }
-
-        // When
-        JetConfig jetConfig = JetConfig.loadFromFile(tempFile);
-
-        // Then
-        assertConfig(jetConfig);
-        assertDefaultMemberConfig(jetConfig.getHazelcastConfig());
-    }
-
-    @Override
-    @Test
-    public void when_classpathSpecified_usesSpecifiedResource() {
-        // When
-        JetConfig jetConfig = JetConfig.loadFromClasspath(getClass().getClassLoader(), TEST_XML_JET);
-
-        // Then
-        assertConfig(jetConfig);
-        assertDefaultMemberConfig(jetConfig.getHazelcastConfig());
-    }
-
-    @Override
     public void when_classpathSpecifiedWithClassloader_usesSpecifiedResource() {
         // When
         JetConfig jetConfig = JetConfig.loadFromClasspath(getClass().getClassLoader(), TEST_XML_JET);
@@ -86,4 +59,5 @@ public class XmlJetConfigLoadFromFileSystemOrClasspathTest extends AbstractJetCo
         assertConfig(jetConfig);
         assertDefaultMemberConfig(jetConfig.getHazelcastConfig());
     }
+
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigWithSystemPropertyTest.java
@@ -237,9 +237,9 @@ public class XmlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigW
         assertEquals("packetSizeLimit", 997, edgeConfig.getPacketSizeLimit());
         assertEquals("receiveWindowMultiplier", 996, edgeConfig.getReceiveWindowMultiplier());
     }
-    
+
     @Test
-    public void when_filePathSpecifiedNonXml_then_loadedAsXml() throws Exception{
+    public void when_filePathSpecifiedNonXml_then_loadedAsXml() throws Exception {
         File tempFile = File.createTempFile("jet", ".xml");
         try (FileOutputStream os = new FileOutputStream(tempFile)) {
             InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream("hazelcast-jet-foo.bar");
@@ -251,7 +251,7 @@ public class XmlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigW
         JetConfig config = configBuilder.build();
         assertEquals("bar", config.getProperties().getProperty("foo"));
     }
-    
+
     @Test
     public void when_classPathSpecifiedNonXml_then_loadedAsXml() {
         System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, "classpath:hazelcast-jet-foo.bar");

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigWithSystemPropertyTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.impl.config.XmlJetConfigBuilder;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -84,6 +86,17 @@ public class XmlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigW
         new XmlJetConfigBuilder().build();
     }
 
+    @Test(expected = HazelcastException.class)
+    public void when_filePathMemberSpecifiedNonExistingNonXmlFile_thenThrowsException() throws Exception {
+        // Given
+        File file = createTempFile("foo", ".bar");
+        file.delete();
+        System.setProperty(HAZELCAST_MEMBER_CONFIG_PROPERTY, file.getAbsolutePath());
+
+        // When
+        new XmlJetConfigBuilder().build();
+    }
+
 
     @Override
     @Test
@@ -140,6 +153,15 @@ public class XmlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigW
         new XmlJetConfigBuilder().build();
     }
 
+    @Test(expected = HazelcastException.class)
+    public void when_classpathMemberSpecifiedNonExistingNonXmlFile_thenThrowsException() {
+        // Given
+        System.setProperty(HAZELCAST_MEMBER_CONFIG_PROPERTY, "classpath:non-existing.bar");
+
+        // When
+        new XmlJetConfigBuilder().build();
+    }
+
 
     @Override
     @Test
@@ -165,7 +187,7 @@ public class XmlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigW
         properties.put("flow.control.period", "50");
         properties.put("backup.count", "2");
         properties.put("scale.up.delay.millis", "1234");
-        properties.put("lossless.restart.enabled", "true");
+        properties.put("lossless.restart.enabled", "false");
         properties.put("metrics.enabled", "false");
         properties.put("metrics.jmxEnabled", "false");
         properties.put("metrics.retention", "124");
@@ -214,6 +236,41 @@ public class XmlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigW
         assertEquals("queueSize", 999, edgeConfig.getQueueSize());
         assertEquals("packetSizeLimit", 997, edgeConfig.getPacketSizeLimit());
         assertEquals("receiveWindowMultiplier", 996, edgeConfig.getReceiveWindowMultiplier());
+    }
+    
+    @Test
+    public void when_filePathSpecifiedNonXml_then_loadedAsXml() throws Exception{
+        File tempFile = File.createTempFile("jet", ".xml");
+        try (FileOutputStream os = new FileOutputStream(tempFile)) {
+            InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream("hazelcast-jet-foo.bar");
+            os.write(Util.readFully(resourceAsStream));
+        }
+        System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, tempFile.getAbsolutePath());
+
+        XmlJetConfigBuilder configBuilder = new XmlJetConfigBuilder();
+        JetConfig config = configBuilder.build();
+        assertEquals("bar", config.getProperties().getProperty("foo"));
+    }
+    
+    @Test
+    public void when_classPathSpecifiedNonXml_then_loadedAsXml() {
+        System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, "classpath:hazelcast-jet-foo.bar");
+
+        XmlJetConfigBuilder configBuilder = new XmlJetConfigBuilder();
+        JetConfig config = configBuilder.build();
+        assertEquals("bar", config.getProperties().getProperty("foo"));
+    }
+
+    @Test
+    public void loadingThroughSystemPropertyViaLocator_nonXmlSuffix() {
+        System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, "classpath:hazelcast-jet-foo.bar");
+
+        JetInstance instance = Jet.newJetInstance();
+        JetConfig config = instance.getConfig();
+        instance.shutdown();
+
+        assertEquals("bar", config.getProperties().getProperty("foo"));
+
     }
 
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigImportVariableReplacementTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigImportVariableReplacementTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.config.replacer.EncryptionReplacer;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(HazelcastParallelClassRunner.class)
 public class YamlJetConfigImportVariableReplacementTest extends AbstractJetConfigImportVariableReplacementTest {
 
     private static final String TEST_YAML_JET_WITH_VARIABLES = "hazelcast-jet-with-variables.yaml";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigLoadFromFileSystemOrClasspathTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigLoadFromFileSystemOrClasspathTest.java
@@ -17,7 +17,8 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.jet.impl.util.Util;
-import org.junit.Test;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -27,6 +28,7 @@ import java.io.InputStream;
 import static com.hazelcast.jet.config.AbstractJetConfigWithSystemPropertyTest.assertConfig;
 import static com.hazelcast.jet.config.AbstractJetConfigWithSystemPropertyTest.assertDefaultMemberConfig;
 
+@RunWith(HazelcastParallelClassRunner.class)
 public class YamlJetConfigLoadFromFileSystemOrClasspathTest extends AbstractJetConfigLoadFromFileSystemOrClasspathTest {
 
     public static final String TEST_YAML_JET = "hazelcast-jet-test.yaml";
@@ -42,35 +44,6 @@ public class YamlJetConfigLoadFromFileSystemOrClasspathTest extends AbstractJetC
 
         // When
         JetConfig jetConfig = JetConfig.loadFromFile(tempFile);
-
-        // Then
-        assertConfig(jetConfig);
-        assertDefaultMemberConfig(jetConfig.getHazelcastConfig());
-    }
-
-    @Override
-    @Test
-    public void when_fileSystemPathSpecified_usesSpecifiedFile() throws IOException {
-        // Given
-        File tempFile = File.createTempFile("jet", ".yaml");
-        try (FileOutputStream os = new FileOutputStream(tempFile)) {
-            InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream(TEST_YAML_JET);
-            os.write(Util.readFully(resourceAsStream));
-        }
-
-        // When
-        JetConfig jetConfig = JetConfig.loadFromFile(tempFile);
-
-        // Then
-        assertConfig(jetConfig);
-        assertDefaultMemberConfig(jetConfig.getHazelcastConfig());
-    }
-
-    @Override
-    @Test
-    public void when_classpathSpecified_usesSpecifiedResource() {
-        // When
-        JetConfig jetConfig = JetConfig.loadFromClasspath(getClass().getClassLoader(), TEST_YAML_JET);
 
         // Then
         assertConfig(jetConfig);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigWithSystemPropertyTest.java
@@ -17,10 +17,14 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.impl.config.YamlJetConfigBuilder;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -36,6 +40,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RunWith(HazelcastSerialClassRunner.class)
 public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigWithSystemPropertyTest {
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
     private static final String JET_TEST_YAML = "hazelcast-jet-test.yaml";
     private static final String JET_TEST_WITH_VARIABLES_YAML = "hazelcast-jet-with-variables.yaml";
     private static final String JET_MEMBER_TEST_YAML = "hazelcast-jet-member-test.yaml";
@@ -43,6 +50,17 @@ public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfig
     @Override
     @Test(expected = HazelcastException.class)
     public void when_filePathSpecifiedNonExistingFile_thenThrowsException() throws Exception {
+        // Given
+        File file = File.createTempFile("foo", ".yaml");
+        file.delete();
+        System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, file.getAbsolutePath());
+
+        // When
+        new YamlJetConfigBuilder().build();
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void when_filePathSpecifiedNonExistingNonYamlFile_thenThrowsException() throws Exception {
         // Given
         File file = File.createTempFile("foo", ".yaml");
         file.delete();
@@ -85,6 +103,18 @@ public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfig
         new YamlJetConfigBuilder().build();
     }
 
+
+    @Test(expected = HazelcastException.class)
+    public void when_filePathMemberSpecifiedNonExistingNonYamlFile_thenThrowsException() throws Exception {
+        // Given
+        File file = File.createTempFile("foo", ".bar");
+        file.delete();
+        System.setProperty(HAZELCAST_MEMBER_CONFIG_PROPERTY, file.getAbsolutePath());
+
+        // When
+        new YamlJetConfigBuilder().build();
+    }
+
     @Override
     @Test
     public void when_filePathMemberSpecified_usesSpecifiedFile() throws IOException {
@@ -109,6 +139,15 @@ public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfig
     public void when_classpathSpecifiedNonExistingFile_thenThrowsException() {
         // Given
         System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, "classpath:non-existing.yaml");
+
+        //When
+        new YamlJetConfigBuilder().build();
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void when_classpathSpecifiedNonExistingNonYamlFile_thenThrowsException() {
+        // Given
+        System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, "classpath:non-existing.bar");
 
         //When
         new YamlJetConfigBuilder().build();
@@ -139,6 +178,15 @@ public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfig
 
     }
 
+    @Test(expected = HazelcastException.class)
+    public void when_classpathMemberSpecifiedNonExistingNonYamlFile_thenThrowsException() {
+        // Given
+        System.setProperty(HAZELCAST_MEMBER_CONFIG_PROPERTY, "classpath:non-existing.bar");
+
+        //When
+        new YamlJetConfigBuilder().build();
+    }
+
     @Override
     @Test
     public void when_classpathMemberSpecified_usesSpecifiedResource() {
@@ -162,7 +210,7 @@ public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfig
         properties.put("flow.control.period", "50");
         properties.put("backup.count", "2");
         properties.put("scale.up.delay.millis", "1234");
-        properties.put("lossless.restart.enabled", "true");
+        properties.put("lossless.restart.enabled", "false");
         properties.put("metrics.enabled", "false");
         properties.put("metrics.jmxEnabled", "false");
         properties.put("metrics.retention", "124");
@@ -210,4 +258,28 @@ public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfig
         assertEquals("packetSizeLimit", 997, edgeConfig.getPacketSizeLimit());
         assertEquals("receiveWindowMultiplier", 996, edgeConfig.getReceiveWindowMultiplier());
     }
+
+    @Test
+    public void loadingThroughSystemPropertyWithLocator_nonYamlSuffix() {
+        System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, "classpath:test-jet.foobar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("hazelcast.jet.config");
+        expectedException.expectMessage("classpath:test-jet.foobar");
+        expectedException.expectMessage("yaml, yml");
+
+        new YamlJetConfigBuilder();
+    }
+
+    @Test
+    public void loadingThroughSystemPropertyWithLocator_existingClasspathResource() {
+        System.setProperty(HAZELCAST_JET_CONFIG_PROPERTY, "classpath:" + JET_TEST_YAML);
+
+        JetInstance instance = Jet.newJetInstance();
+        JetConfig config = instance.getConfig();
+        instance.shutdown();
+
+        assertConfig(config);
+    }
+
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigWithSystemPropertyTest.java
@@ -40,12 +40,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RunWith(HazelcastSerialClassRunner.class)
 public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigWithSystemPropertyTest {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     private static final String JET_TEST_YAML = "hazelcast-jet-test.yaml";
     private static final String JET_TEST_WITH_VARIABLES_YAML = "hazelcast-jet-with-variables.yaml";
     private static final String JET_MEMBER_TEST_YAML = "hazelcast-jet-member-test.yaml";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Override
     @Test(expected = HazelcastException.class)

--- a/hazelcast-jet-core/src/test/resources/hazelcast-jet-foo.bar
+++ b/hazelcast-jet-core/src/test/resources/hazelcast-jet-foo.bar
@@ -18,28 +18,7 @@
 <hazelcast-jet xsi:schemaLocation="http://www.hazelcast.com/schema/jet-config hazelcast-jet-config-3.1.xsd"
                xmlns="http://www.hazelcast.com/schema/jet-config"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <instance>
-        <cooperative-thread-count>55</cooperative-thread-count>
-        <flow-control-period>50</flow-control-period>
-        <backup-count>2</backup-count>
-        <scale-up-delay-millis>1234</scale-up-delay-millis>
-        <lossless-restart-enabled>false</lossless-restart-enabled>
-    </instance>
-
     <properties>
-       <property name="property1">value1</property>
-       <property name="property2">value2</property>
+       <property name="foo">bar</property>
     </properties>
-
-    <edge-defaults>
-       <queue-size>999</queue-size>
-       <packet-size-limit>997</packet-size-limit>
-       <receive-window-multiplier>996</receive-window-multiplier>
-    </edge-defaults>
-
-    <metrics enabled="false" jmxEnabled="false">
-        <collection-interval-seconds>123</collection-interval-seconds>
-        <retention-seconds>124</retention-seconds>
-        <metrics-for-data-structures>true</metrics-for-data-structures>
-    </metrics>
 </hazelcast-jet>

--- a/hazelcast-jet-core/src/test/resources/hazelcast-jet-test.yaml
+++ b/hazelcast-jet-core/src/test/resources/hazelcast-jet-test.yaml
@@ -4,7 +4,7 @@ hazelcast-jet:
     flow-control-period: 50
     backup-count: 2
     scale-up-delay-millis: 1234
-    lossless-restart-enabled: true
+    lossless-restart-enabled: false
   properties:
     property1: value1
     property2: value2


### PR DESCRIPTION
Changed behavior to treat an XML configuration file which has a non .xml file extension as XML files to satisfy backwards compatibility.

YAML configuration has a stricter requirement on file extensions
which only accepts .yaml or .yml extension.

Fixes #1380

Depends on https://github.com/hazelcast/hazelcast/pull/14945