### PR TITLE
Don't call two processor methods w/o outbox.reset

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Outbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Outbox.java
@@ -23,7 +23,7 @@ import javax.annotation.Nonnull;
  * Data sink for a {@link Processor}. The outbox consists of individual
  * output buckets, one per outbound edge of the vertex represented by the
  * associated processor and one for the snapshot state. The processor must
- * deliver its output items separated by destination edge, into the outbox
+ * deliver its output items separated by destination edge into the outbox
  * by calling {@link #offer(int, Object)} or {@link #offer(Object)}.
  * <p>
  * To save its current state to the snapshot, it must call {@link

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -248,7 +248,6 @@ public class ProcessorTasklet implements Tasklet {
                         : processor.tryProcessWatermark(pendingWatermark)) {
                     state = PROCESS_INBOX;
                     pendingWatermark = null;
-                    stateMachineStep(); // recursion
                 }
                 break;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
@@ -117,7 +117,6 @@ public final class AsyncTransformUsingServiceOrderedP<S, T, R> extends AbstractP
     public boolean tryProcessWatermark(@Nonnull Watermark watermark) {
         tryFlushQueue();
         return queue.size() < maxAsyncOps
-                && !getOutbox().hasUnfinishedItem()
                 && queue.add(watermark);
     }
 


### PR DESCRIPTION
When we called `tryProcessWatermark`, we proceeded to `tryProcess` in a
recursion without calling `outbox.reset()`. This could lead to a situation when
each `tryProcessWatermark` and `process` offer to outbox and are rejected.
Without a `reset()`, the second offer will fail on an assertion. This compelled
us to check for `outbox.hasUnfinishedItem()` when returning from
`tryProcessWatermark()` in `AsyncTransformUsingServiceOrderedP`, and this call
seemed superfluous without knowledge of the inner workings of
`ProcessorTasklet`.

The contract of `outbox.offer()` says that if it returns `false, we should
return from the processor method. But it didn't say that we should return
`false` from the processor method, some methods don't even allow it, such as
`process()`.

The fix was to not recurse in `ProcessorTasklet` after calling
`tryProcessorWatermark()`.