### PR TITLE
Default to a lower parallelism(2) in case of non-cooperative context factory

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -64,7 +64,8 @@ public final class PartitionedProcessorTransform<T, K> extends ProcessorTransfor
             @Nonnull FunctionEx<? super T, ? extends K> partitionKeyFn
     ) {
         return new PartitionedProcessorTransform<>("mapUsingPartitionedContext",
-                upstream, ProcessorMetaSupplier.of(mapUsingContextP(contextFactory, mapFn)), partitionKeyFn, contextFactory.isCooperative());
+                upstream, ProcessorMetaSupplier.of(mapUsingContextP(contextFactory, mapFn)), partitionKeyFn,
+                contextFactory.isCooperative());
     }
 
     public static <C, T, K> PartitionedProcessorTransform<T, K> filterUsingPartitionedContextTransform(
@@ -74,7 +75,8 @@ public final class PartitionedProcessorTransform<T, K> extends ProcessorTransfor
             @Nonnull FunctionEx<? super T, ? extends K> partitionKeyFn
     ) {
         return new PartitionedProcessorTransform<>("filterUsingPartitionedContext",
-                upstream, ProcessorMetaSupplier.of(filterUsingContextP(contextFactory, filterFn)), partitionKeyFn, contextFactory.isCooperative());
+                upstream, ProcessorMetaSupplier.of(filterUsingContextP(contextFactory, filterFn)), partitionKeyFn,
+                contextFactory.isCooperative());
     }
 
     public static <C, T, K, R> PartitionedProcessorTransform<T, K> flatMapUsingPartitionedContextTransform(
@@ -84,7 +86,8 @@ public final class PartitionedProcessorTransform<T, K> extends ProcessorTransfor
             @Nonnull FunctionEx<? super T, ? extends K> partitionKeyFn
     ) {
         return new PartitionedProcessorTransform<>("flatMapUsingPartitionedContext",
-                upstream, ProcessorMetaSupplier.of(flatMapUsingContextP(contextFactory, flatMapFn)), partitionKeyFn, contextFactory.isCooperative());
+                upstream, ProcessorMetaSupplier.of(flatMapUsingContextP(contextFactory, flatMapFn)), partitionKeyFn,
+                contextFactory.isCooperative());
     }
 
     public static <C, T, K, R> PartitionedProcessorTransform<T, K> flatMapUsingPartitionedContextAsyncTransform(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -104,7 +104,6 @@ public final class PartitionedProcessorTransform<T, K> extends ProcessorTransfor
     @Override
     public void addToDag(Planner p) {
         PlannerVertex pv = p.addVertex(this, name(), localParallelism(), processorSupplier);
-        pv.v.localParallelism(pv.v.determineLocalParallelism(localParallelism()));
         p.addEdges(this, pv.v, e -> e.partitioned(partitionKeyFn).distributed());
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
@@ -94,7 +94,8 @@ public class ProcessorTransform extends AbstractTransform {
         //      be sent to a random member. We keep it this way for simplicity:
         //      the number of in-flight items is limited (maxAsyncOps)
         return new ProcessorTransform(operationName + "UsingContextAsync", upstream,
-                ProcessorMetaSupplier.of(flatMapUsingContextAsyncP(contextFactory, Object::hashCode, flatMapAsyncFn)), contextFactory.isCooperative());
+                ProcessorMetaSupplier.of(flatMapUsingContextAsyncP(contextFactory, Object::hashCode, flatMapAsyncFn)),
+                contextFactory.isCooperative());
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/ProcessorTransform.java
@@ -35,6 +35,7 @@ import static com.hazelcast.jet.core.processor.Processors.mapUsingContextP;
 
 public class ProcessorTransform extends AbstractTransform {
     public static final int NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM = 2;
+
     final ProcessorMetaSupplier processorSupplier;
 
     ProcessorTransform(
@@ -91,18 +92,17 @@ public class ProcessorTransform extends AbstractTransform {
         //      be sent to a random member. We keep it this way for simplicity:
         //      the number of in-flight items is limited (maxAsyncOps)
         return new ProcessorTransform(operationName + "UsingContextAsync", upstream,
-                ProcessorMetaSupplier.of(getPreferredLP(contextFactory), flatMapUsingContextAsyncP(contextFactory,
-                        Object::hashCode, flatMapAsyncFn)));
+                ProcessorMetaSupplier.of(getPreferredLP(contextFactory),
+                        flatMapUsingContextAsyncP(contextFactory, Object::hashCode, flatMapAsyncFn)));
     }
 
-    protected static <C> int getPreferredLP(@Nonnull ContextFactory<C> contextFactory) {
+    static <C> int getPreferredLP(@Nonnull ContextFactory<C> contextFactory) {
         return contextFactory.isCooperative() ? LOCAL_PARALLELISM_USE_DEFAULT : NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM;
     }
 
     @Override
     public void addToDag(Planner p) {
         PlannerVertex pv = p.addVertex(this, name(), localParallelism(), processorSupplier);
-        pv.v.localParallelism(pv.v.determineLocalParallelism(localParallelism()));
         p.addEdges(this, pv.v);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -1,0 +1,344 @@
+package com.hazelcast.jet.pipeline;
+
+import com.hazelcast.jet.Traversers;
+import com.hazelcast.jet.core.DAG;
+import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.function.FunctionEx;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
+import static com.hazelcast.jet.impl.pipeline.transform.ProcessorTransform.NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM;
+import static com.hazelcast.jet.pipeline.ContextFactory.withCreateFn;
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+public class ProcessorTransformParallelismTest {
+
+    @Parameter(value = 0)
+    public FunctionEx<StreamStage<Integer>, StreamStage<Integer>> cooperativeAndHasExplicitLocalParallelismTransform;
+
+    @Parameter(value = 1)
+    public FunctionEx<StreamStage<Integer>, StreamStage<Integer>> cooperativeAndHasNoExplicitLocalParallelismTransform;
+
+    @Parameter(value = 2)
+    public FunctionEx<StreamStage<Integer>, StreamStage<Integer>> nonCooperativeAndHasExplicitLocalParallelism;
+
+    @Parameter(value = 3)
+    public FunctionEx<StreamStage<Integer>, StreamStage<Integer>> monCooperativeAndHasNoExplicitLocalParallelism;
+
+    @Parameter(value = 4)
+    public String transformName;
+
+    private static final int localParallelism = 11;
+
+
+    @Parameters(name = "{index}: transform={4}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(
+                new Object[][] {
+                        {
+
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContext(withCreateFn(x -> null), (c, t) -> t)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContext(withCreateFn(x -> null), (c, t) -> t),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> t)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> t),
+                                "mapUsingContext"
+                        },
+                        {
+
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContext(withCreateFn(x -> null), (c, k, t) -> t)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContext(withCreateFn(x -> null), (c, k, t) -> t),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> t)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> t),
+                                "mapUsingPartitionedContext"
+                        }
+                        ,
+                        {
+
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> t))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> t)),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> t))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> t)),
+                                "mapUsingContextAsync"
+                        },
+                        {
+
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> t))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> t)),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> t))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> t)),
+                                "mapUsingPartitionedContextAsync"
+                        },
+                        {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContext(withCreateFn(x -> null), (c, t) -> false)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContext(withCreateFn(x -> null), (c, t) -> false),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> false)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> false),
+                                "filterUsingContext"
+                        }
+                        ,
+                        {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContext(withCreateFn(x -> null), (c, k, t) -> false)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContext(withCreateFn(x -> null), (c, k, t) -> false),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> false)
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> false),
+                                "filterUsingPartitionedContext"
+                        }
+                        ,
+                        {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> false))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> false)),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> false))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> false)),
+                                "filterUsingContextAsync"
+                        }
+                        ,                     {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> false))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> false)),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> false))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> false)),
+                                "filterUsingPartitionedContextAsync"
+                        }
+                        ,
+                        {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContext(withCreateFn(x -> null), (c, t) -> Traversers.<Integer>empty())
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContext(withCreateFn(x -> null), (c, t) -> Traversers.<Integer>empty()),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> Traversers.<Integer>empty())
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> Traversers.<Integer>empty()),
+                                "flatMapUsingContext"
+                        },
+                        {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContext(withCreateFn(x -> null), (c, k, t) -> Traversers.<Integer>empty())
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContext(withCreateFn(x -> null), (c, k, t) -> Traversers.<Integer>empty()),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> Traversers.<Integer>empty())
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> Traversers.<Integer>empty()),
+                                "flatMapUsingPartitionedContext"
+                        },
+                        {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(Traversers::<Integer>empty))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(Traversers::<Integer>empty)),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(Traversers::<Integer>empty))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(Traversers::<Integer>empty)),
+
+                                "flatMapUsingContextAsync"
+                        },
+                        {
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
+                                                .setLocalParallelism(localParallelism),
+                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                        stage -> stage
+                                                .groupingKey(i -> i)
+                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
+
+                                "flatMapUsingPartitionedContextAsync"
+                        }
+
+                }
+        );
+    }
+
+    @Test
+    public void when_CooperativeAndHasExplicitLocalParallelism_then_UsesProvidedLP() {
+        // When
+        DAG dag = applyTransformAndGetDAG(cooperativeAndHasExplicitLocalParallelismTransform);
+
+        // Then
+        Vertex tsVertex = dag.getVertex(transformName);
+        assertEquals(localParallelism, tsVertex.getLocalParallelism());
+    }
+
+
+    @Test
+    public void when_CooperativeAndHasNoExplicitLocalParallelism_then_UsesDefaultLP() {
+        // When
+        DAG dag = applyTransformAndGetDAG(cooperativeAndHasNoExplicitLocalParallelismTransform);
+
+        // Then
+        Vertex tsVertex = dag.getVertex(transformName);
+        assertEquals(LOCAL_PARALLELISM_USE_DEFAULT, tsVertex.getLocalParallelism());
+    }
+
+    @Test
+    public void when_NonCooperativeAndHasExplicitLocalParallelism_then_UsesProvidedLP() {
+        // When
+        DAG dag = applyTransformAndGetDAG(nonCooperativeAndHasExplicitLocalParallelism);
+
+        // Then
+        Vertex tsVertex = dag.getVertex(transformName);
+        assertEquals(localParallelism, tsVertex.getLocalParallelism());
+    }
+
+    @Test
+    public void when_NonCooperativeAndHasNoExplicitLocalParallelism_then_UsesDefaultLP() {
+        // When
+        DAG dag = applyTransformAndGetDAG(monCooperativeAndHasNoExplicitLocalParallelism);
+
+        // Then
+        Vertex tsVertex = dag.getVertex(transformName);
+        assertEquals(NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM, tsVertex.getLocalParallelism());
+    }
+
+    private DAG applyTransformAndGetDAG(FunctionEx<StreamStage<Integer>, StreamStage<Integer>> transform) {
+        Pipeline p = Pipeline.create();
+        StreamStage<Integer> source = p.drawFrom(TestSources.items(1))
+                                       .addTimestamps(t -> 0, 0);
+        StreamStage<Integer> applied = source.apply(transform);
+        applied.drainTo(Sinks.noop());
+        return p.toDag();
+    }
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -64,146 +64,134 @@ public class ProcessorTransformParallelismTest {
     @SuppressWarnings(value = {"checkstyle:LineLength", "checkstyle:MethodLength"})
     public static Collection<Object[]> data() {
         return Arrays.asList(
-                new Object[][] {
-                        {
+                new Object[][] {{
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContext(withCreateFn(x -> null), (c, t) -> t)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContext(withCreateFn(x -> null), (c, t) -> t),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> t)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> t),
+                        "mapUsingContext"
+                }, {
 
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContext(withCreateFn(x -> null), (c, t) -> t)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContext(withCreateFn(x -> null), (c, t) -> t),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> t)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> t),
-                                "mapUsingContext"
-                        },
-                        {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContext(withCreateFn(x -> null), (c, k, t) -> t)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContext(withCreateFn(x -> null), (c, k, t) -> t),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> t)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> t),
+                        "mapUsingPartitionedContext"
+                }, {
 
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContext(withCreateFn(x -> null), (c, k, t) -> t)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContext(withCreateFn(x -> null), (c, k, t) -> t),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> t)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> t),
-                                "mapUsingPartitionedContext"
-                        }
-                        ,
-                        {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> t))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> t)),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> t))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> t)),
+                        "mapUsingContextAsync"
+                }, {
 
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> t))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> t)),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> t))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> t)),
-                                "mapUsingContextAsync"
-                        },
-                        {
-
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> t))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> t)),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> t))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> t)),
-                                "mapUsingPartitionedContextAsync"
-                        },
-                        {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContext(withCreateFn(x -> null), (c, t) -> false)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContext(withCreateFn(x -> null), (c, t) -> false),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> false)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> false),
-                                "filterUsingContext"
-                        }
-                        ,
-                        {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContext(withCreateFn(x -> null), (c, k, t) -> false)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContext(withCreateFn(x -> null), (c, k, t) -> false),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> false)
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> false),
-                                "filterUsingPartitionedContext"
-                        }
-                        ,
-                        {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> false))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> false)),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> false))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> false)),
-                                "filterUsingContextAsync"
-                        }
-                        , {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> t))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> t)),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> t))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .mapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> t)),
+                        "mapUsingPartitionedContextAsync"
+                }, {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContext(withCreateFn(x -> null), (c, t) -> false)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContext(withCreateFn(x -> null), (c, t) -> false),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> false)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> false),
+                        "filterUsingContext"
+                }, {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContext(withCreateFn(x -> null), (c, k, t) -> false)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContext(withCreateFn(x -> null), (c, k, t) -> false),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> false)
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> false),
+                        "filterUsingPartitionedContext"
+                }, {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> false))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(() -> false)),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> false))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> false)),
+                        "filterUsingContextAsync"
+                }, {
                         (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
                                 stage -> stage
                                         .groupingKey(i -> i)
@@ -223,89 +211,82 @@ public class ProcessorTransformParallelismTest {
                                         .groupingKey(i -> i)
                                         .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> false)),
                         "filterUsingPartitionedContextAsync"
+                }, {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContext(withCreateFn(x -> null), (c, t) -> Traversers.<Integer>empty())
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContext(withCreateFn(x -> null), (c, t) -> Traversers.<Integer>empty()),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> Traversers.<Integer>empty())
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> Traversers.<Integer>empty()),
+                        "flatMapUsingContext"
+                }, {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContext(withCreateFn(x -> null), (c, k, t) -> Traversers.<Integer>empty())
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContext(withCreateFn(x -> null), (c, k, t) -> Traversers.<Integer>empty()),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> Traversers.<Integer>empty())
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> Traversers.<Integer>empty()),
+                        "flatMapUsingPartitionedContext"
+                }, {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(Traversers::<Integer>empty))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(Traversers::<Integer>empty)),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(Traversers::<Integer>empty))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(Traversers::<Integer>empty)),
+
+                        "flatMapUsingContextAsync"
+                }, {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
+
+                        "flatMapUsingPartitionedContextAsync"
                 }
