### PR TITLE
Fix loss of SnapshotOperation

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -166,7 +166,7 @@ class MasterSnapshotContext {
                 responses -> mc.coordinationService().submitToCoordinatorThread(() ->
                         onSnapshotCompleted(responses, localExecutionId, newSnapshotId, finalMapName, isExport, isTerminal,
                                 future)),
-                null, false);
+                null, true);
     }
 
     private void onSnapshotCompleted(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -350,10 +350,10 @@ public class ProcessorTasklet implements Tasklet {
                 progTracker.notDone();
                 // check ssContext to see if a barrier should be emitted
                 long currSnapshotId = ssContext.activeSnapshotId();
-                assert currSnapshotId >= pendingSnapshotId - 1 : "Unexpected new snapshot id: " + currSnapshotId
-                        + ", expected was " + (pendingSnapshotId - 1) + " or more";
-                if (currSnapshotId >= pendingSnapshotId) {
-                    pendingSnapshotId = currSnapshotId;
+                assert currSnapshotId + 1 == pendingSnapshotId || currSnapshotId == pendingSnapshotId
+                        : "Unexpected new snapshot id: " + currSnapshotId + ", expected was "
+                                + (pendingSnapshotId - 1) + " or " + pendingSnapshotId;
+                if (currSnapshotId == pendingSnapshotId) {
                     if (outbox.hasUnfinishedItem()) {
                         outbox.block();
                     } else {
@@ -463,9 +463,9 @@ public class ProcessorTasklet implements Tasklet {
     }
 
     private void observeBarrier(int ordinal, SnapshotBarrier barrier) {
-        if (barrier.snapshotId() < pendingSnapshotId) {
+        if (barrier.snapshotId() != pendingSnapshotId) {
             throw new JetException("Unexpected snapshot barrier ID " + barrier.snapshotId() + " from ordinal " + ordinal +
-                    " expected " + pendingSnapshotId);
+                    ", expected " + pendingSnapshotId);
         }
         currentBarrier = barrier;
         if (barrier.isTerminal()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -155,18 +155,16 @@ public class SnapshotContext {
      */
     synchronized CompletableFuture<SnapshotOperationResult> startNewSnapshot(
             long snapshotId, String mapName, boolean isTerminal) {
-        if (snapshotId <= currentSnapshotId) {
+        if (snapshotId == currentSnapshotId) {
             // This is possible when a SnapshotOperation is retried. We will throw because we
             // don't know the result of the previous snapshot (it may have failed) and this is rare
             // if not impossible.
-            throw new RuntimeException("new snapshotId not larger. Previous=" + currentSnapshotId + ", new=" + snapshotId);
+            throw new RuntimeException("new snapshotId equal to previous, operation possibly retried. Previous="
+                    + currentSnapshotId + ", new=" + snapshotId);
         }
-        if (snapshotId != currentSnapshotId + 1) {
-            // this can be a result of a lost SnapshotOperation,
-            // see OperationLossTest.when_snapshotOperationLost_then_ignored()
-            logger.warning("New snapshotId for " + jobNameAndExecutionId + " not incremented by 1. " +
-                    "Previous=" + currentSnapshotId + ", new=" + snapshotId + "; this is just a warning");
-        }
+        assert snapshotId == currentSnapshotId + 1
+                : "New snapshotId for " + jobNameAndExecutionId + " not incremented by 1. " +
+                        "Previous=" + currentSnapshotId + ", new=" + snapshotId;
         assert currentSnapshotId == activeSnapshotId : "last snapshot was postponed but not started";
         assert numTasklets >= 0 : "numTasklets=" + numTasklets;
         if (isCancelled) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SnapshotContext.java
@@ -155,8 +155,12 @@ public class SnapshotContext {
      */
     synchronized CompletableFuture<SnapshotOperationResult> startNewSnapshot(
             long snapshotId, String mapName, boolean isTerminal) {
-        assert snapshotId > currentSnapshotId
-                : "new snapshotId not larger than previous. Previous=" + currentSnapshotId + ", new=" + snapshotId;
+        if (snapshotId <= currentSnapshotId) {
+            // This is possible when a SnapshotOperation is retried. We will throw because we
+            // don't know the result of the previous snapshot (it may have failed) and this is rare
+            // if not impossible.
+            throw new RuntimeException("new snapshotId not larger. Previous=" + currentSnapshotId + ", new=" + snapshotId);
+        }
         if (snapshotId != currentSnapshotId + 1) {
             // this can be a result of a lost SnapshotOperation,
             // see OperationLossTest.when_snapshotOperationLost_then_ignored()

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/StoreSnapshotTasklet.java
@@ -138,9 +138,8 @@ public class StoreSnapshotTasklet implements Tasklet {
     private boolean addToInbox(Object o) {
         if (o instanceof SnapshotBarrier) {
             SnapshotBarrier barrier = (SnapshotBarrier) o;
-            assert pendingSnapshotId <= barrier.snapshotId() : "Unexpected barrier, expected was " +
+            assert pendingSnapshotId == barrier.snapshotId() : "Unexpected barrier, expected was " +
                     pendingSnapshotId + ", but barrier was " + barrier.snapshotId() + ", this=" + this;
-            pendingSnapshotId = barrier.snapshotId();
             hasReachedBarrier = true;
         } else {
             if (!ssWriter.offer((Entry<Data, Data>) o)) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -47,11 +47,14 @@ import static com.hazelcast.jet.core.JobStatus.NOT_RUNNING;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.STARTING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
+import static com.hazelcast.jet.core.processor.Processors.mapP;
+import static com.hazelcast.jet.function.FunctionEx.identity;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
+// TODO this test does not test when responses are lost. There is currently no test
+//   harness to simulate that.
 @RunWith(HazelcastSerialClassRunner.class)
 public class OperationLossTest extends JetTestSupport {
 
@@ -92,7 +95,11 @@ public class OperationLossTest extends JetTestSupport {
     private void when_operationLost_then_jobRestarts(int operationId, JobStatus expectedStatus) {
         PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(operationId));
-        DAG dag = new DAG().vertex(new Vertex("v", () -> new NoOutputSourceP()).localParallelism(1));
+        DAG dag = new DAG();
+        Vertex v1 = dag.newVertex("v1", () -> new NoOutputSourceP()).localParallelism(1);
+        Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
+        dag.edge(between(v1, v2).distributed());
+
         Job job = instance1.newJob(dag);
         assertJobStatusEventually(job, expectedStatus);
         // NOT_RUNNING will occur briefly, we might miss to observe it. But restart occurs every
@@ -109,7 +116,11 @@ public class OperationLossTest extends JetTestSupport {
     public void when_completeExecutionOperationLost_then_jobCompletes() {
         PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.COMPLETE_EXECUTION_OP));
-        DAG dag = new DAG().vertex(new Vertex("v", () -> new DummyStatefulP()).localParallelism(1));
+        DAG dag = new DAG();
+        Vertex v1 = dag.newVertex("v1", () -> new DummyStatefulP()).localParallelism(1);
+        Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
+        dag.edge(between(v1, v2).distributed());
+
         Job job = instance1.newJob(dag);
         assertJobStatusEventually(job, RUNNING);
         job.suspend();
@@ -126,10 +137,14 @@ public class OperationLossTest extends JetTestSupport {
     }
 
     @Test
-    public void when_snapshotOperationLost_then_ignored() {
+    public void when_snapshotOperationLost_then_retried() {
         PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.SNAPSHOT_OPERATION));
-        DAG dag = new DAG().vertex(new Vertex("v", () -> new DummyStatefulP()).localParallelism(1));
+        DAG dag = new DAG();
+        Vertex v1 = dag.newVertex("v1", () -> new DummyStatefulP()).localParallelism(1);
+        Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
+        dag.edge(between(v1, v2).distributed());
+
         Job job = instance1.newJob(dag, new JobConfig()
                 .setProcessingGuarantee(EXACTLY_ONCE)
                 .setSnapshotIntervalMillis(100));
@@ -138,9 +153,9 @@ public class OperationLossTest extends JetTestSupport {
         assertTrueEventually(() -> {
             JobExecutionRecord record = jobRepository.getJobExecutionRecord(job.getId());
             assertNotNull("null JobExecutionRecord", record);
-            assertTrue("ongoingSnapshotId not incremented: " + record.ongoingSnapshotId(),
-                    record.ongoingSnapshotId() >= 2);
-        });
+            assertEquals("ongoingSnapshotId", 0, record.ongoingSnapshotId());
+        }, 20);
+        sleepSeconds(1);
         // now lift the filter and check that a snapshot is done
         logger.info("Lifting the packet filter...");
         PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
@@ -179,7 +194,11 @@ public class OperationLossTest extends JetTestSupport {
     public void when_terminateExecutionOperationLost_then_jobTerminates() {
         PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.TERMINATE_EXECUTION_OP));
-        DAG dag = new DAG().vertex(new Vertex("v", () -> new NoOutputSourceP()).localParallelism(1));
+        DAG dag = new DAG();
+        Vertex v1 = dag.newVertex("v1", () -> new NoOutputSourceP()).localParallelism(1);
+        Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
+        dag.edge(between(v1, v2).distributed());
+
         Job job = instance1.newJob(dag);
         assertJobStatusEventually(job, RUNNING);
         job.cancel();
@@ -198,9 +217,13 @@ public class OperationLossTest extends JetTestSupport {
     public void when_terminalSnapshotOperationLost_then_jobRestarts() {
         PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.SNAPSHOT_OPERATION));
-        DAG dag = new DAG().vertex(new Vertex("v", () -> new NoOutputSourceP()).localParallelism(1));
+        DAG dag = new DAG();
+        Vertex v1 = dag.newVertex("v1", () -> new NoOutputSourceP()).localParallelism(1);
+        Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
+        dag.edge(between(v1, v2).distributed());
+
         Job job = instance1.newJob(dag, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
-        assertJobStatusEventually(job, RUNNING);
+        assertJobStatusEventually(job, RUNNING, 20);
         job.restart();
         // sleep so that the SnapshotOperation is sent out, but lost
         sleepSeconds(1);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -232,5 +232,8 @@ public class OperationLossTest extends JetTestSupport {
 
         // Then
         assertTrueEventually(() -> assertEquals(4, NoOutputSourceP.initCount.get()));
+
+        NoOutputSourceP.proceedLatch.countDown();
+        job.join();
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -390,8 +390,9 @@ public final class TestProcessors {
     }
 
     /**
-     * A processor that saves dummy constant data to snapshot and asserts it
-     * receives the same data.
+     * A source processor that saves dummy constant data to the snapshot and
+     * asserts that it receives the same data. It emits no output and never
+     * completes.
      */
     public static class DummyStatefulP extends AbstractProcessor {
         public static volatile boolean wasRestored;


### PR DESCRIPTION
The previous fix in #1377 wasn't sufficient, it only worked when there
was no distributed edge in the DAG. A processor after a distributed edge
got stuck forever waiting for the barrier from a member that did not
receive the SnapshotOp.

The fix here is to retry the SnapshotOperation. If the operation was
lost, the snapshot will eventually succeed. If the response was lost,
even though the snapshot operation is not idempotent and will fail when
retried with the same snapshotId, at least the job won't get stuck.
Snapshot failure is then ignored.

Note that the test does not test when a response to an operation is lost,
there is currently no test harness to simulate that.