### PR TITLE
Fix intermittent test failure in StreamSourceStageTest

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
@@ -41,7 +41,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static java.util.Collections.newSetFromMap;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
@@ -56,12 +56,13 @@ public abstract class StreamSourceStageTestBase extends JetTestSupport {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    // we must use local parallelism 1 on the stages to avoid wm coalescing
     protected final Function<StreamSourceStage<Integer>, StreamStage<Integer>> withoutTimestampsFn =
-            s -> s.withoutTimestamps().addTimestamps(i -> i + 1, 0);
+            s -> s.withoutTimestamps().setLocalParallelism(1).addTimestamps(i -> i + 1, 0);
     protected final Function<StreamSourceStage<Integer>, StreamStage<Integer>> withNativeTimestampsFn =
-            s -> s.withNativeTimestamps(0);
+            s -> s.withNativeTimestamps(0).setLocalParallelism(1);
     protected final Function<StreamSourceStage<Integer>, StreamStage<Integer>> withTimestampsFn =
-            s -> s.withTimestamps(i -> i + 1, 0);
+            s -> s.withTimestamps(i -> i + 1, 0).setLocalParallelism(1);
 
     @Before
     public void before() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamSourceStageTestBase.java
@@ -104,9 +104,6 @@ public abstract class StreamSourceStageTestBase extends JetTestSupport {
         }
         stageWithTimestamps
                 .peek()
-                .window(WindowDefinition.tumbling(1))
-                .aggregate(counting())
-                .peek()
                 .drainTo(Sinks.fromProcessor("wmCollector",
                         ProcessorMetaSupplier.of(WatermarkCollector::new, 1))
                 );


### PR DESCRIPTION
In StreamSourceStageTestBase the WatermarkCollector
would only process one wm and then perpetually return false
since it was trying to emit it. Tests were only passing because
each watermarks was going to a different processor.

Fixes #1591