### PR TITLE
Allow Throwable in user code

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -213,7 +213,7 @@ public class MasterJobContext {
                     Util.doWithClassLoader(classLoader, () ->
                             mc.setExecutionPlanMap(createExecutionPlans(mc.nodeEngine(), membersView, dag, mc.jobId(),
                                     mc.executionId(), mc.jobConfig(), jobExecRec.ongoingSnapshotId())));
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     throw new UserCausedException(e);
                 }
                 logger.fine("Built execution plans for " + mc.jobIdString());
@@ -284,8 +284,8 @@ public class MasterJobContext {
 
     // Used only in tryStartJob() and its callees, should never escape that method.
     private static class UserCausedException extends Exception {
-        UserCausedException(Exception cause) {
-            super("", cause, false, false);
+        UserCausedException(Throwable cause) {
+            super(cause);
         }
     }
 
@@ -709,9 +709,9 @@ public class MasterJobContext {
             for (Vertex vertex : vertices) {
                 try {
                     vertex.getMetaSupplier().close(failure);
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     logger.severe(mc.jobIdString()
-                            + " encountered an exception in ProcessorMetaSupplier.complete(), ignoring it", e);
+                            + " encountered an exception in ProcessorMetaSupplier.close(), ignoring it", e);
                 }
             }
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -177,7 +177,7 @@ public class ExecutionContext {
                 s.close(error);
             } catch (Throwable e) {
                 logger.severe(jobNameAndExecutionId()
-                        + " encountered an exception in ProcessorSupplier.complete(), ignoring it", e);
+                        + " encountered an exception in ProcessorSupplier.close(), ignoring it", e);
             }
         }
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -218,7 +218,7 @@ public class ProcessorTasklet implements Tasklet {
         assert !processorClosed : "processor already closed";
         try {
             processor.close();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             logger.severe(jobNameAndExecutionId(context.jobConfig().getName(), context.executionId())
                     + " encountered an exception in Processor.close(), ignoring it", e);
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.core.AbstractProcessor.FlatMapper;
 import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.jet.core.test.TestInbox;
 import com.hazelcast.jet.core.test.TestOutbox;
+import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -42,7 +43,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class AbstractProcessorTest {
@@ -72,8 +72,7 @@ public class AbstractProcessorTest {
         int[] capacities = new int[OUTBOX_BUCKET_COUNT];
         Arrays.fill(capacities, 1);
         outbox = new TestOutbox(capacities);
-        final Processor.Context ctx = mock(Processor.Context.class);
-        when(ctx.logger()).thenReturn(mock(ILogger.class));
+        final Processor.Context ctx = new TestProcessorContext();
 
         p = new RegisteringMethodCallsP();
         p.init(outbox, ctx);
@@ -99,10 +98,8 @@ public class AbstractProcessorTest {
 
     @Test(expected = UnknownHostException.class)
     public void when_customInitThrows_then_initRethrows() throws Exception {
-        Processor.Context context = mock(Processor.Context.class);
-        when(context.logger()).thenReturn(mock(ILogger.class));
         new MockP().setInitError(new UnknownHostException())
-                .init(mock(Outbox.class), context);
+                .init(mock(Outbox.class), new TestProcessorContext());
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/AbstractProcessorTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.net.UnknownHostException;
@@ -43,6 +42,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class AbstractProcessorTest {
@@ -73,7 +73,7 @@ public class AbstractProcessorTest {
         Arrays.fill(capacities, 1);
         outbox = new TestOutbox(capacities);
         final Processor.Context ctx = mock(Processor.Context.class);
-        Mockito.when(ctx.logger()).thenReturn(mock(ILogger.class));
+        when(ctx.logger()).thenReturn(mock(ILogger.class));
 
         p = new RegisteringMethodCallsP();
         p.init(outbox, ctx);
@@ -99,8 +99,10 @@ public class AbstractProcessorTest {
 
     @Test(expected = UnknownHostException.class)
     public void when_customInitThrows_then_initRethrows() throws Exception {
+        Processor.Context context = mock(Processor.Context.class);
+        when(context.logger()).thenReturn(mock(ILogger.class));
         new MockP().setInitError(new UnknownHostException())
-                .init(mock(Outbox.class), mock(Processor.Context.class));
+                .init(mock(Outbox.class), context);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -40,6 +40,7 @@ import static com.hazelcast.jet.Traversers.traverseStream;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.BroadcastKey.broadcastKey;
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -133,26 +134,26 @@ public final class TestProcessors {
         static AtomicBoolean closeCalled = new AtomicBoolean();
         static AtomicReference<Throwable> receivedCloseError = new AtomicReference<>();
 
-        private RuntimeException initError;
-        private RuntimeException getError;
-        private RuntimeException closeError;
+        private Throwable initError;
+        private Throwable getError;
+        private Throwable closeError;
         private final SupplierEx<ProcessorSupplier> supplierFn;
 
         public MockPMS(SupplierEx<ProcessorSupplier> supplierFn) {
             this.supplierFn = supplierFn;
         }
 
-        public MockPMS setInitError(RuntimeException initError) {
+        public MockPMS setInitError(Throwable initError) {
             this.initError = initError;
             return this;
         }
 
-        public MockPMS setGetError(RuntimeException getError) {
+        public MockPMS setGetError(Throwable getError) {
             this.getError = getError;
             return this;
         }
 
-        public MockPMS setCloseError(RuntimeException closeError) {
+        public MockPMS setCloseError(Throwable closeError) {
             this.closeError = closeError;
             return this;
         }
@@ -163,14 +164,14 @@ public final class TestProcessors {
                     initCalled.compareAndSet(false, true)
             );
             if (initError != null) {
-                throw initError;
+                throw sneakyThrow(initError);
             }
         }
 
         @Nonnull @Override
         public Function<Address, ProcessorSupplier> get(@Nonnull List<Address> addresses) {
             if (getError != null) {
-                throw getError;
+                throw sneakyThrow(getError);
             }
             return a -> supplierFn.get();
         }
@@ -188,7 +189,7 @@ public final class TestProcessors {
             );
 
             if (closeError != null) {
-                throw closeError;
+                throw sneakyThrow(closeError);
             }
         }
     }
@@ -199,9 +200,9 @@ public final class TestProcessors {
         static AtomicInteger closeCount = new AtomicInteger();
         static List<Throwable> receivedCloseErrors = new CopyOnWriteArrayList<>();
 
-        private RuntimeException initError;
-        private RuntimeException getError;
-        private RuntimeException closeError;
+        private Throwable initError;
+        private Throwable getError;
+        private Throwable closeError;
 
         private final SupplierEx<Processor> supplier;
         private final int nodeCount;
@@ -213,17 +214,17 @@ public final class TestProcessors {
             this.nodeCount = nodeCount;
         }
 
-        public MockPS setInitError(RuntimeException initError) {
+        public MockPS setInitError(Throwable initError) {
             this.initError = initError;
             return this;
         }
 
-        public MockPS setGetError(RuntimeException getError) {
+        public MockPS setGetError(Throwable getError) {
             this.getError = getError;
             return this;
         }
 
-        public MockPS setCloseError(RuntimeException closeError) {
+        public MockPS setCloseError(Throwable closeError) {
             this.closeError = closeError;
             return this;
         }
@@ -234,14 +235,14 @@ public final class TestProcessors {
             initCount.incrementAndGet();
 
             if (initError != null) {
-                throw initError;
+                throw sneakyThrow(initError);
             }
         }
 
         @Nonnull @Override
         public List<Processor> get(int count) {
             if (getError != null) {
-                throw getError;
+                throw sneakyThrow(getError);
             }
             return Stream.generate(supplier).limit(count).collect(toList());
         }
@@ -260,7 +261,7 @@ public final class TestProcessors {
                     + initCount.get() + " times!", closeCount.get() <= initCount.get());
 
             if (closeError != null) {
-                throw closeError;
+                throw sneakyThrow(closeError);
             }
         }
     }
@@ -270,10 +271,10 @@ public final class TestProcessors {
         static AtomicInteger initCount = new AtomicInteger();
         static AtomicInteger closeCount = new AtomicInteger();
 
-        private Exception initError;
-        private Exception processError;
-        private RuntimeException completeError;
-        private Exception closeError;
+        private Throwable initError;
+        private Throwable processError;
+        private Throwable completeError;
+        private Throwable closeError;
         private boolean isCooperative;
 
         @Override
@@ -281,22 +282,22 @@ public final class TestProcessors {
             return isCooperative;
         }
 
-        public MockP setInitError(Exception initError) {
+        public MockP setInitError(Throwable initError) {
             this.initError = initError;
             return this;
         }
 
-        public MockP setProcessError(Exception processError) {
+        public MockP setProcessError(Throwable processError) {
             this.processError = processError;
             return this;
         }
 
-        public MockP setCompleteError(RuntimeException completeError) {
+        public MockP setCompleteError(Throwable completeError) {
             this.completeError = completeError;
             return this;
         }
 
-        public MockP setCloseError(Exception closeError) {
+        public MockP setCloseError(Throwable closeError) {
             this.closeError = closeError;
             return this;
         }
@@ -307,34 +308,36 @@ public final class TestProcessors {
         }
 
         @Override
-        protected void init(@Nonnull Context context) throws Exception {
+        protected void init(@Nonnull Context context) {
+            getLogger().info("init");
             initCount.incrementAndGet();
             if (initError != null) {
-                throw initError;
+                throw sneakyThrow(initError);
             }
         }
 
         @Override
-        protected boolean tryProcess(int ordinal, @Nonnull Object item) throws Exception {
+        protected boolean tryProcess(int ordinal, @Nonnull Object item) {
             if (processError != null) {
-                throw processError;
+                throw sneakyThrow(processError);
             }
             return tryEmit(item);
         }
 
         @Override
         public boolean complete() {
+            getLogger().info("complete");
             if (completeError != null) {
-                throw completeError;
+                throw sneakyThrow(completeError);
             }
             return true;
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
             closeCount.incrementAndGet();
             if (closeError != null) {
-                throw closeError;
+                throw sneakyThrow(closeError);
             }
         }
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestProcessors.java
@@ -309,7 +309,6 @@ public final class TestProcessors {
 
         @Override
         protected void init(@Nonnull Context context) {
-            getLogger().info("init");
             initCount.incrementAndGet();
             if (initError != null) {
                 throw sneakyThrow(initError);
@@ -326,7 +325,6 @@ public final class TestProcessors {
 
         @Override
         public boolean complete() {
-            getLogger().info("complete");
             if (completeError != null) {
                 throw sneakyThrow(completeError);
             }


### PR DESCRIPTION
Before, if Error was thrown in PMS.init (and others), the job will end a
half-submitted state, the submission process crashed in an unexpected
place.

Fixes #1712