### PR TITLE
Fix outbox blocking in snapshot phase 2

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Processor.java
@@ -323,10 +323,10 @@ public interface Processor {
      * <p>
      * This method can be called even when the {@link #process(int, Inbox)
      * process()} method didn't process the items in the inbox. For this reason
-     * this method should not add any items to the outbox. After all the input
-     * is exhausted, it is also called between {@link #complete()} calls. Once
-     * {@code complete()} returns {@code true}, this method can still be called
-     * to finish the snapshot that was started before this processor completed.
+     * this method must not add any items to the outbox. It is also called
+     * between {@link #complete()} calls. Once {@code complete()} returns
+     * {@code true}, this method can still be called to finish the snapshot
+     * that was started before this processor completed.
      * <p>
      * The processor should do the following:
      *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorState.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorState.java
@@ -64,7 +64,7 @@ enum ProcessorState {
      * Making calls to {@link Processor#snapshotCommitPrepare()} until it
      * returns {@code true}.
      */
-    SNAPSHOT_PREPARE_COMMIT,
+    SNAPSHOT_COMMIT_PREPARE,
 
     /**
      * Waiting for the outbox to accept the {@link SnapshotBarrier}.
@@ -73,23 +73,32 @@ enum ProcessorState {
 
     /**
      * Making calls to {@link Processor#snapshotCommitFinish(boolean)} until it
-     * returns {@code true}.
+     * returns {@code true} and then return to {@link #PROCESS_INBOX}. Used
+     * when phase-2 was initiated while in {@link #PROCESS_INBOX}.
      */
-    ON_SNAPSHOT_COMPLETED,
+    SNAPSHOT_COMMIT_FINISH__PROCESS,
+
+    /**
+     * Making calls to {@link Processor#snapshotCommitFinish(boolean)} until it
+     * returns {@code true} and then return to {@link #COMPLETE}. Used when
+     * phase-2 was initiated while in {@link #COMPLETE}.
+     */
+    SNAPSHOT_COMMIT_FINISH__COMPLETE,
+
+    /**
+     * Making calls to {@link Processor#snapshotCommitFinish(boolean)} until it
+     * returns {@code true} and then proceed to {@link #EMIT_DONE_ITEM}. Used
+     * when phase-2 was initiated after {@code Processor.complete()} returned
+     * true.
+     */
+    SNAPSHOT_COMMIT_FINISH__FINAL,
 
     /**
      * Processor completed after a phase 1 of a snapshot and is not doing
      * anything, but it cannot be done until a phase 2 is done - this state is
-     * waiting for a phase 2.
+     * waiting for a snapshot phase 2.
      */
     WAITING_FOR_SNAPSHOT_COMPLETED,
-
-    /**
-     * Same as {@link #ON_SNAPSHOT_COMPLETED}, but after the processor
-     * completed. It follows after {@link #WAITING_FOR_SNAPSHOT_COMPLETED} and
-     * is followed by {@link #EMIT_DONE_ITEM}.
-     */
-    FINAL_ON_SNAPSHOT_COMPLETED,
 
     /**
      * Waiting for the outbox to accept the {@code DONE_ITEM}.

--- a/hazelcast-jet-reference-manual/src/main/asciidoc/work-with-jet/configure-fault-tolerance.adoc
+++ b/hazelcast-jet-reference-manual/src/main/asciidoc/work-with-jet/configure-fault-tolerance.adoc
@@ -243,12 +243,12 @@ and resume the jobs.
 = Configure Blue/Green Client (Enterprise Only)
 
 Blue/Green deployment refers to a software technique which can be used
-to reduces system downtime by deploying two mirrored production
+to reduce system downtime by deploying two mirrored production
 environments, referred to as Blue and Green. One of the environments is
-running in production while the other one is in active standby.
+running in production while the other is in active standby.
 
 The Jet client can be configured to switch to the other cluster in case
-of a connection failure to the production environment.
+when a connection to the production environment fails.
 
 == Programmatic Configuration
 
@@ -270,20 +270,19 @@ include::{javasource}/ConfigureFaultTolerance.java[tag=s7]
 </hazelcast-client-failover>
 ----
 
-After switching to the cluster-B, the state of any running job on
-cluster-A will be undefined. The jobs may continue running on cluster-A,
-if the cluster is still alive and the switching was because of a network
-problem. When you try to query the state of the job using the `Job`
-interface you'll get `job not found` exception.
+After switching to cluster B, the state of any running job on cluster A
+will be undefined. The jobs may continue running on cluster A if the
+cluster is still alive and the switching happened due to a network
+problem. If you try to query the state of the job using the `Job`
+interface, you'll get a `JobNotFoundException`.
 
 While you can use the Jet client for any IMDG operation, in Jet context
 a client is mostly used for submitting jobs to the cluster. After the
-submission the job lives on the cluster, client is used to query the
+submission the job lives in the cluster, client is used to query the
 state of the job. Therefore Blue/Green deployment is not applicable for
-long-lived jobs but can be used with short-lived batch jobs which will
+long-lived jobs, but can be used with short-lived batch jobs which will
 not cause any problem if run on different clusters at the same time,
 like queries for example.
-
 
 For more information on Blue/Green configuration options see Hazelcast
 IMDG documentation


### PR DESCRIPTION
This happened:

- in `ProcessorTasklet.processInbox` we discovered that a new phase-2 begun

- there was an unfinished item in the outbox, so we blocked the outbox and
didn't begin the phase-2 in order to ensure that the unfinished item is finished

- however before that, the processor had returned from `process()` with an
empty inbox and an unfinished item. Therefore the process went to `fillInbox`
and found a WM there. So the state proceeded to PROCESS_WATERMARK, but the
outbox was still blocked.

- `tryProcessWatermark` tried to emit the `currentTraverser` first, but
couldn't because the outbox was blocked. And there it remained stuck, trying
that forever.

Returning `true` from `tryProcess()` or returning an empty inbox and having an
unfinished item in the outbox is allowed. So we changed the contract of
`snapshotCommitFinish` that it must not add items to outbox and if there's a
phase-2, we just execute that method and return to where we left.

Fixes #1881

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] Any breaking changes are documented
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] For code samples, code sample main readme is updated
