### PR TITLE
Execute evictFn after completion

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformStatefulP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/TransformStatefulP.java
@@ -168,6 +168,8 @@ public class TransformStatefulP<T, K, S, R> extends AbstractProcessor {
     @Override
     public boolean saveToSnapshot() {
         if (inComplete) {
+            // If we are in completing phase, we can have a half-emitted item. Instead of finishing it and
+            // writing a snapshot, we finish the final items and save no state.
             return complete();
         }
         if (snapshotTraverser == null) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/TransformStatefulPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/TransformStatefulPTest.java
@@ -244,7 +244,9 @@ public class TransformStatefulPTest {
                            jetEvent(3, entry("a", 3L)),
                            jetEvent(4, entry("b", evictSignal)),
                            wm(4),
-                           jetEvent(4, entry("b", 4L))
+                           jetEvent(4, entry("b", 4L)),
+                           jetEvent(Long.MAX_VALUE, entry("a", 99L)),
+                           jetEvent(Long.MAX_VALUE, entry("b", 99L))
                    ));
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -660,7 +660,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         execute();
         Function<Entry<Integer, String>, String> formatFn = e -> String.format("%d %s", e.getKey(), e.getValue());
         assertEquals(
-                streamToString(Stream.of(entry(0, evictedSignal)), formatFn),
+                streamToString(Stream.of(entry(0, evictedSignal), entry(1, evictedSignal)), formatFn),
                 streamToString(sinkStreamOfEntry(), formatFn)
         );
     }


### PR DESCRIPTION
The aim is to make batch jobs more deterministic: all items are evicted at the
end, regardless of the WM.

Fixes #1801