### PR TITLE
Fix snapshot creation after execution is done

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -209,8 +209,11 @@ public class ExecutionContext {
     public CompletableFuture<SnapshotOperationResult> beginSnapshot(long snapshotId, String mapName,
                                                                   boolean isTerminal) {
         synchronized (executionLock) {
-            if (cancellationFuture.isDone() || executionFuture != null && executionFuture.isDone()) {
+            if (cancellationFuture.isDone()) {
                 throw new CancellationException();
+            } else if (executionFuture != null && executionFuture.isDone()) {
+                // if execution is done, there are 0 processors to take snapshots. Therefore we're done now.
+                return CompletableFuture.completedFuture(new SnapshotOperationResult(0, 0, 0, null));
             }
             return snapshotContext.startNewSnapshot(snapshotId, mapName, isTerminal);
         }


### PR DESCRIPTION
For non-distributed sources that use `forceTotalParallelismOne`, batch
processors are created on inactive members. If there's no distributed
edge in the DAG, the execution on those members will complete
immediately, while the execution on the active members tries to do
snapshot.

This PR changes the edge case behavior that if the execution is
completed, we immediately respond to the SnapshotOperation instead of
throwing a CancellationException.