### PR TITLE
Disable persistence of completed job metrics by default

### DIFF
--- a/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/StartServer.java
+++ b/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/StartServer.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.jet.server;
 
-import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.config.JetConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,12 +45,7 @@ public final class StartServer {
      */
     public static void main(String[] args) throws Exception {
         configureLogging();
-        Config config = new Config();
-        config.getGroupConfig().setName("jet");
-        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
-        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true)
-              .addMember("localhost");
-        JetInstance jet = Jet.newJetInstance(new JetConfig().setHazelcastConfig(config));
+        JetInstance jet = Jet.newJetInstance();
         printMemberPort(jet.getHazelcastInstance());
     }
 

--- a/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/StartServer.java
+++ b/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/StartServer.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.jet.server;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.JetConfig;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,7 +47,12 @@ public final class StartServer {
      */
     public static void main(String[] args) throws Exception {
         configureLogging();
-        JetInstance jet = Jet.newJetInstance();
+        Config config = new Config();
+        config.getGroupConfig().setName("jet");
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true)
+              .addMember("localhost");
+        JetInstance jet = Jet.newJetInstance(new JetConfig().setHazelcastConfig(config));
         printMemberPort(jet.getHazelcastInstance());
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
@@ -99,9 +99,16 @@ public interface Job {
      * the metrics are reset too, their values will reflect only updates
      * from the latest execution of the job.
      * <p>
-     * The method returns empty metrics if metrics collection is {@link
-     * MetricsConfig#setEnabled disabled} or until the first collection takes
-     * place. Also keep in mind that the collections may occur at different times on
+     * The method returns empty metrics if either
+     * {@link MetricsConfig#setEnabled global metrics collection} or
+     * {@link JobConfig#isMetricsEnabled() per job metrics collection}
+     * are disabled or until the first metric collection takes place.
+     * <p>
+     * For completed jobs, metrics are only persisted if
+     * {@link JobConfig#setStoreMetricsAfterJobCompletion(boolean)}
+     * was enabled, otherwise empty metrics are returned.
+     * <p>
+     * Also keep in mind that the collections may occur at different times on
      * each member, metrics from various members aren't from the same instant
      * of time.
      *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -52,6 +52,8 @@ public class JobConfig implements IdentifiedDataSerializable {
     private boolean autoScaling = true;
     private boolean splitBrainProtectionEnabled;
     private boolean enableMetrics = true;
+    private boolean storeMetricsAfterJobCompletion;
+
     private List<ResourceConfig> resourceConfigs = new ArrayList<>();
     private JobClassLoaderFactory classLoaderFactory;
     private String initialSnapshotName;
@@ -426,7 +428,11 @@ public class JobConfig implements IdentifiedDataSerializable {
 
     /**
      * Sets whether metrics collection should be enabled for the job.
+     * <p>
+     * Metrics for running jobs can be queried using {@link Job#getMetrics()}
      * It's enabled by default.
+     *
+     * @since 3.2
      */
     @Nonnull
     public JobConfig setMetricsEnabled(boolean enabled) {
@@ -435,10 +441,35 @@ public class JobConfig implements IdentifiedDataSerializable {
     }
 
     /**
-     * Returns if metrics collection is enabled for the job
+     * Returns if metrics collection is enabled for the job.
+     *
+     * @since 3.2
      */
     public boolean isMetricsEnabled() {
         return enableMetrics;
+    }
+
+    /**
+     * Returns whether metrics should be stored in the cluster after the job
+     * completes. If enabled, metrics can be retrieved by calling {@link Job#getMetrics()}.
+     *
+     * @since 3.2
+     */
+    public boolean isStoreMetricsAfterJobCompletion() {
+        return storeMetricsAfterJobCompletion;
+    }
+
+    /**
+     * Sets whether metrics should be stored in the cluster after the job
+     * completes. If enabled, metrics can be retrieved by calling {@link Job#getMetrics()}.
+     * <p>
+     * It's disabled by default.
+     *
+     * @since 3.2
+     */
+    public JobConfig setStoreMetricsAfterJobCompletion(boolean storeMetricsAfterJobCompletion) {
+        this.storeMetricsAfterJobCompletion = storeMetricsAfterJobCompletion;
+        return this;
     }
 
     @Override
@@ -462,6 +493,7 @@ public class JobConfig implements IdentifiedDataSerializable {
         out.writeObject(classLoaderFactory);
         out.writeUTF(initialSnapshotName);
         out.writeBoolean(enableMetrics);
+        out.writeBoolean(storeMetricsAfterJobCompletion);
     }
 
     @Override
@@ -475,6 +507,7 @@ public class JobConfig implements IdentifiedDataSerializable {
         classLoaderFactory = in.readObject();
         initialSnapshotName = in.readUTF();
         enableMetrics = in.readBoolean();
+        storeMetricsAfterJobCompletion = in.readBoolean();
     }
 
     @Override
@@ -503,4 +536,5 @@ public class JobConfig implements IdentifiedDataSerializable {
             splitBrainProtectionEnabled, enableMetrics, resourceConfigs, classLoaderFactory, initialSnapshotName
         );
     }
+
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -510,6 +510,7 @@ public class JobConfig implements IdentifiedDataSerializable {
         storeMetricsAfterJobCompletion = in.readBoolean();
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -523,6 +524,7 @@ public class JobConfig implements IdentifiedDataSerializable {
             autoScaling == jobConfig.autoScaling &&
             splitBrainProtectionEnabled == jobConfig.splitBrainProtectionEnabled &&
             enableMetrics == jobConfig.enableMetrics &&
+            storeMetricsAfterJobCompletion == jobConfig.storeMetricsAfterJobCompletion &&
             Objects.equals(name, jobConfig.name) &&
             processingGuarantee == jobConfig.processingGuarantee &&
             Objects.equals(resourceConfigs, jobConfig.resourceConfigs) &&
@@ -533,8 +535,8 @@ public class JobConfig implements IdentifiedDataSerializable {
     @Override
     public int hashCode() {
         return Objects.hash(name, processingGuarantee, snapshotIntervalMillis, autoScaling,
-            splitBrainProtectionEnabled, enableMetrics, resourceConfigs, classLoaderFactory, initialSnapshotName
+                splitBrainProtectionEnabled, enableMetrics, storeMetricsAfterJobCompletion, resourceConfigs,
+                classLoaderFactory, initialSnapshotName
         );
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
@@ -29,6 +29,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Defines the names and default values for internal Hazelcast Jet properties.
+ *
+ * @since 3.2
  */
 public final class JetProperties {
 
@@ -36,6 +38,8 @@ public final class JetProperties {
      * Jet will periodically check for new jobs to start and perform cleanup of
      * unused resources. This property configures how often this check and
      * cleanup will be done.
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JOB_SCAN_PERIOD
             = new HazelcastProperty("jet.job.scan.period", SECONDS.toMillis(5), MILLISECONDS);
@@ -45,6 +49,8 @@ public final class JetProperties {
      * when the process is terminated. The shutdown hook will terminate all running
      * jobs and then gracefully terminate the note, in a way that is
      * equivalent to calling {@link JetInstance#shutdown()}.
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JET_SHUTDOWNHOOK_ENABLED
             = new HazelcastProperty("jet.shutdownhook.enabled", SHUTDOWNHOOK_ENABLED.getDefaultValue());
@@ -55,6 +61,8 @@ public final class JetProperties {
      * is reached.
      * <p>
      * Default value is 7 days.
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JOB_RESULTS_TTL_SECONDS
             = new HazelcastProperty("jet.job.results.ttl.seconds", DAYS.toSeconds(7), SECONDS);
@@ -64,6 +72,8 @@ public final class JetProperties {
      * results will be automatically deleted after this size is reached.
      * <p>
      * Default value is 1,000 jobs.
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JOB_RESULTS_MAX_SIZE
             = new HazelcastProperty("jet.job.results.max.size", 1_000);
@@ -72,6 +82,8 @@ public final class JetProperties {
      * Root of Jet installation. Used as default location for the lossless recovery
      * store. By default it will be automatically set to the start of the Jet
      * installation path.
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JET_HOME
             = new HazelcastProperty("jet.home", "");
@@ -90,6 +102,8 @@ public final class JetProperties {
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_COOPERATIVE_MAX_MICROSECONDS}
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JET_IDLE_COOPERATIVE_MIN_MICROSECONDS
             = new HazelcastProperty("jet.idle.cooperative.min.microseconds", 25, MICROSECONDS);
@@ -108,6 +122,8 @@ public final class JetProperties {
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_COOPERATIVE_MIN_MICROSECONDS}
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JET_IDLE_COOPERATIVE_MAX_MICROSECONDS
         = new HazelcastProperty("jet.idle.cooperative.max.microseconds", 500, MICROSECONDS);
@@ -126,6 +142,8 @@ public final class JetProperties {
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_NONCOOPERATIVE_MAX_MICROSECONDS}
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JET_IDLE_NONCOOPERATIVE_MIN_MICROSECONDS
         = new HazelcastProperty("jet.idle.noncooperative.min.microseconds", 25, MICROSECONDS);
@@ -144,6 +162,8 @@ public final class JetProperties {
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_NONCOOPERATIVE_MIN_MICROSECONDS}
+     *
+     * @since 3.2
      */
     public static final HazelcastProperty JET_IDLE_NONCOOPERATIVE_MAX_MICROSECONDS
         = new HazelcastProperty("jet.idle.noncooperative.max.microseconds", 5000, MICROSECONDS);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -414,7 +414,7 @@ public class JobCoordinationService {
                     cf.complete(JobMetrics.empty());
                     return;
                 }
-                
+
                 // no job result found,
                 // the job might not be yet discovered by job record scanning
                 JobExecutionRecord record = jobRepository.getJobExecutionRecord(jobId);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -43,6 +43,7 @@ import com.hazelcast.spi.NodeEngine;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -279,7 +280,11 @@ public class JobRepository {
      * @throws IllegalStateException if the JobResult is already present
      */
     void completeJob(
-        long jobId, JobMetrics terminalMetrics, String coordinator, long completionTime, Throwable error
+        long jobId,
+        @Nullable JobMetrics terminalMetrics,
+        @Nonnull String coordinator,
+        long completionTime,
+        @Nullable Throwable error
     ) {
         JobRecord jobRecord = getJobRecord(jobId);
         if (jobRecord == null) {
@@ -291,9 +296,11 @@ public class JobRepository {
         JobResult jobResult = new JobResult(jobId, config, coordinator, creationTime, completionTime,
                 error != null ? error.toString() : null);
 
-        JobMetrics prevMetrics = jobMetrics.put(jobId, terminalMetrics);
-        if (prevMetrics != null) {
-            logger.warning("Overwriting job metrics for job " + jobResult);
+        if (terminalMetrics != null) {
+            JobMetrics prevMetrics = jobMetrics.put(jobId, terminalMetrics);
+            if (prevMetrics != null) {
+                logger.warning("Overwriting job metrics for job " + jobResult);
+            }
         }
         JobResult prev = jobResults.putIfAbsent(jobId, jobResult);
         if (prev != null) {
@@ -410,10 +417,12 @@ public class JobRepository {
         return Util.memoizeConcurrent(() -> instance.getMap(RESOURCES_MAP_NAME_PREFIX + idToString(jobId)));
     }
 
+    @Nullable
     public JobResult getJobResult(long jobId) {
         return jobResults.get(jobId);
     }
 
+    @Nullable
     public JobMetrics getJobMetrics(long jobId) {
         return jobMetrics.get(jobId);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -280,11 +280,11 @@ public class JobRepository {
      * @throws IllegalStateException if the JobResult is already present
      */
     void completeJob(
-        long jobId,
-        @Nullable JobMetrics terminalMetrics,
-        @Nonnull String coordinator,
-        long completionTime,
-        @Nullable Throwable error
+            long jobId,
+            @Nullable JobMetrics terminalMetrics,
+            @Nonnull String coordinator,
+            long completionTime,
+            @Nullable Throwable error
     ) {
         JobRecord jobRecord = getJobRecord(jobId);
         if (jobRecord == null) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/TestInClusterSupport.java
@@ -20,7 +20,9 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -104,6 +106,16 @@ public abstract class TestInClusterSupport extends JetTestSupport {
         for (DistributedObject o : allJetInstances()[0].getHazelcastInstance().getDistributedObjects()) {
             o.destroy();
         }
+    }
+
+    protected JetInstance jet() {
+        return testMode.getJet();
+    }
+
+    protected Job execute(Pipeline p, JobConfig config) {
+        Job job = jet().newJob(p, config);
+        job.join();
+        return job;
     }
 
     protected static JetInstance[] allJetInstances() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -170,6 +170,10 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
         HazelcastTestSupport.assertTrueFiveSeconds(assertTask(runnable));
     }
 
+    public static void assertClusterSizeEventually(int size, JetInstance jetInstance) {
+        HazelcastTestSupport.assertClusterSizeEventually(size, jetInstance.getHazelcastInstance());
+    }
+
     public static JetService getJetService(JetInstance jetInstance) {
         return getNodeEngineImpl(jetInstance).getService(JetService.SERVICE_NAME);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.core.metrics;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.TestInClusterSupport;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
@@ -37,6 +38,9 @@ import static org.junit.Assert.assertNotEquals;
 
 public class JobMetrics_BatchTest extends TestInClusterSupport {
 
+    static final JobConfig JOB_CONFIG_WITH_METRICS =
+        new JobConfig().setStoreMetricsAfterJobCompletion(true);
+
     private static final String SOURCE_VERTEX = "items";
     private static final String FLAT_MAP_AND_FILTER_VERTEX = "fused(flat-map, filter)";
     private static final String GROUP_AND_AGGREGATE_PREPARE_VERTEX = "group-and-aggregate-prepare";
@@ -51,29 +55,39 @@ public class JobMetrics_BatchTest extends TestInClusterSupport {
     public void when_jobCompleted_then_metricsExist() {
         Pipeline p = createPipeline();
 
-        Job job = testMode.getJet().newJob(p);
         // When
-        job.join();
+        Job job = execute(p, JOB_CONFIG_WITH_METRICS);
 
         // Then
-        assertTrueEventually(() -> assertMetrics(job.getMetrics()));
+        assertMetrics(job.getMetrics());
+    }
+
+    @Test
+    public void when_jobCompleted_without_savingMetricsOnCompletionEnabled_then_emptyMetrics() {
+        Pipeline p = createPipeline();
+
+        // When
+        Job job = execute(p, new JobConfig());
+
+        // Then
+        assertEquals("non-empty metrics", JobMetrics.empty(), job.getMetrics());
     }
 
     @Test
     public void when_memberAddedAfterJobFinished_then_metricsNotAffected() {
         Pipeline p = createPipeline();
 
-        Job job = testMode.getJet().newJob(p);
-        job.join();
+        Job job = execute(p, JOB_CONFIG_WITH_METRICS);
 
         // When
-        JetInstance newMember = factory.newMember(prepareConfig());
+        JetInstance instance = factory.newMember(prepareConfig());
         try {
-            assertTrueEventually(() -> assertEquals(MEMBER_COUNT + 1, newMember.getCluster().getMembers().size()));
+            assertClusterSizeEventually(MEMBER_COUNT + 1, jet());
             // Then
-            assertTrueEventually(() -> assertMetrics(job.getMetrics()));
+            assertMetrics(job.getMetrics());
         } finally {
-            newMember.shutdown();
+            instance.shutdown();
+            assertClusterSizeEventually(MEMBER_COUNT, jet());
         }
     }
 
@@ -84,14 +98,13 @@ public class JobMetrics_BatchTest extends TestInClusterSupport {
         JetInstance newMember = factory.newMember(prepareConfig());
         Job job;
         try {
-            assertTrueEventually(() -> assertEquals(MEMBER_COUNT + 1, newMember.getCluster().getMembers().size()));
-            job = testMode.getJet().newJob(p);
-            job.join();
+            assertClusterSizeEventually(MEMBER_COUNT + 1, jet());
+            job = execute(p, JOB_CONFIG_WITH_METRICS);
         } finally {
             newMember.shutdown();
         }
-        assertTrueEventually(() -> assertEquals(MEMBER_COUNT, testMode.getJet().getCluster().getMembers().size()));
-        assertTrueEventually(() -> assertMetrics(job.getMetrics()));
+        assertClusterSizeEventually(MEMBER_COUNT, jet());
+        assertMetrics(job.getMetrics());
     }
 
     @Test
@@ -100,28 +113,28 @@ public class JobMetrics_BatchTest extends TestInClusterSupport {
         Pipeline p = createPipeline();
         Pipeline p2 = createPipeline(anotherText);
 
-        Job job = testMode.getJet().newJob(p);
-        Job job2 = testMode.getJet().newJob(p2);
+        Job job = jet().newJob(p, JOB_CONFIG_WITH_METRICS);
+        Job job2 = jet().newJob(p2, JOB_CONFIG_WITH_METRICS);
         job.join();
         job2.join();
 
         assertNotEquals(job.getMetrics(), job2.getMetrics());
-        assertTrueEventually(() -> assertMetrics(job.getMetrics()));
-        assertTrueEventually(() -> assertMetrics(job2.getMetrics(), anotherText));
+        assertMetrics(job.getMetrics());
+        assertMetrics(job2.getMetrics(), anotherText);
     }
 
     @Test
     public void when_twoDifferentJobsForTheSamePipeline_then_haveDifferentMetrics() {
         Pipeline p = createPipeline();
 
-        Job job = testMode.getJet().newJob(p);
-        Job job2 = testMode.getJet().newJob(p);
+        Job job = jet().newJob(p, JOB_CONFIG_WITH_METRICS);
+        Job job2 = jet().newJob(p, JOB_CONFIG_WITH_METRICS);
         job.join();
         job2.join();
 
         assertNotEquals(job.getMetrics(), job2.getMetrics());
-        assertTrueEventually(() -> assertMetrics(job.getMetrics()));
-        assertTrueEventually(() -> assertMetrics(job2.getMetrics()));
+        assertMetrics(job.getMetrics());
+        assertMetrics(job2.getMetrics());
     }
 
     private Pipeline createPipeline() {
@@ -131,11 +144,11 @@ public class JobMetrics_BatchTest extends TestInClusterSupport {
     private Pipeline createPipeline(String text) {
         Pipeline p = Pipeline.create();
         p.drawFrom(TestSources.items(text))
-                .flatMap(line -> traverseArray(line.toLowerCase().split("\\W+")))
-                .filter(word -> !word.isEmpty())
-                .groupingKey(wholeItem())
-                .aggregate(counting())
-                .drainTo(Sinks.map("counts"));
+         .flatMap(line -> traverseArray(line.toLowerCase().split("\\W+")))
+         .filter(word -> !word.isEmpty())
+         .groupingKey(wholeItem())
+         .aggregate(counting())
+         .drainTo(Sinks.map("counts"));
         return p;
     }
 
@@ -166,5 +179,4 @@ public class JobMetrics_BatchTest extends TestInClusterSupport {
                 .get(metric);
         return measurements.stream().mapToLong(Measurement::getValue).sum();
     }
-
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_BatchTest.java
@@ -38,8 +38,7 @@ import static org.junit.Assert.assertNotEquals;
 
 public class JobMetrics_BatchTest extends TestInClusterSupport {
 
-    static final JobConfig JOB_CONFIG_WITH_METRICS =
-        new JobConfig().setStoreMetricsAfterJobCompletion(true);
+    static final JobConfig JOB_CONFIG_WITH_METRICS = new JobConfig().setStoreMetricsAfterJobCompletion(true);
 
     private static final String SOURCE_VERTEX = "items";
     private static final String FLAT_MAP_AND_FILTER_VERTEX = "fused(flat-map, filter)";
@@ -63,7 +62,7 @@ public class JobMetrics_BatchTest extends TestInClusterSupport {
     }
 
     @Test
-    public void when_jobCompleted_without_savingMetricsOnCompletionEnabled_then_emptyMetrics() {
+    public void when_storeMetricsAfterJobCompletionDisabled_then_metricsEmpty() {
         Pipeline p = createPipeline();
 
         // When

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.TestInClusterSupport;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
-import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
@@ -47,6 +46,7 @@ import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
 import static com.hazelcast.jet.core.TestUtil.assertExceptionInCauses;
+import static com.hazelcast.jet.core.metrics.JobMetrics_BatchTest.JOB_CONFIG_WITH_METRICS;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
@@ -68,7 +68,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         DAG dag = new DAG();
         dag.newVertex("v1", MockP::new);
         dag.newVertex("v2", (SupplierEx<Processor>) NoOutputSourceP::new);
-        Job job = testMode.getJet().newJob(dag);
+        Job job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
 
         //when
         NoOutputSourceP.executionStarted.await();
@@ -90,7 +90,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         // sent. That is before any member ever knew of the job.
         dag.newVertex("v1", new MockPS(MockP::new, 1).setInitError(exc));
 
-        Job job = testMode.getJet().newJob(dag);
+        Job job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
         try {
             job.join();
             fail("job didn't fail");
@@ -107,7 +107,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         BlockingInInitMetaSupplier.latch = new CountDownLatch(1);
         dag.newVertex("v1", new BlockingInInitMetaSupplier());
 
-        Job job = testMode.getJet().newJob(dag);
+        Job job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
         assertTrueAllTheTime(() -> assertEmptyJobMetrics(job), 2);
         BlockingInInitMetaSupplier.latch.countDown();
         assertTrueEventually(() -> assertJobHasMetrics(job));
@@ -124,7 +124,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         Vertex v1 = dag.newVertex("v1", Processors.noopP());
         Vertex v2 = dag.newVertex("v2", Processors.noopP());
         dag.edge(between(v1, v2).distributed());
-        Job job = testMode.getJet().newJob(dag);
+        Job job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
         job.join();
         assertJobHasMetrics(job);
         // If there would be multiple metrics with the same name, then an
@@ -138,7 +138,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         Vertex v2 = dag.newVertex("v2", (SupplierEx<Processor>) TestProcessors.NoOutputSourceP::new);
         dag.edge(between(v1, v2));
 
-        Job job = testMode.getJet().newJob(dag);
+        Job job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
         TestProcessors.NoOutputSourceP.executionStarted.await();
         assertJobStatusEventually(job, JobStatus.RUNNING);
         assertTrueEventually(() -> assertJobHasMetrics(job));
@@ -164,12 +164,12 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         Vertex v2 = dag.newVertex("v2", (SupplierEx<Processor>) TestProcessors.NoOutputSourceP::new);
         dag.edge(between(v1, v2));
 
-        Job job = testMode.getJet().newJob(dag);
+        Job job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
         TestProcessors.NoOutputSourceP.executionStarted.await();
         assertJobStatusEventually(job, JobStatus.RUNNING);
 
         job.restart();
-        JetTestSupport.assertEqualsEventually(job::getStatus, JobStatus.RUNNING);
+        assertJobStatusEventually(job, JobStatus.RUNNING);
         assertTrueEventually(() -> assertJobHasMetrics(job));
 
         TestProcessors.NoOutputSourceP.proceedLatch.countDown();
@@ -200,9 +200,8 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
         dag.newVertex("v1", MockP::new);
         dag.newVertex("v2", (SupplierEx<Processor>) NoOutputSourceP::new);
 
-        JobConfig config = new JobConfig();
-        config.setMetricsEnabled(false);
-        Job job = testMode.getJet().newJob(dag, config);
+        JobConfig config = new JobConfig().setMetricsEnabled(false);
+        Job job = jet().newJob(dag, config);
 
         //when
         NoOutputSourceP.executionStarted.await();
@@ -221,7 +220,7 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
     private Job runJobExpectFailure(@Nonnull DAG dag, @Nonnull RuntimeException expectedException) {
         Job job = null;
         try {
-            job = testMode.getJet().newJob(dag);
+            job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
             job.join();
             fail("Job execution should have failed");
         } catch (Exception actual) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
+import static com.hazelcast.jet.core.metrics.JobMetrics_BatchTest.JOB_CONFIG_WITH_METRICS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -51,7 +52,7 @@ public class JobMetrics_NonSharedClusterTest extends JetTestSupport {
 
         DAG dag = new DAG();
         dag.newVertex("v1", (SupplierEx<Processor>) NoOutputSourceP::new).localParallelism(1);
-        Job job = inst.newJob(dag);
+        Job job = inst.newJob(dag, JOB_CONFIG_WITH_METRICS);
         assertTrue(job.getMetrics().metrics().isEmpty());
     }
 
@@ -65,7 +66,7 @@ public class JobMetrics_NonSharedClusterTest extends JetTestSupport {
         dag.newVertex("v1", (SupplierEx<Processor>) NoOutputSourceP::new).localParallelism(1);
 
         // Initial collection interval is 1 second. So let's run a job and wait until it has metrics.
-        Job job1 = inst.newJob(dag);
+        Job job1 = inst.newJob(dag, JOB_CONFIG_WITH_METRICS);
         try {
             JetTestSupport.assertTrueEventually(() -> assertFalse(job1.getMetrics().metrics().isEmpty()), 10);
         } catch (AssertionError e) {
@@ -76,7 +77,7 @@ public class JobMetrics_NonSharedClusterTest extends JetTestSupport {
 
         // Let's do a second job for which we know there will be no metrics collection. It should
         // return empty metrics because the next collection will be in 10_000 seconds.
-        Job job2 = inst.newJob(dag);
+        Job job2 = inst.newJob(dag, JOB_CONFIG_WITH_METRICS);
         assertJobStatusEventually(job2, RUNNING);
         assertTrue(job2.getMetrics().metrics().isEmpty());
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_StressTest.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
+import static com.hazelcast.jet.core.metrics.JobMetrics_BatchTest.JOB_CONFIG_WITH_METRICS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -76,7 +77,7 @@ public class JobMetrics_StressTest extends JetTestSupport {
 
     private void stressTest(Function<Job, Runnable> restart) throws Throwable {
         DAG dag = buildDag();
-        Job job = instance.newJob(dag);
+        Job job = instance.newJob(dag, JOB_CONFIG_WITH_METRICS);
         try {
             assertTrueEventually(() -> assertEquals(JobStatus.RUNNING, job.getStatus()));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineTestSupport.java
@@ -24,9 +24,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.jet.JetException;
-import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.TestInClusterSupport;
+import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.nio.Address;
 import org.junit.Before;
 
@@ -79,17 +79,17 @@ public abstract class PipelineTestSupport extends TestInClusterSupport {
         sinkList = jet().getList(sinkName);
     }
 
-    protected JetInstance jet() {
-        return testMode.getJet();
+    protected Job execute() {
+        return execute(new JobConfig());
     }
 
-    protected void execute() {
-        jet().newJob(p).join();
+    protected Job execute(JobConfig config) {
+        return execute(p, config);
     }
 
-    protected void executeAndPeel() throws Throwable {
+    protected Job executeAndPeel() throws Throwable {
         try {
-            execute();
+            return execute();
         } catch (CompletionException e) {
             Throwable t = peel(e);
             if (t instanceof JetException && t.getCause() != null) {


### PR DESCRIPTION
New option `JobConfig.setStoreMetricsAfterJobCompletion` 
can be used to control whether metrics are saved upon
job completion.