### PR TITLE
Fix exponential complexity in isHigherPrioritySrc

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -144,6 +144,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
 
         this.ptionArrgmt = new PartitionArrangement(partitionOwners, nodeEngine.getThisAddress());
         JetInstance instance = getJetInstance(nodeEngine);
+        Set<Integer> higherPriorityVertices = VertexDef.getHigherPriorityVertices(vertices);
         for (VertexDef vertex : vertices) {
             Collection<? extends Processor> processors = createProcessors(vertex, vertex.localParallelism());
 
@@ -157,7 +158,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                     new AsyncSnapshotWriterImpl(nodeEngine, snapshotContext, vertex.name(), memberIndex, memberCount),
                     nodeEngine.getLogger(StoreSnapshotTasklet.class.getName() + "."
                             + sanitizeLoggerNamePart(vertex.name())),
-                    vertex.name(), vertex.isHigherPrioritySource());
+                    vertex.name(), higherPriorityVertices.contains(vertex.vertexId()));
             tasklets.add(ssTasklet);
 
             int localProcessorIdx = 0;
@@ -556,9 +557,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
     }
 
     public int getHigherPriorityVertexCount() {
-        return (int) vertices.stream()
-                             .filter(VertexDef::isHigherPrioritySource)
-                             .count();
+        return VertexDef.getHigherPriorityVertices(vertices).size();
     }
 
     // for test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/VertexDef_HigherPrioritySourceTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.Edge.between;
@@ -126,8 +127,9 @@ public class VertexDef_HigherPrioritySourceTest extends SimpleTestInClusterSuppo
         ExecutionPlan plan = executionPlans.values().iterator().next();
         SnapshotContext ssContext = new SnapshotContext(mock(ILogger.class), "job", 0, EXACTLY_ONCE);
         plan.initialize(nodeEngineImpl, 0, 0, ssContext);
+        Set<Integer> higherPriorityVertices = VertexDef.getHigherPriorityVertices(plan.getVertices());
         String actualHigherPriorityVertices = plan.getVertices().stream()
-                .filter(VertexDef::isHigherPrioritySource)
+                .filter(v -> higherPriorityVertices.contains(v.vertexId()))
                 .map(VertexDef::name)
                 .sorted()
                 .collect(joining("\n"));


### PR DESCRIPTION
If the A-B1-B2 sub-DAG is repeated N times in a sequence,
`isHigherPrioritySource` for vertex A would evaluate the sink vertex 2^N
times:

```
    /-- B1 --\       /-- D1 --\       /-- F1 --\
A --+-- B2 --+-- C --+-- D2 --+-- E --+-- F2 --+--  ....
```

Fixes #1805