### PR TITLE
Add `JetConfig.configureHazelcast()` method

### DIFF
--- a/examples/event-journal/src/main/java/com/hazelcast/jet/examples/eventjournal/CacheJournalSource.java
+++ b/examples/event-journal/src/main/java/com/hazelcast/jet/examples/eventjournal/CacheJournalSource.java
@@ -67,17 +67,15 @@ public class CacheJournalSource {
     }
 
     private static JetConfig getJetConfig() {
-        JetConfig cfg = new JetConfig();
-        cfg.getHazelcastConfig().addCacheConfig(new CacheSimpleConfig().setName(CACHE_NAME));
-        // Add an event journal config for cache which has custom capacity of 1000 (default 10_000)
-        // and time to live seconds as 10 seconds (default 0 which means infinite)
-        cfg.getHazelcastConfig()
-           .getCacheConfig(CACHE_NAME)
-           .getEventJournalConfig()
-           .setEnabled(true)
-           .setCapacity(1000)
-           .setTimeToLiveSeconds(10);
-        return cfg;
+        return new JetConfig().configureHazelcast(c -> c.addCacheConfig(new CacheSimpleConfig().setName(CACHE_NAME))
+                // Add an event journal config for cache which has custom capacity of 1000 (default 10_000)
+                // and time to live seconds as 10 seconds (default 0 which means infinite)
+                .getCacheConfig(CACHE_NAME)
+                .getEventJournalConfig()
+                .setEnabled(true)
+                .setCapacity(1000)
+                .setTimeToLiveSeconds(10)
+        );
     }
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfig.java
@@ -33,6 +33,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.function.Consumer;
 
 import static com.hazelcast.internal.util.Preconditions.checkTrue;
 import static com.hazelcast.internal.util.StringUtil.isNullOrEmptyAfterTrim;
@@ -463,6 +464,23 @@ public class JetConfig {
     @Nonnull
     public Config getHazelcastConfig() {
         return hazelcastConfig;
+    }
+
+
+    /**
+     * Convenience method for for configuring underlying Hazelcast IMDG instance.
+     * Example:
+     * <pre>{@code
+     * JetConfig config = new JetConfig().configureHazelcast(c -> {
+     *   c.getNetworkConfig().setPort(8000);
+     *   c.setClusterName("jet-dev");
+     * });
+     * Jet.newJetInstance(config);
+     * }</pre>
+     */
+    public JetConfig configureHazelcast(Consumer<Config> configConsumer) {
+        configConsumer.accept(hazelcastConfig);
+        return this;
     }
 
     /**

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ScaleUpTest.java
@@ -77,8 +77,7 @@ public class ScaleUpTest extends JetTestSupport {
         instances[0].newJob(dag);
         assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
 
-        JetConfig config = new JetConfig();
-        config.getHazelcastConfig().setLiteMember(true);
+        JetConfig config = new JetConfig().configureHazelcast(c -> c.setLiteMember(true));
         createJetMember(config);
         assertTrueEventually(() -> assertEquals(NODE_COUNT, MockPS.initCount.get()));
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobMetrics_NonSharedClusterTest.java
@@ -46,8 +46,7 @@ public class JobMetrics_NonSharedClusterTest extends JetTestSupport {
 
     @Test
     public void when_metricsCollectionOff_then_emptyMetrics() {
-        JetConfig config = new JetConfig();
-        config.getHazelcastConfig().getMetricsConfig().setEnabled(false);
+        JetConfig config = new JetConfig().configureHazelcast(c -> c.getMetricsConfig().setEnabled(false));
         JetInstance inst = createJetMember(config);
 
         DAG dag = new DAG();
@@ -58,8 +57,8 @@ public class JobMetrics_NonSharedClusterTest extends JetTestSupport {
 
     @Test
     public void when_noMetricCollectionYet_then_emptyMetrics() {
-        JetConfig config = new JetConfig();
-        config.getHazelcastConfig().getMetricsConfig().setCollectionIntervalSeconds(10_000);
+        JetConfig config = new JetConfig()
+                .configureHazelcast(c -> c.getMetricsConfig().setCollectionIntervalSeconds(10_000));
         JetInstance inst = createJetMember(config);
 
         DAG dag = new DAG();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_TerminalSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/WatermarkCoalescer_TerminalSnapshotTest.java
@@ -60,16 +60,17 @@ public class WatermarkCoalescer_TerminalSnapshotTest extends JetTestSupport {
 
     @Before
     public void setUp() {
-        JetConfig config = new JetConfig();
-        EventJournalConfig journalConfig = new EventJournalConfig()
-                .setCapacity(1_000_000)
-                .setEnabled(true);
+        JetConfig config = new JetConfig().configureHazelcast(c -> {
+            EventJournalConfig journalConfig = new EventJournalConfig()
+                    .setCapacity(1_000_000)
+                    .setEnabled(true);
+            c.getMapConfig("*").setEventJournalConfig(journalConfig);
+        });
 
         // number of partitions must match number of source processors for coalescing
         // to work correctly
-        config.getHazelcastConfig().setProperty(
-                GroupProperty.PARTITION_COUNT.getName(), String.valueOf(PARTITION_COUNT));
-        config.getHazelcastConfig().getMapConfig("*").setEventJournalConfig(journalConfig);
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), String.valueOf(PARTITION_COUNT));
+
         instance = createJetMember(config);
         sourceMap = instance.getMap("test");
     }


### PR DESCRIPTION
This method provides a convenience where you can configure
JetConfig inline without having to create another variable.
Some test usages are also replaced.