### PR TITLE
Add a type check for the initilized object by ManagedContext

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ConvenientSourceP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ConvenientSourceP.java
@@ -28,6 +28,7 @@ import com.hazelcast.jet.core.EventTimeMapper;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.processor.SourceProcessors;
 import com.hazelcast.jet.impl.JetEvent;
+import com.hazelcast.jet.impl.util.Util;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -108,10 +109,9 @@ public class ConvenientSourceP<C, T, S> extends AbstractProcessor implements Ser
 
     @Override
     protected void init(@Nonnull Context context) {
-        C localCtx = createFn.apply(context);
-        ctx = (C) managedContext.initialize(localCtx);
-        snapshotKey = broadcastKey(context.globalProcessorIndex());
         // createFn is allowed to return null, we'll call `destroyFn` even for null `ctx`
+        ctx = Util.initializeObject(managedContext, createFn.apply(context));
+        snapshotKey = broadcastKey(context.globalProcessorIndex());
         initialized = true;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ConvenientSourceP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ConvenientSourceP.java
@@ -28,7 +28,6 @@ import com.hazelcast.jet.core.EventTimeMapper;
 import com.hazelcast.jet.core.EventTimePolicy;
 import com.hazelcast.jet.core.processor.SourceProcessors;
 import com.hazelcast.jet.impl.JetEvent;
-import com.hazelcast.jet.impl.util.Util;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -110,7 +109,7 @@ public class ConvenientSourceP<C, T, S> extends AbstractProcessor implements Ser
     @Override
     protected void init(@Nonnull Context context) {
         // createFn is allowed to return null, we'll call `destroyFn` even for null `ctx`
-        ctx = Util.initializeObject(managedContext, createFn.apply(context));
+        ctx = (C) managedContext.initialize(createFn.apply(context));
         snapshotKey = broadcastKey(context.globalProcessorIndex());
         initialized = true;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
@@ -29,6 +29,7 @@ import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.processor.SinkProcessors;
+import com.hazelcast.jet.impl.util.Util;
 
 import javax.annotation.Nonnull;
 import java.util.function.Consumer;
@@ -64,7 +65,7 @@ public final class WriteBufferedP<B, T> implements Processor, SerializationServi
         if (localBuff == null) {
             throw new JetException("Null buffer created");
         }
-        buffer = (B) managedContext.initialize(localBuff);
+        buffer = Util.initializeObject(managedContext, localBuff);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteBufferedP.java
@@ -29,7 +29,6 @@ import com.hazelcast.jet.core.Outbox;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.processor.SinkProcessors;
-import com.hazelcast.jet.impl.util.Util;
 
 import javax.annotation.Nonnull;
 import java.util.function.Consumer;
@@ -65,7 +64,7 @@ public final class WriteBufferedP<B, T> implements Processor, SerializationServi
         if (localBuff == null) {
             throw new JetException("Null buffer created");
         }
-        buffer = Util.initializeObject(managedContext, localBuff);
+        buffer = (B) managedContext.initialize(localBuff);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -208,7 +208,7 @@ public class ProcessorTasklet implements Tasklet {
                 toInit = (Processor) initialized;
             } catch (ClassCastException e) {
                 throw new IllegalArgumentException(String.format(
-                        "The initialized object(%s) should be an instance of %s", initialized, Processor.class));
+                        "The initialized object(%s) should be an instance of %s", initialized, Processor.class), e);
             }
             if (processor instanceof ProcessorWrapper) {
                 ((ProcessorWrapper) processor).setWrapped(toInit);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.execution;
 
+import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
@@ -197,10 +198,11 @@ public class ProcessorTasklet implements Tasklet {
 
     @Override
     public void init() {
-        if (serializationService.getManagedContext() != null) {
+        ManagedContext managedContext = serializationService.getManagedContext();
+        if (managedContext != null) {
             Processor toInit = processor instanceof ProcessorWrapper
                     ? ((ProcessorWrapper) processor).getWrapped() : processor;
-            Object initialized = serializationService.getManagedContext().initialize(toInit);
+            Object initialized = managedContext.initialize(toInit);
             assert initialized == toInit : "different object returned";
         }
         try {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorSupplierWithService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorSupplierWithService.java
@@ -21,6 +21,7 @@ import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 
 import javax.annotation.Nonnull;
@@ -56,13 +57,7 @@ public final class ProcessorSupplierWithService<C, S> implements ProcessorSuppli
         ManagedContext managedContext = hazelcastInstance.getSerializationService().getManagedContext();
         serviceContext = serviceFactory.createContextFn().apply(context);
         if (serviceContext != null) {
-            Object initializedObject = managedContext.initialize(serviceContext);
-            Class<?> serviceContextClass = serviceContext.getClass();
-            if (!serviceContextClass.isInstance(initializedObject)) {
-                throw new IllegalArgumentException(String.format("The initialized service context object should " +
-                        "be an instance of %s", serviceContextClass));
-            }
-            serviceContext = (C) initializedObject;
+            serviceContext = Util.initializeObject(managedContext, serviceContext);
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorSupplierWithService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorSupplierWithService.java
@@ -21,7 +21,6 @@ import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.instance.impl.HazelcastInstanceImpl;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
-import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 
 import javax.annotation.Nonnull;
@@ -56,9 +55,7 @@ public final class ProcessorSupplierWithService<C, S> implements ProcessorSuppli
         HazelcastInstanceImpl hazelcastInstance = (HazelcastInstanceImpl) context.jetInstance().getHazelcastInstance();
         ManagedContext managedContext = hazelcastInstance.getSerializationService().getManagedContext();
         serviceContext = serviceFactory.createContextFn().apply(context);
-        if (serviceContext != null) {
-            serviceContext = Util.initializeObject(managedContext, serviceContext);
-        }
+        serviceContext = (C) managedContext.initialize(serviceContext);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorWrapper.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/ProcessorWrapper.java
@@ -35,7 +35,7 @@ import static com.hazelcast.jet.impl.execution.init.ExecutionPlan.createLoggerNa
  */
 public abstract class ProcessorWrapper implements Processor {
 
-    private final Processor wrapped;
+    private Processor wrapped;
 
     protected ProcessorWrapper(Processor wrapped) {
         this.wrapped = wrapped;
@@ -43,6 +43,13 @@ public abstract class ProcessorWrapper implements Processor {
 
     public Processor getWrapped() {
         return wrapped;
+    }
+
+    /**
+     * Can be used only before any other method is called.
+     */
+    public void setWrapped(Processor wrapped) {
+        this.wrapped = wrapped;
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.jet.impl.util;
 
-import com.hazelcast.core.ManagedContext;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.EdgeConfig;
@@ -416,18 +415,4 @@ public final class Util {
     public static ProcessingGuarantee min(ProcessingGuarantee g1, ProcessingGuarantee g2) {
         return g1.ordinal() < g2.ordinal() ? g1 : g2;
     }
-
-    public static <T> T initializeObject(ManagedContext managedContext, T object) {
-        if (object == null) {
-            return null;
-        }
-        Object initializedObject = managedContext.initialize(object);
-        Class<?> objectClass = object.getClass();
-        if (!objectClass.isInstance(initializedObject)) {
-            throw new IllegalArgumentException(String.format("The initialized service context object should " +
-                    "be an instance of %s", objectClass));
-        }
-        return (T) initializedObject;
-    }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.util;
 
+import com.hazelcast.core.ManagedContext;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.EdgeConfig;
@@ -414,6 +415,16 @@ public final class Util {
      */
     public static ProcessingGuarantee min(ProcessingGuarantee g1, ProcessingGuarantee g2) {
         return g1.ordinal() < g2.ordinal() ? g1 : g2;
+    }
+
+    public static <T> T initializeObject(ManagedContext managedContext, T object) {
+        Object initializedObject = managedContext.initialize(object);
+        Class<?> objectClass = object.getClass();
+        if (!objectClass.isInstance(initializedObject)) {
+            throw new IllegalArgumentException(String.format("The initialized service context object should " +
+                    "be an instance of %s", objectClass));
+        }
+        return (T) initializedObject;
     }
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -418,6 +418,9 @@ public final class Util {
     }
 
     public static <T> T initializeObject(ManagedContext managedContext, T object) {
+        if (object == null) {
+            return null;
+        }
         Object initializedObject = managedContext.initialize(object);
         Class<?> objectClass = object.getClass();
         if (!objectClass.isInstance(initializedObject)) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.function.ConsumerEx;
+import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.pipeline.BatchSource;
@@ -53,10 +54,19 @@ public class ManagedContextTest extends JetTestSupport {
 
     @Test
     public void when_managedContextSet_then_processorsInitWithContext() {
+        testProcessors(TestProcessor::new);
+    }
+
+    @Test
+    public void when_managedContextSet_then_differentProcessorReturnedFromContext() {
+        testProcessors(AnotherTestProcessor::new);
+    }
+
+    private void testProcessors(SupplierEx<Processor> processorSupplier) {
         // Given
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.batchFromProcessor("testSource",
-                ProcessorMetaSupplier.preferLocalParallelismOne(TestProcessor::new)))
+                ProcessorMetaSupplier.preferLocalParallelismOne(processorSupplier)))
          .writeTo(assertAnyOrder(singletonList(INJECTED_VALUE)));
 
         // When
@@ -65,9 +75,18 @@ public class ManagedContextTest extends JetTestSupport {
 
     @Test
     public void when_managedContextSet_then_serviceContextInitialized() {
+        testServices(TestServiceContext::new);
+    }
+
+    @Test
+    public void when_managedContextSet_then_differentServiceContextReturnedFromContext() {
+        testServices(AnotherTestServiceContext::new);
+    }
+
+    private void testServices(SupplierEx<? extends AnotherTestServiceContext> serviceSupplier) {
         // Given
-        ServiceFactory<?, TestServiceContext> serviceFactory =
-                ServiceFactories.sharedService(TestServiceContext::new, ConsumerEx.noop());
+        ServiceFactory<?, ? extends AnotherTestServiceContext> serviceFactory =
+                ServiceFactories.sharedService(serviceSupplier, ConsumerEx.noop());
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items("item"))
          .mapUsingService(serviceFactory, (c, item) -> item + c.injectedValue)
@@ -79,7 +98,16 @@ public class ManagedContextTest extends JetTestSupport {
 
     @Test
     public void when_managedContextSet_then_sourceContextInitializedWithContext() {
-        BatchSource<String> src = SourceBuilder.batch("source", c -> new SourceContext())
+        testSources(SourceContext::new);
+    }
+
+    @Test
+    public void when_managedContextSet_then_differentSourceContextReturnedFromContext() {
+        testSources(AnotherSourceContext::new);
+    }
+
+    private void testSources(SupplierEx<? extends AnotherSourceContext> sourceSupplier) {
+        BatchSource<String> src = SourceBuilder.batch("source", c -> sourceSupplier.get())
                 .<String>fillBufferFn((c, b) -> {
                     b.add(c.injectedValue);
                     b.close();
@@ -94,7 +122,16 @@ public class ManagedContextTest extends JetTestSupport {
 
     @Test
     public void when_managedContextSet_then_SinkContextInitializedWithContext() {
-        Sink<Object> sink = SinkBuilder.sinkBuilder("sink", c -> new SinkContext())
+        testSinks(SinkContext::new);
+    }
+
+    @Test
+    public void when_managedContextSet_then_differentSinkContextReturnedFromContext() {
+        testSinks(AnotherSinkContext::new);
+    }
+
+    private void testSinks(SupplierEx<? extends AnotherSinkContext> sinkSupplier) {
+        Sink<Object> sink = SinkBuilder.sinkBuilder("sink", c -> sinkSupplier.get())
                                        .receiveFn((c, i) -> assertEquals(INJECTED_VALUE, c.injectedValue))
                                        .build();
 
@@ -109,29 +146,55 @@ public class ManagedContextTest extends JetTestSupport {
 
         @Override
         public Object initialize(Object obj) {
-            if (obj instanceof TestProcessor) {
-                ((TestProcessor) obj).injectedValue = INJECTED_VALUE;
+            if (obj instanceof AnotherTestProcessor) {
+                return new TestProcessor().setInjectedValue(INJECTED_VALUE);
             }
             if (obj instanceof TestServiceContext) {
                 ((TestServiceContext) obj).injectedValue = INJECTED_VALUE;
+            } else if (obj instanceof AnotherTestServiceContext){
+                return new TestServiceContext().setInjectedValue(INJECTED_VALUE);
             }
             if (obj instanceof SourceContext) {
                 ((SourceContext) obj).injectedValue = INJECTED_VALUE;
+            } else if (obj instanceof AnotherSourceContext) {
+                return new SourceContext().setInjectedValue(INJECTED_VALUE);
             }
             if (obj instanceof SinkContext) {
                 ((SinkContext) obj).injectedValue = INJECTED_VALUE;
+            } else if (obj instanceof AnotherSinkContext) {
+                return new SinkContext().setInjectedValue(INJECTED_VALUE);
+            }
+            if (obj instanceof TestProcessor) {
+                ((TestProcessor) obj).injectedValue = INJECTED_VALUE;
             }
             return obj;
         }
     }
 
-    private static class TestServiceContext {
-        private String injectedValue;
+    private static class TestServiceContext extends AnotherTestServiceContext {
+
+        private TestServiceContext setInjectedValue(String injectedValue) {
+            this.injectedValue = injectedValue;
+            return this;
+        }
+
+    }
+
+    private static class AnotherTestServiceContext {
+        protected String injectedValue;
     }
 
     private static class TestProcessor extends AbstractProcessor {
 
         private String injectedValue;
+
+        public TestProcessor() {
+        }
+
+        public TestProcessor setInjectedValue(String injectedValue) {
+            this.injectedValue = injectedValue;
+            return this;
+        }
 
         @Override
         public boolean complete() {
@@ -139,12 +202,31 @@ public class ManagedContextTest extends JetTestSupport {
         }
     }
 
-    private static final class SourceContext {
-        private String injectedValue;
+    private static class AnotherTestProcessor extends AbstractProcessor {
     }
 
-    private static final class SinkContext {
-        private String injectedValue;
+    private static final class SourceContext extends AnotherSourceContext {
+
+        private SourceContext setInjectedValue(String injectedValue) {
+            this.injectedValue = injectedValue;
+            return this;
+        }
+    }
+
+    private static class AnotherSourceContext {
+        protected String injectedValue;
+    }
+
+    private static final class SinkContext extends AnotherSinkContext {
+
+        private SinkContext setInjectedValue(String injectedValue) {
+            this.injectedValue = injectedValue;
+            return this;
+        }
+    }
+
+    private static class AnotherSinkContext {
+        protected String injectedValue;
     }
 
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
@@ -151,7 +151,7 @@ public class ManagedContextTest extends JetTestSupport {
             }
             if (obj instanceof TestServiceContext) {
                 ((TestServiceContext) obj).injectedValue = INJECTED_VALUE;
-            } else if (obj instanceof AnotherTestServiceContext){
+            } else if (obj instanceof AnotherTestServiceContext) {
                 return new TestServiceContext().setInjectedValue(INJECTED_VALUE);
             }
             if (obj instanceof SourceContext) {
@@ -188,7 +188,7 @@ public class ManagedContextTest extends JetTestSupport {
 
         private String injectedValue;
 
-        public TestProcessor() {
+        TestProcessor() {
         }
 
         public TestProcessor setInjectedValue(String injectedValue) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ManagedContextTest.java
@@ -20,12 +20,14 @@ import com.hazelcast.core.ManagedContext;
 import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.ServiceFactories;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.SinkBuilder;
+import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.jet.pipeline.test.TestSources;
@@ -34,9 +36,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.CompletionException;
+
 import static com.hazelcast.jet.pipeline.test.AssertionSinks.assertAnyOrder;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 public class ManagedContextTest extends JetTestSupport {
@@ -61,6 +66,23 @@ public class ManagedContextTest extends JetTestSupport {
 
         // When
         jet.newJob(p).join();
+    }
+
+    @Test
+    public void when_managedContextSet_then_processorsFailToInitWithContext() {
+        // Given
+        Pipeline p = Pipeline.create();
+        p.readFrom(Sources.batchFromProcessor("testSource",
+                ProcessorMetaSupplier.preferLocalParallelismOne(FailToInitializeProcessor::new)))
+         .writeTo(Sinks.noop());
+
+        // When
+        try {
+            jet.newJob(p).join();
+            fail();
+        } catch (CompletionException e) {
+            assertContains(e.getCause().getMessage(), "different object returned");
+        }
     }
 
     @Test
@@ -109,6 +131,9 @@ public class ManagedContextTest extends JetTestSupport {
 
         @Override
         public Object initialize(Object obj) {
+            if (obj instanceof FailToInitializeProcessor) {
+                return Processors.noopP();
+            }
             if (obj instanceof TestProcessor) {
                 ((TestProcessor) obj).injectedValue = INJECTED_VALUE;
             }
@@ -136,6 +161,14 @@ public class ManagedContextTest extends JetTestSupport {
         @Override
         public boolean complete() {
             return tryEmit(injectedValue);
+        }
+    }
+
+    private static class FailToInitializeProcessor extends AbstractProcessor {
+
+        @Override
+        public boolean complete() {
+            return true;
         }
     }
 


### PR DESCRIPTION
The initialized object can have a different type than the original object passed to the `ManagedContext`. We check and throw exception if so.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [NA] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated
