### PR TITLE
Add exception logging to JUL logging.properties

### DIFF
--- a/hazelcast-jet-all/src/main/resources/logging.properties
+++ b/hazelcast-jet-all/src/main/resources/logging.properties
@@ -17,4 +17,4 @@
 handlers=java.util.logging.ConsoleHandler
 .level=INFO
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=[%1$tF %1$tT.%1$tL] [%4$-7s] %2$s - %5$s %n
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT.%1$tL] [%4$-7s] %2$s - %5$s %6$s %n


### PR DESCRIPTION
Our default logging.properties file inside the Jet JAR sets up the log line format that doesn't include the exception stacktrace. This PR add that. Hopefully we can squeeze in this small detail to the 3.2 release and make life of the users of our ZIP file easier.