### PR TITLE
Move executor-service registration to the constructor of JobCoordinationService to avoid race

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -137,6 +137,9 @@ public class JobCoordinationService {
         this.config = config;
         this.logger = nodeEngine.getLogger(getClass());
         this.jobRepository = jobRepository;
+
+        InternalExecutionService executionService = nodeEngine.getExecutionService();
+        executionService.register(COORDINATOR_EXECUTOR_NAME, COORDINATOR_THREADS_POOL_SIZE, Integer.MAX_VALUE, CACHED);
     }
 
     public JobRepository jobRepository() {
@@ -147,7 +150,6 @@ public class JobCoordinationService {
         InternalExecutionService executionService = nodeEngine.getExecutionService();
         HazelcastProperties properties = new HazelcastProperties(config.getProperties());
         long jobScanPeriodInMillis = properties.getMillis(JOB_SCAN_PERIOD);
-        executionService.register(COORDINATOR_EXECUTOR_NAME, COORDINATOR_THREADS_POOL_SIZE, Integer.MAX_VALUE, CACHED);
         executionService.scheduleWithRepetition(COORDINATOR_EXECUTOR_NAME, this::scanJobs,
                 0, jobScanPeriodInMillis, MILLISECONDS);
     }


### PR DESCRIPTION
Forward-port of https://github.com/hazelcast/hazelcast-jet/pull/1679