### PR TITLE
Fix different exception from join if problem is same

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
@@ -279,7 +279,7 @@ public abstract class AbstractJobProxy<T> implements Job {
         public synchronized void onFailure(Throwable t) {
             Throwable ex = peel(t);
             if (ex instanceof LocalMemberResetException) {
-                String msg = "Job " + idAndName() + " failed because the cluster is performing split-brain merge";
+                String msg = "Job " + idAndName() + " failed because the cluster is performing a split-brain merge";
                 logger.warning(msg, ex);
                 future.internalCompleteExceptionally(new CancellationException(msg));
             } else if (!isRestartable(ex)) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -273,7 +273,13 @@ public class JobCoordinationService {
     public CompletableFuture<Void> joinSubmittedJob(long jobId) {
         checkOperationalState();
         CompletableFuture<CompletableFuture<Void>> future = callWithJob(jobId,
-                mc -> mc.jobContext().jobCompletionFuture(),
+                mc -> mc.jobContext().jobCompletionFuture()
+                        .handle((r, t) -> {
+                            if (t != null) {
+                                throw new JetException(t.toString());
+                            }
+                            return null;
+                        }),
                 JobResult::asCompletableFuture,
                 jobRecord -> {
                     JobExecutionRecord jobExecutionRecord = ensureExecutionRecord(jobId,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -275,6 +275,9 @@ public class JobCoordinationService {
         CompletableFuture<CompletableFuture<Void>> future = callWithJob(jobId,
                 mc -> mc.jobContext().jobCompletionFuture()
                         .handle((r, t) -> {
+                            if (t instanceof CancellationException) {
+                                throw sneakyThrow(t);
+                            }
                             if (t != null) {
                                 throw new JetException(t.toString());
                             }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -16,21 +16,20 @@
 
 package com.hazelcast.jet.core;
 
-import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.IMap;
 import com.hazelcast.internal.cluster.MemberInfo;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.MembersView;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
-import com.hazelcast.jet.TestInClusterSupport;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.TestProcessors.ListSource;
 import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.jet.core.TestProcessors.MockPMS;
 import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
-import com.hazelcast.jet.core.processor.Processors;
+import com.hazelcast.jet.function.SupplierEx;
+import com.hazelcast.jet.impl.JetClientInstanceImpl;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.jet.impl.JobResult;
 import com.hazelcast.jet.impl.execution.ExecutionContext;
@@ -39,12 +38,11 @@ import com.hazelcast.jet.impl.execution.init.ExecutionPlanBuilder;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 import java.util.Collection;
@@ -58,6 +56,7 @@ import java.util.function.Function;
 
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.JobStatus.COMPLETING;
+import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.assertExceptionInCauses;
 import static com.hazelcast.jet.core.TestUtil.executeAndPeel;
 import static com.hazelcast.jet.core.processor.Processors.noopP;
@@ -71,15 +70,22 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
-public class ExecutionLifecycleTest extends TestInClusterSupport {
+public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
+
+    private static final int MEMBER_COUNT = 2;
+    private static final int PARALLELISM = Runtime.getRuntime().availableProcessors();
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    @BeforeClass
+    public static void beforeClass() {
+        initializeWithClient(MEMBER_COUNT, null, null);
+    }
+
     @Before
-    public void setup() {
-        TestProcessors.reset(MEMBER_COUNT * parallelism);
+    public void before() {
+        TestProcessors.reset(MEMBER_COUNT * PARALLELISM);
     }
 
     @Test
@@ -88,7 +94,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
         DAG dag = new DAG().vertex(new Vertex("test", new MockPMS(() -> new MockPS(MockP::new, MEMBER_COUNT))));
 
         // When
-        Job job = member.newJob(dag);
+        Job job = instance().newJob(dag);
         job.join();
 
         // Then
@@ -105,9 +111,9 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
         Vertex v2 = dag.newVertex("v2", () -> new NoOutputSourceP());
         dag.edge(between(v1, v2));
 
-        Job job = member.newJob(dag);
+        Job job = instance().newJob(dag);
         assertTrueEventually(this::assertPClosedWithoutError);
-        assertEquals(JobStatus.RUNNING, job.getStatus());
+        assertEquals(RUNNING, job.getStatus());
         NoOutputSourceP.proceedLatch.countDown();
         job.join();
         assertJobSucceeded(job);
@@ -138,12 +144,12 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
         dagGood.newVertex("good", () -> new NoOutputSourceP());
 
         // When
-        Job jobGood = member.newJob(dagGood);
+        Job jobGood = instance().newJob(dagGood);
         NoOutputSourceP.executionStarted.await();
         runJobExpectFailure(dagFaulty, e);
 
         // Then
-        assertTrueAllTheTime(() -> assertEquals(JobStatus.RUNNING, jobGood.getStatus()), 5);
+        assertTrueAllTheTime(() -> assertEquals(RUNNING, jobGood.getStatus()), 5);
         NoOutputSourceP.proceedLatch.countDown();
         jobGood.join();
     }
@@ -171,7 +177,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
                 new MockPMS(() -> new MockPS(MockP::new, MEMBER_COUNT)).setCloseError(e)));
 
         // When
-        Job job = member.newJob(dag);
+        Job job = instance().newJob(dag);
         job.join();
 
         // Then
@@ -217,7 +223,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
     public void when_psGetOnOtherNodeThrows_then_jobFails() throws Throwable {
         // Given
         RuntimeException e = new RuntimeException("mock error");
-        final int localPort = member.getCluster().getLocalMember().getAddress().getPort();
+        final int localPort = instance().getCluster().getLocalMember().getAddress().getPort();
 
         DAG dag = new DAG().vertex(new Vertex("faulty",
                 ProcessorMetaSupplier.of(
@@ -232,7 +238,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
         expectedException.expectMessage(e.getMessage());
 
         // When
-        executeAndPeel(member.newJob(dag));
+        executeAndPeel(instance().newJob(dag));
     }
 
     @Test
@@ -243,7 +249,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
                 new MockPMS(() -> new MockPS(MockP::new, MEMBER_COUNT).setCloseError(e))));
 
         // When
-        Job job = member.newJob(dag);
+        Job job = instance().newJob(dag);
         job.join();
 
         // Then
@@ -336,7 +342,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
                 new MockPMS(() -> new MockPS(() -> new MockP().setCloseError(e), MEMBER_COUNT)));
 
         // When
-        Job job = member.newJob(dag);
+        Job job = instance().newJob(dag);
         job.join();
 
         // Then
@@ -353,7 +359,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
                 new MockPMS(() -> new MockPS(NoOutputSourceP::new, MEMBER_COUNT))));
 
         // When
-        Job job = member.newJob(dag);
+        Job job = instance().newJob(dag);
         try {
             NoOutputSourceP.executionStarted.await();
             job.cancel();
@@ -375,13 +381,13 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
         DAG dag = new DAG().vertex(new Vertex("test",
                 new MockPS(NoOutputSourceP::new, MEMBER_COUNT)));
 
-        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(member.getHazelcastInstance());
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(instance().getHazelcastInstance());
         Address localAddress = nodeEngineImpl.getThisAddress();
         ClusterServiceImpl clusterService = (ClusterServiceImpl) nodeEngineImpl.getClusterService();
         MembersView membersView = clusterService.getMembershipManager().getMembersView();
         int memberListVersion = membersView.getVersion();
 
-        JetService jetService = getJetService(member);
+        JetService jetService = getJetService(instance());
         final Map<MemberInfo, ExecutionPlan> executionPlans =
                 ExecutionPlanBuilder.createExecutionPlans(nodeEngineImpl, membersView, dag, 1, 1,
                         new JobConfig(), NO_SNAPSHOT);
@@ -412,7 +418,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
                 new MockPS(() -> new NoOutputSourceP(10_000), MEMBER_COUNT)));
 
         // When
-        Job job = member.newJob(dag);
+        Job job = instance().newJob(dag);
 
         assertOpenEventually(NoOutputSourceP.executionStarted);
 
@@ -437,13 +443,12 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
 
     @Test
     public void when_deserializationOnMembersFails_then_jobSubmissionFails__member() throws Throwable {
-        when_deserializationOnMembersFails_then_jobSubmissionFails(createJetMember());
+        when_deserializationOnMembersFails_then_jobSubmissionFails(instance());
     }
 
     @Test
     public void when_deserializationOnMembersFails_then_jobSubmissionFails__client() throws Throwable {
-        createJetMember();
-        when_deserializationOnMembersFails_then_jobSubmissionFails(createJetClient());
+        when_deserializationOnMembersFails_then_jobSubmissionFails(client());
     }
 
     private void when_deserializationOnMembersFails_then_jobSubmissionFails(JetInstance instance) throws Throwable {
@@ -464,28 +469,57 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
 
     @Test
     public void when_deserializationOnMasterFails_then_jobSubmissionFails_member() throws Throwable {
-        when_deserializationOnMasterFails_then_jobSubmissionFails(createJetMember());
+        when_deserializationOnMasterFails_then_jobSubmissionFails(instance());
     }
 
     @Test
     public void when_deserializationOnMasterFails_then_jobSubmissionFails_client() throws Throwable {
-        createJetMember();
-        when_deserializationOnMasterFails_then_jobSubmissionFails(createJetClient());
+        when_deserializationOnMasterFails_then_jobSubmissionFails(client());
     }
 
     @Test
-    public void when_job_withNoSnapshots_completed_then_noSnapshotMapsLeft() {
-        JetInstance instance = createJetMember();
+    public void when_clientJoinBeforeAndAfterComplete_then_exceptionEquals() {
         DAG dag = new DAG();
-        dag.newVertex("noop", Processors.noopP());
-        instance.newJob(dag).join();
-        Collection<DistributedObject> objects = instance.getHazelcastInstance().getDistributedObjects();
-        long snapshotMaps = objects.stream()
-                .filter(obj -> obj instanceof IMap)
-                .filter(obj -> obj.getName().contains("snapshots.data"))
-                .count();
+        Vertex noop = dag.newVertex("noop", (SupplierEx<Processor>) NoOutputSourceP::new)
+                .localParallelism(1);
+        Vertex faulty = dag.newVertex("faulty", () -> new MockP().setCompleteError(new RuntimeException("error")))
+                .localParallelism(1);
+        dag.edge(between(noop, faulty));
 
-        assertEquals(0, snapshotMaps);
+        Job job = client().newJob(dag);
+        assertJobStatusEventually(job, RUNNING);
+        NoOutputSourceP.proceedLatch.countDown();
+        Throwable excBeforeComplete;
+        Throwable excAfterComplete;
+        try {
+            job.join();
+            throw new AssertionError("should have failed");
+        } catch (Exception e) {
+            excBeforeComplete = e;
+        }
+
+        // create a new client that will join the job after completion
+        JetClientInstanceImpl client2 = factory().newClient();
+        Job job2 = client2.getJob(job.getId());
+        try {
+            job2.join();
+            throw new AssertionError("should have failed");
+        } catch (Exception e) {
+            excAfterComplete = e;
+        }
+
+        logger.info("exception before completion", excBeforeComplete);
+        logger.info("exception after completion", excAfterComplete);
+
+        // Then
+        while (excBeforeComplete != null || excAfterComplete != null) {
+            assertNotNull("excBeforeComplete is null", excBeforeComplete);
+            assertNotNull("excAfterComplete is null", excAfterComplete);
+            assertEquals(excBeforeComplete.getClass(), excAfterComplete.getClass());
+            assertEquals(excBeforeComplete.getMessage(), excAfterComplete.getMessage());
+            excBeforeComplete = excBeforeComplete.getCause();
+            excAfterComplete = excAfterComplete.getCause();
+        }
     }
 
     private void when_deserializationOnMasterFails_then_jobSubmissionFails(JetInstance instance) throws Throwable {
@@ -509,7 +543,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
     private Job runJobExpectFailure(@Nonnull DAG dag, @Nonnull RuntimeException expectedException) {
         Job job = null;
         try {
-            job = member.newJob(dag);
+            job = instance().newJob(dag);
             job.join();
             fail("Job execution should have failed");
         } catch (Exception actual) {
@@ -548,12 +582,12 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
     }
 
     private void assertPClosedWithoutError() {
-        assertEquals(MEMBER_COUNT * parallelism, MockP.initCount.get());
-        assertEquals(MEMBER_COUNT * parallelism, MockP.closeCount.get());
+        assertEquals(MEMBER_COUNT * PARALLELISM, MockP.initCount.get());
+        assertEquals(MEMBER_COUNT * PARALLELISM, MockP.closeCount.get());
     }
 
     private void assertPClosedWithError() {
-        assertEquals(MEMBER_COUNT * parallelism, MockP.closeCount.get());
+        assertEquals(MEMBER_COUNT * PARALLELISM, MockP.closeCount.get());
     }
 
     private void assertJobSucceeded(Job job) {
@@ -570,7 +604,7 @@ public class ExecutionLifecycleTest extends TestInClusterSupport {
     }
 
     private JobResult getJobResult(Job job) {
-        JetService jetService = getJetService(member);
+        JetService jetService = getJetService(instance());
         assertNull(jetService.getJobRepository().getJobRecord(job.getId()));
         JobResult jobResult = jetService.getJobRepository().getJobResult(job.getId());
         assertNotNull(jobResult);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -436,7 +436,7 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
         NoOutputSourceP.proceedLatch.countDown();
 
-        expectedException.expectMessage(CancellationException.class.getName());
+        expectedException.expect(CancellationException.class);
         job.join();
 
         assertEquals("PS.close not called after execution finished", MEMBER_COUNT, MockPS.closeCount.get());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -365,7 +365,8 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
             job.cancel();
             job.join();
             fail("Job execution should fail");
-        } catch (CancellationException ignored) {
+        } catch (Exception e) {
+            assertContains(e.toString(), CancellationException.class.getName());
         }
 
         assertTrueEventually(() -> {
@@ -435,7 +436,7 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
 
         NoOutputSourceP.proceedLatch.countDown();
 
-        expectedException.expect(CancellationException.class);
+        expectedException.expectMessage(CancellationException.class.getName());
         job.join();
 
         assertEquals("PS.close not called after execution finished", MEMBER_COUNT, MockPS.closeCount.get());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl;
 
 import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JetConfig;
@@ -172,7 +173,7 @@ public class JobSummaryTest extends JetTestSupport {
         assertEquals(1, list.size());
         JobSummary jobSummary = list.get(0);
 
-        assertEquals(msg, jobSummary.getFailureText());
+        assertEquals(msg, new JetException(jobSummary.getFailureText()).toString());
         assertNotEquals(0, jobSummary.getCompletionTime());
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ExceptionUtilTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.TestProcessors.MockP;
-import com.hazelcast.jet.core.TestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,7 +76,7 @@ public class ExceptionUtilTest extends JetTestSupport {
             dag.newVertex("source", () -> new MockP().setCompleteError(exc)).localParallelism(1);
             client.newJob(dag).join();
         } catch (Exception caught) {
-            TestUtil.assertExceptionInCauses(exc, caught);
+            assertContains(caught.toString(), exc.toString());
         }
     }
 
@@ -93,7 +92,6 @@ public class ExceptionUtilTest extends JetTestSupport {
             client.newJob(dag).join();
         } catch (Exception caught) {
             assertThat(caught.toString(), containsString(exc.toString()));
-            TestUtil.assertExceptionInCauses(exc, caught);
         }
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/test/AssertionsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/test/AssertionsTest.java
@@ -58,7 +58,7 @@ public class AssertionsTest extends PipelineTestSupport {
         p.drawFrom(TestSources.items(4, 3, 2, 1))
          .apply(Assertions.assertOrdered(Arrays.asList(1, 2, 3, 4)));
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
     }
 
@@ -89,7 +89,7 @@ public class AssertionsTest extends PipelineTestSupport {
                 .apply(Assertions.assertOrdered(Arrays.asList(1, 2, 3, 4)))
                 .drainTo(sinkList());
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
 
         assertEquals(4, assertionSink.size());
@@ -125,7 +125,7 @@ public class AssertionsTest extends PipelineTestSupport {
         p.drawFrom(TestSources.items(3, 2, 1))
          .apply(Assertions.assertAnyOrder(Arrays.asList(1, 2, 3, 4)));
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
     }
 
@@ -142,7 +142,7 @@ public class AssertionsTest extends PipelineTestSupport {
         p.drawFrom(TestSources.items(1, 3, 2, 3))
                 .apply(Assertions.assertAnyOrder(Arrays.asList(1, 2, 3)));
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
     }
 
@@ -151,7 +151,7 @@ public class AssertionsTest extends PipelineTestSupport {
         p.drawFrom(TestSources.items(1, 2, 3))
                 .apply(Assertions.assertAnyOrder(Arrays.asList(1, 2, 3, 3)));
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
     }
 
@@ -182,7 +182,7 @@ public class AssertionsTest extends PipelineTestSupport {
                 .apply(Assertions.assertAnyOrder(Arrays.asList(1, 2, 3, 4)))
                 .drainTo(sinkList());
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
 
         assertEquals(4, assertionSink.size());
@@ -204,7 +204,7 @@ public class AssertionsTest extends PipelineTestSupport {
         p.drawFrom(TestSources.items(4, 1, 2, 3))
          .apply(Assertions.assertContains(Arrays.asList(1, 3, 5)));
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
     }
 
@@ -235,7 +235,7 @@ public class AssertionsTest extends PipelineTestSupport {
                 .apply(Assertions.assertContains(Arrays.asList(1, 3, 5)))
                 .drainTo(sinkList());
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
 
         assertEquals(4, assertionSink.size());
@@ -258,7 +258,7 @@ public class AssertionsTest extends PipelineTestSupport {
         p.drawFrom(TestSources.items(1))
          .apply(assertCollected(c -> assertTrue("list size must be at least 4", c.size() >= 4)));
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
     }
 
@@ -289,7 +289,7 @@ public class AssertionsTest extends PipelineTestSupport {
                 .apply(assertCollected(c -> assertTrue("list size must be at least 4", c.size() >= 4)))
                 .drainTo(sinkList());
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
 
         assertEquals(1, assertionSink.size());
@@ -302,7 +302,7 @@ public class AssertionsTest extends PipelineTestSupport {
          .withoutTimestamps()
          .apply(assertCollectedEventually(5, c -> assertTrue("did not receive item '0'", c.contains(0L))));
 
-        expectedException.expect(AssertionCompletedException.class);
+        expectedException.expectMessage(AssertionCompletedException.class.getName());
         executeAndPeel();
     }
 
@@ -312,7 +312,7 @@ public class AssertionsTest extends PipelineTestSupport {
          .withoutTimestamps()
          .apply(assertCollectedEventually(5, c -> assertTrue("did not receive item '1'", c.contains(1L))));
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
     }
 
@@ -326,7 +326,7 @@ public class AssertionsTest extends PipelineTestSupport {
                 .apply(assertCollectedEventually(5, c -> assertTrue("did not receive item '0'", c.contains(0L))))
                 .drainTo(sinkList());
 
-        expectedException.expect(AssertionCompletedException.class);
+        expectedException.expectMessage(AssertionCompletedException.class.getName());
         executeAndPeel();
 
         assertFalse(assertionSink.isEmpty());
@@ -342,7 +342,7 @@ public class AssertionsTest extends PipelineTestSupport {
                 .apply(assertCollectedEventually(5, c -> assertTrue("did not receive item '1'", c.contains(1L))))
                 .drainTo(sinkList());
 
-        expectedException.expect(AssertionError.class);
+        expectedException.expectMessage(AssertionError.class.getName());
         executeAndPeel();
 
         assertFalse(assertionSink.isEmpty());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
@@ -61,7 +61,7 @@ public class TestSourcesTest extends PipelineTestSupport {
              }
          }));
 
-        expectedException.expect(AssertionCompletedException.class);
+        expectedException.expectMessage(AssertionCompletedException.class.getName());
         executeAndPeel();
 
     }
@@ -80,7 +80,7 @@ public class TestSourcesTest extends PipelineTestSupport {
              assertTrue("Did not find any window with 10 items: " + windowResults, matched);
          }));
 
-        expectedException.expect(AssertionCompletedException.class);
+        expectedException.expectMessage(AssertionCompletedException.class.getName());
         executeAndPeel();
     }
 
@@ -106,7 +106,7 @@ public class TestSourcesTest extends PipelineTestSupport {
                             (long) windowResults.get(1).result() < itemsPerSecond * 2);
                 }));
 
-        expectedException.expect(AssertionCompletedException.class);
+        expectedException.expectMessage(AssertionCompletedException.class.getName());
         executeAndPeel();
     }
 

--- a/hazelcast-jet-reference-manual/src/main/java/Testing.java
+++ b/hazelcast-jet-reference-manual/src/main/java/Testing.java
@@ -93,17 +93,15 @@ public class Testing {
                 " but instead completed normally"
             );
         } catch (CompletionException e) {
-            Throwable jetException = e.getCause();
-            assertInstanceOf(AssertionCompletedException.class, jetException.getCause());
+            assertContains(e.toString(), AssertionCompletedException.class.getName());
         }
         //end::assertion-completed-exception[]
     }
 
     private static void fail(String s) {
-
     }
 
-    private static void assertInstanceOf(Class c, Object o) {
+    private static void assertContains(String actual, String expectedSubstring) {
     }
 
     private static class Trade {


### PR DESCRIPTION
Fixes #1598

One difference still remains: if a temporary master context is completed
in `JobCoordinatorService.completeMasterContextIfJobAlreadyCompleted()`,
it will have different error.

Also contains refactor of `ExecutionLifecycleTest` to use
`SimpleTestInClusterSupport`: some tests created a second cluster.

The test `when_job_withNoSnapshots_completed_then_noSnapshotMapsLeft`
was outdated.
