### PR TITLE
Include slf4j-logj12 in the distribution

### DIFF
--- a/hazelcast-jet-distribution/pom.xml
+++ b/hazelcast-jet-distribution/pom.xml
@@ -94,6 +94,11 @@
             <version>${log4j.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-avro</artifactId>
             <version>${project.version}</version>

--- a/hazelcast-jet-distribution/src/assembly-descriptor.xml
+++ b/hazelcast-jet-distribution/src/assembly-descriptor.xml
@@ -29,6 +29,7 @@
             <includes>
                 <include>com.hazelcast.jet:hazelcast-jet</include>
                 <include>log4j:log4j</include>
+                <include>org.slf4j:*</include>
             </includes>
             <outputDirectory>lib</outputDirectory>
             <outputFileNameMapping>${artifact.artifactId}-${artifact.baseVersion}.${artifact.extension}</outputFileNameMapping>


### PR DESCRIPTION
SLF4J is used in client APIs used by some connectors (i.e. Kafka) and without this
binding, these client APIs will not be able to do any logging.