### PR TITLE
Doc: Fixed link from Testing Pipeline to Jet Version Compatibility

### DIFF
--- a/hazelcast-jet-reference-manual/src/main/asciidoc/pipeline-api/pipeline-api.adoc
+++ b/hazelcast-jet-reference-manual/src/main/asciidoc/pipeline-api/pipeline-api.adoc
@@ -836,7 +836,7 @@ testing a pipeline without having to integrate with a real data source
 or sink.
 
 NOTE: These APIs are currently marked as `@Beta` and are not covered
-by the <<appendix, backward-compatibility guarantees>>.
+by the <<jet-version-compatibility, backward-compatibility guarantees>>.
 
 == Test Sources
 


### PR DESCRIPTION
In section `4.15. Developing and testing your pipeline` there is incorrect link https://docs.hazelcast.org/docs/jet/latest-dev/manual/#appendix. It is fixed to use https://docs.hazelcast.org/docs/jet/latest-dev/manual/#jet-version-compatibility.