### PR TITLE
Fixed streaming source must not close the buffer in code samples

### DIFF
--- a/examples/early-window-results/src/main/java/com/hazelcast/jet/examples/earlyresults/support/TradeGenerator.java
+++ b/examples/early-window-results/src/main/java/com/hazelcast/jet/examples/earlyresults/support/TradeGenerator.java
@@ -50,7 +50,6 @@ public final class TradeGenerator {
 
     private void generateTrades(TimestampedSourceBuffer<Trade> buf) {
         if (scheduledTimeNanos >= endTimeNanos) {
-            buf.close();
             return;
         }
         ThreadLocalRandom rnd = ThreadLocalRandom.current();

--- a/examples/rolling-aggregation/src/main/java/com/hazelcast/jet/examples/rollingaggregation/TradeGenerator.java
+++ b/examples/rolling-aggregation/src/main/java/com/hazelcast/jet/examples/rollingaggregation/TradeGenerator.java
@@ -60,7 +60,6 @@ public final class TradeGenerator {
 
     private void generateTrades(TimestampedSourceBuffer<Trade> buf) {
         if (scheduledTimeNanos >= endTimeNanos) {
-            buf.close();
             return;
         }
         ThreadLocalRandom rnd = ThreadLocalRandom.current();


### PR DESCRIPTION
Buffer should not be closed since they are stream jobs. There is thrown Exception in server log otherwise:
```
com.hazelcast.jet.JetException: a streaming source must not close the buffer, only batch source can
	at com.hazelcast.jet.impl.pipeline.SourceBufferImpl.close(SourceBufferImpl.java:64)
	at com.hazelcast.jet.examples.earlyresults.support.TradeGenerator.generateTrades(TradeGenerator.java:53)
	at com.hazelcast.function.BiConsumerEx.accept(BiConsumerEx.java:47)
	at com.hazelcast.jet.impl.connector.ConvenientSourceP.complete(ConvenientSourceP.java:115)
	at com.hazelcast.jet.impl.execution.ProcessorTasklet.stateMachineStep(ProcessorTasklet.java:346)
	at com.hazelcast.jet.impl.execution.ProcessorTasklet.call(ProcessorTasklet.java:208)
	at com.hazelcast.jet.impl.execution.TaskletExecutionService$BlockingWorker.run(TaskletExecutionService.java:293)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```