-                        ,
-                        {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContext(withCreateFn(x -> null), (c, t) -> Traversers.<Integer>empty())
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContext(withCreateFn(x -> null), (c, t) -> Traversers.<Integer>empty()),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> Traversers.<Integer>empty())
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, t) -> Traversers.<Integer>empty()),
-                                "flatMapUsingContext"
-                        },
-                        {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContext(withCreateFn(x -> null), (c, k, t) -> Traversers.<Integer>empty())
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContext(withCreateFn(x -> null), (c, k, t) -> Traversers.<Integer>empty()),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> Traversers.<Integer>empty())
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContext(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> Traversers.<Integer>empty()),
-                                "flatMapUsingPartitionedContext"
-                        },
-                        {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(Traversers::<Integer>empty))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, t) -> supplyAsync(Traversers::<Integer>empty)),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(Traversers::<Integer>empty))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(Traversers::<Integer>empty)),
-
-                                "flatMapUsingContextAsync"
-                        },
-                        {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .flatMapUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
-
-                                "flatMapUsingPartitionedContextAsync"
-                        }
-
-                }
-        );
+                });
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.jet.Traversers;
@@ -26,6 +42,8 @@ import static org.junit.Assert.assertEquals;
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 public class ProcessorTransformParallelismTest {
 
+    private static final int localParallelism = 11;
+
     @Parameter(value = 0)
     public FunctionEx<StreamStage<Integer>, StreamStage<Integer>> cooperativeAndHasExplicitLocalParallelismTransform;
 
@@ -41,10 +59,9 @@ public class ProcessorTransformParallelismTest {
     @Parameter(value = 4)
     public String transformName;
 
-    private static final int localParallelism = 11;
-
 
     @Parameters(name = "{index}: transform={4}")
+    @SuppressWarnings(value = {"checkstyle:LineLength", "checkstyle:MethodLength"})
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[][] {
@@ -186,27 +203,27 @@ public class ProcessorTransformParallelismTest {
                                                 .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, t) -> supplyAsync(() -> false)),
                                 "filterUsingContextAsync"
                         }
-                        ,                     {
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> false))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> false)),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> false))
-                                                .setLocalParallelism(localParallelism),
-                                (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                        stage -> stage
-                                                .groupingKey(i -> i)
-                                                .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> false)),
-                                "filterUsingPartitionedContextAsync"
-                        }
+                        , {
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> false))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContextAsync(withCreateFn(x -> null), (c, k, t) -> supplyAsync(() -> false)),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> false))
+                                        .setLocalParallelism(localParallelism),
+                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
+                                stage -> stage
+                                        .groupingKey(i -> i)
+                                        .filterUsingContextAsync(withCreateFn(x -> null).toNonCooperative(), (c, k, t) -> supplyAsync(() -> false)),
+                        "filterUsingPartitionedContextAsync"
+                }
                         ,
                         {
                                 (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -66,224 +66,186 @@ public class ProcessorTransformParallelismTest {
     @SuppressWarnings(value = {"checkstyle:LineLength", "checkstyle:MethodLength"})
     public static Collection<Object[]> data() {
         return Arrays.asList(
-                new Object[][] {{
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContext(CONTEXT_FACTORY, (c, t) -> t)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContext(CONTEXT_FACTORY, (c, t) -> t),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> t)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> t),
-                        "mapUsingContext"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContext(CONTEXT_FACTORY, (c, k, t) -> t)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContext(CONTEXT_FACTORY, (c, k, t) -> t),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> t)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> t),
-                        "mapUsingPartitionedContext"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t)),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t)),
-                        "mapUsingContextAsync"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t)),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t)),
-                        "mapUsingPartitionedContextAsync"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContext(CONTEXT_FACTORY, (c, t) -> false)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContext(CONTEXT_FACTORY, (c, t) -> false),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContext(NC_CONTEXT_FACTORY, (c, t) -> false)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContext(NC_CONTEXT_FACTORY, (c, t) -> false),
-                        "filterUsingContext"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContext(CONTEXT_FACTORY, (c, k, t) -> false)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContext(CONTEXT_FACTORY, (c, k, t) -> false),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> false)
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> false),
-                        "filterUsingPartitionedContext"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false)),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false)),
-                        "filterUsingContextAsync"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false)),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false)),
-                        "filterUsingPartitionedContextAsync"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContext(CONTEXT_FACTORY, (c, t) -> Traversers.<Integer>empty())
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContext(CONTEXT_FACTORY, (c, t) -> Traversers.<Integer>empty()),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> Traversers.<Integer>empty())
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> Traversers.<Integer>empty()),
-                        "flatMapUsingContext"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContext(CONTEXT_FACTORY, (c, k, t) -> Traversers.<Integer>empty())
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContext(CONTEXT_FACTORY, (c, k, t) -> Traversers.<Integer>empty()),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> Traversers.<Integer>empty())
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> Traversers.<Integer>empty()),
-                        "flatMapUsingPartitionedContext"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty)),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty)),
-                        "flatMapUsingContextAsync"
-                }, {
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
-                                        .setLocalParallelism(LOCAL_PARALLELISM),
-                        (FunctionEx<StreamStage<Integer>, StreamStage<Integer>>)
-                                stage -> stage
-                                        .groupingKey(i -> i)
-                                        .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty)),
-                        "flatMapUsingPartitionedContextAsync"
-                }
-                });
+                createParamSet(
+                        stage -> stage
+                                .mapUsingContext(CONTEXT_FACTORY, (c, t) -> t)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .mapUsingContext(CONTEXT_FACTORY, (c, t) -> t),
+                        stage -> stage
+                                .mapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> t)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .mapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> t),
+                        "mapUsingContext"),
+                createParamSet(
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContext(CONTEXT_FACTORY, (c, k, t) -> t)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContext(CONTEXT_FACTORY, (c, k, t) -> t),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> t)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> t),
+                        "mapUsingPartitionedContext"),
+                createParamSet(
+                        stage -> stage
+                                .mapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .mapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t)),
+                        stage -> stage
+                                .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> t)),
+                        "mapUsingContextAsync"),
+                createParamSet(
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t)),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .mapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> t)),
+                        "mapUsingPartitionedContextAsync"),
+                createParamSet(
+                        stage -> stage
+                                .filterUsingContext(CONTEXT_FACTORY, (c, t) -> false)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .filterUsingContext(CONTEXT_FACTORY, (c, t) -> false),
+                        stage -> stage
+                                .filterUsingContext(NC_CONTEXT_FACTORY, (c, t) -> false)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .filterUsingContext(NC_CONTEXT_FACTORY, (c, t) -> false),
+                        "filterUsingContext"),
+                createParamSet(
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContext(CONTEXT_FACTORY, (c, k, t) -> false)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContext(CONTEXT_FACTORY, (c, k, t) -> false),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> false)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> false),
+                        "filterUsingPartitionedContext"),
+                createParamSet(
+                        stage -> stage
+                                .filterUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .filterUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false)),
+                        stage -> stage
+                                .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(() -> false)),
+                        "filterUsingContextAsync"),
+                createParamSet(
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false)),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .filterUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(() -> false)),
+                        "filterUsingPartitionedContextAsync"),
+                createParamSet(
+                        stage -> stage
+                                .flatMapUsingContext(CONTEXT_FACTORY, (c, t) -> Traversers.<Integer>empty())
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .flatMapUsingContext(CONTEXT_FACTORY, (c, t) -> Traversers.empty()),
+                        stage -> stage
+                                .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> Traversers.<Integer>empty())
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, t) -> Traversers.empty()),
+                        "flatMapUsingContext"),
+                createParamSet(
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContext(CONTEXT_FACTORY, (c, k, t) -> Traversers.<Integer>empty())
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContext(CONTEXT_FACTORY, (c, k, t) -> Traversers.empty()),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> Traversers.<Integer>empty())
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContext(NC_CONTEXT_FACTORY, (c, k, t) -> Traversers.empty()),
+                        "flatMapUsingPartitionedContext"),
+                createParamSet(
+                        stage -> stage
+                                .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::empty)),
+                        stage -> stage
+                                .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, t) -> supplyAsync(Traversers::empty)),
+                        "flatMapUsingContextAsync"),
+                createParamSet(
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContextAsync(CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::empty)),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        stage -> stage
+                                .groupingKey(i -> i)
+                                .flatMapUsingContextAsync(NC_CONTEXT_FACTORY, (c, k, t) -> supplyAsync(Traversers::empty)),
+                        "flatMapUsingPartitionedContextAsync")
+        );
+    }
+
+    private static Object[] createParamSet(
+            FunctionEx<StreamStage<Integer>, StreamStage<Integer>> cooperative_defaultLP,
+            FunctionEx<StreamStage<Integer>, StreamStage<Integer>> cooperative_explicitLP,
+            FunctionEx<StreamStage<Integer>, StreamStage<Integer>> nonCooperative_defaultLP,
+            FunctionEx<StreamStage<Integer>, StreamStage<Integer>> nonCooperative_explicitLP,
+            String transformName
+    ) {
+        return new Object[]{cooperative_defaultLP, cooperative_explicitLP, nonCooperative_defaultLP,
+                nonCooperative_explicitLP, transformName};
     }
 
     @Test


### PR DESCRIPTION
Users still have the ability to override the default