### PR TITLE
Add check for matching expected Hazelcast version with actual version in classpath

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -137,7 +137,7 @@ public final class Jet {
      */
     private static void assertHazelcastVersion() {
         String hzVersion = BuildInfoProvider.getBuildInfo().getVersion();
-        try (InputStream resource = Jet.class.getClassLoader().getResourceAsStream("jet-runtime.properties")){
+        try (InputStream resource = Jet.class.getClassLoader().getResourceAsStream("jet-runtime.properties")) {
             Properties p = new Properties();
             p.load(resource);
             String jetHzVersion = p.getProperty("jet.hazelcast.version");

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
@@ -42,6 +43,8 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Preconditions;
 
 import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 import java.util.function.Function;
 
@@ -60,6 +63,10 @@ import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 public final class Jet {
 
     private static final ILogger LOGGER = Logger.getLogger(Jet.class);
+
+    static {
+        assertHazelcastVersion();
+    }
 
     private Jet() {
     }
@@ -123,6 +130,27 @@ public final class Jet {
 
     static JetClientInstanceImpl getJetClientInstance(HazelcastInstance client) {
         return new JetClientInstanceImpl(((HazelcastClientProxy) client).client);
+    }
+
+    /**
+     * Makes sure that the Jet-expected Hazelcast version and the one in classpath match
+     */
+    private static void assertHazelcastVersion() {
+        String hzVersion = BuildInfoProvider.getBuildInfo().getVersion();
+        try (InputStream resource = Jet.class.getClassLoader().getResourceAsStream("jet-runtime.properties")){
+            Properties p = new Properties();
+            p.load(resource);
+            String jetHzVersion = p.getProperty("jet.hazelcast.version");
+            if (!hzVersion.equals(jetHzVersion)) {
+                throw new JetException("Jet uses Hazelcast version " + jetHzVersion + " however " +
+                        "version " + hzVersion + " was found in the classpath. " +
+                        " As Jet already shades hazelcast jars there is no need to explicitly " +
+                        "add a dependency to it.");
+            }
+        } catch (IOException e) {
+            // could not read properties
+            return;
+        }
     }
 
     private static synchronized void configureJetService(JetConfig jetConfig) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -142,14 +142,13 @@ public final class Jet {
             p.load(resource);
             String jetHzVersion = p.getProperty("jet.hazelcast.version");
             if (!hzVersion.equals(jetHzVersion)) {
-                throw new JetException("Jet uses Hazelcast version " + jetHzVersion + " however " +
+                throw new JetException("Jet uses Hazelcast IMDG version " + jetHzVersion + " however " +
                         "version " + hzVersion + " was found in the classpath. " +
-                        " As Jet already shades hazelcast jars there is no need to explicitly " +
+                        " As Jet already shades Hazelcast jars there is no need to explicitly " +
                         "add a dependency to it.");
             }
         } catch (IOException e) {
-            // could not read properties
-            return;
+            LOGGER.warning("Could not read the file jet-runtime.properties", e);
         }
     }
 

--- a/hazelcast-jet-core/src/main/resources/jet-runtime.properties
+++ b/hazelcast-jet-core/src/main/resources/jet-runtime.properties
@@ -17,3 +17,6 @@
 jet.version = ${project.version}
 jet.build = ${timestamp}
 jet.git.revision = ${git.commit.id.abbrev}
+
+# expected version of hazelcast
+jet.hazelcast.version = ${hazelcast.version}


### PR DESCRIPTION
It can be that different version of Hazelcast is included as a dependency due to misconfiguration. This can cause unexpected behaviour or confusing errors. Jet should fail fast in this scenario and refuse to start with a clear exception message.

Fixes #1405 