### PR TITLE
Fix emission of older watermark

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
@@ -123,9 +123,6 @@ public class OutboxImpl implements OutboxInternal {
         assert numRemainingInBatch != -1 : "Outbox.offer() called again after it returned false, without a " +
                 "call to reset(). You probably didn't return from Processor method after Outbox.offer() " +
                 "or AbstractProcessor.tryEmit() returned false";
-        if (item instanceof Watermark) {
-            lastForwardedWm.set(((Watermark) item).timestamp());
-        }
         numRemainingInBatch--;
         boolean done = true;
         if (numRemainingInBatch == -1) {
@@ -158,6 +155,14 @@ public class OutboxImpl implements OutboxInternal {
             broadcastTracker.clear();
             unfinishedItem = null;
             unfinishedItemOrdinals = null;
+            if (item instanceof Watermark) {
+                long wmTimestamp = ((Watermark) item).timestamp();
+                if (wmTimestamp > Long.MIN_VALUE && wmTimestamp != WatermarkCoalescer.IDLE_MESSAGE.timestamp()) {
+                    assert lastForwardedWm.get() < wmTimestamp
+                            : "current=" + lastForwardedWm.get() + ", new=" + wmTimestamp;
+                    lastForwardedWm.set(wmTimestamp);
+                }
+            }
         } else {
             numRemainingInBatch = -1;
             unfinishedItem = item;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
@@ -157,8 +157,12 @@ public class OutboxImpl implements OutboxInternal {
             unfinishedItemOrdinals = null;
             if (item instanceof Watermark) {
                 long wmTimestamp = ((Watermark) item).timestamp();
-                if (wmTimestamp > Long.MIN_VALUE && wmTimestamp != WatermarkCoalescer.IDLE_MESSAGE.timestamp()) {
-                    assert lastForwardedWm.get() < wmTimestamp
+                if (wmTimestamp != WatermarkCoalescer.IDLE_MESSAGE.timestamp()) {
+                    // We allow equal timestamp here, even though the WMs should be increasing.
+                    // But we don't track WMs per ordinal and the same WM can be offered to different
+                    // ordinals in different calls. Theoretically a completely different WM could be
+                    // emitted to each ordinal, but we don't do that currently.
+                    assert lastForwardedWm.get() <= wmTimestamp
                             : "current=" + lastForwardedWm.get() + ", new=" + wmTimestamp;
                     lastForwardedWm.set(wmTimestamp);
                 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
@@ -110,7 +110,6 @@ public final class AsyncTransformUsingServiceUnorderedP<C, S, T, K, R> extends A
         this.extractKeyFn = extractKeyFn;
     }
 
-
     @Override
     protected void init(@Nonnull Processor.Context context) throws Exception {
         super.init(context);
@@ -155,7 +154,7 @@ public final class AsyncTransformUsingServiceUnorderedP<C, S, T, K, R> extends A
 
     @Override
     public boolean tryProcessWatermark(@Nonnull Watermark watermark) {
-        if (getOutbox().hasUnfinishedItem() && !emitFromTraverser(currentTraverser)) {
+        if (!emitFromTraverser(currentTraverser)) {
             return false;
         }
         assert lastEmittedWm <= lastReceivedWm : "lastEmittedWm=" + lastEmittedWm + ", lastReceivedWm=" + lastReceivedWm;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.jet.core.test.TestOutbox;
 import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 public class PeekingWrapperTest {
 
     private static final JetEvent<Integer> TEST_JET_EVENT = jetEvent(123, 2);
@@ -184,10 +184,10 @@ public class PeekingWrapperTest {
     @Test
     public void when_peekOutput_metaSupplier() throws Exception {
         // Given
-        ProcessorMetaSupplier passThroughPSupplier = ProcessorMetaSupplier.of(peekOutputProcessorSupplier());
+        ProcessorMetaSupplier sourceSupplier = ProcessorMetaSupplier.of(peekOutputProcessorSupplier());
         ProcessorMetaSupplier peekingMetaSupplier = toStringFn == null
-                ? peekOutputP(passThroughPSupplier)
-                : peekOutputP(toStringFn, shouldLogFn, passThroughPSupplier);
+                ? peekOutputP(sourceSupplier)
+                : peekOutputP(toStringFn, shouldLogFn, sourceSupplier);
         peekP = supplierFrom(peekingMetaSupplier).get();
 
         // When+Then
@@ -270,7 +270,7 @@ public class PeekingWrapperTest {
         TestOutbox outbox = new TestOutbox(1, 1);
         peekP.init(outbox, context);
 
-        Watermark wm = new Watermark(3);
+        Watermark wm = new Watermark(1);
         peekP.tryProcessWatermark(wm);
         verify(logger).info("Output to ordinal 0: " + wm);
         verify(logger).info("Output to ordinal 1: " + wm);


### PR DESCRIPTION
This could happen:
- in `currentTraverser` there was a WM pending, but there was no
unfinished item
- the initial check in `tryProcessWatermark` didn't cause to return
immediately nor attempt finishing of the current traverser
- the `watermarkCounts` collection was empty, so we added the new WM
directly to outbox
- later we emitted the `currentTraverser` and an older WM was added to
the outbox

