### PR TITLE
Remove noisy logging from JobCoordinationService

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -550,7 +550,6 @@ public class JobCoordinationService {
             return false;
         }
         if (!getInternalPartitionService().getPartitionStateManager().isInitialized()) {
-            logger.fine("Not starting jobs because partitions are not yet initialized.");
             return false;
         }
         return true;


### PR DESCRIPTION
It continuously logs that partitions are not initialized when this is just business as usual
