### PR TITLE
Set aws plugin version to 3.0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <hazelcast.version>4.0-SNAPSHOT</hazelcast.version>
         <!-- Dependencies on IMDG modules: must be the same versions IMDG depends on! -->
         <hazelcast.protocol.version>1.8.0-5</hazelcast.protocol.version>
-        <hazelcast.aws.version>3.0</hazelcast.aws.version>
+        <hazelcast.aws.version>3.0.1-SNAPSHOT</hazelcast.aws.version>
         <hazelcast.kubernetes.version>2.0</hazelcast.kubernetes.version>
         <hazelcast.gcp.version>2.0</hazelcast.gcp.version>
 


### PR DESCRIPTION
aws plugin has a specific branch which is up to date with the latest IMDG(4.0) changes