### PR TITLE
Fix merging of differently-timestamped streams

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ExplodeSnapshotP.java
@@ -76,8 +76,8 @@ public class ExplodeSnapshotP extends AbstractProcessor {
             // ignore the validation record
             return true;
         }
-        Entry<SnapshotDataKey, byte[]> casted = (Entry<SnapshotDataKey, byte[]>) item;
-        String vertexName = casted.getKey().vertexName();
+        Entry<SnapshotDataKey, byte[]> castItem = (Entry<SnapshotDataKey, byte[]>) item;
+        String vertexName = castItem.getKey().vertexName();
         FlatMapper<byte[], Object> flatMapper = vertexToFlatMapper.get(vertexName);
         if (flatMapper == null) {
             if (!vertexToFlatMapper.containsKey(vertexName)) {
@@ -87,12 +87,12 @@ public class ExplodeSnapshotP extends AbstractProcessor {
             }
             return true;
         }
-        long snapshotId = casted.getKey().snapshotId();
+        long snapshotId = castItem.getKey().snapshotId();
         if (snapshotId != expectedSnapshotId) {
             getLogger().warning("Data for unexpected snapshot ID encountered, ignoring. Expected="
                     + expectedSnapshotId + ", found=" + snapshotId);
             return true;
         }
-        return flatMapper.tryProcess(casted.getValue());
+        return flatMapper.tryProcess(castItem.getValue());
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/UpdateMapP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/UpdateMapP.java
@@ -97,10 +97,10 @@ public final class UpdateMapP<T, K, V, R> extends AsyncHazelcastWriterP {
         map = instance().getMap(mapName);
         int partitionCount;
         if (isLocal()) {
-            HazelcastInstanceImpl castedInstance = (HazelcastInstanceImpl) instance();
+            HazelcastInstanceImpl castInstance = (HazelcastInstanceImpl) instance();
             clientPartitionService = null;
-            memberPartitionService = castedInstance.node.nodeEngine.getPartitionService();
-            serializationService = castedInstance.getSerializationService();
+            memberPartitionService = castInstance.node.nodeEngine.getPartitionService();
+            serializationService = castInstance.getSerializationService();
             partitionCount = memberPartitionService.getPartitionCount();
         } else {
             HazelcastClientProxy clientProxy = (HazelcastClientProxy) instance();
@@ -267,8 +267,8 @@ public final class UpdateMapP<T, K, V, R> extends AsyncHazelcastWriterP {
             }
             if (item instanceof List) {
                 @SuppressWarnings("unchecked")
-                List<Data> castedList = (List<Data>) item;
-                for (Data o : castedList) {
+                List<Data> castList = (List<Data>) item;
+                for (Data o : castList) {
                     handle(entry, o);
                 }
             } else {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -335,7 +335,12 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
 
     @Nonnull
     <RET> RET attachMerge(@Nonnull GeneralStage<? extends T> other) {
-        return attach(new MergeTransform<>(transform, ((AbstractStage) other).transform), fnAdapter);
+        ComputeStageImplBase castedOther = (ComputeStageImplBase) other;
+        if (fnAdapter != castedOther.fnAdapter) {
+            throw new IllegalArgumentException("The merged stages must both have or both not have " +
+                    "timestamp definitions");
+        }
+        return attach(new MergeTransform<>(transform, castedOther.transform), fnAdapter);
     }
 
     @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -335,12 +335,12 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
 
     @Nonnull
     <RET> RET attachMerge(@Nonnull GeneralStage<? extends T> other) {
-        ComputeStageImplBase castedOther = (ComputeStageImplBase) other;
-        if (fnAdapter != castedOther.fnAdapter) {
+        ComputeStageImplBase castOther = (ComputeStageImplBase) other;
+        if (fnAdapter != castOther.fnAdapter) {
             throw new IllegalArgumentException("The merged stages must both have or both not have " +
                     "timestamp definitions");
         }
-        return attach(new MergeTransform<>(transform, castedOther.transform), fnAdapter);
+        return attach(new MergeTransform<>(transform, castOther.transform), fnAdapter);
     }
 
     @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
@@ -105,10 +105,10 @@ public final class AsyncTransformUsingServiceOrderedP<S, T, R> extends AbstractP
             return false;
         }
         @SuppressWarnings("unchecked")
-        T castedItem = (T) item;
-        CompletableFuture<? extends Traverser<R>> future = callAsyncFn.apply(service, castedItem);
+        T castItem = (T) item;
+        CompletableFuture<? extends Traverser<R>> future = callAsyncFn.apply(service, castItem);
         if (future != null) {
-            queue.add(tuple2(castedItem, future));
+            queue.add(tuple2(castItem, future));
         }
         return true;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
@@ -138,8 +138,8 @@ public final class AsyncTransformUsingServiceUnorderedP<S, T, K, R> extends Abst
         }
         asyncOpsCounterMetric.lazySet(asyncOpsCounter);
         @SuppressWarnings("unchecked")
-        T castedItem = (T) item;
-        if (!processItem(castedItem)) {
+        T castItem = (T) item;
+        if (!processItem(castItem)) {
             // if queue is full, try to emit and apply backpressure
             tryFlushQueue();
             return false;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -926,7 +926,24 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         exception.expectMessage("both have or both not have timestamp definitions");
 
         // When
-        nonTimestamped.merge(timestamped);
+        timestamped.merge(nonTimestamped);
+    }
+
+    @Test
+    public void when_mergeToItself_then_doubleOutput() {
+        List<Integer> input = sequence(itemCount);
+        Function<Integer, String> formatFn = i -> String.format("%04d", i);
+        StreamStage<Integer> srcStage0 = streamStageFromList(input);
+
+        // When
+        StreamStage<Integer> merged = srcStage0.merge(srcStage0);
+
+        // Then
+        merged.writeTo(sink);
+        execute();
+        assertEquals(
+                streamToString(input.stream().flatMap(i -> Stream.of(i, i)), formatFn),
+                streamToString(sinkStreamOf(Integer.class), formatFn));
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -32,9 +32,13 @@ import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.datamodel.Tuple3;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.impl.JetEvent;
+import com.hazelcast.jet.pipeline.test.SimpleEvent;
+import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.map.IMap;
 import com.hazelcast.replicatedmap.ReplicatedMap;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,6 +76,9 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
     private static BiFunction<String, Integer, String> ENRICHING_FORMAT_FN =
             (prefix, i) -> String.format("%s-%04d", prefix, i);
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void setName() {
@@ -896,6 +903,30 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         assertEquals(
                 streamToString(input.stream().flatMap(i -> Stream.of(i, i)), formatFn),
                 streamToString(sinkStreamOf(Integer.class), formatFn));
+    }
+
+    @Test
+    public void when_mergeTimestampedToNonTimestamped_then_error() {
+        StreamStage<SimpleEvent> timestamped = p.readFrom(TestSources.itemStream(1)).withIngestionTimestamps();
+        StreamStage<SimpleEvent> nonTimestamped = p.readFrom(TestSources.itemStream(1)).withoutTimestamps();
+
+        // Then
+        exception.expectMessage("both have or both not have timestamp definitions");
+
+        // When
+        nonTimestamped.merge(timestamped);
+    }
+
+    @Test
+    public void when_mergeNonTimestampedToTimestamped_then_error() {
+        StreamStage<SimpleEvent> timestamped = p.readFrom(TestSources.itemStream(1)).withIngestionTimestamps();
+        StreamStage<SimpleEvent> nonTimestamped = p.readFrom(TestSources.itemStream(1)).withoutTimestamps();
+
+        // Then
+        exception.expectMessage("both have or both not have timestamp definitions");
+
+        // When
+        nonTimestamped.merge(timestamped);
     }
 
     @Test


### PR DESCRIPTION
We only improve the reported error, it failed before too, but depending on the order it failed either at runtime with a ClassCastException or when adding a window it complained that the pipeline doesn't have timestamps.