### PR TITLE
Add RabbitMQ tests and fix issues with it

### DIFF
--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -110,6 +110,19 @@
             <version>${activemq.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>rabbitmq</artifactId>
+            <version>1.12.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.rabbitmq.jms</groupId>
+            <artifactId>rabbitmq-jms</artifactId>
+            <version>1.14.0</version>
+        </dependency>
+
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamJmsP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/StreamJmsP.java
@@ -172,6 +172,9 @@ public class StreamJmsP<T> extends AbstractProcessor {
 
     @Override
     public boolean snapshotCommitPrepare() {
+        if (!emitFromTraverser(pendingTraverser)) {
+            return false;
+        }
         snapshotInProgress = guarantee != NONE;
         if (guarantee != EXACTLY_ONCE) {
             return true;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSinkBuilder.java
@@ -114,7 +114,9 @@ public final class JmsSinkBuilder<T> {
 
         checkNotNull(destinationName);
         if (connectionFn == null) {
-            connectionFn = factory -> factory.createConnection(usernameLocal, passwordLocal);
+            connectionFn = factory -> usernameLocal != null || passwordLocal != null
+                    ? factory.createConnection(usernameLocal, passwordLocal)
+                    : factory.createConnection();
         }
         if (messageFn == null) {
             messageFn = (session, item) ->

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSourceBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSourceBuilder.java
@@ -86,8 +86,8 @@ public final class JmsSourceBuilder {
      * If not provided, this function is used:
      * <pre>
      *     connectionFn = factory -> username != null || password != null
-     *                     ? factory.createConnection(usernameLocal, passwordLocal)
-     *                     : factory.createConnection()
+     *         ? factory.createConnection(usernameLocal, passwordLocal)
+     *         : factory.createConnection()
      * </pre>
      * The user name and password set with {@link #connectionParams} are used.
      *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSourceBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JmsSourceBuilder.java
@@ -29,13 +29,13 @@ import javax.jms.ConnectionFactory;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
-import javax.jms.XAConnectionFactory;
 import java.util.function.Function;
 
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamJmsQueueP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamJmsTopicP;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
+import static java.util.Objects.requireNonNull;
 
 /**
  * See {@link Sources#jmsQueueBuilder} or {@link Sources#jmsTopicBuilder}.
@@ -85,11 +85,10 @@ public final class JmsSourceBuilder {
      * <p>
      * If not provided, this function is used:
      * <pre>
-     *     connectionFn = factory -> factory instanceof XAConnectionFactory
-     *            ? ((XAConnectionFactory) factory).createXAConnection(username, password)
-     *            : factory.createConnection(username, password);
+     *     connectionFn = factory -> username != null || password != null
+     *                     ? factory.createConnection(usernameLocal, passwordLocal)
+     *                     : factory.createConnection()
      * </pre>
-     * That means it creates an XA connection if the factory is an XA factory.
      * The user name and password set with {@link #connectionParams} are used.
      *
      * @return this instance for fluent API
@@ -234,9 +233,9 @@ public final class JmsSourceBuilder {
         boolean isTopicLocal = isTopic;
 
         if (connectionFn == null) {
-            connectionFn = factory -> factory instanceof XAConnectionFactory
-                    ? ((XAConnectionFactory) factory).createXAConnection(usernameLocal, passwordLocal)
-                    : factory.createConnection(usernameLocal, passwordLocal);
+            connectionFn = factory -> requireNonNull(usernameLocal != null || passwordLocal != null
+                    ? factory.createConnection(usernameLocal, passwordLocal)
+                    : factory.createConnection());
         }
         if (consumerFn == null) {
             checkNotNull(destinationLocal, "neither consumerFn nor destinationName set");

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest_ActiveMQ.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest_ActiveMQ.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector;
+
+import com.hazelcast.function.SupplierEx;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.junit.EmbeddedActiveMQBroker;
+import org.junit.ClassRule;
+
+import javax.jms.ConnectionFactory;
+
+public class JmsIntegrationTest_ActiveMQ extends JmsIntegrationTestBase {
+
+    @ClassRule
+    public static EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker();
+
+    private static final SupplierEx<ConnectionFactory> FACTORY_SUPPLIER =
+            () -> new ActiveMQConnectionFactory(broker.getVmURL());
+
+    @Override
+    protected SupplierEx<ConnectionFactory> getConnectionFactory() {
+        return FACTORY_SUPPLIER;
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest_RabbitMQ.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegrationTest_RabbitMQ.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.connector;
+
+import com.hazelcast.function.SupplierEx;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.RabbitMQContainer;
+
+import javax.jms.ConnectionFactory;
+
+@Category(NightlyTest.class)
+public class JmsIntegrationTest_RabbitMQ extends JmsIntegrationTestBase {
+
+    @ClassRule
+    public static RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8");
+
+    private static final SupplierEx<ConnectionFactory> FACTORY_SUPPLIER = () -> {
+        RMQConnectionFactory f = new RMQConnectionFactory();
+        f.setUri(container.getAmqpUrl());
+        return f;
+    };
+
+    @Override
+    protected SupplierEx<ConnectionFactory> getConnectionFactory() {
+        return FACTORY_SUPPLIER;
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
@@ -40,11 +40,9 @@ import javax.jms.Destination;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
-import javax.jms.QueueBrowser;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Queue;
 import java.util.function.Function;
@@ -168,23 +166,6 @@ public class StreamJmsPTest extends JetTestSupport {
         session.close();
         connection.close();
         return message;
-    }
-
-    private int queueSize(String queueName) throws Exception {
-        Connection connection = getConnectionFactory().createConnection();
-        connection.start();
-
-        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
-        QueueBrowser browser = session.createBrowser(session.createQueue(queueName));
-        Enumeration enumeration = browser.getEnumeration();
-        int size = 0;
-        while (enumeration.hasMoreElements()) {
-            enumeration.nextElement();
-            size++;
-        }
-        session.close();
-        connection.close();
-        return size;
     }
 
     private static ConnectionFactory getConnectionFactory() {


### PR DESCRIPTION
Add tests for one more JMS broker. RabbitMQ throws very misleading error when `cf.createConnection(null, null)` is used, ActiveMQ is fine with that...

RabbitMQ tests are run nightly.