### PR TITLE
Unified naming of the enterprise features.

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -320,7 +320,7 @@ public final class Jet {
 
         if (jetConfig.getInstanceConfig().isLosslessRestartEnabled() &&
             !hzConfig.getHotRestartPersistenceConfig().isEnabled()) {
-            LOGGER.warning("Lossless recovery is enabled but Hot Restart is disabled. Auto-enabling Hot Restart. " +
+            LOGGER.warning("Lossless Restart is enabled but Hot Restart is disabled. Auto-enabling Hot Restart. " +
                     "The following path will be used: " + hzConfig.getHotRestartPersistenceConfig().getBaseDir());
             hzConfig.getHotRestartPersistenceConfig().setEnabled(true);
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
@@ -79,7 +79,7 @@ public final class JetProperties {
             = new HazelcastProperty("jet.job.results.max.size", 1_000);
 
     /**
-     * Root of Jet installation. Used as default location for the lossless recovery
+     * Root of Jet installation. Used as default location for the lossless restart
      * store. By default it will be automatically set to the start of the Jet
      * installation path.
      *

--- a/reference-manual/src/main/asciidoc/appendix.adoc
+++ b/reference-manual/src/main/asciidoc/appendix.adoc
@@ -69,9 +69,9 @@ Job state is only compatible across the same MINOR version and only
 backwards-compatible i.e. a newer PATCH version is be able to understand
 the job state from a previous PATCH version.
 
-This means that if you have a running job, using the job upgrades
-and lossless recovery features you are able to upgrade the cluster to a
-newer PATCH version without losing the state of a running job.
+This means that if you have a running job, using the Job Upgrade
+and Lossless Cluster Restart features you are able to upgrade the cluster 
+to a newer PATCH version without losing the state of a running job.
 
 == Command Line Tools and Configuration Files
 
@@ -136,9 +136,9 @@ results will be automatically deleted after this size is reached.
 |`jet.home`
 |_Jet installation path_
 |string
-|Root of Jet installation. Used as default location for the lossless
-recovery store. By default it will be automatically set to the start of
-the Jet installation path.
+|Root of Jet installation. Used as default location for the Lossless
+Cluster Restart store. By default it will be automatically set to the 
+start of the Jet installation path.
 
 |`jet.idle.cooperative.min.microseconds`
 |25

--- a/reference-manual/src/main/asciidoc/configuration.adoc
+++ b/reference-manual/src/main/asciidoc/configuration.adoc
@@ -43,8 +43,8 @@ the cluster. It has no effect on jobs with auto scaling disabled. The
 default value is `10000` milliseconds.
 
 |`setLosslessRestartEnabled`
-|Specifies whether the lossless job restart feature is enabled. With this
-feature you can restart the whole cluster without losing the jobs and
+|Specifies whether the Lossless Cluster Restart feature is enabled. With this
+feature, you can restart the whole cluster without losing the jobs and
 their state. It is implemented on top of Hazelcast IMDG's Hot Restart
 Persistence feature, which persists the data to disk. You need to have
 the Hazelcast Jet Enterprise edition and configure Hazelcast IMDG's Hot

--- a/reference-manual/src/main/asciidoc/get-started.adoc
+++ b/reference-manual/src/main/asciidoc/get-started.adoc
@@ -71,8 +71,8 @@ built on top of Hazelcast Jet open source and extends it with the
 following features:
 
 * <<security, Security Suite>>
-* Lossless Restart (in Jet 3.0)
-* Job Upgrades (in Jet 3.0)
+* Lossless Cluster Restart
+* Job Upgrade
 * Enterprise PaaS Deployment Environment (Pivotal Cloud Foundry,
    Openshift Container Platform (Jet 3.0))
 

--- a/reference-manual/src/main/asciidoc/work-with-jet/start-jet-submit-job.adoc
+++ b/reference-manual/src/main/asciidoc/work-with-jet/start-jet-submit-job.adoc
@@ -334,7 +334,7 @@ The new pipeline has to be compatible with the old one, for more details
 about what you can change in the pipeline, see
 <<update-a-dag-without-losing-the-state>>.
 
-Job Upgrades use the snapshots. The Job state is exported to 
+Job Upgrade use the snapshots. The Job state is exported to 
 the snapshot and the new job version starts from from the snapshot.
 
 If you want to preserve the state of the cancelled job, use
@@ -362,7 +362,7 @@ use the state in the snapshot as its initial state:
 include::{javasource}/ManageJob.java[tag=s10]
 ----
 
-The exported snapshots used for Job Upgrades differ from the 
+The exported snapshots used for Job Upgrade differ from the 
 snapshots used for the <<fault-tolerance, Fault Tolerance>>. 
 Exported snapshots aren't deleted automatically by Jet. Therefore you can
 also use the exported snapshot as a point of recovery.


### PR DESCRIPTION
Unify enterprise naming in the reference manual to Job Upgrade and Lossless Cluster Restart.