### PR TITLE
Do not attempt to clear snapshots maps on job start

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -305,10 +305,6 @@ public class JobRepository {
         jobRecords.remove(jobId);
         // delete the execution ids, but keep the job id
         randomIds.removeAll(new FilterExecutionIdByJobIdPredicate(jobId));
-
-        // delete job resources
-        instance.getMap(snapshotDataMapName(jobId, 0)).destroy();
-        instance.getMap(snapshotDataMapName(jobId, 1)).destroy();
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -172,11 +172,6 @@ public class MasterJobContext {
             DAG dag = dagAndClassloader.f0();
             ClassLoader classLoader = dagAndClassloader.f1();
             JobExecutionRecord jobExecRec = mc.jobExecutionRecord();
-            try {
-                mc.jobRepository().clearSnapshotData(mc.jobId(), jobExecRec.ongoingDataMapIndex());
-            } catch (Exception e) {
-                logger.warning("Cannot delete old snapshots for " + mc.jobName(), e);
-            }
             String dotRepresentation = dag.toDotString(); // must call this before rewriteDagWithSnapshotRestore()
             long snapshotId = jobExecRec.snapshotId();
             String snapshotName = mc.jobConfig().getInitialSnapshotName();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -148,9 +148,7 @@ class MasterSnapshotContext {
         boolean isExport = snapshotMapName != null;
         String finalMapName = isExport ? exportedSnapshotMapName(snapshotMapName)
                 : snapshotDataMapName(mc.jobId(), mc.jobExecutionRecord().ongoingDataMapIndex());
-        if (isExport) {
-            mc.nodeEngine().getHazelcastInstance().getMap(finalMapName).clear();
-        }
+        mc.nodeEngine().getHazelcastInstance().getMap(finalMapName).clear();
         logger.info(String.format("Starting snapshot %d for %s", newSnapshotId, mc.jobIdString())
                 + (isTerminal ? ", terminal" : "")
                 + (isExport ? ", exporting to '" + snapshotMapName + '\'' : ""));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -64,7 +64,6 @@ import static com.hazelcast.jet.core.processor.Processors.insertWatermarksP;
 import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static com.hazelcast.jet.core.processor.SinkProcessors.writeListP;
 import static com.hazelcast.jet.function.Functions.entryKey;
-import static com.hazelcast.jet.impl.JobRepository.snapshotDataMapName;
 import static com.hazelcast.jet.impl.util.Util.arrayIndexOf;
 import static com.hazelcast.test.PacketFiltersUtil.delayOperationsFrom;
 import static java.util.Arrays.asList;
@@ -259,11 +258,6 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
             }
             System.out.println("-- end of different keys");
             assertEquals(expectedMap, new HashMap<>(result));
-        }
-
-        for (int i = 0; i <= 1; i++) {
-            assertTrue("Snapshots map " + i + " not empty after job finished",
-                    instance1.getMap(snapshotDataMapName(job.getId(), i)).isEmpty());
         }
     }
 


### PR DESCRIPTION
This causes them to be created even if they won’t be needed by the job