### PR TITLE
Remove -server flag from start script

### DIFF
--- a/hazelcast-jet-distribution/src/main/resources/bin/jet-start.sh
+++ b/hazelcast-jet-distribution/src/main/resources/bin/jet-start.sh
@@ -10,4 +10,4 @@ echo "# CLASSPATH=$CLASSPATH"
 echo "# starting now...."
 echo "########################################"
 
-$JAVA -server "${JAVA_OPTS[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.StartServer
+$JAVA "${JAVA_OPTS[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.StartServer


### PR DESCRIPTION
The flag has no meaning on modern JVM - tiered combination is enabled
by default.

Also it prevents Jet to start on ARMv6 where only the client compiler
is available :)