### PR TITLE
Drop ParallelTest, clean up cluster after tests

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
@@ -95,7 +95,7 @@ public abstract class TestInClusterSupport extends JetTestSupport {
     @After
     public void after() {
         for (Job job : allJetInstances()[0].getJobs()) {
-            ditchJob(job);
+            ditchJob(job, allJetInstances());
         }
         for (DistributedObject o : allJetInstances()[0].getHazelcastInstance().getDistributedObjects()) {
             o.destroy();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
@@ -18,13 +18,13 @@ package com.hazelcast.jet;
 
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
-import com.hazelcast.test.annotation.ParallelTest;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -40,7 +40,6 @@ import static java.lang.Math.max;
  * all tests in the class.
  */
 @RunWith(Parameterized.class)
-@Category(ParallelTest.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @SuppressWarnings("checkstyle:declarationorder")
 public abstract class TestInClusterSupport extends JetTestSupport {
@@ -91,6 +90,16 @@ public abstract class TestInClusterSupport extends JetTestSupport {
         allJetInstances = null;
         member = null;
         client = null;
+    }
+
+    @After
+    public void after() {
+        for (Job job : allJetInstances()[0].getJobs()) {
+            ditchJob(job);
+        }
+        for (DistributedObject o : allJetInstances()[0].getHazelcastInstance().getDistributedObjects()) {
+            o.destroy();
+        }
     }
 
     protected static JetInstance[] allJetInstances() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -73,7 +73,7 @@ public class SinksTest extends PipelineTestSupport {
     }
 
     @AfterClass
-    public static void after() {
+    public static void afterClass() {
         Hazelcast.shutdownAll();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourceBuilderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourceBuilderTest.java
@@ -450,7 +450,7 @@ public class SourceBuilderTest extends PipelineStreamTestSupport {
                 .peek()
                 .drainTo(Sinks.list(result));
 
-        Job job = jet().newJob(p, new JobConfig());
+        Job job = jet().newJob(p);
         assertTrueEventually(() -> assertFalse("result list is still empty", result.isEmpty()));
         // restart the job
         job.restart();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
@@ -71,7 +71,7 @@ public class SourcesTest extends PipelineTestSupport {
     }
 
     @AfterClass
-    public static void after() {
+    public static void afterClass() {
         Hazelcast.shutdownAll();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
@@ -68,7 +68,7 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
     }
 
     @AfterClass
-    public static void after() {
+    public static void afterClass() {
         Hazelcast.shutdownAll();
     }
 


### PR DESCRIPTION
Remove ParallelTest: the logs were mingled and we were not able to
investigate issues. Also ensure that the shared cluster is cleaned up of
all non-terminated jobs and non-destroyed distributed objects.

Related to #1454