### PR TITLE
Fixed enrichment code sample

### DIFF
--- a/examples/enrichment/src/main/java/com/hazelcast/jet/examples/enrichment/Enrichment.java
+++ b/examples/enrichment/src/main/java/com/hazelcast/jet/examples/enrichment/Enrichment.java
@@ -211,7 +211,7 @@ public final class Enrichment {
                                      .map(entryValue());
 
         // The enriching streams: products and brokers
-        String resourcesPath = getClasspathDirectory(".").toString();
+        String resourcesPath = getClasspathDirectory("/").toString();
         BatchSource<Map.Entry<Integer, Product>> products = Sources
                 .filesBuilder(resourcesPath)
                 .sharedFileSystem(true)
@@ -257,7 +257,6 @@ public final class Enrichment {
             // comment out the code to try the appropriate enrichment method
             Pipeline p = enrichUsingIMap();
 //            Pipeline p = enrichUsingReplicatedMap();
-//            Pipeline p = enrichUsingAsyncService();
 //            Pipeline p = enrichUsingHashJoin();
             Job job = jet.newJob(p);
             eventGenerator.generateEventsForFiveSeconds();

--- a/examples/enrichment/src/main/resources/hazelcast.yaml
+++ b/examples/enrichment/src/main/resources/hazelcast.yaml
@@ -1,7 +1,7 @@
 hazelcast:
   properties:
     hazelcast.logging.type: log4j
-  group:
+  cluster:
     name: jet
   network:
     join:
@@ -12,8 +12,8 @@ hazelcast:
         enabled: true
         member-list:
           - 127.0.0.1
-  event-journal:
-    map:
-      trades:
+  map:
+    trades:
+      event-journal:
         enabled: true
-        capacity: 100000
+        capacity: 10000


### PR DESCRIPTION
It fixes:
* map event journal in `hazelcast.yaml` in the example was not adjusted to IMDG 4.0 form
* usage of `enrichUsingAsyncService()` was removed because it was moved to grpc
* `enrichUsingHashJoin` example was not able to load needed text files