### PR TITLE
Fix race in JCS.getJobIds

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/StartExecutionOperation.java
@@ -26,6 +26,8 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Operation sent from master to members to start execution of a job. It is
  * sent after {@link InitExecutionOperation} was successful on all members.
+ * The operation doesn't complete immediately, it completes when the execution
+ * completes on the member.
  */
 public class StartExecutionOperation extends AsyncJobOperation {
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/NonSmartClientTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/NonSmartClientTest.java
@@ -64,7 +64,7 @@ public class NonSmartClientTest extends JetTestSupport {
     }
 
     @Test
-    public void when_jobSubmitted_Then_executedSuccessfully() {
+    public void when_jobSubmitted_then_executedSuccessfully() {
         //Given
         String sourceName = "source";
         String sinkName = "sink";
@@ -81,7 +81,7 @@ public class NonSmartClientTest extends JetTestSupport {
     }
 
     @Test
-    public void when_jobSubmitted_Then_jobCanBeFetchedByIdOrName() {
+    public void when_jobSubmitted_then_jobCanBeFetchedByIdOrName() {
         //Given
         String jobName = randomName();
 
@@ -107,7 +107,7 @@ public class NonSmartClientTest extends JetTestSupport {
 
 
     @Test
-    public void when_jobSuspended_Then_jobStatusIsSuspended() {
+    public void when_jobSuspended_then_jobStatusIsSuspended() {
         //Given
         Job job = startJobAndVerifyItIsRunning();
 
@@ -119,7 +119,7 @@ public class NonSmartClientTest extends JetTestSupport {
     }
 
     @Test
-    public void when_jobResumed_Then_jobStatusIsRunning() {
+    public void when_jobResumed_then_jobStatusIsRunning() {
         //Given
         Job job = startJobAndVerifyItIsRunning();
         job.suspend();
@@ -134,7 +134,7 @@ public class NonSmartClientTest extends JetTestSupport {
     }
 
     @Test
-    public void when_jobCancelled_Then_jobStatusIsCompleted() {
+    public void when_jobCancelled_then_jobStatusIsCompleted() {
         //Given
         Job job = startJobAndVerifyItIsRunning();
 
@@ -146,7 +146,7 @@ public class NonSmartClientTest extends JetTestSupport {
     }
 
     @Test
-    public void when_jobSummaryListIsAsked_Then_jobSummaryListReturned() {
+    public void when_jobSummaryListIsAsked_then_jobSummaryListReturned() {
         //Given
         startJobAndVerifyItIsRunning();
 


### PR DESCRIPTION
We checked JobResults first and the master contexts. We could miss a job
that completed in the meantime. Fixed by reversing the order.

Fixes  #1610