### PR TITLE
Fix exception asserting in causes

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
@@ -126,7 +126,6 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
             fail("job didn't fail");
         } catch (Exception e) {
             assertContains(e.toString(), expected.toString());
-            e.printStackTrace();
         }
 
         assertEmptyJobMetrics(job, true);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_MiscTest.java
@@ -46,7 +46,6 @@ import java.util.function.Function;
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
-import static com.hazelcast.jet.core.TestUtil.assertExceptionInCauses;
 import static com.hazelcast.jet.core.metrics.JobMetrics_BatchTest.JOB_CONFIG_WITH_METRICS;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
 import static java.util.Collections.singletonList;
@@ -116,17 +115,18 @@ public class JobMetrics_MiscTest extends TestInClusterSupport {
     @Test
     public void when_jobFailedBeforeStarted_then_emptyMetrics() {
         DAG dag = new DAG();
-        RuntimeException exc = new RuntimeException("foo");
+        RuntimeException expected = new RuntimeException("foo");
         // Job will fail in ProcessorSupplier.init method, which is called before InitExecutionOp is
         // sent. That is before any member ever knew of the job.
-        dag.newVertex("v1", new MockPS(MockP::new, 1).setInitError(exc));
+        dag.newVertex("v1", new MockPS(MockP::new, 1).setInitError(expected));
 
         Job job = jet().newJob(dag, JOB_CONFIG_WITH_METRICS);
         try {
             job.join();
             fail("job didn't fail");
         } catch (Exception e) {
-            assertExceptionInCauses(exc, e);
+            assertContains(e.toString(), expected.toString());
+            e.printStackTrace();
         }
 
         assertEmptyJobMetrics(job, true);


### PR DESCRIPTION
If the client joined the job before it completed, a real exception was
in the causes. However, if it joined after the job completed, we
reconstitute the exception from `JobResult`, which only stores the
failure text. Therefore not the original exception is throws, but only
"JetException: failureText".

Fixes #1592