### PR TITLE
Add causes from members to job failed with a TCE

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -43,6 +43,7 @@ import com.hazelcast.jet.impl.util.LoggingUtil;
 import com.hazelcast.jet.impl.util.NonCompletableFuture;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.Operation;
 
@@ -66,6 +67,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.config.ProcessingGuarantee.NONE;
 import static com.hazelcast.jet.core.Edge.between;
@@ -508,24 +510,26 @@ public class MasterJobContext {
             return new CancellationException();
         }
 
-        Map<Boolean, List<Object>> grouped = groupResponses(responses);
-        int successfulMembersCount = grouped.get(false).size();
+        Map<Boolean, List<Entry<Address, Object>>> grouped = responses.stream()
+                .map(en -> entry(en.getKey().getAddress(), en.getValue()))
+                .collect(partitioningBy(e1 -> e1.getValue() instanceof Throwable));
 
-        List<Object> failures = grouped.get(true);
-        if (!failures.isEmpty()) {
-            logger.fine(opName + " of " + mc.jobIdString() + " has failures: " + failures);
-        }
-
+        int successfulMembersCount = grouped.getOrDefault(false, emptyList()).size();
         if (successfulMembersCount == mc.executionPlanMap().size()) {
             logger.fine(opName + " of " + mc.jobIdString() + " was successful");
             return null;
+        }
+
+        List<Entry<Address, Object>> failures = grouped.getOrDefault(true, emptyList());
+        if (!failures.isEmpty()) {
+            logger.fine(opName + " of " + mc.jobIdString() + " has failures: " + failures);
         }
 
         // Handle TerminatedWithSnapshotException. If only part of the members
         // threw it and others completed normally, the terminal snapshot will fail,
         // but we still handle it as if terminal snapshot was done. If there are
         // other exceptions, ignore this and handle the other exception.
-        if (failures.stream().allMatch(entry -> entry instanceof TerminatedWithSnapshotException)) {
+        if (failures.stream().allMatch(entry -> entry.getValue() instanceof TerminatedWithSnapshotException)) {
             assert opName.equals("Execution") : "opName is '" + opName + "', expected 'Execution'";
             logger.fine(opName + " of " + mc.jobIdString() + " terminated after a terminal snapshot");
             TerminationMode mode = requestedTerminationMode;
@@ -534,18 +538,16 @@ public class MasterJobContext {
         }
 
         // If all exceptions are of certain type, treat it as TopologyChangedException
-        Map<Boolean, List<Throwable>> splitFailures = failures.stream()
-                .map(entry -> (Throwable) entry)
-                .collect(Collectors.groupingBy(
-                        e -> e instanceof CancellationException
-                                || e instanceof TerminatedWithSnapshotException
-                                || isTopologyException(e),
-                        Collectors.toList()));
-        List<Throwable> topologyFailures = splitFailures.getOrDefault(true, emptyList());
-        List<Throwable> otherFailures = splitFailures.getOrDefault(false, emptyList());
+        Map<Boolean, List<Entry<Address, Object>>> splitFailures = failures.stream()
+                .collect(Collectors.partitioningBy(
+                        e -> e.getValue() instanceof CancellationException
+                                || e.getValue() instanceof TerminatedWithSnapshotException
+                                || isTopologyException((Throwable) e.getValue())));
+        List<Entry<Address, Object>> topologyFailures = splitFailures.getOrDefault(true, emptyList());
+        List<Entry<Address, Object>> otherFailures = splitFailures.getOrDefault(false, emptyList());
 
         if (!otherFailures.isEmpty()) {
-            return otherFailures.get(0);
+            return (Throwable) otherFailures.get(0).getValue();
         } else {
             return new TopologyChangedException("Causes from members: " + topologyFailures);
         }
@@ -838,19 +840,6 @@ public class MasterJobContext {
         } else {
             clientFuture.complete(metrics.stream().map(e -> (RawJobMetrics) e.getValue()).collect(Collectors.toList()));
         }
-    }
-
-    // true -> failures, false -> success responses
-    private Map<Boolean, List<Object>> groupResponses(Collection<Map.Entry<MemberInfo, Object>> responses) {
-        Map<Boolean, List<Object>> grouped = responses
-                .stream()
-                .map(Map.Entry::getValue)
-                .collect(partitioningBy(e -> e instanceof Throwable));
-
-        grouped.putIfAbsent(true, emptyList());
-        grouped.putIfAbsent(false, emptyList());
-
-        return grouped;
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -527,12 +527,12 @@ public class MasterJobContext {
 
         // If all exceptions are of certain type, treat it as TopologyChangedException
         Map<Boolean, List<Throwable>> splitFailures = failures.stream()
-                                                              .map(entry -> (Throwable) entry)
-                                                              .collect(Collectors.groupingBy(
-                                                                      e -> e instanceof CancellationException
-                                                                              || e instanceof TerminatedWithSnapshotException
-                                                                              || isTopologyException(e),
-                                                                      Collectors.toList()));
+                .map(entry -> (Throwable) entry)
+                .collect(Collectors.groupingBy(
+                        e -> e instanceof CancellationException
+                                || e instanceof TerminatedWithSnapshotException
+                                || isTopologyException(e),
+                        Collectors.toList()));
         List<Throwable> topologyFailures = splitFailures.getOrDefault(true, emptyList());
         List<Throwable> otherFailures = splitFailures.getOrDefault(false, emptyList());
 


### PR DESCRIPTION
Multiple exceptions are translated into a TopologyChangeException (TCE)
in `MasterJobContext.getResult`. Sometimes it's not clear what
exceptions they were. This commit adds them to the message of the TCE.

Fixes #1594