### PR TITLE
Client Join message should not be marked as retryable

### DIFF
--- a/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
+++ b/hazelcast-jet-client-protocol/src/main/java/com/hazelcast/client/impl/protocol/template/JetCodecTemplate.java
@@ -36,7 +36,8 @@ public interface JetCodecTemplate {
     @Request(id = 4, retryable = true, response = ResponseMessageConst.LIST_LONG)
     Object getJobIds();
 
-    @Request(id = 5, retryable = true, response = ResponseMessageConst.VOID)
+    // must not be retryable, Jet client has own retry mechanism here
+    @Request(id = 5, retryable = false, response = ResponseMessageConst.VOID)
     void joinSubmittedJob(long jobId);
 
     @Request(id = 6, retryable = true, response = ResponseMessageConst.LIST_LONG)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -16,9 +16,12 @@
 
 package com.hazelcast.jet.core;
 
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.JobAlreadyExistsException;
+import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.TestProcessors.Identity;
@@ -753,6 +756,29 @@ public class JobTest extends JetTestSupport {
         assertNotNull(trackedJob);
         assertNotEquals(0, job.getSubmissionTime());
         assertNotEquals(0, trackedJob.getSubmissionTime());
+    }
+
+    @Test
+    public void when_jobIsJoinedAfterRestart_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
+        DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
+
+        int timeoutSecs = 2;
+        ClientConfig config = new JetClientConfig()
+                .setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), Integer.toString(timeoutSecs));
+        JetInstance client = createJetClient(config);
+
+        Job job = client.newJob(dag);
+        NoOutputSourceP.executionStarted.await();
+        // wait for invocation to timeout
+        Thread.sleep(TimeUnit.SECONDS.toMillis(timeoutSecs));
+
+        // When
+        instance1.shutdown();
+        job.cancel();
+
+        // Then
+        expectedException.expect(CancellationException.class);
+        job.join();
     }
 
     private void joinAndExpectCancellation(Job job) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -759,7 +759,7 @@ public class JobTest extends JetTestSupport {
     }
 
     @Test
-    public void when_jobIsJoinedAfterRestart_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
+    public void when_joinFromClientTimesOut_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
         DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
 
         int timeoutSecs = 2;
@@ -767,9 +767,11 @@ public class JobTest extends JetTestSupport {
                 .setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), Integer.toString(timeoutSecs));
         JetInstance client = createJetClient(config);
 
+        // join request is sent along with job submission
         Job job = client.newJob(dag);
         NoOutputSourceP.executionStarted.await();
-        // wait for invocation to timeout
+
+        // wait for join invocation to timeout
         Thread.sleep(TimeUnit.SECONDS.toMillis(timeoutSecs));
 
         // When


### PR DESCRIPTION
This can cause join() to fail with OperationTimeoutException when the job
fails instead of the actual cause. The default timeout is configured as 120 seconds and job can be running much longer than that and we already have 
custom retrying logic for the join operation.