### PR TITLE
Use ungraceful instance termination in tests

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -22,9 +22,9 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.jet.IMapJet;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.core.JobStatus;
@@ -74,7 +74,7 @@ public class SinksTest extends PipelineTestSupport {
 
     @AfterClass
     public static void afterClass() {
-        Hazelcast.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SourcesTest.java
@@ -20,9 +20,9 @@ import com.hazelcast.cache.ICache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.jet.IMapJet;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
@@ -72,7 +72,7 @@ public class SourcesTest extends PipelineTestSupport {
 
     @AfterClass
     public static void afterClass() {
-        Hazelcast.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/Sources_withEventJournalTest.java
@@ -21,9 +21,9 @@ import com.hazelcast.cache.journal.EventJournalCacheEvent;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.jet.IListJet;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
@@ -69,7 +69,7 @@ public class Sources_withEventJournalTest extends PipelineTestSupport {
 
     @AfterClass
     public static void afterClass() {
-        Hazelcast.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
     }
 
     @Test


### PR DESCRIPTION
I've noticed that `Sources_withEventJournalTest` was running the actual test cases in a reasonable amount of time, but then, at the end was stuck in `Hazelcast.shutdownAll();` for ages. While we should probably investigate the root reason for this, maybe we could switch such test usages to call `HazelcastInstanceFactory.terminateAll();` instead. Should we fine for tests. Pls. correct me if I'm wrong.