### PR TITLE
Add books directory on classpath in word-count examples

### DIFF
--- a/examples/hadoop/pom.xml
+++ b/examples/hadoop/pom.xml
@@ -31,6 +31,14 @@
     </parent>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>../wordcount/src/main/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.avro</groupId>

--- a/examples/source-sink-builder/pom.xml
+++ b/examples/source-sink-builder/pom.xml
@@ -28,6 +28,16 @@
         <version>4.0-SNAPSHOT</version>
     </parent>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>../wordcount/src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/examples/tf-idf/pom.xml
+++ b/examples/tf-idf/pom.xml
@@ -26,6 +26,17 @@
         <version>4.0-SNAPSHOT</version>
     </parent>
 
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>../wordcount/src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>com.hazelcast.jet.examples</groupId>


### PR DESCRIPTION
Historically word-count examples were part of one project. It means that `books` directory was available for them on classpath. Now this directory is part of `word-count` project but other word-count related project fails with Exception like:
```
java.nio.file.FileSystemNotFoundException
	at com.sun.nio.zipfs.ZipFileSystemProvider.getFileSystem(ZipFileSystemProvider.java:171)
	at com.sun.nio.zipfs.ZipFileSystemProvider.getPath(ZipFileSystemProvider.java:157)
	at java.nio.file.Paths.get(Paths.java:143)
	at com.hazelcast.jet.examples.sinkbuilder.TopicSink.getBooksPath(TopicSink.java:87)
	at com.hazelcast.jet.examples.sinkbuilder.TopicSink.buildPipeline(TopicSink.java:46)
	at com.hazelcast.jet.examples.sinkbuilder.TopicSink.main(TopicSink.java:75)
```
This is not nice solution (due to using `../wordcount/` since it is susceptible to start to fail again if anything will be moved to different place) but it causes that related code samples can be executed out of the box again.