### PR TITLE
Add random group.id if not set explicitly

### DIFF
--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaProcessors.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.kafka;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.internal.util.Preconditions;
+import com.hazelcast.internal.util.UuidUtil;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.kafka.impl.StreamKafkaP;
@@ -54,6 +55,7 @@ public final class KafkaProcessors {
     ) {
         Preconditions.checkPositive(topics.length, "At least one topic must be supplied");
         properties.put("enable.auto.commit", false);
+        properties.putIfAbsent("group.id", UuidUtil.newUnsecureUuidString());
         return ProcessorMetaSupplier.of(
                 PREFERRED_LOCAL_PARALLELISM,
                 StreamKafkaP.processorSupplier(properties, Arrays.asList(topics), projectionFn, eventTimePolicy)

--- a/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
+++ b/hazelcast-jet-kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
@@ -95,7 +95,8 @@ public final class KafkaSources {
      *     offsets to Kafka using {@link KafkaConsumer#commitSync()}. But the
      *     offsets are committed before or after the event is fully processed.
      *     Therefore some events can be processed twice or not at all. You can
-     *     configure {@code group.id} in this case.
+     *     configure {@code group.id} in this case. If not configured a random
+     *     UUID will be set.
      * </ol>
      *
      * If you add Kafka partitions at run-time, consumption from them will


### PR DESCRIPTION
`group.id` is used to commit offsets if processing guarantee is none, ignored otherwise. We set it to a random UUID unless explicitly set by user.

Fixes #1705
