### PR TITLE
Expose read function

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SourceProcessors.java
@@ -317,25 +317,26 @@ public final class SourceProcessors {
                     directory,
                     glob,
                     sharedFileSystem,
-                    path -> Files.lines(path, Charset.forName(charsetName)),
-                    mapOutputFn
+                    path -> {
+                        String fileName = path.getFileName().toString();
+                        return Files.lines(path, Charset.forName(charsetName))
+                                    .map(l -> mapOutputFn.apply(fileName, l));
+                    }
                 );
     }
+
     /**
      * Returns a supplier of processors for {@link Sources#filesBuilder}.
      * See {@link FileSourceBuilder#build} for more details.
      */
     @Nonnull
-    public static <I, R> ProcessorMetaSupplier readFilesP(
+    public static <I> ProcessorMetaSupplier readFilesP(
             @Nonnull String directory,
             @Nonnull String glob,
             boolean sharedFileSystem,
-            @Nonnull FunctionEx<? super Path, ? extends Stream<I>> readFileFn,
-            @Nonnull BiFunctionEx<? super String, ? super I, ? extends R> mapOutputFn
+            @Nonnull FunctionEx<? super Path, ? extends Stream<I>> readFileFn
     ) {
-        return ReadFilesP.metaSupplier(directory, glob, sharedFileSystem,
-                readFileFn,
-                mapOutputFn);
+        return ReadFilesP.metaSupplier(directory, glob, sharedFileSystem, readFileFn, (f, l) -> l);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
@@ -35,7 +35,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * its subdirectories) and emits output object created by {@code mapOutputFn}
  * @since 3.0
  */
-@SuppressWarnings("unchecked")
 public final class FileSourceBuilder {
 
     private static final String GLOB_WILDCARD = "*";
@@ -95,7 +94,8 @@ public final class FileSourceBuilder {
      * Source emits lines to downstream without any transformation.
      */
     public BatchSource<String> build() {
-        return build(path -> Files.lines(path, charset), (filename, line) -> line);
+        String charsetName = charset.name();
+        return build(path -> Files.lines(path, Charset.forName(charsetName)), (filename, line) -> line);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 
         <maven.enforcer.plugin.version>3.0.0-M1</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
-        <maven.spotbugs.plugin.version>3.1.12</maven.spotbugs.plugin.version>
+        <maven.spotbugs.plugin.version>3.1.12.2</maven.spotbugs.plugin.version>
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>
         <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>


### PR DESCRIPTION
Exoise readFileFn from SourcesProcessors. This allows to easily plug in custom file reading (like: CSV and TSV parsers, batched parsers, etc.).

Additionally I've added readFileFn to S3 source. 

Checklist
- [ ] Tags Set
- [ ] Milestone Set
- [ ] Any breaking changes are documented
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] For code samples, code sample main readme is updated

Links to issues fixed (if any): #1772

Fixes #1772

List of breaking changes:

* ..
