### PR TITLE
Always initialize executionStartTime

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -106,7 +106,7 @@ public class MasterJobContext {
     private final MasterContext mc;
     private final ILogger logger;
 
-    private volatile long executionStartTime;
+    private volatile long executionStartTime = System.nanoTime();
     private volatile ExecutionFailureCallback executionFailureCallback;
     private volatile Set<Vertex> vertices;
 
@@ -163,6 +163,7 @@ public class MasterJobContext {
      * fixed yet, reschedules the job restart.
      */
     void tryStartJob(Function<Long, Long> executionIdSupplier) {
+        executionStartTime = System.nanoTime();
         try {
             Tuple2<DAG, ClassLoader> dagAndClassloader = resolveDagAndCL(executionIdSupplier);
             if (dagAndClassloader == null) {
@@ -232,7 +233,6 @@ public class MasterJobContext {
             if (scheduleRestartIfQuorumAbsent() || scheduleRestartIfClusterIsNotSafe()) {
                 return null;
             }
-            executionStartTime = System.nanoTime();
             mc.setJobStatus(STARTING);
 
             // ensure JobExecutionRecord exists


### PR DESCRIPTION
Fixes #1436.

It fixes the execution duration when the `executionStartTime` was not
initialized and was 0. On Linux `System.nanoTime` returns 0 at about OS
boot, which explains the 8 hours of runtime. The value was printed
because we've set the `executionStartTime` deeply in `tryStartJob`, but
this time the job was finalized before `tryStartJob` was called. Also
moves the initialization of `executionStartTime` at the very beginning
of `tryStartJob` because other exceptions could lead to garbabe duration
logged.

The commit does not fix the "execution 0000-0000-0000-0000" - it means
that no execution began yet. It might be surprising, but it's at least
not a garbage value.