### PR TITLE
Add SimpleTestInClusterSupport

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet;
+
+import com.hazelcast.core.DistributedObject;
+import com.hazelcast.jet.config.JetClientConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for tests that share the cluster for all jobs. The subclass must
+ * call {@link #beforeClassWithClient} method.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+public class SimpleTestInClusterSupport extends JetTestSupport {
+
+    private static JetTestInstanceFactory factory;
+    private static JetConfig jetConfig;
+    private static JetInstance[] instances;
+    private static JetInstance client;
+
+    protected static void beforeClass(int memberCount, @Nullable JetConfig jetConfig) {
+        factory = new JetTestInstanceFactory();
+        instances = new JetInstance[memberCount];
+        if (jetConfig == null) {
+            jetConfig = new JetConfig();
+        }
+        SimpleTestInClusterSupport.jetConfig = jetConfig;
+        // create members
+        for (int i = 0; i < memberCount; i++) {
+            instances[i] = factory.newMember(jetConfig);
+        }
+    }
+
+    protected static void beforeClassWithClient(
+            int memberCount,
+            @Nullable JetConfig config,
+            @Nullable JetClientConfig clientConfig
+    ) {
+        beforeClass(memberCount, config);
+
+        if (clientConfig == null) {
+            clientConfig = new JetClientConfig();
+        }
+        client = factory.newClient(clientConfig);
+    }
+
+    @After
+    public void supportAfter() {
+        // after each test ditch all jobs and objects
+        for (Job job : instances[0].getJobs()) {
+            ditchJob(job, instances());
+        }
+        for (DistributedObject o : instances()[0].getHazelcastInstance().getDistributedObjects()) {
+            o.destroy();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        factory.terminateAll();
+        factory = null;
+        instances = null;
+        client = null;
+    }
+
+    @Nonnull
+    protected static JetTestInstanceFactory factory() {
+        return factory;
+    }
+
+    /**
+     * Returns the config used to create member instances (even if null was
+     * passed).
+     */
+    @Nonnull
+    protected static JetConfig jetConfig() {
+        return jetConfig;
+    }
+
+    /**
+     * Returns the first instance.
+     */
+    @Nonnull
+    protected static JetInstance instance() {
+        return instances[0];
+    }
+
+    /**
+     * Returns all instances (except for the client).
+     */
+    @Nonnull
+    protected static JetInstance[] instances() {
+        return instances;
+    }
+
+    /**
+     * Returns the client or null, if a client wasn't requested.
+     */
+    protected static JetInstance client() {
+        return client;
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/SimpleTestInClusterSupport.java
@@ -30,17 +30,18 @@ import javax.annotation.Nullable;
 
 /**
  * Base class for tests that share the cluster for all jobs. The subclass must
- * call {@link #beforeClassWithClient} method.
+ * call {@link #initialize} or {@link #initializeWithClient} method.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-public class SimpleTestInClusterSupport extends JetTestSupport {
+public abstract class SimpleTestInClusterSupport extends JetTestSupport {
 
     private static JetTestInstanceFactory factory;
     private static JetConfig jetConfig;
     private static JetInstance[] instances;
     private static JetInstance client;
 
-    protected static void beforeClass(int memberCount, @Nullable JetConfig jetConfig) {
+    protected static void initialize(int memberCount, @Nullable JetConfig jetConfig) {
+        assert factory == null : "already initialized";
         factory = new JetTestInstanceFactory();
         instances = new JetInstance[memberCount];
         if (jetConfig == null) {
@@ -53,12 +54,12 @@ public class SimpleTestInClusterSupport extends JetTestSupport {
         }
     }
 
-    protected static void beforeClassWithClient(
+    protected static void initializeWithClient(
             int memberCount,
             @Nullable JetConfig config,
             @Nullable JetClientConfig clientConfig
     ) {
-        beforeClass(memberCount, config);
+        initialize(memberCount, config);
 
         if (clientConfig == null) {
             clientConfig = new JetClientConfig();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -59,7 +59,7 @@ public class OperationLossTest extends SimpleTestInClusterSupport {
         JetConfig config = new JetConfig();
         config.getHazelcastConfig().setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "1000");
 
-        SimpleTestInClusterSupport.initialize(2, config);
+        initialize(2, config);
     }
 
     @Before

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -59,7 +59,7 @@ public class OperationLossTest extends SimpleTestInClusterSupport {
         JetConfig config = new JetConfig();
         config.getHazelcastConfig().setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "1000");
 
-        SimpleTestInClusterSupport.beforeClass(2, config);
+        SimpleTestInClusterSupport.initialize(2, config);
     }
 
     @Before

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.TestProcessors.DummyStatefulP;
@@ -30,13 +30,10 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.PacketFiltersUtil;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.concurrent.CancellationException;
 
@@ -55,31 +52,22 @@ import static org.junit.Assert.assertNotNull;
 
 // TODO this test does not test when responses are lost. There is currently no test
 //   harness to simulate that.
-@RunWith(HazelcastSerialClassRunner.class)
-public class OperationLossTest extends JetTestSupport {
-
-    private static JetTestInstanceFactory factory = new JetTestInstanceFactory();
-    private static JetInstance instance1;
-    private static JetInstance instance2;
+public class OperationLossTest extends SimpleTestInClusterSupport {
 
     @BeforeClass
     public static void beforeClass() {
         JetConfig config = new JetConfig();
         config.getHazelcastConfig().setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "1000");
-        instance1 = factory.newMember(config);
-        instance2 = factory.newMember(config);
-    }
 
-    @AfterClass
-    public static void afterClass() {
-        factory.terminateAll();
+        SimpleTestInClusterSupport.beforeClass(2, config);
     }
 
     @Before
     public void before() {
         TestProcessors.reset(1);
-        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
-        PacketFiltersUtil.resetPacketFiltersFrom(instance2.getHazelcastInstance());
+        for (JetInstance instance : instances()) {
+            PacketFiltersUtil.resetPacketFiltersFrom(instance.getHazelcastInstance());
+        }
     }
 
     @Test
@@ -93,40 +81,40 @@ public class OperationLossTest extends JetTestSupport {
     }
 
     private void when_operationLost_then_jobRestarts(int operationId, JobStatus expectedStatus) {
-        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+        PacketFiltersUtil.dropOperationsFrom(instance().getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(operationId));
         DAG dag = new DAG();
         Vertex v1 = dag.newVertex("v1", () -> new NoOutputSourceP()).localParallelism(1);
         Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
         dag.edge(between(v1, v2).distributed());
 
-        Job job = instance1.newJob(dag);
+        Job job = instance().newJob(dag);
         assertJobStatusEventually(job, expectedStatus);
         // NOT_RUNNING will occur briefly, we might miss to observe it. But restart occurs every
         // second (that's the operation heartbeat timeout) so hopefully we'll eventually succeed.
         assertJobStatusEventually(job, NOT_RUNNING);
 
         // now allow the job to complete normally
-        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        PacketFiltersUtil.resetPacketFiltersFrom(instance().getHazelcastInstance());
         NoOutputSourceP.proceedLatch.countDown();
         job.join();
     }
 
     @Test
     public void when_completeExecutionOperationLost_then_jobCompletes() {
-        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+        PacketFiltersUtil.dropOperationsFrom(instance().getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.COMPLETE_EXECUTION_OP));
         DAG dag = new DAG();
         Vertex v1 = dag.newVertex("v1", () -> new DummyStatefulP()).localParallelism(1);
         Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
         dag.edge(between(v1, v2).distributed());
 
-        Job job = instance1.newJob(dag);
+        Job job = instance().newJob(dag);
         assertJobStatusEventually(job, RUNNING);
         job.suspend();
         assertJobStatusEventually(job, COMPLETING);
         assertTrueAllTheTime(() -> assertEquals(COMPLETING, job.getStatus()), 1);
-        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        PacketFiltersUtil.resetPacketFiltersFrom(instance().getHazelcastInstance());
         assertJobStatusEventually(job, SUSPENDED);
         job.resume();
         assertJobStatusEventually(job, RUNNING);
@@ -138,18 +126,18 @@ public class OperationLossTest extends JetTestSupport {
 
     @Test
     public void when_snapshotOperationLost_then_retried() {
-        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+        PacketFiltersUtil.dropOperationsFrom(instance().getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.SNAPSHOT_OPERATION));
         DAG dag = new DAG();
         Vertex v1 = dag.newVertex("v1", () -> new DummyStatefulP()).localParallelism(1);
         Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
         dag.edge(between(v1, v2).distributed());
 
-        Job job = instance1.newJob(dag, new JobConfig()
+        Job job = instance().newJob(dag, new JobConfig()
                 .setProcessingGuarantee(EXACTLY_ONCE)
                 .setSnapshotIntervalMillis(100));
         assertJobStatusEventually(job, RUNNING);
-        JobRepository jobRepository = new JobRepository(instance1);
+        JobRepository jobRepository = new JobRepository(instance());
         assertTrueEventually(() -> {
             JobExecutionRecord record = jobRepository.getJobExecutionRecord(job.getId());
             assertNotNull("null JobExecutionRecord", record);
@@ -158,7 +146,7 @@ public class OperationLossTest extends JetTestSupport {
         sleepSeconds(1);
         // now lift the filter and check that a snapshot is done
         logger.info("Lifting the packet filter...");
-        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        PacketFiltersUtil.resetPacketFiltersFrom(instance().getHazelcastInstance());
         waitForFirstSnapshot(jobRepository, job.getId(), 10, false);
         job.cancel();
         try {
@@ -172,12 +160,12 @@ public class OperationLossTest extends JetTestSupport {
         Vertex source = dag.newVertex("source", () -> new NoOutputSourceP()).localParallelism(1);
         Vertex sink = dag.newVertex("sink", DiagnosticProcessors.writeLoggerP());
         dag.edge(between(source, sink).distributed());
-        Job job = instance1.newJob(dag);
+        Job job = instance().newJob(dag);
         assertJobStatusEventually(job, RUNNING);
         assertTrueEventually(() -> assertEquals(2, NoOutputSourceP.initCount.get()));
 
-        Connection connection = ImdgUtil.getMemberConnection(getNodeEngineImpl(instance1),
-                instance2.getHazelcastInstance().getCluster().getLocalMember().getAddress());
+        Connection connection = ImdgUtil.getMemberConnection(getNodeEngineImpl(instance()),
+                instances()[1].getHazelcastInstance().getCluster().getLocalMember().getAddress());
         // When
         connection.close(null, null);
         System.out.println("connection closed");
@@ -192,20 +180,20 @@ public class OperationLossTest extends JetTestSupport {
 
     @Test
     public void when_terminateExecutionOperationLost_then_jobTerminates() {
-        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+        PacketFiltersUtil.dropOperationsFrom(instance().getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.TERMINATE_EXECUTION_OP));
         DAG dag = new DAG();
         Vertex v1 = dag.newVertex("v1", () -> new NoOutputSourceP()).localParallelism(1);
         Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
         dag.edge(between(v1, v2).distributed());
 
-        Job job = instance1.newJob(dag);
+        Job job = instance().newJob(dag);
         assertJobStatusEventually(job, RUNNING);
         job.cancel();
         // sleep so that the TerminateExecutionOperation is sent out, but lost
         sleepSeconds(1);
         // reset filters so that the situation can resolve
-        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        PacketFiltersUtil.resetPacketFiltersFrom(instance().getHazelcastInstance());
 
         try {
             // Then
@@ -215,20 +203,20 @@ public class OperationLossTest extends JetTestSupport {
 
     @Test
     public void when_terminalSnapshotOperationLost_then_jobRestarts() {
-        PacketFiltersUtil.dropOperationsFrom(instance1.getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
+        PacketFiltersUtil.dropOperationsFrom(instance().getHazelcastInstance(), JetInitDataSerializerHook.FACTORY_ID,
                 singletonList(JetInitDataSerializerHook.SNAPSHOT_OPERATION));
         DAG dag = new DAG();
         Vertex v1 = dag.newVertex("v1", () -> new NoOutputSourceP()).localParallelism(1);
         Vertex v2 = dag.newVertex("v2", mapP(identity())).localParallelism(1);
         dag.edge(between(v1, v2).distributed());
 
-        Job job = instance1.newJob(dag, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
+        Job job = instance().newJob(dag, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
         assertJobStatusEventually(job, RUNNING, 20);
         job.restart();
         // sleep so that the SnapshotOperation is sent out, but lost
         sleepSeconds(1);
         // reset filters so that the situation can resolve
-        PacketFiltersUtil.resetPacketFiltersFrom(instance1.getHazelcastInstance());
+        PacketFiltersUtil.resetPacketFiltersFrom(instance().getHazelcastInstance());
 
         // Then
         assertTrueEventually(() -> assertEquals(4, NoOutputSourceP.initCount.get()));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
@@ -34,7 +34,7 @@ public class SlowSourceYieldTest extends SimpleTestInClusterSupport {
 
     @Before
     public void before() {
-        SimpleTestInClusterSupport.beforeClass(1, null);
+        SimpleTestInClusterSupport.initialize(1, null);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
@@ -34,7 +34,7 @@ public class SlowSourceYieldTest extends SimpleTestInClusterSupport {
 
     @Before
     public void before() {
-        SimpleTestInClusterSupport.initialize(1, null);
+        initialize(1, null);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SlowSourceYieldTest.java
@@ -16,14 +16,10 @@
 
 package com.hazelcast.jet.core;
 
-import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.Traverser;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 import java.util.stream.IntStream;
@@ -34,21 +30,11 @@ import static com.hazelcast.jet.core.processor.Processors.noopP;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
-public class SlowSourceYieldTest {
-
-    private JetInstance instance;
-    private JetTestInstanceFactory factory;
+public class SlowSourceYieldTest extends SimpleTestInClusterSupport {
 
     @Before
     public void before() {
-        factory = new JetTestInstanceFactory();
-        instance = factory.newMember();
-    }
-
-    @After
-    public void after() {
-        factory.shutdownAll();
+        SimpleTestInClusterSupport.beforeClass(1, null);
     }
 
     @Test
@@ -58,7 +44,7 @@ public class SlowSourceYieldTest {
         Vertex sink = dag.newVertex("sink", noopP()).localParallelism(1);
         dag.edge(between(source, sink));
 
-        instance.newJob(dag).join();
+        instance().newJob(dag).join();
         assertTrue("processor never yielded", SlowSourceP.yieldCount > 0);
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
@@ -35,11 +35,9 @@ import com.hazelcast.map.journal.EventJournalMapEvent;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.Map.Entry;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
@@ -82,7 +82,7 @@ public class HazelcastConnectorTest extends SimpleTestInClusterSupport {
         hazelcastConfig.addCacheConfig(new CacheSimpleConfig().setName("*"));
         hazelcastConfig.addEventJournalConfig(new EventJournalConfig().setCacheName("stream*").setMapName("stream*"));
 
-        SimpleTestInClusterSupport.beforeClass(2, jetConfig);
+        SimpleTestInClusterSupport.initialize(2, jetConfig);
     }
 
     @Before

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
@@ -82,7 +82,7 @@ public class HazelcastConnectorTest extends SimpleTestInClusterSupport {
         hazelcastConfig.addCacheConfig(new CacheSimpleConfig().setName("*"));
         hazelcastConfig.addEventJournalConfig(new EventJournalConfig().setCacheName("stream*").setMapName("stream*"));
 
-        SimpleTestInClusterSupport.initialize(2, jetConfig);
+        initialize(2, jetConfig);
     }
 
     @Before

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnectorTest.java
@@ -25,12 +25,10 @@ import com.hazelcast.jet.ICacheJet;
 import com.hazelcast.jet.IListJet;
 import com.hazelcast.jet.IMapJet;
 import com.hazelcast.jet.JetCacheManager;
-import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.core.DAG;
-import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SourceProcessors;
 import com.hazelcast.map.journal.EventJournalMapEvent;
@@ -38,7 +36,6 @@ import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -70,14 +67,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastSerialClassRunner.class)
-public class HazelcastConnectorTest extends JetTestSupport {
+public class HazelcastConnectorTest extends SimpleTestInClusterSupport {
 
     private static final int ENTRY_COUNT = 100;
-
-    private static JetTestInstanceFactory factory = new JetTestInstanceFactory();
-    private static JetInstance jetInstance;
-    private static JetInstance jetInstance2;
 
     private String sourceName;
     private String sinkName;
@@ -91,8 +83,8 @@ public class HazelcastConnectorTest extends JetTestSupport {
         Config hazelcastConfig = jetConfig.getHazelcastConfig();
         hazelcastConfig.addCacheConfig(new CacheSimpleConfig().setName("*"));
         hazelcastConfig.addEventJournalConfig(new EventJournalConfig().setCacheName("stream*").setMapName("stream*"));
-        jetInstance = factory.newMember(jetConfig);
-        jetInstance2 = factory.newMember(jetConfig);
+
+        SimpleTestInClusterSupport.beforeClass(2, jetConfig);
     }
 
     @Before
@@ -104,21 +96,16 @@ public class HazelcastConnectorTest extends JetTestSupport {
         streamSinkName = "stream" + sinkName;
 
         // workaround for `cache is not created` exception, create cache locally on all nodes
-        JetCacheManager cacheManager = jetInstance2.getCacheManager();
+        JetCacheManager cacheManager = instances()[1].getCacheManager();
         cacheManager.getCache(sourceName);
         cacheManager.getCache(sinkName);
         cacheManager.getCache(streamSourceName);
         cacheManager.getCache(streamSinkName);
     }
 
-    @AfterClass
-    public static void afterClass() {
-        factory.shutdownAll();
-    }
-
     @Test
     public void when_readMap_and_writeMap() {
-        IMapJet<Integer, Integer> sourceMap = jetInstance.getMap(sourceName);
+        IMapJet<Integer, Integer> sourceMap = instance().getMap(sourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, i));
 
         DAG dag = new DAG();
@@ -127,14 +114,14 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        jetInstance.newJob(dag).join();
+        instance().newJob(dag).join();
 
-        assertEquals(ENTRY_COUNT, jetInstance.getMap(sinkName).size());
+        assertEquals(ENTRY_COUNT, instance().getMap(sinkName).size());
     }
 
     @Test
     public void when_readMap_withNativePredicateAndProjection() {
-        IMapJet<Integer, Integer> sourceMap = jetInstance.getMap(sourceName);
+        IMapJet<Integer, Integer> sourceMap = instance().getMap(sourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, i));
 
         DAG dag = new DAG();
@@ -147,9 +134,9 @@ public class HazelcastConnectorTest extends JetTestSupport {
         Vertex sink = dag.newVertex("sink", writeListP(sinkName));
         dag.edge(between(source, sink));
 
-        jetInstance.newJob(dag).join();
+        instance().newJob(dag).join();
 
-        IListJet<Object> list = jetInstance.getList(sinkName);
+        IListJet<Object> list = instance().getList(sinkName);
         assertEquals(ENTRY_COUNT - 1, list.size());
         for (int i = 0; i < ENTRY_COUNT; i++) {
             assertEquals(i != 0, list.contains(i));
@@ -158,7 +145,7 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
     @Test
     public void when_readMap_withProjectionToNull_then_nullsSkipped() {
-        IMapJet<Integer, Entry<Integer, String>> sourceMap = jetInstance.getMap(sourceName);
+        IMapJet<Integer, Entry<Integer, String>> sourceMap = instance().getMap(sourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, entry(i, i % 2 == 0 ? null : String.valueOf(i))));
 
         DAG dag = new DAG();
@@ -169,7 +156,7 @@ public class HazelcastConnectorTest extends JetTestSupport {
         Vertex sink = dag.newVertex("sink", writeListP(sinkName));
         dag.edge(between(source, sink));
 
-        jetInstance.newJob(dag).join();
+        instance().newJob(dag).join();
 
         checkContents_projectedToNull(sinkName);
     }
@@ -181,14 +168,14 @@ public class HazelcastConnectorTest extends JetTestSupport {
                          .mapToObj(String::valueOf)
                          .sorted()
                          .collect(joining("\n")),
-                jetInstance.getHazelcastInstance().<String>getList(sinkName).stream()
+                instance().getHazelcastInstance().<String>getList(sinkName).stream()
                         .sorted()
                         .collect(joining("\n")));
     }
 
     @Test
     public void when_readMap_withPredicateAndFunction() {
-        IMapJet<Integer, Integer> sourceMap = jetInstance.getMap(sourceName);
+        IMapJet<Integer, Integer> sourceMap = instance().getMap(sourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, i));
 
         DAG dag = new DAG();
@@ -197,9 +184,9 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        jetInstance.newJob(dag).join();
+        instance().newJob(dag).join();
 
-        IListJet<Object> list = jetInstance.getList(sinkName);
+        IListJet<Object> list = instance().getList(sinkName);
         assertEquals(ENTRY_COUNT - 1, list.size());
         assertFalse(list.contains(0));
         assertTrue(list.contains(1));
@@ -214,12 +201,12 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        Job job = jetInstance.newJob(dag);
+        Job job = instance().newJob(dag);
 
-        IMapJet<Integer, Integer> sourceMap = jetInstance.getMap(streamSourceName);
+        IMapJet<Integer, Integer> sourceMap = instance().getMap(streamSourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, i));
 
-        assertSizeEventually(ENTRY_COUNT, jetInstance.getList(streamSinkName));
+        assertSizeEventually(ENTRY_COUNT, instance().getList(streamSinkName));
         job.cancel();
     }
 
@@ -234,9 +221,9 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        Job job = jetInstance.newJob(dag);
+        Job job = instance().newJob(dag);
 
-        IMapJet<Integer, Entry<Integer, String>> sourceMap = jetInstance.getMap(streamSourceName);
+        IMapJet<Integer, Entry<Integer, String>> sourceMap = instance().getMap(streamSourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, entry(i, i % 2 == 0 ? null : String.valueOf(i))));
 
         assertTrueEventually(() -> checkContents_projectedToNull(streamSinkName));
@@ -253,20 +240,20 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        Job job = jetInstance.newJob(dag);
+        Job job = instance().newJob(dag);
 
-        IMapJet<Integer, Integer> sourceMap = jetInstance.getMap(streamSourceName);
+        IMapJet<Integer, Integer> sourceMap = instance().getMap(streamSourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceMap.put(i, i));
 
-        assertSizeEventually(ENTRY_COUNT - 1, jetInstance.getList(streamSinkName));
-        assertFalse(jetInstance.getList(streamSinkName).contains(0));
-        assertTrue(jetInstance.getList(streamSinkName).contains(1));
+        assertSizeEventually(ENTRY_COUNT - 1, instance().getList(streamSinkName));
+        assertFalse(instance().getList(streamSinkName).contains(0));
+        assertTrue(instance().getList(streamSinkName).contains(1));
         job.cancel();
     }
 
     @Test
     public void when_readCache_and_writeCache() {
-        ICache<Integer, Integer> sourceCache = jetInstance.getCacheManager().getCache(sourceName);
+        ICache<Integer, Integer> sourceCache = instance().getCacheManager().getCache(sourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceCache.put(i, i));
 
         DAG dag = new DAG();
@@ -275,9 +262,9 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        jetInstance.newJob(dag).join();
+        instance().newJob(dag).join();
 
-        assertEquals(ENTRY_COUNT, jetInstance.getCacheManager().getCache(sinkName).size());
+        assertEquals(ENTRY_COUNT, instance().getCacheManager().getCache(sinkName).size());
     }
 
     @Test
@@ -289,12 +276,12 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        Job job = jetInstance.newJob(dag);
+        Job job = instance().newJob(dag);
 
-        ICacheJet<Integer, Integer> sourceCache = jetInstance.getCacheManager().getCache(streamSourceName);
+        ICacheJet<Integer, Integer> sourceCache = instance().getCacheManager().getCache(streamSourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceCache.put(i, i));
 
-        assertSizeEventually(ENTRY_COUNT, jetInstance.getList(streamSinkName));
+        assertSizeEventually(ENTRY_COUNT, instance().getList(streamSinkName));
         job.cancel();
     }
 
@@ -308,20 +295,20 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        Job job = jetInstance.newJob(dag);
+        Job job = instance().newJob(dag);
 
-        ICacheJet<Integer, Integer> sourceCache = jetInstance.getCacheManager().getCache(streamSourceName);
+        ICacheJet<Integer, Integer> sourceCache = instance().getCacheManager().getCache(streamSourceName);
         range(0, ENTRY_COUNT).forEach(i -> sourceCache.put(i, i));
 
-        assertSizeEventually(ENTRY_COUNT - 1, jetInstance.getList(streamSinkName));
-        assertFalse(jetInstance.getList(streamSinkName).contains(0));
-        assertTrue(jetInstance.getList(streamSinkName).contains(1));
+        assertSizeEventually(ENTRY_COUNT - 1, instance().getList(streamSinkName));
+        assertFalse(instance().getList(streamSinkName).contains(0));
+        assertTrue(instance().getList(streamSinkName).contains(1));
         job.cancel();
     }
 
     @Test
     public void when_readList_and_writeList() {
-        IListJet<Integer> list = jetInstance.getList(sourceName);
+        IListJet<Integer> list = instance().getList(sourceName);
         list.addAll(range(0, ENTRY_COUNT).boxed().collect(toList()));
 
         DAG dag = new DAG();
@@ -330,9 +317,9 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        jetInstance.newJob(dag).join();
+        instance().newJob(dag).join();
 
-        assertEquals(ENTRY_COUNT, jetInstance.getList(sinkName).size());
+        assertEquals(ENTRY_COUNT, instance().getList(sinkName).size());
     }
 
     @Test
@@ -344,14 +331,14 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        Job job = jetInstance.newJob(dag);
+        Job job = instance().newJob(dag);
 
-        IMapJet<Integer, Integer> sourceMap = jetInstance.getMap(streamSourceName);
+        IMapJet<Integer, Integer> sourceMap = instance().getMap(streamSourceName);
         sourceMap.put(1, 1); // ADDED
         sourceMap.remove(1); // REMOVED - filtered out
         sourceMap.put(1, 2); // ADDED
 
-        IListJet<Entry<Integer, Integer>> sinkList = jetInstance.getList(streamSinkName);
+        IListJet<Entry<Integer, Integer>> sinkList = instance().getList(streamSinkName);
         assertTrueEventually(() -> {
             assertEquals(2, sinkList.size());
 
@@ -376,14 +363,14 @@ public class HazelcastConnectorTest extends JetTestSupport {
 
         dag.edge(between(source, sink));
 
-        Job job = jetInstance.newJob(dag);
+        Job job = instance().newJob(dag);
 
-        ICacheJet<Object, Object> sourceCache = jetInstance.getCacheManager().getCache(streamSourceName);
+        ICacheJet<Object, Object> sourceCache = instance().getCacheManager().getCache(streamSourceName);
         sourceCache.put(1, 1); // ADDED
         sourceCache.remove(1); // REMOVED - filtered out
         sourceCache.put(1, 2); // UPDATED
 
-        IListJet<Entry<Integer, Integer>> sinkList = jetInstance.getList(streamSinkName);
+        IListJet<Entry<Integer, Integer>> sinkList = instance().getList(streamSinkName);
         assertTrueEventually(() -> {
             assertEquals(2, sinkList.size());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
@@ -62,7 +62,7 @@ public class VertexDef_HigherPrioritySourceTest extends SimpleTestInClusterSuppo
 
     @BeforeClass
     public static void beforeClass() {
-        SimpleTestInClusterSupport.beforeClass(1, null);
+        SimpleTestInClusterSupport.initialize(1, null);
         nodeEngineImpl = getNodeEngineImpl(instance().getHazelcastInstance());
         ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngineImpl.getClusterService();
         membersView = clusterService.getMembershipManager().getMembersView();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
@@ -19,8 +19,7 @@ package com.hazelcast.jet.impl.execution.init;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.MembersView;
-import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.Edge;
@@ -31,7 +30,6 @@ import com.hazelcast.jet.impl.MasterJobContext;
 import com.hazelcast.jet.impl.execution.SnapshotContext;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,17 +41,15 @@ import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.Edge.from;
 import static com.hazelcast.jet.impl.execution.init.ExecutionPlanBuilder.createExecutionPlans;
-import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.joining;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
-public class VertexDef_HigherPrioritySourceTest {
+public class VertexDef_HigherPrioritySourceTest extends SimpleTestInClusterSupport {
 
     private static final ProcessorMetaSupplier MOCK_PMS =
             addresses -> address -> count -> nCopies(count, new DummyProcessor());
-    private static final JetTestInstanceFactory factory = new JetTestInstanceFactory();
     private static NodeEngineImpl nodeEngineImpl;
     private static MembersView membersView;
 
@@ -66,15 +62,10 @@ public class VertexDef_HigherPrioritySourceTest {
 
     @BeforeClass
     public static void beforeClass() {
-        JetInstance inst = factory.newMember();
-        nodeEngineImpl = getNodeEngineImpl(inst.getHazelcastInstance());
+        SimpleTestInClusterSupport.beforeClass(1, null);
+        nodeEngineImpl = getNodeEngineImpl(instance().getHazelcastInstance());
         ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngineImpl.getClusterService();
         membersView = clusterService.getMembershipManager().getMembersView();
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        factory.shutdownAll();
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
@@ -62,7 +62,7 @@ public class VertexDef_HigherPrioritySourceTest extends SimpleTestInClusterSuppo
 
     @BeforeClass
     public static void beforeClass() {
-        SimpleTestInClusterSupport.initialize(1, null);
+        initialize(1, null);
         nodeEngineImpl = getNodeEngineImpl(instance().getHazelcastInstance());
         ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngineImpl.getClusterService();
         membersView = clusterService.getMembershipManager().getMembersView();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextP_IntegrationTest.java
@@ -19,20 +19,18 @@ package com.hazelcast.jet.impl.processor;
 import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.jet.IListJet;
 import com.hazelcast.jet.IMapJet;
-import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.EdgeConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
-import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.WatermarkPolicy;
 import com.hazelcast.jet.core.processor.SinkProcessors;
-import com.hazelcast.jet.function.FunctionEx;
 import com.hazelcast.jet.function.BiFunctionEx;
+import com.hazelcast.jet.function.FunctionEx;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.pipeline.ContextFactory;
 import com.hazelcast.jet.pipeline.Pipeline;
@@ -40,8 +38,6 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.journal.EventJournalMapEvent;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -60,12 +56,10 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
-import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.EventTimePolicy.eventTimePolicy;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
-import static com.hazelcast.jet.core.JobStatus.FAILED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.jet.core.processor.Processors.flatMapUsingContextAsyncP;
@@ -82,12 +76,9 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport {
+public class AsyncTransformUsingContextP_IntegrationTest extends SimpleTestInClusterSupport {
 
     private static final int NUM_ITEMS = 100;
-
-    private static JetTestInstanceFactory factory = new JetTestInstanceFactory();
-    private static JetInstance inst;
 
     @Parameter
     public boolean ordered;
@@ -108,42 +99,20 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
         config.getHazelcastConfig().addEventJournalConfig(new EventJournalConfig()
                 .setMapName("journaledMap*")
                 .setCapacity(100_000));
-        inst = factory.newMember(config);
-        factory.newMember(config);
-    }
 
-    @AfterClass
-    public static void afterClass() {
-        factory.terminateAll();
+        SimpleTestInClusterSupport.beforeClass(1, config);
     }
 
     @Before
     public void before() {
-        journaledMap = inst.getMap(randomMapName("journaledMap"));
+        journaledMap = instance().getMap(randomMapName("journaledMap"));
         journaledMap.putAll(IntStream.range(0, NUM_ITEMS).boxed().collect(toMap(i -> i, i -> i)));
-        sinkList = inst.getList(randomMapName("sinkList"));
+        sinkList = instance().getList(randomMapName("sinkList"));
         jobConfig = new JobConfig().setProcessingGuarantee(EXACTLY_ONCE).setSnapshotIntervalMillis(0);
 
         contextFactory = ContextFactory.withCreateFn(jet -> Executors.newFixedThreadPool(8)).withLocalSharing();
         if (!ordered) {
             contextFactory = contextFactory.withUnorderedAsyncResponses();
-        }
-    }
-
-    @After
-    public void after() {
-        journaledMap.destroy();
-        sinkList.destroy();
-        for (Job job : inst.getJobs()) {
-            assertTrueEventually(() -> {
-                logger.info("Cancelling job " + idToString(job.getId()));
-                try {
-                    job.cancel();
-                } catch (Exception e) {
-                    logger.warning("Failed to cancel the job, will retry", e);
-                }
-                assertJobStatusEventually(job, FAILED, 3);
-            });
         }
     }
 
@@ -190,7 +159,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
         dag.edge(between(source, map).setConfig(edgeToMapperConfig))
            .edge(between(map, sink).setConfig(edgeFromMapperConfig));
 
-        Job job = inst.newJob(dag, jobConfig);
+        Job job = instance().newJob(dag, jobConfig);
         for (int i = 0; restart && i < 5; i++) {
             assertNotNull(job);
             assertTrueEventually(() -> {
@@ -218,7 +187,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
          .setLocalParallelism(2)
          .drainTo(Sinks.list(sinkList));
 
-        inst.newJob(p, jobConfig);
+        instance().newJob(p, jobConfig);
         assertResult(i -> Stream.of(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"), NUM_ITEMS);
     }
 
@@ -232,7 +201,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
          .setLocalParallelism(2)
          .drainTo(Sinks.list(sinkList));
 
-        inst.newJob(p, jobConfig);
+        instance().newJob(p, jobConfig);
         assertResult(i -> Stream.of(i + "-1"), NUM_ITEMS);
     }
 
@@ -246,7 +215,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
          .setLocalParallelism(2)
          .drainTo(Sinks.list(sinkList));
 
-        inst.newJob(p, jobConfig);
+        instance().newJob(p, jobConfig);
         assertResult(i -> i % 2 == 0 ? Stream.of(i + "") : Stream.empty(), NUM_ITEMS);
     }
 
@@ -261,7 +230,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
          .setLocalParallelism(2)
          .drainTo(Sinks.list(sinkList));
 
-        inst.newJob(p, jobConfig);
+        instance().newJob(p, jobConfig);
         assertResult(i -> Stream.of(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"), NUM_ITEMS);
     }
 
@@ -276,7 +245,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
          .setLocalParallelism(2)
          .drainTo(Sinks.list(sinkList));
 
-        inst.newJob(p, jobConfig);
+        instance().newJob(p, jobConfig);
         assertResult(i -> Stream.of(i + "-1"), NUM_ITEMS);
     }
 
@@ -291,7 +260,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends JetTestSupport 
          .setLocalParallelism(2)
          .drainTo(Sinks.list(sinkList));
 
-        inst.newJob(p, jobConfig);
+        instance().newJob(p, jobConfig);
         assertResult(i -> i % 2 == 0 ? Stream.of(i + "") : Stream.empty(), NUM_ITEMS);
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextP_IntegrationTest.java
@@ -100,7 +100,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends SimpleTestInClu
                 .setMapName("journaledMap*")
                 .setCapacity(100_000));
 
-        SimpleTestInClusterSupport.beforeClass(1, config);
+        SimpleTestInClusterSupport.initialize(1, config);
     }
 
     @Before

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextP_IntegrationTest.java
@@ -100,7 +100,7 @@ public class AsyncTransformUsingContextP_IntegrationTest extends SimpleTestInClu
                 .setMapName("journaledMap*")
                 .setCapacity(100_000));
 
-        SimpleTestInClusterSupport.initialize(1, config);
+        initialize(1, config);
     }
 
     @Before

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
@@ -57,7 +57,7 @@ public class ImdgUtilTest extends SimpleTestInClusterSupport {
         clientConfig.addNearCacheConfig(new NearCacheConfig(NEAR_CACHED_NON_SERIALIZED_MAP)
                 .setInMemoryFormat(InMemoryFormat.OBJECT));
 
-        SimpleTestInClusterSupport.beforeClassWithClient(2, jetConfig, clientConfig);
+        SimpleTestInClusterSupport.initializeWithClient(2, jetConfig, clientConfig);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
@@ -57,7 +57,7 @@ public class ImdgUtilTest extends SimpleTestInClusterSupport {
         clientConfig.addNearCacheConfig(new NearCacheConfig(NEAR_CACHED_NON_SERIALIZED_MAP)
                 .setInMemoryFormat(InMemoryFormat.OBJECT));
 
-        SimpleTestInClusterSupport.initializeWithClient(2, jetConfig, clientConfig);
+        initializeWithClient(2, jetConfig, clientConfig);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ImdgUtilTest.java
@@ -16,26 +16,16 @@
 
 package com.hazelcast.jet.impl.util;
 
-import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.IMap;
 import com.hazelcast.jet.IMapJet;
-import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestInstanceFactory;
-import com.hazelcast.jet.Job;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.config.JetConfig;
-import com.hazelcast.jet.core.JetTestSupport;
-import com.hazelcast.jet.impl.JetClientInstanceImpl;
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,16 +35,10 @@ import java.util.stream.IntStream;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 
-@RunWith(HazelcastSerialClassRunner.class)
-public class ImdgUtilTest extends JetTestSupport {
+public class ImdgUtilTest extends SimpleTestInClusterSupport {
 
     private static final String NEAR_CACHED_SERIALIZED_MAP = "nearCachedSerialized";
     private static final String NEAR_CACHED_NON_SERIALIZED_MAP = "nearCachedNonSerialized";
-
-    private static JetTestInstanceFactory factory = new JetTestInstanceFactory();
-    private static JetInstance instance1;
-    private static JetInstance instance2;
-    private static JetClientInstanceImpl client;
 
     @BeforeClass
     public static void setupCluster() {
@@ -66,50 +50,33 @@ public class ImdgUtilTest extends JetTestSupport {
         hzConfig.getMapConfig(NEAR_CACHED_NON_SERIALIZED_MAP).setNearCacheConfig(
                 new NearCacheConfig().setInMemoryFormat(InMemoryFormat.OBJECT)
         );
-        instance1 = factory.newMember(jetConfig);
-        instance2 = factory.newMember(jetConfig);
 
-        ClientConfig clientConfig = new JetClientConfig();
+        JetClientConfig clientConfig = new JetClientConfig();
         clientConfig.addNearCacheConfig(new NearCacheConfig(NEAR_CACHED_SERIALIZED_MAP)
                 .setInMemoryFormat(InMemoryFormat.BINARY));
         clientConfig.addNearCacheConfig(new NearCacheConfig(NEAR_CACHED_NON_SERIALIZED_MAP)
                 .setInMemoryFormat(InMemoryFormat.OBJECT));
-        client = factory.newClient(clientConfig);
-    }
 
-    @AfterClass
-    public static void tearDown() {
-        factory.terminateAll();
-        factory = null;
-    }
-
-    @After
-    public void after() {
-        for (Job job : instance1.getJobs()) {
-            ditchJob(job, instance1, instance2);
-        }
-        for (DistributedObject o : instance1.getHazelcastInstance().getDistributedObjects()) {
-            o.destroy();
-        }
+        SimpleTestInClusterSupport.beforeClassWithClient(2, jetConfig, clientConfig);
     }
 
     @Test
     public void test_copyMap() throws Exception {
         logger.info("Populating source map...");
-        IMapJet<Object, Object> srcMap = instance1.getMap("src");
+        IMapJet<Object, Object> srcMap = instance().getMap("src");
         Map<Integer, Integer> testData = IntStream.range(0, 100_000).boxed().collect(toMap(e -> e, e -> e));
         srcMap.putAll(testData);
 
         logger.info("Copying using job...");
-        Util.copyMapUsingJob(instance1, 128, srcMap.getName(), "target").get();
+        Util.copyMapUsingJob(instance(), 128, srcMap.getName(), "target").get();
         logger.info("Done copying");
 
-        assertEquals(testData, new HashMap<>(instance1.getMap("target")));
+        assertEquals(testData, new HashMap<>(instance().getMap("target")));
     }
 
     @Test
     public void mapPutAllAsync_noNearCache_member() throws Exception {
-        IMap<Object, Object> map = instance1.getHazelcastInstance().getMap(randomMapName());
+        IMap<Object, Object> map = instance().getHazelcastInstance().getMap(randomMapName());
         Map<String, String> tmpMap = new HashMap<>();
         tmpMap.put("k1", "v1");
         tmpMap.put("k2", "v1");
@@ -121,7 +88,7 @@ public class ImdgUtilTest extends JetTestSupport {
 
     @Test
     public void mapPutAllAsync_noNearCache_client() throws Exception {
-        IMap<Object, Object> map = client.getHazelcastInstance().getMap(randomMapName());
+        IMap<Object, Object> map = client().getHazelcastInstance().getMap(randomMapName());
         Map<String, String> tmpMap = new HashMap<>();
         tmpMap.put("k1", "v1");
         tmpMap.put("k2", "v1");
@@ -133,7 +100,7 @@ public class ImdgUtilTest extends JetTestSupport {
 
     @Test
     public void mapPutAllAsync_large_member() throws Exception {
-        IMap<Object, Object> map = instance1.getHazelcastInstance().getMap(randomMapName());
+        IMap<Object, Object> map = instance().getHazelcastInstance().getMap(randomMapName());
         Map<Integer, Integer> tmpMap = new HashMap<>();
         for (int i = 0; i < 32_768; i++) {
             tmpMap.put(i, i);
@@ -146,7 +113,7 @@ public class ImdgUtilTest extends JetTestSupport {
 
     @Test
     public void mapPutAllAsync_large_client() throws Exception {
-        IMap<Object, Object> map = client.getHazelcastInstance().getMap(randomMapName());
+        IMap<Object, Object> map = client().getHazelcastInstance().getMap(randomMapName());
         Map<Integer, Integer> tmpMap = new HashMap<>();
         for (int i = 0; i < 32_768; i++) {
             tmpMap.put(i, i);
@@ -159,7 +126,7 @@ public class ImdgUtilTest extends JetTestSupport {
 
     @Test
     public void mapPutAllAsync_withNearCache_serialized_member() throws Exception {
-        IMap<Object, Object> map = instance1.getHazelcastInstance().getMap(NEAR_CACHED_SERIALIZED_MAP);
+        IMap<Object, Object> map = instance().getHazelcastInstance().getMap(NEAR_CACHED_SERIALIZED_MAP);
         map.put("key", "value");
         map.get("key"); // populate the near cache
 
@@ -171,7 +138,7 @@ public class ImdgUtilTest extends JetTestSupport {
 
     @Test
     public void mapPutAllAsync_withNearCache_nonSerialized_member() throws Exception {
-        IMap<Object, Object> map = instance1.getHazelcastInstance().getMap(NEAR_CACHED_NON_SERIALIZED_MAP);
+        IMap<Object, Object> map = instance().getHazelcastInstance().getMap(NEAR_CACHED_NON_SERIALIZED_MAP);
         map.put("key", "value");
         map.get("key"); // populate the near cache
 
@@ -183,7 +150,7 @@ public class ImdgUtilTest extends JetTestSupport {
 
     @Test
     public void mapPutAllAsync_withNearCache_serialized_client() throws Exception {
-        IMap<Object, Object> map = client.getHazelcastInstance().getMap(NEAR_CACHED_SERIALIZED_MAP);
+        IMap<Object, Object> map = client().getHazelcastInstance().getMap(NEAR_CACHED_SERIALIZED_MAP);
         map.put("key", "value");
         map.get("key"); // populate the near cache
 
@@ -195,7 +162,7 @@ public class ImdgUtilTest extends JetTestSupport {
 
     @Test
     public void mapPutAllAsync_withNearCache_nonSerialized_client() throws Exception {
-        IMap<Object, Object> map = client.getHazelcastInstance().getMap(NEAR_CACHED_NON_SERIALIZED_MAP);
+        IMap<Object, Object> map = client().getHazelcastInstance().getMap(NEAR_CACHED_NON_SERIALIZED_MAP);
         map.put("key", "value");
         map.get("key"); // populate the near cache
 


### PR DESCRIPTION
This class is like TestInClusterSupport, but more flexible: allows
configuring member count, instance config, isn't parametrized, has
optional client.