### PR TITLE
Mark some client operations as retryable

### DIFF
--- a/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
+++ b/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
@@ -54,7 +54,7 @@ public interface JetCodecTemplate {
     @Request(id = 10, retryable = false, response = ResponseMessageConst.VOID)
     void resumeJob(long jobId);
 
-    @Request(id = 11, retryable = true, response = ResponseMessageConst.VOID)
+    @Request(id = 11, retryable = false, response = ResponseMessageConst.VOID)
     void exportSnapshot(long jobId, String name, boolean cancelJob);
 
     @Request(id = 12, retryable = true, response = ResponseMessageConst.DATA)

--- a/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
+++ b/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
@@ -30,13 +30,13 @@ public interface JetCodecTemplate {
     @Request(id = 2, retryable = false, response = ResponseMessageConst.VOID)
     void terminateJob(long jobId, int terminateMode);
 
-    @Request(id = 3, retryable = false, response = ResponseMessageConst.INTEGER)
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER)
     Object getJobStatus(long jobId);
 
     @Request(id = 4, retryable = true, response = ResponseMessageConst.LIST_LONG)
     Object getJobIds();
 
-    @Request(id = 5, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 5, retryable = true, response = ResponseMessageConst.VOID)
     void joinSubmittedJob(long jobId);
 
     @Request(id = 6, retryable = true, response = ResponseMessageConst.LIST_LONG)
@@ -45,7 +45,7 @@ public interface JetCodecTemplate {
     @Request(id = 7, retryable = true, response = ResponseMessageConst.LONG)
     long getJobSubmissionTime(long jobId);
 
-    @Request(id = 8, retryable = false, response = ResponseMessageConst.DATA)
+    @Request(id = 8, retryable = true, response = ResponseMessageConst.DATA)
     Object getJobConfig(long jobId);
 
     @Request(id = 9, retryable = true, response = ResponseMessageConst.DATA)
@@ -54,7 +54,7 @@ public interface JetCodecTemplate {
     @Request(id = 10, retryable = false, response = ResponseMessageConst.VOID)
     void resumeJob(long jobId);
 
-    @Request(id = 11, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 11, retryable = true, response = ResponseMessageConst.VOID)
     void exportSnapshot(long jobId, String name, boolean cancelJob);
 
     @Request(id = 12, retryable = true, response = ResponseMessageConst.DATA)


### PR DESCRIPTION
We had this failure:
```
com.hazelcast.spi.exception.TargetNotMemberException: Target '[10.0.0.81]:5701' is not a member.
    ...
    at com.hazelcast.jet.impl.ClientJobProxy.getStatus(ClientJobProxy.java:72)
    at com.hazelcast.jet.tests.rolling.RollingAggregateTest.test(RollingAggregateTest.java:83)
    ...
```

Fixes a part of #1606