### PR TITLE
Fixed test-coverage profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,6 +491,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <argLine>@{argLine}</argLine>
                             <excludedGroups combine.self="override">
                                 com.hazelcast.jet.test.IgnoredForCoverage
                             </excludedGroups>


### PR DESCRIPTION
`argLine` property was not correctly passed to jacoco plugin which caused that Sonar build was not able to show code coverage.