### PR TITLE
Fixes file cleanup on the test and runs them in serial, fixes #1851

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -18,7 +18,8 @@ package com.hazelcast.jet.impl.util;
 
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.test.JetAssert;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.Repeat;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -36,7 +37,7 @@ import java.util.stream.Collectors;
 import static com.hazelcast.jet.impl.util.IOUtil.packDirectoryIntoZip;
 import static com.hazelcast.jet.impl.util.IOUtil.unzip;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 public class IOUtilTest extends JetTestSupport {
 
     @Rule
@@ -51,8 +52,13 @@ public class IOUtilTest extends JetTestSupport {
     @Test
     public void test_zipAndUnzipNestedFoldersWithAnEmptySubFolder_then_contentsShouldBeSame() throws Exception {
         Path originalPath = Paths.get(this.getClass().getResource("/nested").toURI());
-        Files.createDirectory(originalPath.resolve(randomName())).toFile().deleteOnExit();
-        test(originalPath);
+        Path randomFile = originalPath.resolve(randomName());
+        Files.createDirectory(randomFile);
+        try {
+            test(originalPath);
+        } finally {
+            com.hazelcast.internal.nio.IOUtil.delete(randomFile);
+        }
     }
 
     public void test(Path originalPath) throws IOException {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/IOUtilTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.impl.util;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.test.JetAssert;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.Repeat;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;


### PR DESCRIPTION
Add description here

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #1851 

