### PR TITLE
Make return-results-to-caller more discoverable via examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -102,6 +102,30 @@ samples using the Core API.
   - hash-join an unbounded stream with two batch streams in one step
   - print the results on the console
 
+## Return Results to the Caller
+### [Basic Observables](return-results/src/main/java/com/hazelcast/jet/examples/returnresults/Observables.java)
+  - obtain an `Observable`
+  - incorporate it in a streaming pipeline by wrapping it in a `Sink` 
+  - register an `Observer` on it
+  - execute the pipeline (streaming job)
+  - observe the results as they show up in the `Observer`
+  
+### [Iterable results](return-results/src/main/java/com/hazelcast/jet/examples/returnresults/IterableResults.java)
+  - obtain an `Observable`
+  - use it as `Sink` in a batch job
+  - get a result `Iterator` form of the `Observable`
+  - execute the batch job
+  - observe the results by iterating once execution has finished
+
+### [Results as a Future](return-results/src/main/java/com/hazelcast/jet/examples/returnresults/FutureResults.java)
+  - obtain an `Observable`
+  - use it as `Sink` in a batch job
+  - get the `CompletableFuture` form of the `Observable`
+  - specify actions to be executed once the results are complete
+  - execute the batch job
+  - observe the results when they become available
+  
+
 ## Job Management
 
 - [Suspend/Resume a Job](job-management/src/main/java/com/hazelcast/jet/examples/jobmanagement/JobSuspendResume.java)

--- a/examples/README.md
+++ b/examples/README.md
@@ -103,7 +103,7 @@ samples using the Core API.
   - print the results on the console
 
 ## Return Results to the Caller
-### [Basic Observables](return-results/src/main/java/com/hazelcast/jet/examples/returnresults/Observables.java)
+### [Basic Observables](return-results/src/main/java/com/hazelcast/jet/examples/returnresults/BasicObservable.java)
   - obtain an `Observable`
   - incorporate it in a streaming pipeline by wrapping it in a `Sink` 
   - register an `Observer` on it

--- a/examples/hello-world/src/main/java/com/hazelcast/jet/examples/helloworld/HelloWorld.java
+++ b/examples/hello-world/src/main/java/com/hazelcast/jet/examples/helloworld/HelloWorld.java
@@ -75,11 +75,12 @@ public class HelloWorld {
         jet.newJobIfAbsent(p, config);
     }
 
