### PR TITLE
Do not use log4j for HelloWorld example

### DIFF
--- a/examples/hello-world/src/main/java/com/hazelcast/jet/examples/helloworld/HelloWorld.java
+++ b/examples/hello-world/src/main/java/com/hazelcast/jet/examples/helloworld/HelloWorld.java
@@ -27,7 +27,6 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.map.IMap;
-import org.apache.log4j.Logger;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -44,8 +43,6 @@ public class HelloWorld {
 
     private static final String KEY = "top10";
     private static final String MAP_NAME = "top10_results";
-
-    private static Logger LOGGER = Logger.getLogger(HelloWorld.class);
 
     private static Pipeline buildPipeline() {
         Pipeline p = Pipeline.create();
@@ -73,17 +70,17 @@ public class HelloWorld {
         config.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
         Job job = jet.newJobIfAbsent(p, config);
 
-        LOGGER.info("Generating a stream of random numbers and calculating the top 10");
-        LOGGER.info("The results will be written to a distributed map");
+        System.out.println("Generating a stream of random numbers and calculating the top 10");
+        System.out.println("The results will be written to a distributed map");
 
         while (true) {
             IMap<String, List<Long>> top10Map = jet.getMap(MAP_NAME);
 
             List<Long> top10numbers = top10Map.get(KEY);
             if (top10numbers != null) {
-                LOGGER.info("Top 10 random numbers observed so far in the stream are: ");
+                System.out.println("Top 10 random numbers observed so far in the stream are: ");
                 for (int i = 0; i < top10numbers.size(); i++) {
-                    LOGGER.info(String.format("%d. %,d", i + 1, top10numbers.get(i)));
+                    System.out.println(String.format("%d. %,d", i + 1, top10numbers.get(i)));
                 }
             }
             Thread.sleep(1000);


### PR DESCRIPTION
When using jet submit command, log4j's classloader is different than the
one used for the main class. For finding the log4j.properties log4j is
supposed to look at TCCL, which we are able to set, but in JDK9+ log4j 
because of buggy parsing logic thinks it's running in Java 1.1 instead 
and doesn't try to use TCCL (which was added in JDK 1.2). This is not a full
fix but a workaround for now.

Fixes #1837 