### PR TITLE
Don't assert unfinished item after completeEdge

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -154,10 +154,6 @@ public interface Processor {
      * If the call returns {@code false}, it will be called again before
      * proceeding to call any other method. Default implementation returns
      * {@code true}.
-     * <p>
-     * If this method tried to offer to the outbox and the offer call returned
-     * false, this method must also return false and retry to offer in the
-     * next call.
      */
     default boolean tryProcess() {
         return true;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
@@ -62,7 +62,6 @@ public final class AsyncTransformUsingServiceOrderedP<S, T, R> extends AbstractP
     private Traverser<?> currentTraverser = Traversers.empty();
     private int maxAsyncOps;
     private ResettableSingletonTraverser<Watermark> watermarkTraverser = new ResettableSingletonTraverser<>();
-    private boolean tryProcessSucceeded;
 
     @Probe(name = "numInFlightOps")
     private final AtomicInteger asyncOpsCounterMetric = new AtomicInteger();
@@ -124,13 +123,9 @@ public final class AsyncTransformUsingServiceOrderedP<S, T, R> extends AbstractP
 
     @Override
     public boolean tryProcess() {
-        if (tryProcessSucceeded) {
-            tryFlushQueue();
-        } else {
-            emitFromTraverser(currentTraverser);
-        }
+        tryFlushQueue();
         asyncOpsCounterMetric.lazySet(queue.size());
-        return tryProcessSucceeded = !getOutbox().hasUnfinishedItem();
+        return true;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
@@ -167,6 +167,9 @@ public final class AsyncTransformUsingServiceUnorderedP<S, T, K, R> extends Abst
 
     @Override
     public boolean tryProcessWatermark(@Nonnull Watermark watermark) {
+        if (getOutbox().hasUnfinishedItem() && !emitFromTraverser(currentTraverser)) {
+            return false;
+        }
         assert lastEmittedWm <= lastReceivedWm : "lastEmittedWm=" + lastEmittedWm + ", lastReceivedWm=" + lastReceivedWm;
         // Ignore a watermark that is going back. This is possible after restoring from a snapshot
         // taken in at-least-once mode.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
@@ -85,7 +85,6 @@ public final class AsyncTransformUsingServiceUnorderedP<S, T, K, R> extends Abst
     private final Map<T, Integer> inFlightItems = new IdentityHashMap<>();
     private Traverser<Object> currentTraverser = Traversers.empty();
     private Traverser<Entry> snapshotTraverser;
-    private boolean tryProcessSucceeded;
 
     private Long lastReceivedWm = Long.MIN_VALUE;
     private long lastEmittedWm = Long.MIN_VALUE;
@@ -186,13 +185,9 @@ public final class AsyncTransformUsingServiceUnorderedP<S, T, K, R> extends Abst
 
     @Override
     public boolean tryProcess() {
-        if (tryProcessSucceeded) {
-            tryFlushQueue();
-        } else {
-            // if we're running tryProcess for the second time, emit just the current traverser
-            emitFromTraverser(currentTraverser);
-        }
-        return tryProcessSucceeded = !getOutbox().hasUnfinishedItem();
+        tryFlushQueue();
+        asyncOpsCounterMetric.lazySet(asyncOpsCounter);
+        return true;
     }
 
     @Override

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
@@ -33,8 +33,10 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -48,6 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastSerialClassRunner.class)
 public class MetricsTest extends JetTestSupport {
 
     private static final JobConfig JOB_CONFIG_WITH_METRICS = new JobConfig().setStoreMetricsAfterJobCompletion(true);
@@ -195,7 +198,7 @@ public class MetricsTest extends JetTestSupport {
                             );
                         }
                 )
-                .drainTo(Sinks.logger());
+                .drainTo(Sinks.noop());
 
         Job job = instance.newJob(pipeline, JOB_CONFIG_WITH_METRICS);
         assertTrueEventually(() -> assertEquals(inputSize,


### PR DESCRIPTION
We normally allow unfinished items after `process()` even when the inbox is
empty. We proceed to `saveToSnapshot()`, `tryProcess()`, `completeEdge()` or
`complete()` as needed and those should deal with it. This is only an issue
with async processors, sync processors finish emitting the items before they
remove the item from the inbox.

We could do a similar process as with do with `complete()`: if `complete()`
returns with an unfinished item in the outbox, we block the outbox and call
`complete()` until it's finished, before proceeding to other methods (such as
to `saveToSnapshot()`). However, doing similar thing with the `process()`
method makes no sense since it's normally implemented to only act on items in
the inbox and the inbox would be empty. We could call `tryProcess()` until
there's no unfinished item, but the async processor again doesn't need it - the
`tryProcess()` method is essentially `process()` method called with an empty
inbox. Merging these two methods might even simplify things.

We could ensure that there's no unfinished item before interrupting the
`process/tryProcess/completeEdge` to proceed to `saveToSnapshot`, but current
impls of the async processors don't need it: it would not be enough for them,
they need to flush more than just the current item anyway.

This PR removes two asserts for unfinished item and takes the advantage from
this in the async processors.

Fixes #1716