### PR TITLE
Reduce memory usage of JobSubmissionRegressionTest

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/job/JobSubmissionSlownessRegressionTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.job;
 
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.config.EdgeConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
@@ -26,6 +27,10 @@ import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.test.IgnoredForCoverage;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,10 +40,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import static com.hazelcast.jet.core.processor.Processors.noopP;
 import static org.junit.Assert.assertTrue;
@@ -124,7 +125,7 @@ public final class JobSubmissionSlownessRegressionTest extends JetTestSupport {
         DAG dag = new DAG();
         Vertex v1 = dag.newVertex("v", noopP());
         Vertex v2 = dag.newVertex("v2", noopP());
-        dag.edge(Edge.between(v1, v2));
+        dag.edge(Edge.between(v1, v2).setConfig(new EdgeConfig().setQueueSize(1)));
         return dag;
     }
 


### PR DESCRIPTION
The test is using a lot of memory when there is a lot of cores:
Each job creates core-count * core-count amount of queues, and each queue
has 1024 elements. On jenkins with 72 cores, this causes about 50mb of
memory usage per job, and the test submits 72 jobs at the same time.-

The fix is to set the queue size on edge to 1 as this is not related
to the regression tested by this test.

Fixes #1540