### PR TITLE
Fixed issue with the unzipping the nested directories.

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
@@ -20,7 +20,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -62,7 +61,8 @@ public final class IOUtil {
                     }
                     String relativePath = baseDir.relativize(p).toString();
                     boolean directory = Files.isDirectory(p);
-                    relativePath = directory ? relativePath + File.separator : relativePath;
+                    // slash has been added instead of File.seperator since ZipEntry.isDirectory is checking against it.
+                    relativePath = directory ? relativePath + "/" : relativePath;
                     zipOut.putNextEntry(new ZipEntry(relativePath));
                     if (!directory) {
                         Files.copy(p, zipOut);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/IOUtil.java
@@ -20,6 +20,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -59,8 +60,11 @@ public final class IOUtil {
                     if (Files.isHidden(p) || p == baseDir) {
                         return;
                     }
-                    zipOut.putNextEntry(new ZipEntry(baseDir.relativize(p).toString()));
-                    if (!Files.isDirectory(p)) {
+                    String relativePath = baseDir.relativize(p).toString();
+                    boolean directory = Files.isDirectory(p);
+                    relativePath = directory ? relativePath + File.separator : relativePath;
+                    zipOut.putNextEntry(new ZipEntry(relativePath));
+                    if (!directory) {
                         Files.copy(p, zipOut);
                     }
                     zipOut.closeEntry();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -44,13 +44,24 @@ public class IOUtilTest extends JetTestSupport {
 
     @Test
     public void test_zipAndUnzipNestedFolder_then_contentsShouldBeSame() throws Exception {
+        Path originalPath = Paths.get(this.getClass().getResource("/nested").toURI());
+        test(originalPath);
+    }
+
+    @Test
+    public void test_zipAndUnzipNestedFoldersWithAnEmptySubFolder_then_contentsShouldBeSame() throws Exception {
+        Path originalPath = Paths.get(this.getClass().getResource("/nested").toURI());
+        Files.createDirectory(originalPath.resolve(randomName())).toFile().deleteOnExit();
+        test(originalPath);
+    }
+
+    public void test(Path originalPath) throws IOException {
         //Given
         ByteArrayOutputStream baos = new ByteArrayOutputStream(1000);
 
         //When
-        Path originalPath = Paths.get(this.getClass().getResource("/nested").toURI());
-        Path unzippedPath = temporaryFolder.newFolder().toPath();
         packDirectoryIntoZip(originalPath, baos);
+        Path unzippedPath = temporaryFolder.newFolder().toPath();
         unzip(new ByteArrayInputStream(baos.toByteArray()), unzippedPath);
 
         //Then

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.core.test.JetAssert;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.jet.impl.util.IOUtil.packDirectoryIntoZip;
+import static com.hazelcast.jet.impl.util.IOUtil.unzip;
+
+@RunWith(HazelcastParallelClassRunner.class)
+public class IOUtilTest extends JetTestSupport {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void test_zipAndUnzipNestedFolder_then_contentsShouldBeSame() throws Exception {
+        //Given
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(1000);
+
+        //When
+        Path originalPath = Paths.get(this.getClass().getResource("/nested").toURI());
+        Path unzippedPath = temporaryFolder.newFolder().toPath();
+        packDirectoryIntoZip(originalPath, baos);
+        unzip(new ByteArrayInputStream(baos.toByteArray()), unzippedPath);
+
+        //Then
+        Set<Path> originalSet = getChildrenFromRoot(originalPath);
+        Set<Path> unzippedSet = getChildrenFromRoot(unzippedPath);
+
+        assertCollection(originalSet, unzippedSet);
+
+        boolean allMatch = Files.walk(unzippedPath)
+                                .filter(Files::isRegularFile)
+                                .allMatch(p -> {
+                                    try {
+                                        String line = Files.lines(p).iterator().next();
+                                        return line.equals(p.getFileName().toString() + " content");
+                                    } catch (IOException e) {
+                                        throw ExceptionUtil.rethrow(e);
+                                    }
+                                });
+        JetAssert.assertTrue("File contents are not matching", allMatch);
+    }
+
+    private Set<Path> getChildrenFromRoot(Path path) throws IOException {
+        return Files.walk(path)
+                    .map(path::relativize)
+                    .filter(p -> !p.toString().isEmpty())
+                    .collect(Collectors.toSet());
+    }
+}

--- a/hazelcast-jet-core/src/test/resources/nested/folder/test
+++ b/hazelcast-jet-core/src/test/resources/nested/folder/test
@@ -1,0 +1,1 @@
+test content

--- a/hazelcast-jet-core/src/test/resources/nested/folder1/test1
+++ b/hazelcast-jet-core/src/test/resources/nested/folder1/test1
@@ -1,0 +1,1 @@
+test1 content

--- a/hazelcast-jet-core/src/test/resources/nested/folder2/test2
+++ b/hazelcast-jet-core/src/test/resources/nested/folder2/test2
@@ -1,0 +1,1 @@
+test2 content


### PR DESCRIPTION
The issue is related to the ZIP entries are not being correctly created for the directories which doesn't include a trailing slash so it leads to ZipEntry.isDirectory() calls to always return false.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] Any breaking changes are documented
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #1845
