### PR TITLE
Spring module should not depend on jet-core

### DIFF
--- a/hazelcast-jet-spring/pom.xml
+++ b/hazelcast-jet-spring/pom.xml
@@ -87,7 +87,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
-            <artifactId>hazelcast-jet-core</artifactId>
+            <artifactId>hazelcast-jet</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Spring module depends on jet-core which is wrong. It's an internal module
which is not part of the distribution. This seems like a regression from 3.2.