### PR TITLE
Simplify creation of queues when edge is not partitioned

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConveyorCollector.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConveyorCollector.java
@@ -19,13 +19,15 @@ package com.hazelcast.jet.impl.execution;
 import com.hazelcast.internal.util.concurrent.ConcurrentConveyor;
 import com.hazelcast.jet.impl.util.ProgressState;
 
+import javax.annotation.Nullable;
+
 public class ConveyorCollector implements OutboundCollector {
 
     private final ConcurrentConveyor<Object> conveyor;
     private final int queueIndex;
     private final int[] partitions;
 
-    public ConveyorCollector(ConcurrentConveyor<Object> conveyor, int queueIndex, int[] partitions) {
+    public ConveyorCollector(ConcurrentConveyor<Object> conveyor, int queueIndex, @Nullable int[] partitions) {
         this.conveyor = conveyor;
         this.queueIndex = queueIndex;
         this.partitions = partitions;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -468,15 +468,12 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         final int numRemoteMembers = ptionArrgmt.remotePartitionAssignment.get().size();
         final int queueSize = edge.getConfig().getQueueSize();
 
-        final int[][] ptionsPerProcessor =
-                ptionArrgmt.assignPartitionsToProcessors(downstreamParallelism, edge.isDistributed());
-
         if (edge.routingPolicy() == RoutingPolicy.ISOLATED) {
             if (downstreamParallelism < upstreamParallelism) {
                 throw new IllegalArgumentException(String.format(
-                        "The edge %s specifies the %s routing policy, but the downstream vertex" +
+                    "The edge %s specifies the %s routing policy, but the downstream vertex" +
                         " parallelism (%d) is less than the upstream vertex parallelism (%d)",
-                        edge, RoutingPolicy.ISOLATED.name(), downstreamParallelism, upstreamParallelism));
+                    edge, RoutingPolicy.ISOLATED.name(), downstreamParallelism, upstreamParallelism));
             }
             if (edge.isDistributed()) {
                 throw new IllegalArgumentException("Isolated edges must be local: " + edge);
@@ -484,10 +481,10 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
 
             // there is only one producer per consumer for a one to many edge, so queueCount is always 1
             ConcurrentConveyor<Object>[] localConveyors = localConveyorMap.computeIfAbsent(edge.edgeId(),
-                    e -> createConveyorArray(downstreamParallelism, 1, queueSize));
+                e -> createConveyorArray(downstreamParallelism, 1, queueSize));
             return IntStream.range(0, downstreamParallelism)
                             .filter(i -> i % upstreamParallelism == processorIndex)
-                            .mapToObj(i -> new ConveyorCollector(localConveyors[i], 0, ptionsPerProcessor[i]))
+                            .mapToObj(i -> new ConveyorCollector(localConveyors[i], 0, null))
                             .toArray(OutboundCollector[]::new);
         }
 
@@ -499,14 +496,15 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
          * For a distributed edge, there is one additional producer per member represented
          * by the ReceiverTasklet.
          */
+        final int[][] ptionsPerProcessor = getPartitionDistribution(edge, downstreamParallelism);
         final ConcurrentConveyor<Object>[] localConveyors = localConveyorMap.computeIfAbsent(edge.edgeId(),
-                e -> {
-                    int queueCount = upstreamParallelism + (edge.isDistributed() ? numRemoteMembers : 0);
-                    return createConveyorArray(downstreamParallelism, queueCount, queueSize);
-                });
+            e -> {
+                int queueCount = upstreamParallelism + (edge.isDistributed() ? numRemoteMembers : 0);
+                return createConveyorArray(downstreamParallelism, queueCount, queueSize);
+            });
         final OutboundCollector[] localCollectors = new OutboundCollector[downstreamParallelism];
         Arrays.setAll(localCollectors, n ->
-                new ConveyorCollector(localConveyors[n], processorIndex, ptionsPerProcessor[n]));
+            new ConveyorCollector(localConveyors[n], processorIndex, ptionsPerProcessor[n]));
 
         // in a local edge, we only have the local collectors.
         if (!edge.isDistributed()) {
@@ -526,9 +524,15 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         int index = 1;
         for (Map.Entry<Address, int[]> entry : memberToPartitions.entrySet()) {
             allCollectors[index++] = new ConveyorCollectorWithPartition(senderConveyorMap.get(entry.getKey()),
-                    processorIndex, entry.getValue());
+                processorIndex, entry.getValue());
         }
         return allCollectors;
+    }
+
+    private int[][] getPartitionDistribution(EdgeDef edge, int downstreamParallelism) {
+        return edge.routingPolicy().equals(RoutingPolicy.PARTITIONED) ?
+            ptionArrgmt.assignPartitionsToProcessors(downstreamParallelism, edge.isDistributed())
+            : new int[downstreamParallelism][];
     }
 
     private void createIfAbsentReceiverTasklet(


### PR DESCRIPTION
Previously partitions were calculated and assigned for every edge whether it was
partitioned or not and this caused unnecessary overhead during job initialisation.