-    private static void printResults(List<Long> top10numbers) {
-        System.out.println("Top " + TOP + " random numbers observed since last print: ");
-        for (int i = 0; i < top10numbers.size(); i++) {
-            System.out.println(String.format("%d. %,d", i + 1, top10numbers.get(i)));
+    private static void printResults(List<Long> topNumbers) {
+        StringBuilder sb = new StringBuilder(String.format("\nTop %d random numbers in the latest window: ", TOP));
+        for (int i = 0; i < topNumbers.size(); i++) {
+            sb.append(String.format("\n\t%d. %,d", i + 1, topNumbers.get(i)));
         }
+        System.out.println(sb.toString());
     }
 
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -49,6 +49,7 @@
         <module>job-management</module>
         <module>kafka</module>
         <module>pattern-matching</module>
+        <module>return-results</module>
         <module>rolling-aggregation</module>
         <module>session-windows</module>
         <module>sockets</module>

--- a/examples/return-results/pom.xml
+++ b/examples/return-results/pom.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hazelcast-jet-examples-return-results</artifactId>
+    <parent>
+        <groupId>com.hazelcast.jet.examples</groupId>
+        <artifactId>hazelcast-jet-examples</artifactId>
+        <version>4.0-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast.jet.examples</groupId>
+            <artifactId>hazelcast-jet-examples-wordcount</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/BasicObservable.java
+++ b/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/BasicObservable.java
@@ -64,12 +64,12 @@ public class BasicObservable {
         jet.newJob(p);
     }
 
-    private static void printResults(List<Long> top10numbers) {
-        System.out.println("Top " + TOP + " random numbers observed since last print: ");
-        for (int i = 0; i < top10numbers.size(); i++) {
-            System.out.println(String.format("%d. %,d", i + 1, top10numbers.get(i)));
+    private static void printResults(List<Long> topNumbers) {
+        StringBuilder sb = new StringBuilder(String.format("\nTop %d random numbers in the latest window: ", TOP));
+        for (int i = 0; i < topNumbers.size(); i++) {
+            sb.append(String.format("\n\t%d. %,d", i + 1, topNumbers.get(i)));
         }
-        System.out.println();
+        System.out.println(sb.toString());
     }
 
 }

--- a/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/BasicObservable.java
+++ b/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/BasicObservable.java
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package com.hazelcast.jet.examples.helloworld;
+package com.hazelcast.jet.examples.returnresults;
 
 import com.hazelcast.function.ComparatorEx;
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Observable;
 import com.hazelcast.jet.aggregate.AggregateOperations;
-import com.hazelcast.jet.config.JobConfig;
-import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.datamodel.WindowResult;
 import com.hazelcast.jet.function.Observer;
 import com.hazelcast.jet.pipeline.Pipeline;
@@ -34,45 +32,36 @@ import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
- * Demonstrates a simple job which calculates the top 10 numbers from a
- * stream of random numbers. This code is included in Jet's distribution
- * package as {@code examples/hello-world.jar}, ready to be submitted to
- * a running Jet cluster with {@code bin/jet submit examples/hello-world.java}.
+ * Demonstrates the usage of observable results on client side in most
+ * basic form (similar to Reactive Java Observers & Observables). The biggest
+ * advantage of this form is that it's applicable to both batch and streaming
+ * jobs, as illustrated here.
  * <p>
- * It also uses an {@link Observable} to print the results on the client side.
+ * The concrete job we are observing produces a simple stream of random
+ * numbers, from which we compute the top N for each one second tumbling window.
+ * <p>
+ * The results observed are ordered lists of the top N numbers and are printed
+ * once for each window, as they become available.
  */
-public class HelloWorld {
+public class BasicObservable {
 
-    public static final int TOP = 10;
-    private static final String RESULTS = "top10_results";
+    public static final int TOP = 3;
 
-    private static Pipeline buildPipeline() {
+    public static void main(String[] args) {
+        JetInstance jet = Jet.newJetInstance();
+
+        Observable<List<Long>> observable = jet.newObservable();
+        observable.addObserver(Observer.of(BasicObservable::printResults));
+
         Pipeline p = Pipeline.create();
-        p.readFrom(TestSources.itemStream(100, (ts, seq) -> nextRandomNumber()))
+        p.readFrom(TestSources.itemStream(100, (ts, seq) -> ThreadLocalRandom.current().nextLong()))
                 .withIngestionTimestamps()
                 .window(WindowDefinition.tumbling(1000))
                 .aggregate(AggregateOperations.topN(TOP, ComparatorEx.comparingLong(l -> l)))
                 .map(WindowResult::result)
-                .writeTo(Sinks.observable(RESULTS));
-        return p;
-    }
+                .writeTo(Sinks.observable(observable));
 
-    private static long nextRandomNumber() {
-        return ThreadLocalRandom.current().nextLong();
-    }
-
-    public static void main(String[] args) {
-        JetInstance jet = Jet.bootstrappedInstance();
-
-        Observable<List<Long>> observable = jet.getObservable(RESULTS);
-        observable.addObserver(Observer.of(HelloWorld::printResults));
-
-        Pipeline p = buildPipeline();
-
-        JobConfig config = new JobConfig();
-        config.setName("hello-world");
-        config.setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE);
-        jet.newJobIfAbsent(p, config);
+        jet.newJob(p);
     }
 
     private static void printResults(List<Long> top10numbers) {
@@ -80,6 +69,7 @@ public class HelloWorld {
         for (int i = 0; i < top10numbers.size(); i++) {
             System.out.println(String.format("%d. %,d", i + 1, top10numbers.get(i)));
         }
+        System.out.println();
     }
 
 }

--- a/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/FutureResults.java
+++ b/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/FutureResults.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.examples.returnresults;
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Observable;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.Sources;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.regex.Pattern;
+
+import static com.hazelcast.function.Functions.wholeItem;
+import static com.hazelcast.jet.Traversers.traverseArray;
+import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
+import static java.util.Comparator.comparingLong;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Demonstrates the usage of observable results on client side in their
+ * {@link CompletableFuture} form (applicable only to batch jobs).
+ * <p>
+ * The concrete job we are observing the results of is a simple Word Count.
+ * It inserts the text of The Complete Works of William Shakespeare into a
+ * Hazelcast IMap, then lets Jet count the words in it.
+ * <p>
+ * The results observed are {@link Map.Entry}s containing words and their
+ * counts, from which we then print the top N ones.
+ */
+public class FutureResults {
+
+    private static final String BOOK_LINES = "bookLines";
+
+    public static void main(String[] args) {
+        JetInstance jet = Jet.newJetInstance();
+
+        loadLines(jet);
+
+        Observable<Map.Entry<String, Long>> observable = jet.newObservable();
+        Pipeline p = buildPipeline(observable);
+        observable.toFuture(s -> s.collect(toMap(Map.Entry::getKey, Map.Entry::getValue)))
+                .thenAccept(FutureResults::printResults)
+                .thenAccept(v -> Jet.shutdownAll());
+
+        jet.newJob(p).join();
+    }
+
+    private static void loadLines(JetInstance jet) {
+        try {
+            long[] lineNum = {0};
+            Map<Long, String> bookLines = new HashMap<>();
+            InputStream stream = FutureResults.class.getResourceAsStream("/books/shakespeare-complete-works.txt");
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+                reader.lines().forEach(line -> bookLines.put(++lineNum[0], line));
+            }
+            jet.getMap(BOOK_LINES).putAll(bookLines);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Pipeline buildPipeline(Observable<Map.Entry<String, Long>> observable) {
+        Pattern delimiter = Pattern.compile("\\W+");
+        Pipeline p = Pipeline.create();
+        p.readFrom(Sources.<Long, String>map(BOOK_LINES))
+                .flatMap(e -> traverseArray(delimiter.split(e.getValue().toLowerCase())))
+                .filter(word -> !word.isEmpty())
+                .groupingKey(wholeItem())
+                .aggregate(counting())
+                .writeTo(Sinks.observable(observable));
+        return p;
+    }
+
+    private static void printResults(Map<String, Long> counts) {
+        final int limit = 25;
+
+        StringBuilder sb = new StringBuilder(String.format(" Top %d entries are:%n", limit));
+        sb.append("/-------+---------\\\n");
+        sb.append("| Count | Word    |\n");
+        sb.append("|-------+---------|\n");
+        counts.entrySet().stream()
+                .sorted(comparingLong(Map.Entry<String, Long>::getValue).reversed())
+                .limit(limit)
+                .forEach(e -> sb.append(String.format("|%6d | %-8s|%n", e.getValue(), e.getKey())));
+        sb.append("\\-------+---------/\n");
+
+        System.out.println(sb.toString());
+    }
+
+}

--- a/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/FutureResults.java
+++ b/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/FutureResults.java
@@ -42,7 +42,7 @@ import static java.util.stream.Collectors.toMap;
  * Demonstrates the usage of observable results on client side in their
  * {@link CompletableFuture} form (applicable only to batch jobs).
  * <p>
- * The concrete job we are observing the results of is a simple Word Count.
+ * The concrete job we are observing the results of is a simple word count.
  * It inserts the text of The Complete Works of William Shakespeare into a
  * Hazelcast IMap, then lets Jet count the words in it.
  * <p>

--- a/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/IterableResults.java
+++ b/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/IterableResults.java
@@ -44,7 +44,7 @@ import static java.util.Comparator.comparingLong;
  * Demonstrates the usage of observable results on client side via an
  * {@link Iterator} (applicable only to batch jobs).
  * <p>
- * The concrete job we are observing the results of is a simple Word Count.
+ * The concrete job we are observing the results of is a simple word count.
  * It inserts the text of The Complete Works of William Shakespeare into a
  * Hazelcast IMap, then lets Jet count the words in it.
  * <p>

--- a/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/IterableResults.java
+++ b/examples/return-results/src/main/java/com/hazelcast/jet/examples/returnresults/IterableResults.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.examples.returnresults;
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Observable;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.Sources;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
+
+import static com.hazelcast.function.Functions.wholeItem;
+import static com.hazelcast.jet.Traversers.traverseArray;
+import static com.hazelcast.jet.aggregate.AggregateOperations.counting;
+import static java.util.Comparator.comparingLong;
+
+/**
+ * Demonstrates the usage of observable results on client side via an
+ * {@link Iterator} (applicable only to batch jobs).
+ * <p>
+ * The concrete job we are observing the results of is a simple Word Count.
+ * It inserts the text of The Complete Works of William Shakespeare into a
+ * Hazelcast IMap, then lets Jet count the words in it.
+ * <p>
+ * The results observed are {@link Map.Entry}s containing words and their
+ * counts, from which we then print the top N ones.
+ */
+public class IterableResults {
+
+    private static final String BOOK_LINES = "bookLines";
+
+    public static void main(String[] args) {
+        try {
+            JetInstance jet = Jet.newJetInstance();
+
+            loadLines(jet);
+
+            Observable<Map.Entry<String, Long>> observable = jet.newObservable();
+            Pipeline p = buildPipeline(observable);
+
+            Iterator<Map.Entry<String, Long>> iterator = observable.iterator();
+            jet.newJob(p).join();
+            printResults(iterator);
+        } finally {
+            Jet.shutdownAll();
+        }
+    }
+
+    private static void loadLines(JetInstance jet) {
+        try {
+            long[] lineNum = {0};
+            Map<Long, String> bookLines = new HashMap<>();
+            InputStream stream = FutureResults.class.getResourceAsStream("/books/shakespeare-complete-works.txt");
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
+                reader.lines().forEach(line -> bookLines.put(++lineNum[0], line));
+            }
+            jet.getMap(BOOK_LINES).putAll(bookLines);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Pipeline buildPipeline(Observable<Map.Entry<String, Long>> observable) {
+        Pattern delimiter = Pattern.compile("\\W+");
+        Pipeline p = Pipeline.create();
+        p.readFrom(Sources.<Long, String>map(BOOK_LINES))
+                .flatMap(e -> traverseArray(delimiter.split(e.getValue().toLowerCase())))
+                .filter(word -> !word.isEmpty())
+                .groupingKey(wholeItem())
+                .aggregate(counting())
+                .writeTo(Sinks.observable(observable));
+        return p;
+    }
+
+    private static void printResults(Iterator<Map.Entry<String, Long>> counts) {
+        final int limit = 25;
+
+        StringBuilder sb = new StringBuilder(String.format(" Top %d entries are:%n", limit));
+        sb.append("/-------+---------\\\n");
+        sb.append("| Count | Word    |\n");
+        sb.append("|-------+---------|\n");
+        StreamSupport.stream(Spliterators.spliteratorUnknownSize(counts, Spliterator.ORDERED), false)
+                .sorted(comparingLong(Map.Entry<String, Long>::getValue).reversed())
+                .limit(limit)
+                .forEach(e -> sb.append(String.format("|%6d | %-8s|%n", e.getValue(), e.getKey())));
+        sb.append("\\-------+---------/\n");
+
+        System.out.println(sb.toString());
+    }
+
+}

--- a/examples/wordcount/src/main/java/com/hazelcast/jet/examples/wordcount/WordCount.java
+++ b/examples/wordcount/src/main/java/com/hazelcast/jet/examples/wordcount/WordCount.java
@@ -118,14 +118,17 @@ public class WordCount {
 
     private static void printResults(Map<String, Long> counts) {
         final int limit = 100;
-        System.out.format(" Top %d entries are:%n", limit);
-        System.out.println("/-------+---------\\");
-        System.out.println("| Count | Word    |");
-        System.out.println("|-------+---------|");
+
+        StringBuilder sb = new StringBuilder(String.format(" Top %d entries are:%n", limit));
+        sb.append("/-------+---------\\\n");
+        sb.append("| Count | Word    |\n");
+        sb.append("|-------+---------|\n");
         counts.entrySet().stream()
-              .sorted(comparingLong(Entry<String, Long>::getValue).reversed())
-              .limit(limit)
-              .forEach(e -> System.out.format("|%6d | %-8s|%n", e.getValue(), e.getKey()));
-        System.out.println("\\-------+---------/");
+                .sorted(comparingLong(Map.Entry<String, Long>::getValue).reversed())
+                .limit(limit)
+                .forEach(e -> sb.append(String.format("|%6d | %-8s|%n", e.getValue(), e.getKey())));
+        sb.append("\\-------+---------/\n");
+
+        System.out.println(sb.toString());
     }
 }


### PR DESCRIPTION
Create a separate section of examples for return-results-to-caller feature.

Checklist
- [x] Tags Set
- [x] Milestone Set