### PR TITLE
Added a new category to the tests which should not be run in parallel…

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JetConfigLoadFromClasspathOrderTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JetConfigLoadFromClasspathOrderTest.java
@@ -17,8 +17,10 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.jet.test.FilteringAndDelegatingResourceLoadingClassLoader;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
@@ -32,6 +34,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class JetConfigLoadFromClasspathOrderTest {
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JetConfigMixAndMatchTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/JetConfigMixAndMatchTest.java
@@ -17,11 +17,13 @@
 package com.hazelcast.jet.config;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -35,6 +37,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class JetConfigMixAndMatchTest {
 
     @Rule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetClientConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetClientConfigWithSystemPropertyTest.java
@@ -21,8 +21,10 @@ import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.config.XmlJetClientConfigLocator;
 import com.hazelcast.jet.impl.util.IOUtil;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -35,6 +37,7 @@ import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class XmlJetClientConfigWithSystemPropertyTest extends AbstractJetConfigWithSystemPropertyTest {
 
     private static final String JET_CLIENT_XML = "hazelcast-client-test.xml";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/XmlJetConfigWithSystemPropertyTest.java
@@ -20,8 +20,10 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.config.ConfigProvider;
 import com.hazelcast.jet.impl.config.XmlJetConfigBuilder;
 import com.hazelcast.jet.impl.util.IOUtil;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -38,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class XmlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigWithSystemPropertyTest {
 
     private static final String TEST_XML_1 = "hazelcast-jet-test.xml";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetClientConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetClientConfigWithSystemPropertyTest.java
@@ -21,8 +21,10 @@ import com.hazelcast.client.config.YamlClientConfigBuilder;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.config.YamlJetClientConfigLocator;
 import com.hazelcast.jet.impl.util.IOUtil;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.File;
@@ -35,6 +37,7 @@ import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_CLIENT
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class YamlJetClientConfigWithSystemPropertyTest extends AbstractJetConfigWithSystemPropertyTest {
 
     private static final String JET_CLIENT_YAML = "hazelcast-client-test.yaml";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigResolutionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigResolutionTest.java
@@ -19,11 +19,13 @@ package com.hazelcast.jet.config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.config.YamlJetConfigBuilder;
 import com.hazelcast.jet.test.JetDeclarativeConfigFileHelper;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -34,6 +36,7 @@ import static com.hazelcast.jet.impl.config.JetDeclarativeConfigUtil.SYSPROP_JET
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class YamlJetConfigResolutionTest {
 
     @Rule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigWithSystemPropertyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigWithSystemPropertyTest.java
@@ -20,9 +20,11 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.config.ConfigProvider;
 import com.hazelcast.jet.impl.config.YamlJetConfigBuilder;
 import com.hazelcast.jet.impl.util.IOUtil;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -39,6 +41,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class YamlJetConfigWithSystemPropertyTest extends AbstractJetMemberConfigWithSystemPropertyTest {
 
     private static final String JET_TEST_YAML = "hazelcast-jet-test.yaml";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetMemberConfigResolutionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetMemberConfigResolutionTest.java
@@ -19,11 +19,13 @@ package com.hazelcast.jet.config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.jet.impl.config.YamlJetConfigBuilder;
 import com.hazelcast.jet.test.JetDeclarativeConfigFileHelper;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -31,6 +33,7 @@ import static com.hazelcast.internal.config.DeclarativeConfigUtil.SYSPROP_MEMBER
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({SerialTest.class})
 public class YamlJetMemberConfigResolutionTest {
 
     @Rule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/SerialTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/SerialTest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.test;
+
+/**
+ * Category marker for the tests which are executed in series within a single JVM
+ */
+public interface SerialTest {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -329,19 +329,45 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>serial-tests</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${maven.test.skip}</skip>
+                            <forkCount>1</forkCount>
+                            <groups>com.hazelcast.jet.test.SerialTest</groups>
+                            <excludedGroups>
+                                com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
+                            </excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>regular-tests</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${maven.test.skip}</skip>
+                            <forkCount>4</forkCount>
+                            <includes>
+                                <include>/com/hazelcast/jet/**/**.java</include>
+                            </includes>
+                            <excludedGroups>
+                                com.hazelcast.jet.test.SerialTest,com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
+                            </excludedGroups>
+                        </configuration>
+                    </execution>
+                </executions>
                 <configuration>
+                    <skip>true</skip>
                     <runOrder>failedfirst</runOrder>
-                    <forkCount>4</forkCount>
                     <trimStackTrace>false</trimStackTrace>
                     <argLine>
                         ${argLine}
                     </argLine>
-                    <includes>
-                        <include>/com/hazelcast/jet/**/**.java</include>
-                    </includes>
-                    <excludedGroups>
-                        com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest
-                    </excludedGroups>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
… jvms

There was some intermittent failing YAML configuration tests which are loading the configuration files from the work directory. When the configuration tests which touches to the filesystem run parallel, since they are creating files like `hazelcast.yaml`, `hazelcast-jet.yaml` etc. Those files picked up by other configuration tests and caused a failure.


Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
