### PR TITLE
Mark additional tests as serial

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
@@ -24,17 +24,20 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.config.JetClientConfig;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.TestProcessors;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category(SerialTest.class)
 public class MulticastDiscoveryTest extends JetTestSupport {
 
     private static final String UNABLE_TO_CONNECT_MESSAGE = "Unable to connect";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastRemoteConnectorTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastRemoteConnectorTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.processor.SourceProcessors;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.map.EventJournalMapEvent;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicates;
@@ -44,6 +45,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Map;
@@ -69,6 +71,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category(SerialTest.class)
 public class HazelcastRemoteConnectorTest extends JetTestSupport {
 
     private static final int ITEM_COUNT = 20;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
@@ -28,11 +28,13 @@ import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
@@ -53,6 +55,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category(SerialTest.class)
 public class ReadMapOrCacheP_ConsistencyTest extends JetTestSupport {
 
     private static final String MAP_NAME = "map";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/SerialTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/SerialTest.java
@@ -18,6 +18,9 @@ package com.hazelcast.jet.test;
 
 /**
  * Category marker for the tests which are executed in series within a single JVM
+ * <p>
+ * These typically need to create a real Hazelcast or Jet instance which can
+ * conflict with other such instances created in other tests
  */
 public interface SerialTest {
 }

--- a/hazelcast-jet-distribution/src/root/README.md
+++ b/hazelcast-jet-distribution/src/root/README.md
@@ -22,12 +22,8 @@ What's Included
 * `config/hazelcast-client.yaml`: The client configuration file used by the 
   Jet Command Line client
 * `config/log4j.properties`: Logging configuration used by the Jet Instance
-* `opt`: Optional plugins, sources and sinks for Jet. The following are included:
-    * Kafka
-    * Hadoop
-    * S3 
-    * Avro
-    * Python
+* `opt`: Optional extensions for Jet. You can include them in the classpath by moving
+them to the lib folder.
    
 Quickstart
 ----------


### PR DESCRIPTION
Mark additional tests which create Hazelcast/Jet Instances as serial.

Fixes #1900