### PR TITLE
Drop unstable mapStateful_keyedWithTtl, add coverage

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformStatefulP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformStatefulP.java
@@ -46,9 +46,9 @@ import static com.hazelcast.jet.impl.util.Util.logLateEvent;
 import static java.lang.Math.min;
 
 public class TransformStatefulP<T, K, S, R, OUT> extends AbstractProcessor {
+    static final int MAX_ITEMS_TO_EVICT = 100;
     private static final int HASH_MAP_INITIAL_CAPACITY = 16;
     private static final float HASH_MAP_LOAD_FACTOR = 0.75f;
-    private static final int MAX_ITEMS_TO_EVICT = 100;
 
     @Probe
     private final AtomicLong lateEventsDropped = new AtomicLong();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/TransformStatefulPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/TransformStatefulPTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.processor;
 
+import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.core.test.TestSupport;
@@ -27,12 +28,16 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map.Entry;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.JetTestSupport.wm;
 import static com.hazelcast.jet.impl.JetEvent.jetEvent;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 @Category(ParallelTest.class)
 @RunWith(HazelcastParallelClassRunner.class)
@@ -67,6 +72,39 @@ public class TransformStatefulPTest {
     }
 
     @Test
+    public void mapStateful_toNull_inMapToOutputFn() {
+        SupplierEx<Processor> supplier = Processors.mapStatefulP(
+                0,
+                Entry::getKey,
+                e -> 0L,
+                () -> new long[1],
+                (long[] s, Entry<String, Long> e) -> {
+                    s[0] += e.getValue();
+                    return s[0];
+                },
+                (e, k, r) -> null);
+
+        TestSupport.verifyProcessor(supplier)
+                   .input(singletonList(entry("a", 1L)))
+                   .expectOutput(emptyList());
+    }
+
+    @Test
+    public void mapStateful_toNull_inMapFn() {
+        SupplierEx<Processor> supplier = Processors.mapStatefulP(
+                0,
+                Entry::getKey,
+                e -> 0L,
+                () -> new long[1],
+                (long[] s, Entry<String, Long> e) -> null,
+                (e, k, r) -> entry(k, r));
+
+        TestSupport.verifyProcessor(supplier)
+                   .input(singletonList(entry("a", 1L)))
+                   .expectOutput(emptyList());
+    }
+
+    @Test
     public void mapStateful_withTTL() {
         SupplierEx<Processor> supplier = Processors.mapStatefulP(
                 2,
@@ -97,6 +135,47 @@ public class TransformStatefulPTest {
                            wm(4),
                            jetEvent(4, entry("b", 4L))
                    ));
+    }
+
+    @Test
+    public void mapStateful_withTTL_manyKeys() {
+        /*
+        This test is designed to test TTL handling if not all items are evicted in tryProcessWatermark
+        due to the MAX_ITEMS_TO_EVICT.
+         */
+        SupplierEx<Processor> supplier = Processors.mapStatefulP(
+                2,
+                jetEvent -> jetEvent.payload().getKey(),
+                JetEvent::timestamp,
+                () -> new long[1],
+                (long[] s, JetEvent<Entry<String, Long>> e) -> {
+                    s[0] += e.payload().getValue();
+                    return s[0];
+                },
+                (event, k, r) -> jetEvent(event.timestamp(), entry(k, r))
+        );
+
+        // use more keys than MAX_ITEMS_TO_EVICT
+        int numKeys = TransformStatefulP.MAX_ITEMS_TO_EVICT + 1;
+
+        // Build the input. First add entries with keys 0..max, then with keys max..0.
+        // The reason is that the eviction goes in the order items were processed so
+        // after the eviction the keys at the end will remain. And we should evict those
+        // instead of continuing to use them.
+        List<Object> input = new ArrayList<>();
+        for (int i = 0; i < numKeys; i++) {
+            input.add(jetEvent(0, entry("k" + i, 1L)));
+        }
+        input.add(wm(3));
+        for (int i = numKeys; i > 0; ) {
+            i--;
+            input.add(jetEvent(3, entry("k" + i, 3L)));
+        }
+
+        TestSupport.verifyProcessor(supplier)
+                   .input(input)
+                   .disableLogging()
+                   .expectOutput(input);
     }
 
     @Test
@@ -159,6 +238,38 @@ public class TransformStatefulPTest {
                            jetEvent(-7, entry("b", 5L)),
                            wm(-4),
                            jetEvent(-4, entry("b", 4L))
+                   ));
+    }
+
+    @Test
+    public void flatMapStateful() {
+        SupplierEx<Processor> supplier = Processors.flatMapStatefulP(
+                0,
+                Entry::getKey,
+                e -> 0L,
+                () -> new long[1],
+                (long[] s, Entry<String, Long> e) -> {
+                    s[0] += e.getValue();
+                    return Traversers.traverseItems(s[0], -s[0]);
+                },
+                (e, k, r) -> entry(k, r));
+
+        TestSupport.verifyProcessor(supplier)
+                   .input(asList(
+                           entry("a", 1L),
+                           entry("b", 2L),
+                           entry("a", 3L),
+                           entry("b", 4L)
+                   ))
+                   .expectOutput(asList(
+                           entry("a", 1L),
+                           entry("a", -1L),
+                           entry("b", 2L),
+                           entry("b", -2L),
+                           entry("a", 4L),
+                           entry("a", -4L),
+                           entry("b", 6L),
+                           entry("b", -6L)
                    ));
     }
 }


### PR DESCRIPTION
The test was unstable because when processor has total parallelism > 1,
the watermarks are non-deterministic. They can be postponed if waiting
for another processor. The unit test covered the TTL handling enough.

I also added a test for the interrupted cleanup logic in
`tryProcessWatermarks` and more, the unit test coverage is 100% now.

Fixes #1560