### PR TITLE
Fix OperationLossTest

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -174,7 +174,7 @@ public class OperationLossTest extends JetTestSupport {
         dag.edge(between(source, sink).distributed());
         Job job = instance1.newJob(dag);
         assertJobStatusEventually(job, RUNNING);
-        assertEquals(2, NoOutputSourceP.initCount.get());
+        assertTrueEventually(() -> assertEquals(2, NoOutputSourceP.initCount.get()));
 
         Connection connection = Util.getMemberConnection(getNodeEngineImpl(instance1),
                 instance2.getHazelcastInstance().getCluster().getLocalMember().getAddress());


### PR DESCRIPTION
`Processor.init()` is called as a part of Execute phase. So the job
might be running and init might not yet be called -> change the assert
to assertEventually.

Fixes #1491