### PR TITLE
Make enabling job metrics optional

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -485,43 +485,22 @@ public class JobConfig implements IdentifiedDataSerializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         JobConfig jobConfig = (JobConfig) o;
-
-        if (snapshotIntervalMillis != jobConfig.snapshotIntervalMillis) {
-            return false;
-        }
-        if (autoScaling != jobConfig.autoScaling) {
-            return false;
-        }
-        if (splitBrainProtectionEnabled != jobConfig.splitBrainProtectionEnabled) {
-            return false;
-        }
-        if (!Objects.equals(name, jobConfig.name)) {
-            return false;
-        }
-        if (processingGuarantee != jobConfig.processingGuarantee) {
-            return false;
-        }
-        if (!Objects.equals(resourceConfigs, jobConfig.resourceConfigs)) {
-            return false;
-        }
-        if (!Objects.equals(classLoaderFactory, jobConfig.classLoaderFactory)) {
-            return false;
-        }
-        return Objects.equals(initialSnapshotName, jobConfig.initialSnapshotName);
+        return snapshotIntervalMillis == jobConfig.snapshotIntervalMillis &&
+            autoScaling == jobConfig.autoScaling &&
+            splitBrainProtectionEnabled == jobConfig.splitBrainProtectionEnabled &&
+            enableMetrics == jobConfig.enableMetrics &&
+            Objects.equals(name, jobConfig.name) &&
+            processingGuarantee == jobConfig.processingGuarantee &&
+            Objects.equals(resourceConfigs, jobConfig.resourceConfigs) &&
+            Objects.equals(classLoaderFactory, jobConfig.classLoaderFactory) &&
+            Objects.equals(initialSnapshotName, jobConfig.initialSnapshotName);
     }
 
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (processingGuarantee != null ? processingGuarantee.hashCode() : 0);
-        result = 31 * result + (int) (snapshotIntervalMillis ^ (snapshotIntervalMillis >>> 32));
-        result = 31 * result + (autoScaling ? 1 : 0);
-        result = 31 * result + (splitBrainProtectionEnabled ? 1 : 0);
-        result = 31 * result + (resourceConfigs != null ? resourceConfigs.hashCode() : 0);
-        result = 31 * result + (classLoaderFactory != null ? classLoaderFactory.hashCode() : 0);
-        result = 31 * result + (initialSnapshotName != null ? initialSnapshotName.hashCode() : 0);
-        return result;
+        return Objects.hash(name, processingGuarantee, snapshotIntervalMillis, autoScaling,
+            splitBrainProtectionEnabled, enableMetrics, resourceConfigs, classLoaderFactory, initialSnapshotName
+        );
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -51,6 +51,7 @@ public class JobConfig implements IdentifiedDataSerializable {
     private long snapshotIntervalMillis = SNAPSHOT_INTERVAL_MILLIS_DEFAULT;
     private boolean autoScaling = true;
     private boolean splitBrainProtectionEnabled;
+    private boolean enableMetrics = true;
     private List<ResourceConfig> resourceConfigs = new ArrayList<>();
     private JobClassLoaderFactory classLoaderFactory;
     private String initialSnapshotName;
@@ -423,6 +424,23 @@ public class JobConfig implements IdentifiedDataSerializable {
         return this;
     }
 
+    /**
+     * Sets whether metrics collection should be enabled for the job.
+     * It's enabled by default.
+     */
+    @Nonnull
+    public JobConfig setMetricsEnabled(boolean enabled) {
+        this.enableMetrics = enabled;
+        return this;
+    }
+
+    /**
+     * Returns if metrics collection is enabled for the job
+     */
+    public boolean isMetricsEnabled() {
+        return enableMetrics;
+    }
+
     @Override
     public int getFactoryId() {
         return JetConfigDataSerializerHook.FACTORY_ID;
@@ -443,6 +461,7 @@ public class JobConfig implements IdentifiedDataSerializable {
         out.writeObject(resourceConfigs);
         out.writeObject(classLoaderFactory);
         out.writeUTF(initialSnapshotName);
+        out.writeBoolean(enableMetrics);
     }
 
     @Override
@@ -455,6 +474,7 @@ public class JobConfig implements IdentifiedDataSerializable {
         resourceConfigs = in.readObject();
         classLoaderFactory = in.readObject();
         initialSnapshotName = in.readUTF();
+        enableMetrics = in.readBoolean();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -25,6 +25,7 @@ import com.hazelcast.jet.impl.TerminationMode;
 import com.hazelcast.jet.impl.exception.JobTerminateRequestedException;
 import com.hazelcast.jet.impl.exception.TerminatedWithSnapshotException;
 import com.hazelcast.jet.impl.execution.init.ExecutionPlan;
+import com.hazelcast.jet.impl.metrics.JetMetricsService;
 import com.hazelcast.jet.impl.operation.SnapshotOperation.SnapshotOperationResult;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
@@ -107,7 +108,10 @@ public class ExecutionContext {
         processors = plan.getProcessors();
         snapshotContext = new SnapshotContext(nodeEngine.getLogger(SnapshotContext.class), jobNameAndExecutionId(),
                 plan.lastSnapshotId(), jobConfig.getProcessingGuarantee());
-        plan.initialize(nodeEngine, jobId, executionId, snapshotContext);
+
+        JetMetricsService service = nodeEngine.getService(JetMetricsService.SERVICE_NAME);
+        boolean registerMetrics = jobConfig.isMetricsEnabled() && service.isEnabled();
+        plan.initialize(nodeEngine, jobId, executionId, snapshotContext, registerMetrics);
         snapshotContext.initTaskletCount(plan.getStoreSnapshotTaskletCount(), plan.getHigherPriorityVertexCount());
         receiverMap = unmodifiableMap(plan.getReceiverMap());
         senderMap = unmodifiableMap(plan.getSenderMap());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -57,6 +57,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.StringUtil;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -134,7 +135,9 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         this.memberCount = memberCount;
     }
 
-    public void initialize(NodeEngine nodeEngine, long jobId, long executionId, SnapshotContext snapshotContext) {
+    public void initialize(
+        NodeEngine nodeEngine, long jobId, long executionId, SnapshotContext snapshotContext, boolean registerMetrics
+    ) {
         this.nodeEngine = (NodeEngineImpl) nodeEngine;
         this.executionId = executionId;
         initProcSuppliers(jobId, executionId);
@@ -182,26 +185,30 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                         memberCount
                 );
 
-                ProbeBuilder probeBuilder = this.nodeEngine.getMetricsRegistry().newProbeBuilder()
-                        .withTag("module", "jet")
-                        .withTag("job", idToString(jobId))
-                        .withTag("exec", idToString(executionId))
-                        .withTag("vertex", vertex.name());
 
-                // ignore vertices which are only used for snapshot restore and do not
-                // consider snapshot restore edges for determining source tag
-                if (vertex.inboundEdges().stream().allMatch(EdgeDef::isSnapshotRestoreEdge)
+                ProbeBuilder probeBuilder = null;
+                ProbeBuilder processorProbeBuilder = null;
+                if (registerMetrics) {
+                    probeBuilder = this.nodeEngine.getMetricsRegistry().newProbeBuilder()
+                                                               .withTag("module", "jet")
+                                                               .withTag("job", idToString(jobId))
+                                                               .withTag("exec", idToString(executionId))
+                                                               .withTag("vertex", vertex.name());
+                    // ignore vertices which are only used for snapshot restore and do not
+                    // consider snapshot restore edges for determining source tag
+                    if (vertex.inboundEdges().stream().allMatch(EdgeDef::isSnapshotRestoreEdge)
                         && !vertex.isSnapshotVertex()) {
-                    probeBuilder = probeBuilder.withTag("source", "true");
-                }
-                if (vertex.outboundEdges().size() == 0) {
-                    probeBuilder = probeBuilder.withTag("sink", "true");
-                }
-                ProbeBuilder processorProbeBuilder = probeBuilder
+                        probeBuilder = probeBuilder.withTag("source", "true");
+                    }
+                    if (vertex.outboundEdges().size() == 0) {
+                        probeBuilder = probeBuilder.withTag("sink", "true");
+                    }
+                    processorProbeBuilder = probeBuilder
                         .withTag("proc", String.valueOf(globalProcessorIndex));
-                processorProbeBuilder
+                    processorProbeBuilder
                         .withTag("procType", processor.getClass().getSimpleName())
                         .scanAndRegister(processor);
+                }
 
                 // createOutboundEdgeStreams() populates localConveyorMap and edgeSenderConveyorMap.
                 // Also populates instance fields: senderMap, receiverMap, tasklets.
@@ -362,16 +369,19 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
      * Populates {@link #senderMap} and {@link #tasklets} fields.
      */
     private List<OutboundEdgeStream> createOutboundEdgeStreams(
-            VertexDef srcVertex, int processorIdx, final ProbeBuilder probeBuilder
+            VertexDef srcVertex, int processorIdx, @Nullable final ProbeBuilder probeBuilder
     ) {
         final List<OutboundEdgeStream> outboundStreams = new ArrayList<>();
         for (EdgeDef edge : srcVertex.outboundEdges()) {
-            ProbeBuilder probeBuilder2 = probeBuilder.withTag("ordinal", String.valueOf(edge.sourceOrdinal()));
+            ProbeBuilder builder = null;
+            if (probeBuilder != null) {
+                builder = probeBuilder.withTag("ordinal", String.valueOf(edge.sourceOrdinal()));
+            }
             Map<Address, ConcurrentConveyor<Object>> memberToSenderConveyorMap = null;
             if (edge.isDistributed()) {
-                memberToSenderConveyorMap = memberToSenderConveyorMap(edgeSenderConveyorMap, edge, probeBuilder2);
+                memberToSenderConveyorMap = memberToSenderConveyorMap(edgeSenderConveyorMap, edge, builder);
             }
-            outboundStreams.add(createOutboundEdgeStream(edge, processorIdx, memberToSenderConveyorMap, probeBuilder2));
+            outboundStreams.add(createOutboundEdgeStream(edge, processorIdx, memberToSenderConveyorMap, builder));
         }
         return outboundStreams;
     }
@@ -383,7 +393,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
      */
     private Map<Address, ConcurrentConveyor<Object>> memberToSenderConveyorMap(
             Map<String, Map<Address, ConcurrentConveyor<Object>>> edgeSenderConveyorMap, EdgeDef edge,
-            ProbeBuilder probeBuilder
+            @Nullable ProbeBuilder probeBuilder
     ) {
         assert edge.isDistributed() : "Edge is not distributed";
         return edgeSenderConveyorMap.computeIfAbsent(edge.edgeId(), x -> {
@@ -415,7 +425,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             // We register the metrics to the first tasklet. The metrics itself aggregate counters from all tasklets
             // and don't use the reference to source, but we use the source to deregister the metrics when the job
             // finishes.
-            if (firstTasklet != null) {
+            if (probeBuilder != null && firstTasklet != null) {
                 probeBuilder.register(firstTasklet, "distributedBytesOut", ProbeLevel.INFO, ProbeUnit.BYTES,
                         addCountersProbeFunction(bytesCounters));
                 probeBuilder.register(firstTasklet, "distributedItemsOut", ProbeLevel.INFO, ProbeUnit.BYTES,
@@ -564,7 +574,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                            itemCounters.add(receiverTasklet.getItemsInCounter());
                            bytesCounters.add(receiverTasklet.getBytesInCounter());
                        }
-                       if (firstTasklet != null) {
+                       if (probeBuilder != null && firstTasklet != null) {
                            // We register the metrics to the first tasklet. The metrics itself aggregate counters from
                            // all tasklets and don't use the reference to source, but we use the source to deregister
                            // the metrics when the job finishes.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/JetMetricsService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/JetMetricsService.java
@@ -61,7 +61,7 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
     private final LiveOperationRegistry liveOperationRegistry;
     // Holds futures for pending read metrics operations
     private final ConcurrentMap<CompletableFuture<RingbufferSlice<Map.Entry<Long, byte[]>>>, Long>
-            pendingReads = new ConcurrentHashMap<>();
+        pendingReads = new ConcurrentHashMap<>();
 
     /**
      * Ringbuffer which stores a bounded history of metrics. For each round of collection,
@@ -97,8 +97,8 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
         }
 
         logger.info("Configuring metrics collection, collection interval=" + config.getCollectionIntervalSeconds()
-                + " seconds, retention=" + config.getRetentionSeconds() + " seconds, publishers="
-                + publishers.stream().map(MetricsPublisher::name).collect(joining(", ", "[", "]")));
+            + " seconds, retention=" + config.getRetentionSeconds() + " seconds, publishers="
+            + publishers.stream().map(MetricsPublisher::name).collect(joining(", ", "[", "]")));
 
         ProbeRenderer renderer = new PublisherProbeRenderer();
         scheduledFuture = nodeEngine.getExecutionService().scheduleWithRepetition("MetricsPublisher", () -> {
@@ -115,6 +115,10 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
                 }
             }
         }, 1, config.getCollectionIntervalSeconds(), TimeUnit.SECONDS);
+    }
+
+    public boolean isEnabled() {
+        return config.isEnabled();
     }
 
     public LiveOperationRegistry getLiveOperationRegistry() {
@@ -188,14 +192,14 @@ public class JetMetricsService implements ManagedService, ConfigurableService<Me
         List<MetricsPublisher> publishers = new ArrayList<>();
         if (config.isEnabled()) {
             int journalSize = Math.max(
-                    1, (int) Math.ceil((double) config.getRetentionSeconds() / config.getCollectionIntervalSeconds())
+                1, (int) Math.ceil((double) config.getRetentionSeconds() / config.getCollectionIntervalSeconds())
             );
             metricsJournal = new ConcurrentArrayRingbuffer<>(journalSize);
             ManagementCenterPublisher publisher = new ManagementCenterPublisher(this.nodeEngine.getLoggingService(),
-                    (blob, ts) -> {
-                        metricsJournal.add(entry(ts, blob));
-                        pendingReads.forEach(this::tryCompleteRead);
-                    }
+                (blob, ts) -> {
+                    metricsJournal.add(entry(ts, blob));
+                    pendingReads.forEach(this::tryCompleteRead);
+                }
             );
             publishers.add(publisher);
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
@@ -133,7 +133,8 @@ public class VertexDef_HigherPrioritySourceTest {
         Map<MemberInfo, ExecutionPlan> executionPlans =
                 createExecutionPlans(nodeEngineImpl, membersView, dag, 0, 0, new JobConfig(), 0);
         ExecutionPlan plan = executionPlans.values().iterator().next();
-        plan.initialize(nodeEngineImpl, 0, 0, new SnapshotContext(mock(ILogger.class), "job", 0, EXACTLY_ONCE));
+        SnapshotContext ssContext = new SnapshotContext(mock(ILogger.class), "job", 0, EXACTLY_ONCE);
+        plan.initialize(nodeEngineImpl, 0, 0, ssContext, true);
         String actualHigherPriorityVertices = plan.getVertices().stream()
                 .filter(VertexDef::isHigherPrioritySource)
                 .map(VertexDef::name)


### PR DESCRIPTION
Registering metrics for running very small jobs incurs additional overhead without
bringing much value. It should be made optional