### PR TITLE
Fix emission of older watermark (backport of #1879)

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboxImpl.java
@@ -122,9 +122,6 @@ public class OutboxImpl implements OutboxInternal {
         assert numRemainingInBatch != -1 : "Outbox.offer() called again after it returned false, without a " +
                 "call to reset(). You probably didn't return from Processor method after Outbox.offer() " +
                 "or AbstractProcessor.tryEmit() returned false";
-        if (item instanceof Watermark) {
-            lastForwardedWm.lazySet(((Watermark) item).timestamp());
-        }
         numRemainingInBatch--;
         boolean done = true;
         if (numRemainingInBatch == -1) {
@@ -157,6 +154,18 @@ public class OutboxImpl implements OutboxInternal {
             broadcastTracker.clear();
             unfinishedItem = null;
             unfinishedItemOrdinals = null;
+            if (item instanceof Watermark) {
+                long wmTimestamp = ((Watermark) item).timestamp();
+                if (wmTimestamp != WatermarkCoalescer.IDLE_MESSAGE.timestamp()) {
+                    // We allow equal timestamp here, even though the WMs should be increasing.
+                    // But we don't track WMs per ordinal and the same WM can be offered to different
+                    // ordinals in different calls. Theoretically a completely different WM could be
+                    // emitted to each ordinal, but we don't do that currently.
+                    assert lastForwardedWm.get() <= wmTimestamp
+                            : "current=" + lastForwardedWm.get() + ", new=" + wmTimestamp;
+                    lastForwardedWm.lazySet(wmTimestamp);
+                }
+            }
         } else {
             numRemainingInBatch = -1;
             unfinishedItem = item;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextUnorderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingContextUnorderedP.java
@@ -168,6 +168,9 @@ public final class AsyncTransformUsingContextUnorderedP<C, T, K, R> extends Abst
 
     @Override
     public boolean tryProcessWatermark(@Nonnull Watermark watermark) {
+        if (!emitFromTraverser(currentTraverser)) {
+            return false;
+        }
         assert lastEmittedWm <= lastReceivedWm : "lastEmittedWm=" + lastEmittedWm + ", lastReceivedWm=" + lastReceivedWm;
         // Ignore a watermark that is going back. This is possible after restoring from a snapshot
         // taken in at-least-once mode.

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.jet.function.SupplierEx;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +56,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 public class PeekingWrapperTest {
 
     private static final JetEvent<Integer> TEST_JET_EVENT = jetEvent(123, 2);
@@ -184,10 +185,10 @@ public class PeekingWrapperTest {
     @Test
     public void when_peekOutput_metaSupplier() throws Exception {
         // Given
-        ProcessorMetaSupplier passThroughPSupplier = ProcessorMetaSupplier.of(peekOutputProcessorSupplier());
+        ProcessorMetaSupplier sourceSupplier = ProcessorMetaSupplier.of(peekOutputProcessorSupplier());
         ProcessorMetaSupplier peekingMetaSupplier = toStringFn == null
-                ? peekOutputP(passThroughPSupplier)
-                : peekOutputP(toStringFn, shouldLogFn, passThroughPSupplier);
+                ? peekOutputP(sourceSupplier)
+                : peekOutputP(toStringFn, shouldLogFn, sourceSupplier);
         peekP = supplierFrom(peekingMetaSupplier).get();
 
         // When+Then
@@ -270,7 +271,7 @@ public class PeekingWrapperTest {
         TestOutbox outbox = new TestOutbox(1, 1);
         peekP.init(outbox, context);
 
-        Watermark wm = new Watermark(3);
+        Watermark wm = new Watermark(1);
         peekP.tryProcessWatermark(wm);
         verify(logger).info("Output to ordinal 0: " + wm);
         verify(logger).info("Output to ordinal 1: " + wm);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/PeekingWrapperTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.jet.function.PredicateEx;
 import com.hazelcast.jet.function.SupplierEx;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
This could happen:
- in `currentTraverser` there was a WM pending
- the initial check in `tryProcessWatermark` didn't cause to return
immediately nor attempt finishing of the current traverser
- the `watermarkCounts` collection was empty, so we added the new WM
directly to outbox
- later we emitted the `currentTraverser` and an older WM was added to
the outbox