### PR TITLE
Print collection contents in case of failure

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
@@ -314,5 +315,11 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
             fail("join didn't fail with CancellationException");
         } catch (CancellationException ignored) {
         }
+    }
+
+    public static <T> void assertCollection(Collection<T> expected, Collection<T> actual) {
+        assertEquals(String.format("Expected collection: `%s`, actual collection: `%s`", expected, actual),
+                expected.size(), actual.size());
+        assertContainsAll(expected, actual);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -35,7 +35,6 @@ import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.impl.util.IOUtil.packDirectoryIntoZip;
 import static com.hazelcast.jet.impl.util.IOUtil.unzip;
-import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class IOUtilTest extends JetTestSupport {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.impl.util.IOUtil.packDirectoryIntoZip;
 import static com.hazelcast.jet.impl.util.IOUtil.unzip;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class IOUtilTest extends JetTestSupport {
@@ -68,6 +69,9 @@ public class IOUtilTest extends JetTestSupport {
         Set<Path> originalSet = getChildrenFromRoot(originalPath);
         Set<Path> unzippedSet = getChildrenFromRoot(unzippedPath);
 
+        if (originalSet.size() != unzippedSet.size()) {
+            fail(String.format("Expected children set: ` %s`, actual children set: `%s`", originalSet, unzippedPath));
+        }
         assertCollection(originalSet, unzippedSet);
 
         boolean allMatch = Files.walk(unzippedPath)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -69,9 +69,6 @@ public class IOUtilTest extends JetTestSupport {
         Set<Path> originalSet = getChildrenFromRoot(originalPath);
         Set<Path> unzippedSet = getChildrenFromRoot(unzippedPath);
 
-        if (originalSet.size() != unzippedSet.size()) {
-            fail(String.format("Expected children set: ` %s`, actual children set: `%s`", originalSet, unzippedPath));
-        }
         assertCollection(originalSet, unzippedSet);
 
         boolean allMatch = Files.walk(unzippedPath)


### PR DESCRIPTION


Checklist
- [x] Tags Set
- [x] Milestone Set
- [NA] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

related to #1851

