### PR TITLE
Change max parallel ops limit to 1 per processor for writeMapP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -208,11 +208,6 @@ public final class HazelcastWriters {
             throw new UnsupportedOperationException();
         }
 
-        @Override
-        public void clear() {
-            entries.clear();
-        }
-
         private class ArraySet extends AbstractSet<Entry<K, V>> {
 
             @Override @Nonnull
@@ -223,6 +218,11 @@ public final class HazelcastWriters {
             @Override
             public int size() {
                 return entries.size();
+            }
+
+            @Override
+            public void clear() {
+                entries.clear();
             }
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -208,6 +208,11 @@ public final class HazelcastWriters {
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public void clear() {
+            entries.clear();
+        }
+
         private class ArraySet extends AbstractSet<Entry<K, V>> {
 
             @Override @Nonnull


### PR DESCRIPTION
Currently the limit is higher per processor, which may overload the cluster if the writes are slow. This allows the parallelism of the sink to be controlled in a more fine-grained way.