### PR TITLE
 Fix issues in JetClassLoader

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
@@ -113,6 +113,11 @@ public class JetClassLoader extends ClassLoader {
 
     private boolean checkShutdown(String resource) {
         if (isShutdown) {
+            // This class loader is used as the thread context CL in several places. It's possible
+            // that another thread inherits this classloader since a Thread inherits the parent's
+            // context CL by default (see for example: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8172726)
+            // In these scenarios the thread might essentially hold a reference to an obsolete classloader.
+            // Rather than throwing an unexpected exception we instead print a warning.
             String jobName = this.jobName == null ? idToString(jobId) : "'" + this.jobName + "'";
             logger.warning("Classloader for job " + jobName + " tried to load '" + resource
                     + "' after the job was completed. The classloader used for jobs is disposed after " +

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
@@ -99,6 +99,10 @@ public class JetClassLoader extends ClassLoader {
         isShutdown = true;
     }
 
+    public boolean isShutdown() {
+        return isShutdown;
+    }
+
     @SuppressWarnings("unchecked")
     private InputStream resourceStream(String name) {
         if (!checkShutdown(name)) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
@@ -24,10 +24,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class JetClassLoaderTest extends JetTestSupport {
+import static org.junit.Assert.assertTrue;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
+public class JetClassLoaderTest extends JetTestSupport {
 
     @Test
     public void when_jobCompleted_then_classLoaderShutDown() throws Exception {
@@ -40,9 +39,9 @@ public class JetClassLoaderTest extends JetTestSupport {
         instance.newJob(dag).join();
 
         // Then
-        exception.expect(IllegalStateException.class);
-        exception.expectMessage("The classloader used for jobs is disposed after job is completed");
-        LeakClassLoaderP.classLoader.findClass("foo.Class");
+        assertTrue("The classloader should have been shutdown after job completion",
+                LeakClassLoaderP.classLoader.isShutdown()
+        );
     }
 
     private static class LeakClassLoaderP extends AbstractProcessor {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/JetClassLoaderTest.java
@@ -20,16 +20,14 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertTrue;
 
 public class JetClassLoaderTest extends JetTestSupport {
 
     @Test
-    public void when_jobCompleted_then_classLoaderShutDown() throws Exception {
+    public void when_jobCompleted_then_classLoaderShutDown() {
         DAG dag = new DAG();
         dag.newVertex("v", LeakClassLoaderP::new).localParallelism(1);
 


### PR DESCRIPTION
During ProcessorSupplier.init(), the ThreadContextCL
was not set to the correct class loader. Besides this,
it’s still possible that the context class loader
can leak to other threads (see https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8172726) because it’s inherited during thread creation. In the case that 
the class loader is still referenced by some thread
we should only print a warning instead of throwing an exception