### PR TITLE
Fix few Job methods when master is going down

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -39,18 +39,25 @@ import com.hazelcast.jet.impl.client.protocol.codec.JetSubmitJobCodec;
 import com.hazelcast.jet.impl.client.protocol.codec.JetTerminateJobCodec;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 
 import javax.annotation.Nonnull;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.LockSupport;
 
 import static com.hazelcast.jet.impl.JobMetricsUtil.toJobMetrics;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * {@link Job} proxy on client.
  */
 public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl> {
+
+    private static final long RETRY_DELAY_NS = MILLISECONDS.toNanos(100);
 
     ClientJobProxy(JetClientInstanceImpl client, long jobId) {
         super(client, jobId);
@@ -63,27 +70,23 @@ public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl> {
     @Nonnull
     @Override
     public JobStatus getStatus() {
-        ClientMessage request = JetGetJobStatusCodec.encodeRequest(getId());
-        try {
+        return callAndRetryIfTargetNotFound(()  -> {
+            ClientMessage request = JetGetJobStatusCodec.encodeRequest(getId());
             ClientMessage response = invocation(request, masterAddress()).invoke().get();
             ResponseParameters parameters = JetGetJobStatusCodec.decodeResponse(response);
             return JobStatus.values()[parameters.response];
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
+        });
     }
 
     @Nonnull
     @Override
     public JobMetrics getMetrics() {
-        ClientMessage request = JetGetJobMetricsCodec.encodeRequest(getId());
-        try {
+        return callAndRetryIfTargetNotFound(()  -> {
+            ClientMessage request = JetGetJobMetricsCodec.encodeRequest(getId());
             ClientMessage response = invocation(request, masterAddress()).invoke().get();
             JetGetJobMetricsCodec.ResponseParameters parameters = JetGetJobMetricsCodec.decodeResponse(response);
             return toJobMetrics(serializationService().toObject(parameters.response));
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
+        });
     }
 
     @Override
@@ -140,25 +143,21 @@ public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl> {
 
     @Override
     protected long doGetJobSubmissionTime() {
-        ClientMessage request = JetGetJobSubmissionTimeCodec.encodeRequest(getId());
-        try {
+        return callAndRetryIfTargetNotFound(() -> {
+            ClientMessage request = JetGetJobSubmissionTimeCodec.encodeRequest(getId());
             ClientMessage response = invocation(request, masterAddress()).invoke().get();
             return JetGetJobSubmissionTimeCodec.decodeResponse(response).response;
-        } catch (Throwable t) {
-            throw rethrow(t);
-        }
+        });
     }
 
     @Override
     protected JobConfig doGetJobConfig() {
-        ClientMessage request = JetGetJobConfigCodec.encodeRequest(getId());
-        try {
+        return callAndRetryIfTargetNotFound(() -> {
+            ClientMessage request = JetGetJobConfigCodec.encodeRequest(getId());
             ClientMessage response = invocation(request, masterAddress()).invoke().get();
             Data data = JetGetJobConfigCodec.decodeResponse(response).response;
             return serializationService().toObject(data);
-        } catch (Throwable t) {
-            throw rethrow(t);
-        }
+        });
     }
 
     @Override
@@ -181,6 +180,21 @@ public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl> {
         return new ClientInvocation(
                 container().getHazelcastClient(), request, "jobId=" + getIdString(), invocationAddr
         );
+    }
+
+    private <T> T callAndRetryIfTargetNotFound(Callable<T> action) {
+        for (;;) {
+            try {
+                return action.call();
+            } catch (Exception e) {
+                if (e instanceof ExecutionException && e.getCause() instanceof TargetNotMemberException) {
+                    // ignore the TargetNotMemberException and retry with new master
+                    LockSupport.parkNanos(RETRY_DELAY_NS);
+                    continue;
+                }
+                throw rethrow(e);
+            }
+        }
     }
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/AbstractJetMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/AbstractJetMessageTask.java
@@ -18,10 +18,12 @@ package com.hazelcast.jet.impl.client.protocol.task;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.AbstractInvocationMessageTask;
+import com.hazelcast.cluster.Address;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.operationservice.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
@@ -76,8 +78,12 @@ abstract class AbstractJetMessageTask<P, R> extends AbstractInvocationMessageTas
 
     @Override
     protected InvocationBuilder getInvocationBuilder(Operation operation) {
+        Address masterAddress = nodeEngine.getMasterAddress();
+        if (masterAddress == null) {
+            throw new RetryableHazelcastException("master not yet known");
+        }
         return nodeEngine.getOperationService().createInvocationBuilder(JetService.SERVICE_NAME,
-                operation, nodeEngine.getMasterAddress());
+                operation, masterAddress);
     }
 
     protected JetService getJetService() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Job_SeparateClusterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/Job_SeparateClusterTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.properties.ClientProperty;
+import com.hazelcast.cluster.Address;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.JobAlreadyExistsException;
+import com.hazelcast.jet.config.JetClientConfig;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.config.JobConfig;
+import com.hazelcast.jet.core.TestProcessors.MockPS;
+import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.jet.core.JobStatus.RUNNING;
+import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link Job} with a separate cluster for each test.
+ */
+public class Job_SeparateClusterTest extends JetTestSupport {
+
+    private static final int NODE_COUNT = 2;
+    private static final int LOCAL_PARALLELISM = 1;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private JetInstance instance1;
+    private JetInstance instance2;
+
+    @Before
+    public void setup() {
+        TestProcessors.reset(NODE_COUNT * LOCAL_PARALLELISM);
+
+        JetConfig config = new JetConfig();
+        config.getInstanceConfig().setCooperativeThreadCount(LOCAL_PARALLELISM);
+        config.getInstanceConfig().setScaleUpDelayMillis(10);
+        instance1 = createJetMember(config);
+        instance2 = createJetMember(config);
+    }
+
+    @Test
+    public void when_suspendedJobScannedOnNewMaster_then_newJobWithEqualNameFails() {
+        // Given
+        DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT * 2)));
+        JobConfig config = new JobConfig()
+                .setName("job1");
+
+        // When
+        Job job1 = instance1.newJob(dag, config);
+        assertJobStatusEventually(job1, RUNNING);
+        job1.suspend();
+        assertJobStatusEventually(job1, SUSPENDED);
+        // gracefully shutdown the master
+        instance1.shutdown();
+
+        // Then
+        expectedException.expect(JobAlreadyExistsException.class);
+        instance2.newJob(dag, config);
+    }
+
+    @Test
+    public void when_joinFromClientTimesOut_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
+        DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
+
+        int timeoutSecs = 1;
+        ClientConfig config = new JetClientConfig()
+                .setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), Integer.toString(timeoutSecs));
+        JetInstance client = createJetClient(config);
+
+        // join request is sent along with job submission
+        Job job = client.newJob(dag);
+        NoOutputSourceP.executionStarted.await();
+
+        // wait for join invocation to timeout
+        Thread.sleep(TimeUnit.SECONDS.toMillis(timeoutSecs));
+
+        // When
+        NoOutputSourceP.initCount.set(0);
+        instance1.getHazelcastInstance().getLifecycleService().terminate();
+        // wait for job to be restarted on remaining node
+        assertTrueEventually(() -> assertEquals(LOCAL_PARALLELISM, NoOutputSourceP.initCount.get()));
+
+        RuntimeException ex = new RuntimeException("Faulty job");
+        NoOutputSourceP.failure.set(ex);
+
+        // Then
+        expectedException.expectMessage(Matchers.containsString(ex.getMessage()));
+        job.join();
+    }
+
+    @Test
+    public void when_joinFromClientSentToNonMaster_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
+        DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
+
+        int timeoutSecs = 1;
+        Address address = getAddress(instance2);
+        ClientConfig config = new JetClientConfig()
+                .setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), Integer.toString(timeoutSecs))
+                .setNetworkConfig(new ClientNetworkConfig()
+                        .setSmartRouting(false)
+                        .addAddress(address.getHost() + ":" + address.getPort())
+                );
+        JetInstance client = createJetClient(config);
+
+        // join request is sent along with job submission
+        Job job = client.newJob(dag);
+        NoOutputSourceP.executionStarted.await();
+
+        // wait for join invocation to timeout
+        Thread.sleep(TimeUnit.SECONDS.toMillis(timeoutSecs));
+
+        // When
+        NoOutputSourceP.initCount.set(0);
+        instance1.getHazelcastInstance().getLifecycleService().terminate();
+        // wait for job to be restarted on remaining node
+        assertTrueEventually(() -> assertEquals(LOCAL_PARALLELISM, NoOutputSourceP.initCount.get()));
+
+        RuntimeException ex = new RuntimeException("Faulty job");
+        NoOutputSourceP.failure.set(ex);
+
+        // Then
+        expectedException.expectMessage(Matchers.containsString(ex.getMessage()));
+        job.join();
+    }
+}


### PR DESCRIPTION
`Job.getJobStatus` can fail if executed when the master is going down and the client doesn't know yet. This PR fixes 3 similar methods on the client, but similar issue remains on member and with other methods. `newJob` handles it on its own and differently.

Also rewrite the `JobTest` to use shared cluster, went from 130s to 11+13 seconds locally.