### PR TITLE
Add context for service tests to isolate it from other tests

### DIFF
--- a/hazelcast-jet-spring/src/test/java/com/hazelcast/jet/spring/SpringServiceFactoriesTest.java
+++ b/hazelcast-jet-spring/src/test/java/com/hazelcast/jet/spring/SpringServiceFactoriesTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.fail;
 
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
-@ContextConfiguration(locations = {"application-context-processor.xml"})
+@ContextConfiguration(locations = {"application-context-service.xml"})
 public class SpringServiceFactoriesTest {
 
     @Resource(name = "jet-instance")

--- a/hazelcast-jet-spring/src/test/resources/com/hazelcast/jet/spring/application-context-service.xml
+++ b/hazelcast-jet-spring/src/test/resources/com/hazelcast/jet/spring/application-context-service.xml
@@ -29,18 +29,16 @@
         <hz:config>
             <hz:spring-aware/>
             <hz:cluster-name>jet-spring</hz:cluster-name>
-            <hz:network port="5737" port-auto-increment="true">
+            <hz:network port="5767" port-auto-increment="true">
                 <hz:join>
                     <hz:multicast enabled="false"/>
                     <hz:tcp-ip enabled="true">
-                        <hz:member>127.0.0.1:5737</hz:member>
+                        <hz:member>127.0.0.1:5767</hz:member>
                     </hz:tcp-ip>
                 </hz:join>
             </hz:network>
         </hz:config>
     </jet:instance>
 
-    <jet:list instance-ref="jet-instance" name="my-list" id="my-list-bean"/>
-
-    <jet:map instance-ref="jet-instance" name="my-map" id="my-map-bean"/>
+    <bean name="calculator" class="com.hazelcast.jet.spring.SillyCalculator" />
 </beans>


### PR DESCRIPTION
The tests in the spring module creates normal instances not test instances and since the tests run in parallel they affect each other. 

Checklist
- [x] Tags Set
- [x] Milestone Set
- [NA] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #1853
