### PR TITLE
Move JobMetrics to own map to avoid querying during job cleanup

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import static com.hazelcast.jet.impl.JobRepository.INTERNAL_JET_OBJECTS_PREFIX;
+import static com.hazelcast.jet.impl.JobRepository.JOB_METRICS_MAP_NAME;
 import static com.hazelcast.jet.impl.JobRepository.JOB_RESULTS_MAP_NAME;
 import static com.hazelcast.jet.impl.config.ConfigProvider.locateAndGetClientConfig;
 import static com.hazelcast.jet.impl.config.ConfigProvider.locateAndGetJetConfig;
@@ -198,8 +199,13 @@ public final class Jet {
                 .setName(JOB_RESULTS_MAP_NAME)
                 .setTimeToLiveSeconds(properties.getSeconds(JOB_RESULTS_TTL_SECONDS));
 
+        MapConfig metricsMapConfig = new MapConfig(internalMapConfig)
+            .setName(JOB_METRICS_MAP_NAME)
+            .setTimeToLiveSeconds(properties.getSeconds(JOB_RESULTS_TTL_SECONDS));
+
         hzConfig.addMapConfig(internalMapConfig)
-                .addMapConfig(resultsMapConfig);
+                .addMapConfig(resultsMapConfig)
+                .addMapConfig(metricsMapConfig);
 
         if (jetConfig.getInstanceConfig().isLosslessRestartEnabled() &&
             !hzConfig.getHotRestartPersistenceConfig().isEnabled()) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
@@ -63,10 +63,10 @@ public final class JetProperties {
      * Maximum number of job results to keep in the cluster, the oldest
      * results will be automatically deleted after this size is reached.
      * <p>
-     * Default value is 10,000 jobs.
+     * Default value is 1,000 jobs.
      */
     public static final HazelcastProperty JOB_RESULTS_MAX_SIZE
-            = new HazelcastProperty("jet.job.results.max.size", 10_000);
+            = new HazelcastProperty("jet.job.results.max.size", 1_000);
 
     /**
      * Root of Jet installation. Used as default location for the lossless recovery

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -403,9 +403,9 @@ public class JobCoordinationService {
                 () -> {
                     // first check if there is a job result present.
                     // this map is updated first during completion.
-                    JobResult jobResult = jobRepository.getJobResult(jobId);
-                    if (jobResult != null) {
-                        cf.complete(jobResult.getJobMetrics());
+                    JobMetrics metrics = jobRepository.getJobMetrics(jobId);
+                    if (metrics != null) {
+                        cf.complete(metrics);
                         return;
                     }
 
@@ -424,9 +424,9 @@ public class JobCoordinationService {
                     } else {
                         // no job record found, but check job results again
                         // since job might have been completed meanwhile.
-                        jobResult = jobRepository.getJobResult(jobId);
-                        if (jobResult != null) {
-                            cf.complete(jobResult.getJobMetrics());
+                        metrics = jobRepository.getJobMetrics(jobId);
+                        if (metrics != null) {
+                            cf.complete(metrics);
                             return;
                         }
                     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -104,12 +104,6 @@ public class JobRepository {
     public static final String JOB_RECORDS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "records";
 
     /**
-     * Name of internal IMap which stores {@link JobRecord}s.
-     */
-    public static final String JOB_METRICS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "metrics";
-
-
-    /**
      * Name of internal IMap which stores {@link JobExecutionRecord}s.
      */
     public static final String JOB_EXECUTION_RECORDS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "executionRecords";
@@ -118,6 +112,11 @@ public class JobRepository {
      * Name of internal IMap which stores job results
      */
     public static final String JOB_RESULTS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "results";
+
+    /**
+     * Name of internal IMap which stores {@link JobMetrics}s.
+     */
+    public static final String JOB_METRICS_MAP_NAME = INTERNAL_JET_OBJECTS_PREFIX + "results.metrics";
 
     /**
      * Prefix for internal IMaps which store snapshot data. Snapshot data for

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -269,7 +269,7 @@ public class JobRepository {
     /**
      * Generates a new execution id for the given job id, guaranteed to be unique across the cluster
      */
-    long newExecutionId(long jobId) {
+    long newExecutionId() {
         return idGenerator.newId();
     }
 
@@ -291,9 +291,9 @@ public class JobRepository {
         JobResult jobResult = new JobResult(jobId, config, coordinator, creationTime, completionTime,
                 error != null ? error.toString() : null);
 
-        JobMetrics prevMetrics = jobMetrics.putIfAbsent(jobId, terminalMetrics);
+        JobMetrics prevMetrics = jobMetrics.put(jobId, terminalMetrics);
         if (prevMetrics != null) {
-            logger.warning("Overwrote job metrics for job " + jobResult);
+            logger.warning("Overwriting job metrics for job " + jobResult);
         }
         JobResult prev = jobResults.putIfAbsent(jobId, jobResult);
         if (prev != null) {
@@ -366,8 +366,8 @@ public class JobRepository {
                       .map(JobResult::getJobId)
                       .collect(Collectors.toSet())
                       .forEach(id -> {
-                          jobResults.delete(id);
                           jobMetrics.delete(id);
+                          jobResults.delete(id);
                       });
         }
         long elapsed = System.nanoTime() - start;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobResult.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobResult.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.impl;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
-import com.hazelcast.jet.core.metrics.JobMetrics;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -42,7 +41,6 @@ public class JobResult implements IdentifiedDataSerializable {
 
     private String coordinatorUUID;
     private long jobId;
-    private JobMetrics jobMetrics;
     private JobConfig jobConfig;
     private long creationTime;
     private long completionTime;
@@ -52,14 +50,12 @@ public class JobResult implements IdentifiedDataSerializable {
     }
 
     JobResult(long jobId,
-              @Nonnull JobMetrics jobMetrics,
               @Nonnull JobConfig jobConfig,
               @Nonnull String coordinatorUUID,
               long creationTime, long completionTime,
               @Nullable String failureText
     ) {
         this.jobId = jobId;
-        this.jobMetrics = jobMetrics;
         this.jobConfig = jobConfig;
         this.coordinatorUUID = coordinatorUUID;
         this.creationTime = creationTime;
@@ -125,11 +121,6 @@ public class JobResult implements IdentifiedDataSerializable {
     }
 
     @Nonnull
-    public JobMetrics getJobMetrics() {
-        return jobMetrics;
-    }
-
-    @Nonnull
     CompletableFuture<Void> asCompletableFuture() {
         return failureText == null ? completedFuture(null) : exceptionallyCompletedFuture(getFailureAsThrowable());
     }
@@ -144,7 +135,6 @@ public class JobResult implements IdentifiedDataSerializable {
         return "JobResult{" +
                 "coordinatorUUID='" + coordinatorUUID + '\'' +
                 ", jobId=" + idToString(jobId) +
-                ", jobMetrics=" + jobMetrics +
                 ", name=" + jobConfig.getName() +
                 ", creationTime=" + toLocalDateTime(creationTime) +
                 ", completionTime=" + toLocalDateTime(completionTime) +
@@ -165,7 +155,6 @@ public class JobResult implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeLong(jobId);
-        out.writeObject(jobMetrics);
         out.writeObject(jobConfig);
         out.writeUTF(coordinatorUUID);
         out.writeLong(creationTime);
@@ -176,7 +165,6 @@ public class JobResult implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         jobId = in.readLong();
-        jobMetrics = in.readObject();
         jobConfig = in.readObject();
         coordinatorUUID = in.readUTF();
         creationTime = in.readLong();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.function.SupplierEx;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -41,6 +42,7 @@ import static com.hazelcast.jet.core.processor.Processors.noopP;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Ignore("https://github.com/hazelcast/hazelcast-jet/issues/1470")
 public class ExecutionLifecycle_RestartableExceptionTest extends TestInClusterSupport {
 
     private static final RestartableException RESTARTABLE_EXCEPTION =

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobRepositoryTest.java
@@ -82,8 +82,8 @@ public class JobRepositoryTest extends JetTestSupport {
         Data dag = createDAGData();
         JobRecord jobRecord = createJobRecord(jobId, dag);
         jobRepository.putNewJobRecord(jobRecord);
-        jobRepository.newExecutionId(jobId);
-        jobRepository.newExecutionId(jobId);
+        jobRepository.newExecutionId();
+        jobRepository.newExecutionId();
 
         sleepUntilJobExpires();
 
@@ -99,8 +99,8 @@ public class JobRepositoryTest extends JetTestSupport {
         Data dag = createDAGData();
         JobRecord jobRecord = createJobRecord(jobId, dag);
         jobRepository.putNewJobRecord(jobRecord);
-        jobRepository.newExecutionId(jobId);
-        jobRepository.newExecutionId(jobId);
+        jobRepository.newExecutionId();
+        jobRepository.newExecutionId();
 
         sleepUntilJobExpires();
 


### PR DESCRIPTION
During job cleanup all the job results were queried, causing deserialization of all completed job metrics which causes excessive GC. Fixes #1540 