### PR TITLE
Remove too much flexibility from the JMS sink & improvements

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -295,11 +295,11 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeJmsQueueP(
+            @Nonnull String queueName,
             @Nonnull SupplierEx<? extends Connection> newConnectionFn,
-            @Nonnull BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn,
-            @Nonnull String name
+            @Nonnull BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn
     ) {
-        return WriteJmsP.supplier(newConnectionFn, messageFn, name, false);
+        return WriteJmsP.supplier(queueName, newConnectionFn, messageFn, false);
     }
 
     /**
@@ -307,11 +307,11 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeJmsTopicP(
+            @Nonnull String topicName,
             @Nonnull SupplierEx<? extends Connection> newConnectionFn,
-            @Nonnull BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn,
-            @Nonnull String name
+            @Nonnull BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn
     ) {
-        return WriteJmsP.supplier(newConnectionFn, messageFn, name, true);
+        return WriteJmsP.supplier(topicName, newConnectionFn, messageFn, true);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -37,7 +37,6 @@ import com.hazelcast.map.EntryProcessor;
 import javax.annotation.Nonnull;
 import javax.jms.Connection;
 import javax.jms.Message;
-import javax.jms.MessageProducer;
 import javax.jms.Session;
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
@@ -297,13 +296,10 @@ public final class SinkProcessors {
     @Nonnull
     public static <T> ProcessorMetaSupplier writeJmsQueueP(
             @Nonnull SupplierEx<? extends Connection> newConnectionFn,
-            @Nonnull FunctionEx<? super Connection, ? extends Session> newSessionFn,
             @Nonnull BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn,
-            @Nonnull BiConsumerEx<? super MessageProducer, ? super Message> sendFn,
-            @Nonnull ConsumerEx<? super Session> flushFn,
             @Nonnull String name
     ) {
-        return WriteJmsP.supplier(newConnectionFn, newSessionFn, messageFn, sendFn, flushFn, name, false);
+        return WriteJmsP.supplier(newConnectionFn, messageFn, name, false);
     }
 
     /**
@@ -312,13 +308,10 @@ public final class SinkProcessors {
     @Nonnull
     public static <T> ProcessorMetaSupplier writeJmsTopicP(
             @Nonnull SupplierEx<? extends Connection> newConnectionFn,
-            @Nonnull FunctionEx<? super Connection, ? extends Session> newSessionFn,
             @Nonnull BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn,
-            @Nonnull BiConsumerEx<? super MessageProducer, ? super Message> sendFn,
-            @Nonnull ConsumerEx<? super Session> flushFn,
             @Nonnull String name
     ) {
-        return WriteJmsP.supplier(newConnectionFn, newSessionFn, messageFn, sendFn, flushFn, name, true);
+        return WriteJmsP.supplier(newConnectionFn, messageFn, name, true);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteJmsP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteJmsP.java
@@ -55,16 +55,16 @@ public final class WriteJmsP {
      * SinkProcessors#writeJmsTopicP} instead
      */
     public static <T> ProcessorMetaSupplier supplier(
+            String destinationName,
             SupplierEx<? extends Connection> newConnectionFn,
             BiFunctionEx<? super Session, T, ? extends Message> messageFn,
-            String name,
             boolean isTopic
     ) {
         checkSerializable(newConnectionFn, "newConnectionFn");
         checkSerializable(messageFn, "messageFn");
 
         return ProcessorMetaSupplier.of(PREFERRED_LOCAL_PARALLELISM,
-                new Supplier<>(newConnectionFn, messageFn, name, isTopic));
+                new Supplier<>(destinationName, newConnectionFn, messageFn, isTopic));
     }
 
     private static final class Supplier<T> implements ProcessorSupplier {
@@ -78,14 +78,15 @@ public final class WriteJmsP {
 
         private transient Connection connection;
 
-        private Supplier(SupplierEx<? extends Connection> newConnectionFn,
-                         BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn,
-                         String name,
-                         boolean isTopic
+        private Supplier(
+                String destinationName,
+                SupplierEx<? extends Connection> newConnectionFn,
+                BiFunctionEx<? super Session, ? super T, ? extends Message> messageFn,
+                boolean isTopic
         ) {
             this.newConnectionFn = newConnectionFn;
             this.messageFn = messageFn;
-            this.name = name;
+            this.name = destinationName;
             this.isTopic = isTopic;
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
@@ -126,7 +126,7 @@ public final class JmsSinkBuilder<T> {
         SupplierEx<ConnectionFactory> factorySupplierLocal = factorySupplier;
         SupplierEx<Connection> newConnectionFn = () -> connectionFnLocal.apply(factorySupplierLocal.get());
         return Sinks.fromProcessor(sinkName(),
-                WriteJmsP.supplier(newConnectionFn, messageFn, destinationName, isTopic));
+                WriteJmsP.supplier(destinationName, newConnectionFn, messageFn, isTopic));
     }
 
     private String sinkName() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.jet.pipeline;
 
-import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.BiFunctionEx;
-import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.impl.connector.WriteJmsP;
@@ -27,7 +25,6 @@ import javax.annotation.Nonnull;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Message;
-import javax.jms.MessageProducer;
 import javax.jms.Session;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -46,15 +43,10 @@ public final class JmsSinkBuilder<T> {
     private final boolean isTopic;
 
     private FunctionEx<ConnectionFactory, Connection> connectionFn;
-    private FunctionEx<Connection, Session> sessionFn;
     private BiFunctionEx<Session, T, Message> messageFn;
-    private BiConsumerEx<MessageProducer, Message> sendFn;
-    private ConsumerEx<Session> flushFn;
 
     private String username;
     private String password;
-    private boolean transacted;
-    private int acknowledgeMode = Session.AUTO_ACKNOWLEDGE;
     private String destinationName;
 
     /**
@@ -93,34 +85,6 @@ public final class JmsSinkBuilder<T> {
     }
 
     /**
-     * Sets the session parameters. If {@code sessionFn} is provided, these
-     * parameters are ignored.
-     *
-     * @param transacted       if true, marks the session as transacted.
-     *                         Default value is false.
-     * @param acknowledgeMode  sets the acknowledge mode of the session,
-     *                         Default value is {@code Session.AUTO_ACKNOWLEDGE}
-     */
-    public JmsSinkBuilder<T> sessionParams(boolean transacted, int acknowledgeMode) {
-        this.transacted = transacted;
-        this.acknowledgeMode = acknowledgeMode;
-        return this;
-    }
-
-    /**
-     * Sets the function which creates a session from a connection.
-     * <p>
-     * If not provided, the builder creates a function which uses {@code
-     * Connection#createSession(boolean transacted, int acknowledgeMode)} to
-     * create the session. See {@link #sessionParams(boolean, int)}.
-     */
-    public JmsSinkBuilder<T> sessionFn(@Nonnull FunctionEx<Connection, Session> sessionFn) {
-        checkSerializable(sessionFn, "sessionFn");
-        this.sessionFn = sessionFn;
-        return this;
-    }
-
-    /**
      * Sets the name of the destination.
      */
     public JmsSinkBuilder<T> destinationName(@Nonnull String destinationName) {
@@ -142,61 +106,27 @@ public final class JmsSinkBuilder<T> {
     }
 
     /**
-     * Sets the function which sends the message via message producer.
-     * <p>
-     * If not provided, the builder creates a function which sends the message via
-     * {@code MessageProducer#send(Message message)}.
-     */
-    public JmsSinkBuilder<T> sendFn(BiConsumerEx<MessageProducer, Message> sendFn) {
-        checkSerializable(sendFn, "sendFn");
-        this.sendFn = sendFn;
-        return this;
-    }
-
-    /**
-     * Sets the function which flushes the session after a batch of messages is
-     * sent.
-     * <p>
-     * If not provided, the builder creates a no-op consumer.
-     */
-    public JmsSinkBuilder<T> flushFn(ConsumerEx<Session> flushFn) {
-        checkSerializable(flushFn, "flushFn");
-        this.flushFn = flushFn;
-        return this;
-    }
-
-    /**
      * Creates and returns the JMS {@link Sink} with the supplied components.
      */
     public Sink<T> build() {
         String usernameLocal = username;
         String passwordLocal = password;
-        boolean transactedLocal = transacted;
-        int acknowledgeModeLocal = acknowledgeMode;
 
         checkNotNull(destinationName);
         if (connectionFn == null) {
             connectionFn = factory -> factory.createConnection(usernameLocal, passwordLocal);
         }
-        if (sessionFn == null) {
-            sessionFn = connection -> connection.createSession(transactedLocal, acknowledgeModeLocal);
-        }
         if (messageFn == null) {
             messageFn = (session, item) ->
                     item instanceof Message ? (Message) item : session.createTextMessage(item.toString());
         }
-        if (sendFn == null) {
-            sendFn = MessageProducer::send;
-        }
-        if (flushFn == null) {
-            flushFn = ConsumerEx.noop();
-        }
 
         FunctionEx<ConnectionFactory, Connection> connectionFnLocal = connectionFn;
+        @SuppressWarnings("UnnecessaryLocalVariable") // it's necessary to not capture this in the lambda
         SupplierEx<ConnectionFactory> factorySupplierLocal = factorySupplier;
         SupplierEx<Connection> newConnectionFn = () -> connectionFnLocal.apply(factorySupplierLocal.get());
         return Sinks.fromProcessor(sinkName(),
-                WriteJmsP.supplier(newConnectionFn, sessionFn, messageFn, sendFn, flushFn, destinationName, isTopic));
+                WriteJmsP.supplier(newConnectionFn, messageFn, destinationName, isTopic));
     }
 
     private String sinkName() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -787,9 +787,8 @@ public final class Sinks {
 
     /**
      * Convenience for {@link #jmsQueueBuilder(SupplierEx)}. Creates a
-     * connection without any authentication parameters and uses non-transacted
-     * sessions with {@code Session.AUTO_ACKNOWLEDGE} mode. If a received item
-     * is not an instance of {@code javax.jms.Message}, the sink wraps {@code
+     * connection without any authentication parameters. If a received item is
+     * not an instance of {@code javax.jms.Message}, the sink wraps {@code
      * item.toString()} into a {@link javax.jms.TextMessage}.
      *
      * @param factorySupplier supplier to obtain JMS connection factory
@@ -807,12 +806,13 @@ public final class Sinks {
 
     /**
      * Returns a builder object that offers a step-by-step fluent API to build
-     * a custom JMS queue sink for the Pipeline API. See javadoc on {@link
+     * a custom JMS queue sink for the Pipeline API. See javadoc for {@link
      * JmsSinkBuilder} methods for more details.
      * <p>
-     * Behavior on job restart: the processor is stateless. If the job is
-     * restarted, duplicate events can occur. If you need exactly-once behavior,
-     * you must ensure idempotence on the application level.
+     * Behavior on job restart: the processor is stateless. Items are written
+     * in auto-acknowledge mode. If the job is restarted, duplicate events can
+     * occur, giving you at-least-once guarantee. If you need exactly-once
+     * behavior, you must ensure idempotence on the consumer end.
      * <p>
      * IO failures should be handled by the JMS provider. If any JMS operation
      * throws an exception, the job will fail. Most of the providers offer a
@@ -854,9 +854,10 @@ public final class Sinks {
      * a custom JMS topic sink for the Pipeline API. See javadoc on {@link
      * JmsSinkBuilder} methods for more details.
      * <p>
-     * Behavior on job restart: the processor is stateless. If the job is
-     * restarted, duplicate events can occur. If you need exactly-once behavior,
-     * you must ensure idempotence on the application level.
+     * Behavior on job restart: the processor is stateless. Items are written
+     * in auto-acknowledge mode. If the job is restarted, duplicate events can
+     * occur, giving you at-least-once guarantee. If you need exactly-once
+     * behavior, you must ensure idempotence on the consumer end.
      * <p>
      * IO failures should be handled by the JMS provider. If any JMS operation
      * throws an exception, the job will fail. Most of the providers offer a

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest.java
@@ -270,10 +270,7 @@ public class JmsIntegrationTest extends PipelineTestSupport {
 
         Sink<String> sink = Sinks.<String>jmsQueueBuilder(() -> broker.createConnectionFactory())
                 .connectionFn(ConnectionFactory::createConnection)
-                .sessionFn(connection -> connection.createSession(false, AUTO_ACKNOWLEDGE))
                 .messageFn(Session::createTextMessage)
-                .sendFn(MessageProducer::send)
-                .flushFn(ConsumerEx.noop())
                 .destinationName(destinationName)
                 .build();
 
@@ -314,7 +311,6 @@ public class JmsIntegrationTest extends PipelineTestSupport {
 
         Sink<String> sink = Sinks.<String>jmsTopicBuilder(() -> broker.createConnectionFactory())
                 .connectionParams(null, null)
-                .sessionParams(false, AUTO_ACKNOWLEDGE)
                 .destinationName(destinationName)
                 .build();
 


### PR DESCRIPTION
They would prevent implementing ex-once in the future without breaking changes.