### PR TITLE
Fix for OperationTimeoutException when join request is sent to non-master

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -99,7 +99,10 @@ public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl> {
     @Override
     protected ICompletableFuture<Void> invokeJoinJob() {
         ClientMessage request = JetJoinSubmittedJobCodec.encodeRequest(getId());
-        return new CancellableFuture<>(invocation(request, masterAddress()).invoke());
+        ClientInvocation invocation = invocation(request, masterAddress());
+        // this invocation should never time out, as the job may be running for a long time
+        invocation.setInvocationTimeoutMillis(Long.MAX_VALUE); // 0 is not supported
+        return new CancellableFuture<>(invocation.invoke());
     }
 
     @Override

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -789,7 +789,7 @@ public class JobTest extends JetTestSupport {
     public void when_joinFromClientSentToNonMaster_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
         DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
 
-        int timeoutSecs = 2;
+        int timeoutSecs = 1;
         Address address = getAddress(instance2);
         ClientConfig config = new JetClientConfig()
                 .setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), Integer.toString(timeoutSecs))


### PR DESCRIPTION
When a join request is sent to non-master, it is automatically routed to the
master node. However if the master node is to leave the cluster then the join
request can be failed early with a OperationTimeoutException. The fix is
to make a join request never timeout - as the job can be potentially running for
a long time.