### PR TITLE
Fix output of hello-world example

### DIFF
--- a/examples/hello-world/src/main/java/com/hazelcast/jet/examples/helloworld/HelloWorld.java
+++ b/examples/hello-world/src/main/java/com/hazelcast/jet/examples/helloworld/HelloWorld.java
@@ -86,7 +86,7 @@ public class HelloWorld {
             if (top10numbers != null) {
                 LOGGER.info("Top 10 random numbers observed so far in the stream are: ");
                 for (int i = 0; i < top10numbers.size(); i++) {
-                    LOGGER.info(String.format("%d. %,d", i, top10numbers.get(i)));
+                    LOGGER.info(String.format("%d. %,d", i + 1, top10numbers.get(i)));
                 }
             }
             Thread.sleep(1000);


### PR DESCRIPTION
Output in this example should be indexed from `1.`. Currently it looks like this:
```
2019-11-15 08:50:17,702  INFO [HelloWorld] [main] - Top 10 random numbers observed so far in the stream are: 
2019-11-15 08:50:17,702  INFO [HelloWorld] [main] - 0. 9,215,250,687,646,003,515
2019-11-15 08:50:17,702  INFO [HelloWorld] [main] - 1. 8,965,949,692,594,839,883
2019-11-15 08:50:17,702  INFO [HelloWorld] [main] - 2. 8,811,902,117,834,639,543
2019-11-15 08:50:17,703  INFO [HelloWorld] [main] - 3. 8,676,926,573,567,461,817
2019-11-15 08:50:17,703  INFO [HelloWorld] [main] - 4. 8,528,816,033,953,131,797
2019-11-15 08:50:17,703  INFO [HelloWorld] [main] - 5. 8,307,847,392,982,656,741
2019-11-15 08:50:17,703  INFO [HelloWorld] [main] - 6. 8,248,347,955,411,719,963
2019-11-15 08:50:17,703  INFO [HelloWorld] [main] - 7. 8,233,921,079,216,109,637
2019-11-15 08:50:17,704  INFO [HelloWorld] [main] - 8. 8,209,023,535,497,113,522
2019-11-15 08:50:17,704  INFO [HelloWorld] [main] - 9. 8,086,850,629,717,252,605
```