### PR TITLE
jet CLI shouldn’t use log4j

### DIFF
--- a/hazelcast-jet-distribution/src/bin-filemode-755/jet
+++ b/hazelcast-jet-distribution/src/bin-filemode-755/jet
@@ -4,4 +4,10 @@ SCRIPT_DIR="$(dirname "$0")"
 #shellcheck source=bin-regular/common.sh
 . "$SCRIPT_DIR/common.sh"
 
+JAVA_OPTS_ARRAY=(\
+$JDK_OPTS \
+"-Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml" \
+$JAVA_OPTS \
+)
+
 $JAVA "${JAVA_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetCommandLine "$@"

--- a/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
+++ b/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
@@ -13,6 +13,16 @@ fi
 
 . "$SCRIPT_DIR"/common.sh
 
+JAVA_OPTS_ARRAY=(\
+$JDK_OPTS \
+"-Dhazelcast.logging.type=log4j" \
+"-Dlog4j.configuration=file:$JET_HOME/config/log4j.properties" \
+"-Djet.home=$JET_HOME" \
+"-Dhazelcast.config=$JET_HOME/config/hazelcast.yaml" \
+"-Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml" \
+$JAVA_OPTS \
+)
+
 echo "########################################"
 echo "# JAVA=$JAVA"
 echo "# JAVA_OPTS=${JAVA_OPTS_ARRAY[*]}"

--- a/hazelcast-jet-distribution/src/bin-regular/common.sh
+++ b/hazelcast-jet-distribution/src/bin-regular/common.sh
@@ -27,18 +27,6 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
     "
 fi
 
-JAVA_OPTS_ARRAY=(\
-$JDK_OPTS \
-"-Dhazelcast.logging.type=log4j" \
-"-Dlog4j.configuration=file:$JET_HOME/config/log4j.properties" \
-"-Djet.home=$JET_HOME" \
-"-Dhazelcast.config=$JET_HOME/config/hazelcast.yaml" \
-"-Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml" \
-"-Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml" \
-$JAVA_OPTS \
-)
-
-
 if [ "$JET_LICENSE_KEY" ]; then
   JAVA_OPTS_ARRAY+=("-Dhazelcast.enterprise.license.key=${JET_LICENSE_KEY}")
 fi

--- a/hazelcast-jet-distribution/src/bin-regular/jet-start.bat
+++ b/hazelcast-jet-distribution/src/bin-regular/jet-start.bat
@@ -10,7 +10,6 @@ set JAVA_OPTS=%JAVA_OPTS%^
  "-Dhazelcast.logging.type=log4j"^
  "-Dlog4j.configuration=file:%JET_HOME%\config\log4j.properties"^
  "-Dhazelcast.config=%JET_HOME%\config\hazelcast.yaml"^
- "-Dhazelcast.client.config=%JET_HOME%\config\hazelcast-client.yaml"^
  "-Dhazelcast.jet.config=%JET_HOME%\config\hazelcast-jet.yaml"^
  "-Djet.home=%JET_HOME%"
 

--- a/hazelcast-jet-distribution/src/root/config/hazelcast-client.yaml
+++ b/hazelcast-jet-distribution/src/root/config/hazelcast-client.yaml
@@ -6,5 +6,9 @@ hazelcast-client:
     # List of addresses for the client to try to connect to. All members of
     # a Hazelcast Jet cluster accept client connections.
     cluster-members:
-      - 127.0.0.1
+      - 127.0.0.1:5701
     connection-timeout: 60000
+  connection-strategy:
+    connection-retry:
+      # how long the client should keep trying connecting to the server
+      cluster-connect-timeout-millis: 3000

--- a/hazelcast-jet-distribution/src/root/config/hazelcast-client.yaml
+++ b/hazelcast-jet-distribution/src/root/config/hazelcast-client.yaml
@@ -7,7 +7,6 @@ hazelcast-client:
     # a Hazelcast Jet cluster accept client connections.
     cluster-members:
       - 127.0.0.1:5701
-    connection-timeout: 60000
   connection-strategy:
     connection-retry:
       # how long the client should keep trying connecting to the server


### PR DESCRIPTION
Jet CLI was using log4j as with the start script, which meant it was 
logging to file and also verbosity had no effect. This is a regression
from when log4j was introduced.

Fixes #1802 and #1811