### PR TITLE
Clean-up Maven repositories in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,19 +44,12 @@
             <id>snapshot-repository</id>
             <name>Maven2 Snapshot Repository</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-        <repository>
-            <id>main-repo</id>
-            <url>http://repo1.maven.org/maven2/</url>
-        </repository>
-        <repository>
-            <id>backup-repo</id>
-            <url>http://repo2.maven.org/maven2/</url>
-        </repository>
-        <repository>
-            <id>release-repository</id>
-            <name>release repository</name>
-            <url>https://oss.sonatype.org/content/repositories/releases</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This PR cleans root `pom.xml` to allow utilizing Maven artifact proxies.

The same approach is used in the Hazelcast IMDG.