### PR TITLE
Fix cancellation race with RestartableException

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycle_RestartableExceptionTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.jet.function.SupplierEx;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,7 +41,6 @@ import static com.hazelcast.jet.core.processor.Processors.noopP;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Ignore("https://github.com/hazelcast/hazelcast-jet/issues/1470")
 public class ExecutionLifecycle_RestartableExceptionTest extends TestInClusterSupport {
 
     private static final RestartableException RESTARTABLE_EXCEPTION =


### PR DESCRIPTION
If a job that failed with RestartableException was cancelled, the
cancellation might be ignored and job restarted anyway.

Fixes #1470