### PR TITLE
Fix for OperationTimeoutException when join request is sent to non-master

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -99,7 +99,10 @@ public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl> {
     @Override
     protected ICompletableFuture<Void> invokeJoinJob() {
         ClientMessage request = JetJoinSubmittedJobCodec.encodeRequest(getId());
-        return new CancellableFuture<>(invocation(request, masterAddress()).invoke());
+        ClientInvocation invocation = invocation(request, masterAddress());
+        // this invocation should never time out, as the job may be running for a long time
+        invocation.setInvocationTimeoutMillis(Long.MAX_VALUE); // 0 is not supported
+        return new CancellableFuture<>(invocation.invoke());
     }
 
     @Override

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.function.SupplierEx;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -778,10 +779,11 @@ public class JobTest extends JetTestSupport {
 
         // When
         instance1.getHazelcastInstance().getLifecycleService().terminate();
-        job.cancel();
+        RuntimeException ex = new RuntimeException("Faulty job");
+        NoOutputSourceP.failure.set(ex);
 
         // Then
-        expectedException.expect(CancellationException.class);
+        expectedException.expectMessage(Matchers.containsString(ex.getMessage()));
         job.join();
     }
 
@@ -808,10 +810,11 @@ public class JobTest extends JetTestSupport {
 
         // When
         instance1.getHazelcastInstance().getLifecycleService().terminate();
-        job.cancel();
+        RuntimeException ex = new RuntimeException("Faulty job");
+        NoOutputSourceP.failure.set(ex);
 
         // Then
-        expectedException.expect(CancellationException.class);
+        expectedException.expectMessage(Matchers.containsString(ex.getMessage()));
         job.join();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
@@ -29,6 +30,7 @@ import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.jet.core.TestProcessors.MockPS;
 import com.hazelcast.jet.core.TestProcessors.NoOutputSourceP;
 import com.hazelcast.jet.function.SupplierEx;
+import com.hazelcast.nio.Address;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
@@ -762,7 +764,7 @@ public class JobTest extends JetTestSupport {
     public void when_joinFromClientTimesOut_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
         DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
 
-        int timeoutSecs = 2;
+        int timeoutSecs = 1;
         ClientConfig config = new JetClientConfig()
                 .setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), Integer.toString(timeoutSecs));
         JetInstance client = createJetClient(config);
@@ -775,7 +777,37 @@ public class JobTest extends JetTestSupport {
         Thread.sleep(TimeUnit.SECONDS.toMillis(timeoutSecs));
 
         // When
-        instance1.shutdown();
+        instance1.getHazelcastInstance().getLifecycleService().terminate();
+        job.cancel();
+
+        // Then
+        expectedException.expect(CancellationException.class);
+        job.join();
+    }
+
+    @Test
+    public void when_joinFromClientSentToNonMaster_then_futureShouldNotBeCompletedEarly() throws InterruptedException {
+        DAG dag = new DAG().vertex(new Vertex("test", new MockPS(NoOutputSourceP::new, NODE_COUNT)));
+
+        int timeoutSecs = 1;
+        Address address = getAddress(instance2);
+        ClientConfig config = new JetClientConfig()
+                .setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), Integer.toString(timeoutSecs))
+                .setNetworkConfig(new ClientNetworkConfig()
+                        .setSmartRouting(false)
+                        .addAddress(address.getHost() + ":" + address.getPort())
+                );
+        JetInstance client = createJetClient(config);
+
+        // join request is sent along with job submission
+        Job job = client.newJob(dag);
+        NoOutputSourceP.executionStarted.await();
+
+        // wait for join invocation to timeout
+        Thread.sleep(TimeUnit.SECONDS.toMillis(timeoutSecs));
+
+        // When
+        instance1.getHazelcastInstance().getLifecycleService().terminate();
         job.cancel();
 
         // Then
@@ -805,7 +837,8 @@ public class JobTest extends JetTestSupport {
             initLatch.await();
         }
 
-        @Nonnull @Override
+        @Nonnull
+        @Override
         public Collection<? extends Processor> get(int count) {
             return Stream.generate(supplier).limit(count).collect(toList());
 


### PR DESCRIPTION
When a join request is sent to non-master, it is automatically routed to the
master node. However if the master node is to leave the cluster then the join
request can be failed early with a OperationTimeoutException. The fix is
to make a join request never timeout - as the job can be potentially running for
a long time.

Forward port of #1659 