### PR TITLE
Service async cleanup

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
@@ -85,8 +85,7 @@ final class PythonService {
                 .withCreateContextFn(ctx -> new PythonServiceContext(ctx, cfg))
                 .withDestroyContextFn(PythonServiceContext::destroy)
                 .withCreateServiceFn((procCtx, serviceCtx) -> new PythonService(procCtx, serviceCtx))
-                .withDestroyServiceFn(PythonService::destroy)
-                .withMaxPendingCallsPerProcessor(2);
+                .withDestroyServiceFn(PythonService::destroy);
         if (cfg.baseDir() != null) {
             File baseDir = Objects.requireNonNull(cfg.baseDir());
             return fac.withAttachedDirectory(baseDir.toString(), baseDir);

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
@@ -44,7 +44,7 @@ public final class PythonTransforms {
             @Nonnull PythonServiceConfig cfg
     ) {
         return s -> s
-                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), Integer.MAX_VALUE, PythonService::sendRequest)
+                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), 2, Integer.MAX_VALUE, PythonService::sendRequest)
                 .setName("mapUsingPython");
     }
 
@@ -57,7 +57,7 @@ public final class PythonTransforms {
             @Nonnull PythonServiceConfig cfg
     ) {
         return s -> s
-                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), Integer.MAX_VALUE, PythonService::sendRequest)
+                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), 2, Integer.MAX_VALUE, PythonService::sendRequest)
                 .setName("mapUsingPython");
     }
 }

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
@@ -44,7 +44,7 @@ public final class PythonTransforms {
             @Nonnull PythonServiceConfig cfg
     ) {
         return s -> s
-                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), 2, Integer.MAX_VALUE, PythonService::sendRequest)
+                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), Integer.MAX_VALUE, PythonService::sendRequest)
                 .setName("mapUsingPython");
     }
 
@@ -57,7 +57,7 @@ public final class PythonTransforms {
             @Nonnull PythonServiceConfig cfg
     ) {
         return s -> s
-                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), 2, Integer.MAX_VALUE, PythonService::sendRequest)
+                .mapUsingServiceAsyncBatched(PythonService.factory(cfg), Integer.MAX_VALUE, PythonService::sendRequest)
                 .setName("mapUsingPython");
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/metrics/Metrics.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/metrics/Metrics.java
@@ -65,18 +65,15 @@ public final class Metrics {
      * <pre>
      * {@code
      *  p.readFrom(...)
-     *   .filterUsingServiceAsync(
-     *       ServiceFactory.withCreateFn(i -> "foo"),
+     *   .mapUsingServiceAsync(
+     *       nonSharedService(pctx -> 10L),
      *       (ctx, item) -> {
-     *           Metric dropped = Metrics.threadSafeMetric("dropCount", Unit.COUNT);
+     *           // need to use thread-safe metric since it will be mutated from another thread
+     *           Metric mapped = Metrics.threadSafeMetric("mapped", Unit.COUNT);
      *           return CompletableFuture.supplyAsync(
      *               () -> {
-     *                   // the callback runs on another thread
-     *                   boolean pass = item % 2L == 0;
-     *                   if (!pass) {
-     *                       dropped.increment();
-     *                   }
-     *                   return pass;
+     *                   mapped.increment();
+     *                   return item * ctx;
      *               }
      *           );
      *       }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -936,37 +936,6 @@ public final class Processors {
     }
 
     /**
-     * Asynchronous version of {@link #mapUsingServiceP}: the {@code
-     * filterAsyncFn} returns a {@code CompletableFuture<Boolean>} instead of
-     * just a {@code boolean}.
-     * <p>
-     * The function can return a null future, but the future must not return
-     * null {@code Boolean}.
-     * <p>
-     * The {@code extractKeyFn} is used to extract keys under which to save
-     * in-flight items to the snapshot. If the input to this processor is over
-     * a partitioned edge, you should use the same key. If it's a round-robin
-     * edge, you can use any key, for example {@code Object::hashCode}.
-     *
-     * @param serviceFactory the service factory
-     * @param extractKeyFn a function to extract snapshot keys
-     * @param filterAsyncFn a stateless predicate to test each received item against
-     * @param <C> type of context object
-     * @param <S> type of service object
-     * @param <T> type of received item
-     * @param <K> type of key
-     */
-    @Nonnull
-    public static <C, S, T, K> ProcessorSupplier filterUsingServiceAsyncP(
-            @Nonnull ServiceFactory<C, S> serviceFactory,
-            @Nonnull FunctionEx<T, K> extractKeyFn,
-            @Nonnull BiFunctionEx<? super S, ? super T, CompletableFuture<Boolean>> filterAsyncFn
-    ) {
-        return flatMapUsingServiceAsyncP(serviceFactory, extractKeyFn,
-                (s, t) -> filterAsyncFn.apply(s, t).thenApply(passed -> passed ? Traversers.singleton(t) : null));
-    }
-
-    /**
      * Returns a supplier of processors for a vertex that applies the provided
      * item-to-traverser mapping function to each received item and emits all
      * the items from the resulting traverser. The traverser must be

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -889,6 +889,7 @@ public final class Processors {
      * edge, you can use any key, for example {@code Object::hashCode}.
      *
      * @param serviceFactory the service factory
+     * @param maxAsyncOps maximum number of concurrent async operations per processor
      * @param extractKeyFn a function to extract snapshot keys
      * @param mapAsyncFn a stateless mapping function
      * @param <C> type of context object
@@ -900,14 +901,15 @@ public final class Processors {
     @Nonnull
     public static <C, S, T, K, R> ProcessorSupplier mapUsingServiceAsyncP(
             @Nonnull ServiceFactory<C, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull FunctionEx<T, K> extractKeyFn,
             @Nonnull BiFunctionEx<? super S, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
         BiFunctionEx<S, T, CompletableFuture<Traverser<R>>> flatMapAsyncFn = (s, t) ->
                 mapAsyncFn.apply(s, t).thenApply(Traversers::singleton);
         return serviceFactory.hasOrderedAsyncResponses()
-                ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, flatMapAsyncFn)
-                : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, flatMapAsyncFn, extractKeyFn);
+                ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, maxAsyncOps, flatMapAsyncFn)
+                : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, maxAsyncOps, flatMapAsyncFn, extractKeyFn);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -890,6 +890,7 @@ public final class Processors {
      *
      * @param serviceFactory the service factory
      * @param maxAsyncOps maximum number of concurrent async operations per processor
+     * @param orderedAsyncResponses whether the async responses are ordered or not
      * @param extractKeyFn a function to extract snapshot keys
      * @param mapAsyncFn a stateless mapping function
      * @param <C> type of context object
@@ -902,12 +903,13 @@ public final class Processors {
     public static <C, S, T, K, R> ProcessorSupplier mapUsingServiceAsyncP(
             @Nonnull ServiceFactory<C, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull FunctionEx<T, K> extractKeyFn,
             @Nonnull BiFunctionEx<? super S, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
         BiFunctionEx<S, T, CompletableFuture<Traverser<R>>> flatMapAsyncFn = (s, t) ->
                 mapAsyncFn.apply(s, t).thenApply(Traversers::singleton);
-        return serviceFactory.hasOrderedAsyncResponses()
+        return orderedAsyncResponses
                 ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, maxAsyncOps, flatMapAsyncFn)
                 : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, maxAsyncOps, flatMapAsyncFn, extractKeyFn);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -150,14 +150,6 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     }
 
     @Nonnull @Override
-    public <S, R> BatchStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> flatMapAsyncFn
-    ) {
-        return attachFlatMapUsingServiceAsync("flatMap", serviceFactory, flatMapAsyncFn);
-    }
-
-    @Nonnull @Override
     public BatchStage<T> merge(@Nonnull BatchStage<? extends T> other) {
         return attachMerge(other);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -118,9 +118,10 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     public <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps,
+        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -142,15 +142,6 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     }
 
     @Nonnull @Override
-    public <S> BatchStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Boolean>> filterAsyncFn
-    ) {
-        return attachFlatMapUsingServiceAsync("filter", serviceFactory,
-                (s, t) -> filterAsyncFn.apply(s, t).thenApply(passed -> passed ? Traversers.singleton(t) : null));
-    }
-
-    @Nonnull @Override
     public <S, R> BatchStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends Traverser<R>> flatMapFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -128,11 +128,10 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     @Nonnull @Override
     public <S, R> BatchStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxAsyncOps, maxBatchSize,
+        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, 2, maxBatchSize,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(list -> toList(list, Traversers::singleton)));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -117,19 +117,21 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     @Nonnull @Override
     public <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsync("map", serviceFactory,
+        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(Traversers::singleton));
     }
 
     @Nonnull @Override
     public <S, R> BatchStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxBatchSize,
+        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxAsyncOps, maxBatchSize,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(list -> toList(list, Traversers::singleton)));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -117,11 +117,11 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     @Nonnull @Override
     public <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
+        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxConcurrentOps, preserveOrder,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(Traversers::singleton));
     }
 
@@ -131,7 +131,7 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, 2, maxBatchSize,
+        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxBatchSize,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(list -> toList(list, Traversers::singleton)));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
@@ -92,9 +92,10 @@ public class BatchStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> imp
     public <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps,
+        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
                 (s, k, t) -> mapAsyncFn.apply(s, k, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
@@ -91,9 +91,10 @@ public class BatchStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> imp
     @Nonnull @Override
     public <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachTransformUsingServiceAsync("map", serviceFactory,
+        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps,
                 (s, k, t) -> mapAsyncFn.apply(s, k, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
@@ -106,16 +106,6 @@ public class BatchStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> imp
     }
 
     @Nonnull @Override
-    public <S> BatchStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Boolean>>
-                    filterAsyncFn
-    ) {
-        return attachTransformUsingServiceAsync("filter", serviceFactory,
-                (s, k, t) -> filterAsyncFn.apply(s, k, t).thenApply(passed -> passed ? Traversers.singleton(t) : null));
-    }
-
-    @Nonnull @Override
     public <S, R> BatchStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull TriFunction<? super S, ? super K, ? super T, ? extends Traverser<R>> flatMapFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
@@ -91,11 +91,11 @@ public class BatchStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> imp
     @Nonnull @Override
     public <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
+        return attachTransformUsingServiceAsync("map", serviceFactory, maxConcurrentOps, preserveOrder,
                 (s, k, t) -> mapAsyncFn.apply(s, k, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageWithKeyImpl.java
@@ -114,15 +114,6 @@ public class BatchStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> imp
     }
 
     @Nonnull @Override
-    public <S, R> BatchStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>>
-                    flatMapAsyncFn
-    ) {
-        return attachTransformUsingServiceAsync("flatMap", serviceFactory, flatMapAsyncFn);
-    }
-
-    @Nonnull @Override
     public <R> BatchStage<R> customTransform(@Nonnull String stageName, @Nonnull ProcessorMetaSupplier procSupplier) {
         return computeStage.attachPartitionedCustomTransform(stageName, procSupplier, keyFn());
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -263,13 +263,14 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     <S, R, RET> RET attachFlatMapUsingServiceAsync(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> flatMapAsyncFn
     ) {
         checkSerializable(flatMapAsyncFn, operationName + "AsyncFn");
         serviceFactory = moveAttachedFilesToPipeline(serviceFactory);
         BiFunctionEx adaptedFlatMapFn = fnAdapter.adaptFlatMapUsingServiceAsyncFn(flatMapAsyncFn);
         return (RET) attach(
-                flatMapUsingServiceAsyncTransform(transform, operationName, serviceFactory, adaptedFlatMapFn),
+                flatMapUsingServiceAsyncTransform(transform, operationName, serviceFactory, maxAsyncOps, adaptedFlatMapFn),
                 fnAdapter);
     }
 
@@ -278,6 +279,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     <S, R, RET> RET attachFlatMapUsingServiceAsyncBatched(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>,
                     ? extends CompletableFuture<List<Traverser<R>>>> flatMapAsyncBatchedFn
@@ -298,7 +300,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
 
         return (RET) attach(
                 flatMapUsingServiceAsyncBatchedTransform(
-                        transform, operationName, serviceFactory, maxBatchSize, flattenedFn),
+                        transform, operationName, serviceFactory, maxAsyncOps, maxBatchSize, flattenedFn),
                 fnAdapter);
     }
 
@@ -360,6 +362,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     <S, K, R, RET> RET attachTransformUsingPartitionedServiceAsync(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull FunctionEx<? super T, ? extends K> partitionKeyFn,
             @Nonnull BiFunctionEx<? super S, ? super T, CompletableFuture<Traverser<R>>> flatMapAsyncFn
     ) {
@@ -370,7 +373,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
         FunctionEx adaptedPartitionKeyFn = fnAdapter.adaptKeyFn(partitionKeyFn);
         return (RET) attach(
                 flatMapUsingServiceAsyncPartitionedTransform(
-                        transform, operationName, serviceFactory, adaptedFlatMapFn, adaptedPartitionKeyFn),
+                        transform, operationName, serviceFactory, maxAsyncOps, adaptedFlatMapFn, adaptedPartitionKeyFn),
                 fnAdapter);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -80,6 +80,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
 
     public static final FunctionAdapter ADAPT_TO_JET_EVENT = new JetEventFunctionAdapter();
     static final FunctionAdapter DO_NOT_ADAPT = new FunctionAdapter();
+    private static final int MAX_CONCURRENT_ASYNC_BATCHES = 2;
 
     @Nonnull
     public FunctionAdapter fnAdapter;
@@ -302,7 +303,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
 
         return (RET) attach(
                 flatMapUsingServiceAsyncBatchedTransform(
-                        transform, operationName, serviceFactory, 2, maxBatchSize, flattenedFn),
+                        transform, operationName, serviceFactory, MAX_CONCURRENT_ASYNC_BATCHES, maxBatchSize, flattenedFn),
                 fnAdapter);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -265,15 +265,15 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     <S, R, RET> RET attachFlatMapUsingServiceAsync(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> flatMapAsyncFn
     ) {
         checkSerializable(flatMapAsyncFn, operationName + "AsyncFn");
         serviceFactory = moveAttachedFilesToPipeline(serviceFactory);
         BiFunctionEx adaptedFlatMapFn = fnAdapter.adaptFlatMapUsingServiceAsyncFn(flatMapAsyncFn);
         ProcessorTransform processorTransform = flatMapUsingServiceAsyncTransform(
-                transform, operationName, serviceFactory, maxAsyncOps, orderedAsyncResponses, adaptedFlatMapFn);
+                transform, operationName, serviceFactory, maxConcurrentOps, preserveOrder, adaptedFlatMapFn);
         return (RET) attach(processorTransform, fnAdapter);
     }
 
@@ -282,7 +282,6 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     <S, R, RET> RET attachFlatMapUsingServiceAsyncBatched(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>,
                     ? extends CompletableFuture<List<Traverser<R>>>> flatMapAsyncBatchedFn
@@ -303,7 +302,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
 
         return (RET) attach(
                 flatMapUsingServiceAsyncBatchedTransform(
-                        transform, operationName, serviceFactory, maxAsyncOps, maxBatchSize, flattenedFn),
+                        transform, operationName, serviceFactory, 2, maxBatchSize, flattenedFn),
                 fnAdapter);
     }
 
@@ -365,8 +364,8 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     <S, K, R, RET> RET attachTransformUsingPartitionedServiceAsync(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull FunctionEx<? super T, ? extends K> partitionKeyFn,
             @Nonnull BiFunctionEx<? super S, ? super T, CompletableFuture<Traverser<R>>> flatMapAsyncFn
     ) {
@@ -379,8 +378,8 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
                 transform,
                 operationName,
                 serviceFactory,
-                maxAsyncOps,
-                orderedAsyncResponses,
+                maxConcurrentOps,
+                preserveOrder,
                 adaptedFlatMapFn,
                 adaptedPartitionKeyFn
         );

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
@@ -110,14 +110,14 @@ class StageWithGroupingBase<T, K> {
     <S, R, RET> RET attachTransformUsingServiceAsync(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>>
                     flatMapAsyncFn
     ) {
         FunctionEx<? super T, ? extends K> keyFn = keyFn();
         return computeStage.attachTransformUsingPartitionedServiceAsync(
-                operationName, serviceFactory, maxAsyncOps, orderedAsyncResponses, keyFn,
+                operationName, serviceFactory, maxConcurrentOps, preserveOrder, keyFn,
                 (s, t) -> {
                     K k = keyFn.apply(t);
                     return flatMapAsyncFn.apply(s, k, t);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
@@ -110,11 +110,12 @@ class StageWithGroupingBase<T, K> {
     <S, R, RET> RET attachTransformUsingServiceAsync(
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>>
                     flatMapAsyncFn
     ) {
         FunctionEx<? super T, ? extends K> keyFn = keyFn();
-        return computeStage.attachTransformUsingPartitionedServiceAsync(operationName, serviceFactory, keyFn,
+        return computeStage.attachTransformUsingPartitionedServiceAsync(operationName, serviceFactory, maxAsyncOps, keyFn,
                 (s, t) -> {
                     K k = keyFn.apply(t);
                     return flatMapAsyncFn.apply(s, k, t);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StageWithGroupingBase.java
@@ -111,11 +111,13 @@ class StageWithGroupingBase<T, K> {
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>>
                     flatMapAsyncFn
     ) {
         FunctionEx<? super T, ? extends K> keyFn = keyFn();
-        return computeStage.attachTransformUsingPartitionedServiceAsync(operationName, serviceFactory, maxAsyncOps, keyFn,
+        return computeStage.attachTransformUsingPartitionedServiceAsync(
+                operationName, serviceFactory, maxAsyncOps, orderedAsyncResponses, keyFn,
                 (s, t) -> {
                     K k = keyFn.apply(t);
                     return flatMapAsyncFn.apply(s, k, t);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -149,14 +149,6 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
     }
 
     @Nonnull @Override
-    public <S, R> StreamStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> flatMapAsyncFn
-    ) {
-        return attachFlatMapUsingServiceAsync("flatMap", serviceFactory, flatMapAsyncFn);
-    }
-
-    @Nonnull @Override
     public StreamStage<T> merge(@Nonnull StreamStage<? extends T> other) {
         return attachMerge(other);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -116,9 +116,10 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
     public <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps,
+        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -39,7 +39,6 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static com.hazelcast.jet.Traversers.singleton;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static com.hazelcast.jet.impl.util.Util.toList;
 
@@ -139,15 +138,6 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
             @Nonnull BiPredicateEx<? super S, ? super T> filterFn
     ) {
         return attachFilterUsingService(serviceFactory, filterFn);
-    }
-
-    @Nonnull @Override
-    public <S> StreamStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Boolean>> filterAsyncFn
-    ) {
-        return attachFlatMapUsingServiceAsync("filter", serviceFactory,
-                (s, t) -> filterAsyncFn.apply(s, t).thenApply(passed -> passed ? singleton(t) : Traversers.empty()));
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -126,11 +126,10 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
     @Nonnull @Override
     public <S, R> StreamStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncBatchedFn
     ) {
-        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxAsyncOps, maxBatchSize,
+        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, 2, maxBatchSize,
                 (s, t) -> mapAsyncBatchedFn.apply(s, t).thenApply(list ->
                         toList(list, Traversers::singleton)));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -115,19 +115,21 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
     @Nonnull @Override
     public <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsync("map", serviceFactory,
+        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(Traversers::singleton));
     }
 
     @Nonnull @Override
     public <S, R> StreamStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncBatchedFn
     ) {
-        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxBatchSize,
+        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxAsyncOps, maxBatchSize,
                 (s, t) -> mapAsyncBatchedFn.apply(s, t).thenApply(list ->
                         toList(list, Traversers::singleton)));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -115,11 +115,11 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
     @Nonnull @Override
     public <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
+        return attachFlatMapUsingServiceAsync("map", serviceFactory, maxConcurrentOps, preserveOrder,
                 (s, t) -> mapAsyncFn.apply(s, t).thenApply(Traversers::singleton));
     }
 
@@ -129,7 +129,7 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncBatchedFn
     ) {
-        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, 2, maxBatchSize,
+        return attachFlatMapUsingServiceAsyncBatched("map", serviceFactory, maxBatchSize,
                 (s, t) -> mapAsyncBatchedFn.apply(s, t).thenApply(list ->
                         toList(list, Traversers::singleton)));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
@@ -102,9 +102,10 @@ public class StreamStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> im
     @Nonnull @Override
     public <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachTransformUsingServiceAsync("map", serviceFactory,
+        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps,
                 (s, k, t) -> mapAsyncFn.apply(s, k, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
@@ -125,15 +125,6 @@ public class StreamStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> im
     }
 
     @Nonnull @Override
-    public <S, R> StreamStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>>
-                    flatMapAsyncFn
-    ) {
-        return attachTransformUsingServiceAsync("flatMap", serviceFactory, flatMapAsyncFn);
-    }
-
-    @Nonnull @Override
     public <R> StreamStage<R> customTransform(@Nonnull String stageName, @Nonnull ProcessorMetaSupplier procSupplier) {
         return computeStage.attachPartitionedCustomTransform(stageName, procSupplier, keyFn());
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
@@ -117,15 +117,6 @@ public class StreamStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> im
     }
 
     @Nonnull @Override
-    public <S> StreamStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Boolean>> filterAsyncFn
-    ) {
-        return attachTransformUsingServiceAsync("filter", serviceFactory,
-                (s, k, t) -> filterAsyncFn.apply(s, k, t).thenApply(passed -> passed ? Traversers.singleton(t) : null));
-    }
-
-    @Nonnull @Override
     public <S, R> StreamStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull TriFunction<? super S, ? super K, ? super T, ? extends Traverser<R>> flatMapFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
@@ -103,9 +103,10 @@ public class StreamStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> im
     public <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps,
+        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
                 (s, k, t) -> mapAsyncFn.apply(s, k, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageWithKeyImpl.java
@@ -102,11 +102,11 @@ public class StreamStageWithKeyImpl<T, K> extends StageWithGroupingBase<T, K> im
     @Nonnull @Override
     public <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return attachTransformUsingServiceAsync("map", serviceFactory, maxAsyncOps, orderedAsyncResponses,
+        return attachTransformUsingServiceAsync("map", serviceFactory, maxConcurrentOps, preserveOrder,
                 (s, k, t) -> mapAsyncFn.apply(s, k, t).thenApply(Traversers::singleton));
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -93,14 +93,14 @@ public final class PartitionedProcessorTransform<T, K> extends ProcessorTransfor
             @Nonnull Transform upstream,
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull BiFunctionEx<? super S, ? super T, CompletableFuture<Traverser<R>>> flatMapAsyncFn,
             @Nonnull FunctionEx<? super T, ? extends K> partitionKeyFn
     ) {
         String name = operationName + "UsingPartitionedServiceAsync";
         ProcessorSupplier supplier = flatMapUsingServiceAsyncP(
-                serviceFactory, maxAsyncOps, orderedAsyncResponses, partitionKeyFn, flatMapAsyncFn);
+                serviceFactory, maxConcurrentOps, preserveOrder, partitionKeyFn, flatMapAsyncFn);
         ProcessorMetaSupplier metaSupplier = ProcessorMetaSupplier.of(getPreferredLP(serviceFactory), supplier);
         return new PartitionedProcessorTransform<>(name, upstream, metaSupplier, partitionKeyFn);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -92,12 +92,14 @@ public final class PartitionedProcessorTransform<T, K> extends ProcessorTransfor
             @Nonnull Transform upstream,
             @Nonnull String operationName,
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull BiFunctionEx<? super S, ? super T, CompletableFuture<Traverser<R>>> flatMapAsyncFn,
             @Nonnull FunctionEx<? super T, ? extends K> partitionKeyFn
     ) {
         return new PartitionedProcessorTransform<>(operationName + "UsingPartitionedServiceAsync", upstream,
                 ProcessorMetaSupplier.of(getPreferredLP(serviceFactory),
-                        flatMapUsingServiceAsyncP(serviceFactory, partitionKeyFn, flatMapAsyncFn)), partitionKeyFn);
+                        flatMapUsingServiceAsyncP(serviceFactory, maxAsyncOps, partitionKeyFn, flatMapAsyncFn)),
+                partitionKeyFn);
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PartitionedProcessorTransform.java
@@ -30,7 +30,6 @@ import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.core.processor.Processors.filterUsingServiceP;
-import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceAsyncP;
 import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceP;
 
 public final class PartitionedProcessorTransform<T, K> extends ProcessorTransform {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AbstractAsyncTransformUsingServiceP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AbstractAsyncTransformUsingServiceP.java
@@ -23,21 +23,21 @@ import javax.annotation.Nonnull;
 public abstract class AbstractAsyncTransformUsingServiceP<C, S> extends AbstractTransformUsingServiceP<C, S> {
 
     /**
-     * Default value for {@link #maxAsyncOps}.
+     * Default value for {@link #maxConcurrentOps}.
      */
-    public static final int MAX_ASYNC_OPS = 256;
+    public static final int MAX_CONCURRENT_OPS = 256;
     /**
-     * Default value for {@link #orderedAsyncResponses}.
+     * Default value for {@link #preserveOrder}.
      */
-    public static final boolean ORDERED_ASYNC_RESPONSES = true;
+    public static final boolean PRESERVE_ORDER = true;
 
     /**
      * Jet will execute at most this many concurrent async operations per processor
      * and will apply backpressure to the upstream to enforce it.
      * <p>
-     * Default value is {@value #MAX_ASYNC_OPS}.
+     * Default value is {@value #MAX_CONCURRENT_OPS}.
      */
-    protected final int maxAsyncOps;
+    protected final int maxConcurrentOps;
 
     /**
      * Jet can process asynchronous responses in two modes:
@@ -64,20 +64,18 @@ public abstract class AbstractAsyncTransformUsingServiceP<C, S> extends Abstract
      * operation downstream from finishing, but if the operation is configured
      * to emit early results, they will be more correct with the unordered
      * approach.
-     * <p>
-     * Default value is {@value #ORDERED_ASYNC_RESPONSES}.
      */
-    protected final boolean orderedAsyncResponses;
+    protected final boolean preserveOrder;
 
     public AbstractAsyncTransformUsingServiceP(
             @Nonnull ServiceFactory<C, S> serviceFactory,
             @Nonnull C serviceContext,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses
+            int maxConcurrentOps,
+            boolean preserveOrder
     ) {
         super(serviceFactory, serviceContext);
-        this.maxAsyncOps = maxAsyncOps;
-        this.orderedAsyncResponses = orderedAsyncResponses;
+        this.maxConcurrentOps = maxConcurrentOps;
+        this.preserveOrder = preserveOrder;
     }
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AbstractAsyncTransformUsingServiceP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AbstractAsyncTransformUsingServiceP.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.pipeline.ServiceFactory;
+
+import javax.annotation.Nonnull;
+
+public abstract class AbstractAsyncTransformUsingServiceP<C, S> extends AbstractTransformUsingServiceP<C, S> {
+
+    /**
+     * Default value for {@link #maxAsyncOps}.
+     */
+    public static final int MAX_ASYNC_OPS = 256;
+
+    protected final int maxAsyncOps;
+
+    public AbstractAsyncTransformUsingServiceP(
+            @Nonnull ServiceFactory<C, S> serviceFactory,
+            @Nonnull C serviceContext,
+            int maxAsyncOps
+    ) {
+        super(serviceFactory, serviceContext);
+        this.maxAsyncOps = maxAsyncOps;
+    }
+
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedP.java
@@ -53,11 +53,11 @@ public final class AsyncTransformUsingServiceBatchedP<C, S, T, R>
     private AsyncTransformUsingServiceBatchedP(
             @Nonnull ServiceFactory<C, S> serviceFactory,
             @Nonnull C serviceContext,
-            int maxAsyncOps,
+            int maxConcurrentOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<Traverser<R>>> callAsyncFn
     ) {
-        super(serviceFactory, serviceContext, maxAsyncOps, callAsyncFn);
+        super(serviceFactory, serviceContext, maxConcurrentOps, callAsyncFn);
         this.maxBatchSize = maxBatchSize;
     }
 
@@ -79,11 +79,11 @@ public final class AsyncTransformUsingServiceBatchedP<C, S, T, R>
      */
     public static <C, S, T, R> ProcessorSupplier supplier(
             @Nonnull ServiceFactory<C, S> serviceFactory,
-            int maxAsyncOps,
+            int maxConcurrentOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<Traverser<R>>> callAsyncFn
     ) {
         return supplierWithService(serviceFactory, (factory, context) ->
-                new AsyncTransformUsingServiceBatchedP<>(factory, context, maxAsyncOps, maxBatchSize, callAsyncFn));
+                new AsyncTransformUsingServiceBatchedP<>(factory, context, maxConcurrentOps, maxBatchSize, callAsyncFn));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedP.java
@@ -53,10 +53,11 @@ public final class AsyncTransformUsingServiceBatchedP<C, S, T, R>
     private AsyncTransformUsingServiceBatchedP(
             @Nonnull ServiceFactory<C, S> serviceFactory,
             @Nonnull C serviceContext,
+            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<Traverser<R>>> callAsyncFn
     ) {
-        super(serviceFactory, serviceContext, callAsyncFn);
+        super(serviceFactory, serviceContext, maxAsyncOps, callAsyncFn);
         this.maxBatchSize = maxBatchSize;
     }
 
@@ -78,10 +79,11 @@ public final class AsyncTransformUsingServiceBatchedP<C, S, T, R>
      */
     public static <C, S, T, R> ProcessorSupplier supplier(
             @Nonnull ServiceFactory<C, S> serviceFactory,
+            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<Traverser<R>>> callAsyncFn
     ) {
         return supplierWithService(serviceFactory, (factory, context) ->
-                new AsyncTransformUsingServiceBatchedP<>(factory, context, maxBatchSize, callAsyncFn));
+                new AsyncTransformUsingServiceBatchedP<>(factory, context, maxAsyncOps, maxBatchSize, callAsyncFn));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
@@ -69,10 +69,10 @@ public class AsyncTransformUsingServiceOrderedP<C, S, T, R> extends AbstractAsyn
     AsyncTransformUsingServiceOrderedP(
             @Nonnull ServiceFactory<C, S> serviceFactory,
             @Nonnull C serviceContext,
-            int maxAsyncOps,
+            int maxConcurrentOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> callAsyncFn
     ) {
-        super(serviceFactory, serviceContext, maxAsyncOps, true);
+        super(serviceFactory, serviceContext, maxConcurrentOps, true);
         this.callAsyncFn = callAsyncFn;
     }
 
@@ -80,7 +80,7 @@ public class AsyncTransformUsingServiceOrderedP<C, S, T, R> extends AbstractAsyn
     protected void init(@Nonnull Context context) throws Exception {
         super.init(context);
         // Size for the worst case: interleaved output items an WMs
-        queue = new ArrayDeque<>(maxAsyncOps * 2);
+        queue = new ArrayDeque<>(maxConcurrentOps * 2);
     }
 
     @Override
@@ -98,7 +98,7 @@ public class AsyncTransformUsingServiceOrderedP<C, S, T, R> extends AbstractAsyn
     }
 
     boolean isQueueFull() {
-        return queue.size() - queuedWmCount == maxAsyncOps;
+        return queue.size() - queuedWmCount == maxConcurrentOps;
     }
 
     @Override
@@ -188,10 +188,10 @@ public class AsyncTransformUsingServiceOrderedP<C, S, T, R> extends AbstractAsyn
      */
     public static <C, S, T, R> ProcessorSupplier supplier(
             @Nonnull ServiceFactory<C, S> serviceFactory,
-            int maxAsyncOps,
+            int maxConcurrentOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> callAsyncFn
     ) {
         return supplierWithService(serviceFactory, (serviceFn, context) ->
-                new AsyncTransformUsingServiceOrderedP<>(serviceFn, context, maxAsyncOps, callAsyncFn));
+                new AsyncTransformUsingServiceOrderedP<>(serviceFn, context, maxConcurrentOps, callAsyncFn));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceOrderedP.java
@@ -72,7 +72,7 @@ public class AsyncTransformUsingServiceOrderedP<C, S, T, R> extends AbstractAsyn
             int maxAsyncOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> callAsyncFn
     ) {
-        super(serviceFactory, serviceContext, maxAsyncOps);
+        super(serviceFactory, serviceContext, maxAsyncOps, true);
         this.callAsyncFn = callAsyncFn;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceUnorderedP.java
@@ -106,7 +106,7 @@ public final class AsyncTransformUsingServiceUnorderedP<C, S, T, K, R> extends A
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> callAsyncFn,
             @Nonnull Function<? super T, ? extends K> extractKeyFn
     ) {
-        super(serviceFactory, serviceContext, maxAsyncOps);
+        super(serviceFactory, serviceContext, maxAsyncOps, false);
         this.callAsyncFn = callAsyncFn;
         this.extractKeyFn = extractKeyFn;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -109,12 +109,6 @@ public interface BatchStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
-    <S> BatchStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Boolean>> filterAsyncFn
-    );
-
-    @Nonnull @Override
     <S, R> BatchStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends Traverser<R>> flatMapFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -115,13 +115,6 @@ public interface BatchStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
-    <S, R> BatchStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>>
-                    flatMapAsyncFn
-    );
-
-    @Nonnull @Override
     <S, R> BatchStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxBatchSize,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -107,8 +107,8 @@ public interface BatchStage<T> extends GeneralStage<T> {
     @Nonnull @Override
     <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -108,6 +108,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
     <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -97,8 +97,17 @@ public interface BatchStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
+    default <S, R> BatchStage<R> mapUsingServiceAsync(
+            @Nonnull ServiceFactory<?, S> serviceFactory,
+            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
+    ) {
+        return (BatchStage<R>) GeneralStage.super.mapUsingServiceAsync(serviceFactory, mapAsyncFn);
+    }
+
+    @Nonnull @Override
     <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     );
 
@@ -115,8 +124,18 @@ public interface BatchStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
+    default <S, R> BatchStage<R> mapUsingServiceAsyncBatched(
+            @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxBatchSize,
+            @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
+    ) {
+        return (BatchStage<R>) GeneralStage.super.mapUsingServiceAsyncBatched(serviceFactory, maxBatchSize, mapAsyncFn);
+    }
+
+    @Nonnull @Override
     <S, R> BatchStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     );

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -125,18 +125,8 @@ public interface BatchStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
-    default <S, R> BatchStage<R> mapUsingServiceAsyncBatched(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxBatchSize,
-            @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
-    ) {
-        return (BatchStage<R>) GeneralStage.super.mapUsingServiceAsyncBatched(serviceFactory, maxBatchSize, mapAsyncFn);
-    }
-
-    @Nonnull @Override
     <S, R> BatchStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     );

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -122,8 +122,8 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     @Nonnull @Override
     <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -124,12 +124,6 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     );
 
     @Nonnull @Override
-    <S> BatchStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Boolean>> filterAsyncFn
-    );
-
-    @Nonnull @Override
     <S, R> BatchStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull TriFunction<? super S, ? super K, ? super T, ? extends Traverser<R>> flatMapFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -129,13 +129,6 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
             @Nonnull TriFunction<? super S, ? super K, ? super T, ? extends Traverser<R>> flatMapFn
     );
 
-    @Nonnull @Override
-    <S, R> BatchStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>>
-                    flatMapAsyncFn
-    );
-
     /**
      * Attaches a stage that performs the given group-and-aggregate operation.
      * It emits one key-value pair (in a {@code Map.Entry}) for each distinct

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -123,6 +123,7 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStageWithKey.java
@@ -112,8 +112,17 @@ public interface BatchStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     );
 
     @Nonnull @Override
+    default <S, R> BatchStage<R> mapUsingServiceAsync(
+            @Nonnull ServiceFactory<?, S> serviceFactory,
+            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
+    ) {
+        return (BatchStage<R>) GeneralStageWithKey.super.mapUsingServiceAsync(serviceFactory, mapAsyncFn);
+    }
+
+    @Nonnull @Override
     <S, R> BatchStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -424,46 +424,6 @@ public interface GeneralStage<T> extends Stage {
     );
 
     /**
-     * Asynchronous version of {@link #filterUsingService}: the {@code
-     * filterAsyncFn} returns a {@code CompletableFuture<Boolean>} instead of
-     * just a {@code boolean}.
-     * <p>
-     * The function must not return a null future.
-     * <p>
-     * The latency of the async call will add to the total latency of the
-     * output.
-     * <p>
-     * This sample takes a stream of photos, uses an image classifier to reason
-     * about their contents, and keeps only photos of cats:
-     * <pre>{@code
-     * photos.filterUsingServiceAsync(
-     *     ServiceFactory.withCreateFn(jet -> new ImageClassifier(jet)),
-     *     (classifier, photo) -> reg.classifyAsync(photo)
-     *                               .thenApply(it -> it.equals("cat"))
-     * )
-     * }</pre>
-     *
-     * <h3>Interaction with fault-tolerant unbounded jobs</h3>
-     *
-     * If you use this stage in a fault-tolerant unbounded job, keep in mind
-     * that any state the service object maintains doesn't participate in Jet's
-     * fault tolerance protocol. If the state is local, it will be lost after a
-     * job restart; if it is saved to some durable storage, the state of that
-     * storage won't be rewound to the last checkpoint, so you'll perform
-     * duplicate updates.
-     *
-     * @param serviceFactory the service factory
-     * @param filterAsyncFn a stateless filtering function
-     * @param <S> type of service object
-     * @return the newly attached stage
-     */
-    @Nonnull
-    <S> GeneralStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Boolean>> filterAsyncFn
-    );
-
-    /**
      * Attaches a flat-mapping stage which applies the supplied function to
      * each input item independently and emits all items from the {@link
      * Traverser} it returns as the output items. The traverser must be

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -465,53 +465,6 @@ public interface GeneralStage<T> extends Stage {
     );
 
     /**
-     * Asynchronous version of {@link #flatMapUsingService}: the {@code
-     * flatMapAsyncFn} returns a {@code CompletableFuture<Traverser<R>>}
-     * instead of just {@code Traverser<R>}.
-     * <p>
-     * The function can return a null future or the future can return a null
-     * traverser: in both cases it will act just like a filter.
-     * <p>
-     * The latency of the async call will add to the total latency of the
-     * output.
-     * <p>
-     * This sample takes a stream of products and outputs an "exploded" stream
-     * of all the parts that go into making them:
-     * <pre>{@code
-     * StreamStage<Part> parts = products.flatMapUsingServiceAsync(
-     *     ServiceFactory.withCreateFn(jet -> new PartRegistryCtx()),
-     *     (registry, product) -> registry
-     *          .fetchPartsAsync(product)
-     *          .thenApply(parts -> Traversers.traverseIterable(parts))
-     * );
-     * }</pre>
-     *
-     * <h3>Interaction with fault-tolerant unbounded jobs</h3>
-     *
-     * If you use this stage in a fault-tolerant unbounded job, keep in mind
-     * that any state the service object maintains doesn't participate in Jet's
-     * fault tolerance protocol. If the state is local, it will be lost after a
-     * job restart; if it is saved to some durable storage, the state of that
-     * storage won't be rewound to the last checkpoint, so you'll perform
-     * duplicate updates.
-     *
-     * @param serviceFactory the service factory
-     * @param flatMapAsyncFn a stateless flatmapping function. Can map to null
-     *      (return a null future). The future must not return a null
-     *      traverser, but can return an {@linkplain Traversers#empty() empty
-     *      traverser}.
-     * @param <S> type of service object
-     * @param <R> the type of the returned stage
-     * @return the newly attached stage
-     */
-    @Nonnull
-    <S, R> GeneralStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>>
-                    flatMapAsyncFn
-    );
-
-    /**
      * Attaches a mapping stage where for each item a lookup in the
      * {@code ReplicatedMap} with the supplied name is performed and the
      * result of the lookup is merged with the item and emitted.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -431,65 +431,8 @@ public interface GeneralStage<T> extends Stage {
      * @since 4.0
      */
     @Nonnull
-    default <S, R> GeneralStage<R> mapUsingServiceAsyncBatched(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxBatchSize,
-            @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
-    ) {
-        return mapUsingServiceAsyncBatched(serviceFactory, MAX_ASYNC_OPS, maxBatchSize, mapAsyncFn);
-    }
-
-    /**
-     * Batched version of {@link #mapUsingService}: {@code mapAsyncFn} takes
-     * a list of input items and returns a {@code CompletableFuture<List<R>>}.
-     * The size of the input list is limited by the given {@code maxBatchSize}.
-     * <p>
-     * As opposed to the non-batched variant, this transform cannot perform
-     * filtering. The output list's items must match one-to-one with the input
-     * list's.
-     * <p>
-     * The latency of the async call will add to the total latency of the
-     * output.
-     * <p>
-     * This sample takes a stream of stock items and sets the {@code detail}
-     * field on them by performing batched lookups from a registry. The max
-     * size of the items to lookup is specified as {@code 100}:
-     * <pre>{@code
-     * stage.mapUsingServiceAsyncBatched(
-     *     ServiceFactory.withCreateFn(jet -> new ItemDetailRegistry(jet)),
-     *     100,
-     *     (reg, itemList) -> reg
-     *             .fetchDetailsAsync(itemList)
-     *             .thenApply(detailList -> {
-     *                 for (int i = 0; i < itemList.size(); i++) {
-     *                     itemList.get(i).setDetail(detailList.get(i))
-     *                 }
-     *             })
-     * )
-     * }</pre>
-     *
-     * <h3>Interaction with fault-tolerant unbounded jobs</h3>
-     *
-     * If you use this stage in a fault-tolerant unbounded job, keep in mind
-     * that any state the service object maintains doesn't participate in Jet's
-     * fault tolerance protocol. If the state is local, it will be lost after a
-     * job restart; if it is saved to some durable storage, the state of that
-     * storage won't be rewound to the last checkpoint, so you'll perform
-     * duplicate updates.
-     *
-     * @param serviceFactory the service factory
-     * @param maxAsyncOps maxAsyncOps maximum number of concurrent async operations per processor
-     * @param maxBatchSize max size of the input list
-     * @param mapAsyncFn a stateless mapping function
-     * @param <S> type of service object
-     * @param <R> the future result type of the mapping function
-     * @return the newly attached stage
-     * @since 4.0
-     */
-    @Nonnull
     <S, R> GeneralStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     );

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -368,44 +368,6 @@ public interface GeneralStageWithKey<T, K> {
     );
 
     /**
-     * Asynchronous version of {@link #flatMapUsingService}: the {@code
-     * flatMapAsyncFn} returns a {@code CompletableFuture<Traverser<R>>}
-     * instead of just {@code Traverser<R>}.
-     * <p>
-     * The function can return a null future or the future can return a null
-     * traverser: in both cases it will act just like a filter.
-     * <p>
-     * Sample usage:
-     * <pre>{@code
-     * StreamStage<Part> productParts = products
-     *     .groupingKey(Product::getId)
-     *     .flatMapUsingServiceAsync(
-     *         ServiceFactory.withCreateFn(jet -> new PartRegistry()),
-     *         (registry, productId, product) -> registry
-     *                 .fetchPartsAsync(productId)
-     *                 .thenApply(parts -> Traversers.traverseIterable(parts))
-     *     );
-     * }</pre>
-     * <p>
-     * The latency of the async call will add to the latency of the items.
-     *
-     * @param <S> type of service object
-     * @param <R> the type of the returned stage
-     * @param serviceFactory the service factory
-     * @param flatMapAsyncFn a stateless flatmapping function. Can map to null
-     *                      (return a null future), but the future must not
-     *                      return null traverser, but can return an {@linkplain
-     *                      Traversers#empty() empty traverser}.
-     * @return the newly attached stage
-     */
-    @Nonnull
-    <S, R> GeneralStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>>
-                    flatMapAsyncFn
-    );
-
-    /**
      * Attaches a mapping stage where for each item a lookup in the
      * {@code IMap} with the supplied name using the grouping key is performed
      * and the result of the lookup is merged with the item and emitted.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.ORDERED_ASYNC_RESPONSES;
 
 /**
  * An intermediate step when constructing a group-and-aggregate pipeline
@@ -277,7 +278,7 @@ public interface GeneralStageWithKey<T, K> {
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return mapUsingServiceAsync(serviceFactory, MAX_ASYNC_OPS, mapAsyncFn);
+        return mapUsingServiceAsync(serviceFactory, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, mapAsyncFn);
     }
 
     /**
@@ -303,6 +304,7 @@ public interface GeneralStageWithKey<T, K> {
      * @param <R> the future's result type of the mapping function
      * @param serviceFactory the service factory
      * @param maxAsyncOps maximum number of concurrent async operations per processor
+     * @param orderedAsyncResponses whether the async responses are ordered or not
      * @param mapAsyncFn a stateless mapping function. Can map to null (return
      *      a null future)
      * @return the newly attached stage
@@ -311,6 +313,7 @@ public interface GeneralStageWithKey<T, K> {
     <S, R> GeneralStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 
@@ -445,7 +448,7 @@ public interface GeneralStageWithKey<T, K> {
             @Nonnull String mapName,
             @Nonnull BiFunctionEx<? super T, ? super V, ? extends R> mapFn
     ) {
-        return mapUsingServiceAsync(ServiceFactories.<K, V>iMapService(mapName), MAX_ASYNC_OPS,
+        return mapUsingServiceAsync(ServiceFactories.<K, V>iMapService(mapName), MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES,
                 (map, key, item) -> map.getAsync(key).toCompletableFuture()
                                        .thenApply(value -> mapFn.apply(item, value)));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -37,8 +37,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 
 import static com.hazelcast.jet.Util.entry;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.ORDERED_ASYNC_RESPONSES;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_CONCURRENT_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.PRESERVE_ORDER;
 
 /**
  * An intermediate step when constructing a group-and-aggregate pipeline
@@ -278,7 +278,7 @@ public interface GeneralStageWithKey<T, K> {
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     ) {
-        return mapUsingServiceAsync(serviceFactory, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, mapAsyncFn);
+        return mapUsingServiceAsync(serviceFactory, MAX_CONCURRENT_OPS, PRESERVE_ORDER, mapAsyncFn);
     }
 
     /**
@@ -303,8 +303,8 @@ public interface GeneralStageWithKey<T, K> {
      * @param <S> type of service object
      * @param <R> the future's result type of the mapping function
      * @param serviceFactory the service factory
-     * @param maxAsyncOps maximum number of concurrent async operations per processor
-     * @param orderedAsyncResponses whether the async responses are ordered or not
+     * @param maxConcurrentOps maximum number of concurrent async operations per processor
+     * @param preserveOrder whether the async responses are ordered or not
      * @param mapAsyncFn a stateless mapping function. Can map to null (return
      *      a null future)
      * @return the newly attached stage
@@ -312,8 +312,8 @@ public interface GeneralStageWithKey<T, K> {
     @Nonnull
     <S, R> GeneralStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 
@@ -448,7 +448,7 @@ public interface GeneralStageWithKey<T, K> {
             @Nonnull String mapName,
             @Nonnull BiFunctionEx<? super T, ? super V, ? extends R> mapFn
     ) {
-        return mapUsingServiceAsync(ServiceFactories.<K, V>iMapService(mapName), MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES,
+        return mapUsingServiceAsync(ServiceFactories.<K, V>iMapService(mapName), MAX_CONCURRENT_OPS, PRESERVE_ORDER,
                 (map, key, item) -> map.getAsync(key).toCompletableFuture()
                                        .thenApply(value -> mapFn.apply(item, value)));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -320,37 +320,6 @@ public interface GeneralStageWithKey<T, K> {
     );
 
     /**
-     * Asynchronous version of {@link #filterUsingService}: the {@code
-     * filterAsyncFn} returns a {@code CompletableFuture<Boolean>} instead of
-     * just a {@code boolean}.
-     * <p>
-     * The function must not return a null future.
-     * <p>
-     * Sample usage:
-     * <pre>{@code
-     * items.groupingKey(Item::getDetailId)
-     *      .filterUsingServiceAsync(
-     *          ServiceFactory.withCreateFn(jet -> new ItemDetailRegistry()),
-     *          (reg, key, item) -> reg.fetchDetailAsync(key)
-     *                                 .thenApply(detail -> detail.contains("blade"))
-     *      );
-     * }</pre>
-     * <p>
-     * The latency of the async call will add to the total latency of the
-     * output.
-     *
-     * @param <S> type of service object
-     * @param serviceFactory the service factory
-     * @param filterAsyncFn a stateless filtering function
-     * @return the newly attached stage
-     */
-    @Nonnull
-    <S> GeneralStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Boolean>> filterAsyncFn
-    );
-
-    /**
      * Attaches a flat-mapping stage which applies the supplied function to
      * each input item independently and emits all the items from the
      * {@link Traverser} it returns as the output items. The traverser must

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
@@ -74,13 +74,11 @@ import static java.util.Collections.emptyMap;
  *     <li>{@link GeneralStage#filterUsingService}
  *     <li>{@link GeneralStage#flatMapUsingService}
  *     <li>{@link GeneralStage#mapUsingServiceAsync}
- *     <li>{@link GeneralStage#flatMapUsingServiceAsync}
  *     <li>{@link GeneralStage#mapUsingServiceAsyncBatched}
  *     <li>{@link GeneralStageWithKey#mapUsingService}
  *     <li>{@link GeneralStageWithKey#filterUsingService}
  *     <li>{@link GeneralStageWithKey#flatMapUsingService}
  *     <li>{@link GeneralStageWithKey#mapUsingServiceAsync}
- *     <li>{@link GeneralStageWithKey#flatMapUsingServiceAsync}
  * </ul>
  *
  * @param <C> type of the shared context object

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
@@ -19,7 +19,6 @@ package com.hazelcast.jet.pipeline;
 import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.function.FunctionEx;
-import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorSupplier;
@@ -64,9 +63,9 @@ import static java.util.Collections.emptyMap;
  *      Finally, Jet calls {@link #destroyContextFn()} with the context object.
  * </ol>
  * If you don't need the member-wide context object, you can call the simpler
- * methods {@link ServiceFactories#nonSharedService(SupplierEx, ConsumerEx)
+ * methods {@link ServiceFactories#nonSharedService(FunctionEx, ConsumerEx)}
  * ServiceFactories.processorLocalService} or {@link
- * ServiceFactories#sharedService(SupplierEx, ConsumerEx)
+ * ServiceFactories#sharedService(FunctionEx, ConsumerEx)}
  * ServiceFactories.memberLocalService}.
  * <p>
  * Here's a list of pipeline transforms that require a {@code ServiceFactory}:
@@ -75,14 +74,12 @@ import static java.util.Collections.emptyMap;
  *     <li>{@link GeneralStage#filterUsingService}
  *     <li>{@link GeneralStage#flatMapUsingService}
  *     <li>{@link GeneralStage#mapUsingServiceAsync}
- *     <li>{@link GeneralStage#filterUsingServiceAsync}
  *     <li>{@link GeneralStage#flatMapUsingServiceAsync}
  *     <li>{@link GeneralStage#mapUsingServiceAsyncBatched}
  *     <li>{@link GeneralStageWithKey#mapUsingService}
  *     <li>{@link GeneralStageWithKey#filterUsingService}
  *     <li>{@link GeneralStageWithKey#flatMapUsingService}
  *     <li>{@link GeneralStageWithKey#mapUsingServiceAsync}
- *     <li>{@link GeneralStageWithKey#filterUsingServiceAsync}
  *     <li>{@link GeneralStageWithKey#flatMapUsingServiceAsync}
  * </ul>
  *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 import static java.util.Collections.emptyMap;
 
@@ -89,11 +88,6 @@ import static java.util.Collections.emptyMap;
 public final class ServiceFactory<C, S> implements Serializable, Cloneable {
 
     /**
-     * Default value for {@link #maxPendingCallsPerProcessor}.
-     */
-    public static final int MAX_PENDING_CALLS_DEFAULT = 256;
-
-    /**
      * Default value for {@link #isCooperative}.
      */
     public static final boolean COOPERATIVE_DEFAULT = true;
@@ -106,7 +100,6 @@ public final class ServiceFactory<C, S> implements Serializable, Cloneable {
     private boolean isCooperative = COOPERATIVE_DEFAULT;
 
     // options for async
-    private int maxPendingCallsPerProcessor = MAX_PENDING_CALLS_DEFAULT;
     private boolean orderedAsyncResponses = ORDERED_ASYNC_RESPONSES_DEFAULT;
 
     @Nonnull
@@ -240,33 +233,6 @@ public final class ServiceFactory<C, S> implements Serializable, Cloneable {
         ServiceFactory<C, S> copy = clone();
         copy.isCooperative = false;
         return copy;
-    }
-
-    /**
-     * Returns a copy of this {@link ServiceFactory} with the {@code
-     * maxPendingCallsPerProcessor} property set to the given value. Jet
-     * will execute at most this many concurrent async operations per processor
-     * and will apply backpressure to the upstream to enforce it.
-     * <p>
-     * If you use the same service factory on multiple pipeline stages, each
-     * stage will count the pending calls independently.
-     * <p>
-     * This value is ignored when the {@code ServiceFactory} is used in a
-     * synchronous transformation because synchronous operations are by nature
-     * performed one at a time.
-     * <p>
-     * Default value is {@value #MAX_PENDING_CALLS_DEFAULT}.
-     *
-     * @return a copy of this factory with the {@code maxPendingCallsPerProcessor}
-     *         property set
-     */
-    @Nonnull
-    public ServiceFactory<C, S> withMaxPendingCallsPerProcessor(int maxPendingCallsPerProcessor) {
-        checkPositive(maxPendingCallsPerProcessor, "maxPendingCallsPerProcessor must be >= 1");
-        ServiceFactory<C, S> copy = clone();
-        copy.maxPendingCallsPerProcessor = maxPendingCallsPerProcessor;
-        return copy;
-
     }
 
     /**
@@ -419,14 +385,6 @@ public final class ServiceFactory<C, S> implements Serializable, Cloneable {
      */
     public boolean isCooperative() {
         return isCooperative;
-    }
-
-    /**
-     * Returns the maximum pending calls per processor, see {@link
-     * #withMaxPendingCallsPerProcessor(int)}.
-     */
-    public int maxPendingCallsPerProcessor() {
-        return maxPendingCallsPerProcessor;
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/ServiceFactory.java
@@ -92,15 +92,7 @@ public final class ServiceFactory<C, S> implements Serializable, Cloneable {
      */
     public static final boolean COOPERATIVE_DEFAULT = true;
 
-    /**
-     * Default value for {@link #hasOrderedAsyncResponses}.
-     */
-    public static final boolean ORDERED_ASYNC_RESPONSES_DEFAULT = true;
-
     private boolean isCooperative = COOPERATIVE_DEFAULT;
-
-    // options for async
-    private boolean orderedAsyncResponses = ORDERED_ASYNC_RESPONSES_DEFAULT;
 
     @Nonnull
     private FunctionEx<? super Context, ? extends C> createContextFn;
@@ -236,48 +228,6 @@ public final class ServiceFactory<C, S> implements Serializable, Cloneable {
     }
 
     /**
-     * Returns a copy of this {@link ServiceFactory} with the {@code
-     * unorderedAsyncResponses} flag set to true.
-     * <p>
-     * Jet can process asynchronous responses in two modes:
-     * <ol><li>
-     *     <b>Ordered:</b> results of the async calls are emitted in the submission
-     *     order. This is the default.
-     * <li>
-     *     <b>Unordered:</b> results of the async calls are emitted as they
-     *     arrive. This mode is enabled by this method.
-     * </ol>
-     * The unordered mode can be faster:
-     * <ul><li>
-     *     in the ordered mode, one stalling call will block all subsequent items,
-     *     even though responses for them were already received
-     * <li>
-     *     to preserve the order after a restart, the ordered implementation when
-     *     saving the state to the snapshot waits for all async calls to complete.
-     *     This creates a hiccup depending on the async call latency. The unordered
-     *     one saves in-flight items to the state snapshot.
-     * </ul>
-     * The order of watermarks is preserved even in the unordered mode. Jet
-     * forwards the watermark after having emitted all the results of the items
-     * that came before it. One stalling response will prevent a windowed
-     * operation downstream from finishing, but if the operation is configured
-     * to emit early results, they will be more correct with the unordered
-     * approach.
-     * <p>
-     * This value is ignored when the {@code ServiceFactory} is used in a
-     * synchronous transformation: the output is always ordered in this case.
-     *
-     * @return a copy of this factory with the {@code unorderedAsyncResponses} flag set.
-     */
-    @Nonnull
-    public ServiceFactory<C, S> withUnorderedAsyncResponses() {
-        ServiceFactory<C, S> copy = clone();
-        copy.orderedAsyncResponses = false;
-        return copy;
-
-    }
-
-    /**
      * Attaches a file to this service factory under the given ID. It will
      * become a part of the Jet job and available to {@link #createContextFn()}
      * as {@link ProcessorSupplier.Context#attachedFile
@@ -385,14 +335,6 @@ public final class ServiceFactory<C, S> implements Serializable, Cloneable {
      */
     public boolean isCooperative() {
         return isCooperative;
-    }
-
-    /**
-     * Tells whether the async responses are ordered, see {@link
-     * #withUnorderedAsyncResponses()}.
-     */
-    public boolean hasOrderedAsyncResponses() {
-        return orderedAsyncResponses;
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -133,12 +133,6 @@ public interface StreamStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
-    <S, R> StreamStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Traverser<R>>> flatMapAsyncFn
-    );
-
-    @Nonnull @Override
     default <K, V, R> StreamStage<R> mapUsingReplicatedMap(
             @Nonnull String mapName,
             @Nonnull FunctionEx<? super T, ? extends K> lookupKeyFn,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -124,18 +124,8 @@ public interface StreamStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
-    default <S, R> StreamStage<R> mapUsingServiceAsyncBatched(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxBatchSize,
-            @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
-    ) {
-        return (StreamStage<R>) GeneralStage.super.mapUsingServiceAsyncBatched(serviceFactory, maxBatchSize, mapAsyncFn);
-    }
-
-    @Nonnull @Override
     <S, R> StreamStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     );

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -118,8 +118,8 @@ public interface StreamStage<T> extends GeneralStage<T> {
     @Nonnull @Override
     <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -108,14 +108,33 @@ public interface StreamStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
+    default <S, R> StreamStage<R> mapUsingServiceAsync(
+            @Nonnull ServiceFactory<?, S> serviceFactory,
+            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
+    ) {
+        return (StreamStage<R>) GeneralStage.super.mapUsingServiceAsync(serviceFactory, mapAsyncFn);
+    }
+
+    @Nonnull @Override
     <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     );
 
     @Nonnull @Override
+    default <S, R> StreamStage<R> mapUsingServiceAsyncBatched(
+            @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxBatchSize,
+            @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
+    ) {
+        return (StreamStage<R>) GeneralStage.super.mapUsingServiceAsyncBatched(serviceFactory, maxBatchSize, mapAsyncFn);
+    }
+
+    @Nonnull @Override
     <S, R> StreamStage<R> mapUsingServiceAsyncBatched(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             int maxBatchSize,
             @Nonnull BiFunctionEx<? super S, ? super List<T>, ? extends CompletableFuture<List<R>>> mapAsyncFn
     );

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -119,6 +119,7 @@ public interface StreamStage<T> extends GeneralStage<T> {
     <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -127,12 +127,6 @@ public interface StreamStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
-    <S> StreamStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull BiFunctionEx<? super S, ? super T, ? extends CompletableFuture<Boolean>> filterAsyncFn
-    );
-
-    @Nonnull @Override
     <S, R> StreamStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull BiFunctionEx<? super S, ? super T, ? extends Traverser<R>> flatMapFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
@@ -327,6 +327,7 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             int maxAsyncOps,
+            boolean orderedAsyncResponses,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
@@ -326,8 +326,8 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     @Nonnull @Override
     <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
-            int maxAsyncOps,
-            boolean orderedAsyncResponses,
+            int maxConcurrentOps,
+            boolean preserveOrder,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
@@ -316,8 +316,17 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     );
 
     @Nonnull @Override
+    default <S, R> GeneralStage<R> mapUsingServiceAsync(
+            @Nonnull ServiceFactory<?, S> serviceFactory,
+            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
+    ) {
+        return (GeneralStage<R>) GeneralStageWithKey.super.mapUsingServiceAsync(serviceFactory, mapAsyncFn);
+    }
+
+    @Nonnull @Override
     <S, R> StreamStage<R> mapUsingServiceAsync(
             @Nonnull ServiceFactory<?, S> serviceFactory,
+            int maxAsyncOps,
             @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<R>> mapAsyncFn
     );
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
@@ -328,12 +328,6 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     );
 
     @Nonnull @Override
-    <S> StreamStage<T> filterUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Boolean>> filterAsyncFn
-    );
-
-    @Nonnull @Override
     <S, R> StreamStage<R> flatMapUsingService(
             @Nonnull ServiceFactory<?, S> serviceFactory,
             @Nonnull TriFunction<? super S, ? super K, ? super T, ? extends Traverser<R>> flatMapFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStageWithKey.java
@@ -334,12 +334,6 @@ public interface StreamStageWithKey<T, K> extends GeneralStageWithKey<T, K> {
     );
 
     @Nonnull @Override
-    <S, R> StreamStage<R> flatMapUsingServiceAsync(
-            @Nonnull ServiceFactory<?, S> serviceFactory,
-            @Nonnull TriFunction<? super S, ? super K, ? super T, CompletableFuture<Traverser<R>>> flatMapAsyncFn
-    );
-
-    @Nonnull @Override
     default <R> StreamStage<R> customTransform(@Nonnull String stageName,
                                                @Nonnull SupplierEx<Processor> procSupplier
     ) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -46,6 +46,7 @@ import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceP;
 import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static com.hazelcast.jet.core.processor.Processors.mapUsingServiceAsyncP;
 import static com.hazelcast.jet.core.processor.Processors.noopP;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
 import static com.hazelcast.jet.pipeline.ServiceFactories.nonSharedService;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -87,6 +88,7 @@ public class ProcessorsTest extends SimpleTestInClusterSupport {
         TestSupport
                 .verifyProcessor(mapUsingServiceAsyncP(
                         nonSharedService(pctx -> new AtomicInteger(), ctx -> assertEquals(6, ctx.get())),
+                        MAX_ASYNC_OPS,
                         t -> "k",
                         (AtomicInteger context, Integer item) -> supplyAsync(() -> {
                             sleepMillis(100);
@@ -131,6 +133,7 @@ public class ProcessorsTest extends SimpleTestInClusterSupport {
         TestSupport
                 .verifyProcessor(mapUsingServiceAsyncP(
                         nonSharedService(pctx -> new int[]{2}, arr -> assertEquals(2, arr[0])),
+                        MAX_ASYNC_OPS,
                         t -> "k",
                         (int[] context, Integer item) ->
                                 supplyAsync(() -> item % context[0] != 0 ? item : null)))

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -47,6 +47,7 @@ import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static com.hazelcast.jet.core.processor.Processors.mapUsingServiceAsyncP;
 import static com.hazelcast.jet.core.processor.Processors.noopP;
 import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.ORDERED_ASYNC_RESPONSES;
 import static com.hazelcast.jet.pipeline.ServiceFactories.nonSharedService;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -89,6 +90,7 @@ public class ProcessorsTest extends SimpleTestInClusterSupport {
                 .verifyProcessor(mapUsingServiceAsyncP(
                         nonSharedService(pctx -> new AtomicInteger(), ctx -> assertEquals(6, ctx.get())),
                         MAX_ASYNC_OPS,
+                        ORDERED_ASYNC_RESPONSES,
                         t -> "k",
                         (AtomicInteger context, Integer item) -> supplyAsync(() -> {
                             sleepMillis(100);
@@ -134,6 +136,7 @@ public class ProcessorsTest extends SimpleTestInClusterSupport {
                 .verifyProcessor(mapUsingServiceAsyncP(
                         nonSharedService(pctx -> new int[]{2}, arr -> assertEquals(2, arr[0])),
                         MAX_ASYNC_OPS,
+                        ORDERED_ASYNC_RESPONSES,
                         t -> "k",
                         (int[] context, Integer item) ->
                                 supplyAsync(() -> item % context[0] != 0 ? item : null)))

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -46,8 +46,8 @@ import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceP;
 import static com.hazelcast.jet.core.processor.Processors.mapP;
 import static com.hazelcast.jet.core.processor.Processors.mapUsingServiceAsyncP;
 import static com.hazelcast.jet.core.processor.Processors.noopP;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.ORDERED_ASYNC_RESPONSES;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_CONCURRENT_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.PRESERVE_ORDER;
 import static com.hazelcast.jet.pipeline.ServiceFactories.nonSharedService;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -89,8 +89,8 @@ public class ProcessorsTest extends SimpleTestInClusterSupport {
         TestSupport
                 .verifyProcessor(mapUsingServiceAsyncP(
                         nonSharedService(pctx -> new AtomicInteger(), ctx -> assertEquals(6, ctx.get())),
-                        MAX_ASYNC_OPS,
-                        ORDERED_ASYNC_RESPONSES,
+                        MAX_CONCURRENT_OPS,
+                        PRESERVE_ORDER,
                         t -> "k",
                         (AtomicInteger context, Integer item) -> supplyAsync(() -> {
                             sleepMillis(100);
@@ -135,8 +135,8 @@ public class ProcessorsTest extends SimpleTestInClusterSupport {
         TestSupport
                 .verifyProcessor(mapUsingServiceAsyncP(
                         nonSharedService(pctx -> new int[]{2}, arr -> assertEquals(2, arr[0])),
-                        MAX_ASYNC_OPS,
-                        ORDERED_ASYNC_RESPONSES,
+                        MAX_CONCURRENT_OPS,
+                        PRESERVE_ORDER,
                         t -> "k",
                         (int[] context, Integer item) ->
                                 supplyAsync(() -> item % context[0] != 0 ? item : null)))

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ProcessorsTest.java
@@ -30,7 +30,6 @@ import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
@@ -41,7 +40,6 @@ import static com.hazelcast.jet.core.processor.Processors.aggregateByKeyP;
 import static com.hazelcast.jet.core.processor.Processors.combineByKeyP;
 import static com.hazelcast.jet.core.processor.Processors.combineP;
 import static com.hazelcast.jet.core.processor.Processors.filterP;
-import static com.hazelcast.jet.core.processor.Processors.filterUsingServiceAsyncP;
 import static com.hazelcast.jet.core.processor.Processors.filterUsingServiceP;
 import static com.hazelcast.jet.core.processor.Processors.flatMapP;
 import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceP;
@@ -168,23 +166,6 @@ public class ProcessorsTest extends SimpleTestInClusterSupport {
                 .input(asList(1, 2, 1, 2))
                 .disableSnapshots()
                 .expectOutput(asList(1, 2, 2));
-    }
-
-    @Test
-    public void filterUsingServiceAsync() {
-        TestSupport
-                .verifyProcessor(filterUsingServiceAsyncP(
-                        nonSharedService(pctx -> new AtomicInteger(), ctx -> assertEquals(4, ctx.get())),
-                        t -> "k",
-                        (AtomicInteger context, Integer item) -> CompletableFuture.supplyAsync(() -> {
-                            context.incrementAndGet();
-                            return item > 1;
-                        })))
-                .jetInstance(instance())
-                .input(asList(1, 2, 1, 2))
-                .disableSnapshots()
-                .disableProgressAssertion()
-                .expectOutput(asList(2, 2));
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/MetricsTest.java
@@ -192,7 +192,7 @@ public class MetricsTest extends JetTestSupport {
 
         pipeline.readFrom(TestSources.items(inputs))
                 .addTimestamps(i -> i, 0L)
-                .filterUsingServiceAsync(
+                .mapUsingServiceAsync(
                         nonSharedService(pctx -> 0L),
                         (ctx, l) -> {
                             Metric dropped = Metrics.threadSafeMetric("dropped");
@@ -204,7 +204,7 @@ public class MetricsTest extends JetTestSupport {
                                             dropped.increment();
                                         }
                                         total.increment();
-                                        return pass;
+                                        return l;
                                     }
                             );
                         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
@@ -62,7 +62,7 @@ import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_CONCURRENT_OPS;
 import static com.hazelcast.jet.impl.util.Util.toList;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.jet.pipeline.ServiceFactories.sharedService;
@@ -136,7 +136,7 @@ public class AsyncTransformUsingServiceBatchP_IntegrationTest extends SimpleTest
                 transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"))
                 .andThen(r -> r.thenApply(results -> traverseIterable(results).flatMap(Function.identity())));
         ProcessorSupplier processorSupplier =
-                AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, MAX_ASYNC_OPS, 128, flatMapAsyncFn);
+                AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, MAX_CONCURRENT_OPS, 128, flatMapAsyncFn);
         Vertex map = dag.newVertex("map", processorSupplier).localParallelism(2);
         Vertex sink = dag.newVertex("sink", SinkProcessors.writeListP(sinkList.getName()));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
@@ -172,8 +172,7 @@ public class AsyncTransformUsingServiceBatchP_IntegrationTest extends SimpleTest
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
          .withoutTimestamps()
-         .mapUsingServiceAsyncBatched(serviceFactory, MAX_ASYNC_OPS, 128,
-                 transformNotPartitionedFn(i -> i + "-1"))
+         .mapUsingServiceAsyncBatched(serviceFactory, 128, transformNotPartitionedFn(i -> i + "-1"))
          .setLocalParallelism(2)
          .writeTo(Sinks.list(sinkList));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
@@ -21,11 +21,13 @@ import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.config.EdgeConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.WatermarkPolicy;
 import com.hazelcast.jet.core.processor.SinkProcessors;
@@ -59,7 +61,6 @@ import static com.hazelcast.jet.core.EventTimePolicy.eventTimePolicy;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
-import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceAsyncBatchedP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
 import static com.hazelcast.jet.impl.util.Util.toList;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
@@ -130,11 +131,12 @@ public class AsyncTransformUsingServiceBatchP_IntegrationTest extends SimpleTest
                         WatermarkPolicy.limitingLag(10),
                         10, 0, 0
                 )), 5000));
-        Vertex map = dag.newVertex("map",
-                flatMapUsingServiceAsyncBatchedP(serviceFactory, 128, transformNotPartitionedFn(
-                        item -> traverseItems(item + "-1", item + "-2", item + "-3", item + "-4", item + "-5"))
-                .andThen(r -> r.thenApply(results -> traverseIterable(results).flatMap(Function.identity())))))
-                        .localParallelism(2);
+        BiFunctionEx<ExecutorService, List<Integer>, CompletableFuture<Traverser<String>>> flatMapAsyncFn =
+                transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"))
+                .andThen(r -> r.thenApply(results -> traverseIterable(results).flatMap(Function.identity())));
+        ProcessorSupplier processorSupplier =
+                AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, 128, flatMapAsyncFn);
+        Vertex map = dag.newVertex("map", processorSupplier).localParallelism(2);
         Vertex sink = dag.newVertex("sink", SinkProcessors.writeListP(sinkList.getName()));
 
         // Use a shorter queue to not block the barrier from the source for too long due to

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchP_IntegrationTest.java
@@ -62,6 +62,7 @@ import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
 import static com.hazelcast.jet.impl.util.Util.toList;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.jet.pipeline.ServiceFactories.sharedService;
@@ -135,7 +136,7 @@ public class AsyncTransformUsingServiceBatchP_IntegrationTest extends SimpleTest
                 transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"))
                 .andThen(r -> r.thenApply(results -> traverseIterable(results).flatMap(Function.identity())));
         ProcessorSupplier processorSupplier =
-                AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, 128, flatMapAsyncFn);
+                AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, MAX_ASYNC_OPS, 128, flatMapAsyncFn);
         Vertex map = dag.newVertex("map", processorSupplier).localParallelism(2);
         Vertex sink = dag.newVertex("sink", SinkProcessors.writeListP(sinkList.getName()));
 
@@ -171,7 +172,7 @@ public class AsyncTransformUsingServiceBatchP_IntegrationTest extends SimpleTest
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
          .withoutTimestamps()
-         .mapUsingServiceAsyncBatched(serviceFactory, 128,
+         .mapUsingServiceAsyncBatched(serviceFactory, MAX_ASYNC_OPS, 128,
                  transformNotPartitionedFn(i -> i + "-1"))
          .setLocalParallelism(2)
          .writeTo(Sinks.list(sinkList));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
 import static com.hazelcast.jet.Traversers.traverseIterable;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_CONCURRENT_OPS;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -54,7 +54,7 @@ public class AsyncTransformUsingServiceBatchedPTest extends SimpleTestInClusterS
                             CompletableFuture<Traverser<String>>> mapFn
     ) {
         ServiceFactory<?, String> serviceFactory = ServiceFactories.nonSharedService(pctx -> "foo");
-        return AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, MAX_ASYNC_OPS, 128, mapFn);
+        return AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, MAX_CONCURRENT_OPS, 128, mapFn);
     }
 
     @BeforeClass

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
 import static com.hazelcast.jet.Traversers.traverseIterable;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -53,7 +54,7 @@ public class AsyncTransformUsingServiceBatchedPTest extends SimpleTestInClusterS
                             CompletableFuture<Traverser<String>>> mapFn
     ) {
         ServiceFactory<?, String> serviceFactory = ServiceFactories.nonSharedService(pctx -> "foo");
-        return AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, 128, mapFn);
+        return AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, MAX_ASYNC_OPS, 128, mapFn);
     }
 
     @BeforeClass

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceBatchedPTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
 import static com.hazelcast.jet.Traversers.traverseIterable;
-import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceAsyncBatchedP;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -54,7 +53,7 @@ public class AsyncTransformUsingServiceBatchedPTest extends SimpleTestInClusterS
                             CompletableFuture<Traverser<String>>> mapFn
     ) {
         ServiceFactory<?, String> serviceFactory = ServiceFactories.nonSharedService(pctx -> "foo");
-        return flatMapUsingServiceAsyncBatchedP(serviceFactory, 128, mapFn);
+        return AsyncTransformUsingServiceBatchedP.supplier(serviceFactory, 128, mapFn);
     }
 
     @BeforeClass

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
@@ -44,7 +44,6 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
-import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceAsyncP;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
 import static com.hazelcast.jet.pipeline.ServiceFactory.MAX_PENDING_CALLS_DEFAULT;
 import static java.util.Arrays.asList;
@@ -81,10 +80,8 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
         ServiceFactory<?, String> serviceFactory = ServiceFactories
                 .nonSharedService(pctx -> "foo")
                 .withMaxPendingCallsPerProcessor(maxPendingCalls);
-        if (!ordered) {
-            serviceFactory = serviceFactory.withUnorderedAsyncResponses();
-        }
-        return flatMapUsingServiceAsyncP(serviceFactory, FunctionEx.identity(), mapFn);
+        return ordered ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, mapFn) :
+                AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, mapFn, FunctionEx.identity());
     }
 
     @BeforeClass

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
@@ -44,7 +44,7 @@ import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_CONCURRENT_OPS;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -70,20 +70,20 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
     private ProcessorSupplier getSupplier(
             BiFunctionEx<? super String, ? super String, CompletableFuture<Traverser<String>>> mapFn
     ) {
-        return getSupplier(MAX_ASYNC_OPS, mapFn);
+        return getSupplier(MAX_CONCURRENT_OPS, mapFn);
     }
 
     private ProcessorSupplier getSupplier(
-            int maxAsyncOps,
+            int maxConcurrentOps,
             BiFunctionEx<? super String, ? super String, CompletableFuture<Traverser<String>>> mapFn
     ) {
         ServiceFactory<?, String> serviceFactory = ServiceFactories
                 .nonSharedService(pctx -> "foo");
         return ordered
                 ? AsyncTransformUsingServiceOrderedP.supplier(
-                        serviceFactory, maxAsyncOps, mapFn)
+                        serviceFactory, maxConcurrentOps, mapFn)
                 : AsyncTransformUsingServiceUnorderedP.supplier(
-                        serviceFactory, maxAsyncOps, mapFn, FunctionEx.identity());
+                        serviceFactory, maxConcurrentOps, mapFn, FunctionEx.identity());
     }
 
     @BeforeClass

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServicePTest.java
@@ -45,7 +45,6 @@ import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.Traversers.traverseItems;
 import static com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture;
-import static com.hazelcast.jet.pipeline.ServiceFactory.MAX_PENDING_CALLS_DEFAULT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -70,18 +69,17 @@ public class AsyncTransformUsingServicePTest extends SimpleTestInClusterSupport 
     private ProcessorSupplier getSupplier(
             BiFunctionEx<? super String, ? super String, CompletableFuture<Traverser<String>>> mapFn
     ) {
-        return getSupplier(MAX_PENDING_CALLS_DEFAULT, mapFn);
+        return getSupplier(AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS, mapFn);
     }
 
     private ProcessorSupplier getSupplier(
-            int maxPendingCalls,
+            int maxAsyncOps,
             BiFunctionEx<? super String, ? super String, CompletableFuture<Traverser<String>>> mapFn
     ) {
         ServiceFactory<?, String> serviceFactory = ServiceFactories
-                .nonSharedService(pctx -> "foo")
-                .withMaxPendingCallsPerProcessor(maxPendingCalls);
-        return ordered ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, mapFn) :
-                AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, mapFn, FunctionEx.identity());
+                .nonSharedService(pctx -> "foo");
+        return ordered ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, maxAsyncOps, mapFn) :
+                AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, maxAsyncOps, mapFn, FunctionEx.identity());
     }
 
     @BeforeClass

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
@@ -21,11 +21,13 @@ import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.config.EdgeConfig;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.core.Vertex;
 import com.hazelcast.jet.core.WatermarkPolicy;
 import com.hazelcast.jet.core.processor.SinkProcessors;
@@ -63,7 +65,6 @@ import static com.hazelcast.jet.core.EventTimePolicy.eventTimePolicy;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
-import static com.hazelcast.jet.core.processor.Processors.flatMapUsingServiceAsyncP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.jet.pipeline.ServiceFactories.sharedService;
@@ -145,10 +146,12 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
                         WatermarkPolicy.limitingLag(10),
                         10, 0, 0
                 )), 5000));
-        Vertex map = dag.newVertex("map",
-                flatMapUsingServiceAsyncP(serviceFactory, identity(), transformNotPartitionedFn(
-                        item -> traverseItems(item + "-1", item + "-2", item + "-3", item + "-4", item + "-5"))))
-                        .localParallelism(2);
+        BiFunctionEx<ExecutorService, Integer, CompletableFuture<Traverser<String>>> flatMapAsyncFn =
+                transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"));
+        ProcessorSupplier processorSupplier = serviceFactory.hasOrderedAsyncResponses()
+                ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, flatMapAsyncFn)
+                : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, flatMapAsyncFn, identity());
+        Vertex map = dag.newVertex("map", processorSupplier).localParallelism(2);
         Vertex sink = dag.newVertex("sink", SinkProcessors.writeListP(sinkList.getName()));
 
         // Use a shorter queue to not block the barrier from the source for too long due to
@@ -178,20 +181,6 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
     }
 
     @Test
-    public void test_pipelineApi_flatMapNotPartitioned() {
-        Pipeline p = Pipeline.create();
-        p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
-         .withoutTimestamps()
-         .flatMapUsingServiceAsync(serviceFactory,
-                 transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5")))
-         .setLocalParallelism(2)
-         .writeTo(Sinks.list(sinkList));
-
-        instance().newJob(p, jobConfig);
-        assertResultEventually(i -> Stream.of(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"), NUM_ITEMS);
-    }
-
-    @Test
     public void test_pipelineApi_mapNotPartitioned() {
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
@@ -203,21 +192,6 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
 
         instance().newJob(p, jobConfig);
         assertResultEventually(i -> Stream.of(i + "-1"), NUM_ITEMS);
-    }
-
-    @Test
-    public void test_pipelineApi_flatMapPartitioned() {
-        Pipeline p = Pipeline.create();
-        p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
-         .withoutTimestamps()
-         .groupingKey(i -> i % 10)
-         .flatMapUsingServiceAsync(serviceFactory,
-                 transformPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5")))
-         .setLocalParallelism(2)
-         .writeTo(Sinks.list(sinkList));
-
-        instance().newJob(p, jobConfig);
-        assertResultEventually(i -> Stream.of(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"), NUM_ITEMS);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
@@ -114,9 +114,6 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
         jobConfig = new JobConfig().setProcessingGuarantee(EXACTLY_ONCE).setSnapshotIntervalMillis(0);
 
         serviceFactory = sharedService(pctx -> Executors.newFixedThreadPool(8), ExecutorService::shutdown);
-        if (!ordered) {
-            serviceFactory = serviceFactory.withUnorderedAsyncResponses();
-        }
     }
 
     @Test
@@ -149,7 +146,7 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
                 )), 5000));
         BiFunctionEx<ExecutorService, Integer, CompletableFuture<Traverser<String>>> flatMapAsyncFn =
                 transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"));
-        ProcessorSupplier processorSupplier = serviceFactory.hasOrderedAsyncResponses()
+        ProcessorSupplier processorSupplier = ordered
                 ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, MAX_ASYNC_OPS, flatMapAsyncFn)
                 : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, MAX_ASYNC_OPS, flatMapAsyncFn, identity());
         Vertex map = dag.newVertex("map", processorSupplier).localParallelism(2);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
@@ -206,20 +206,6 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
     }
 
     @Test
-    public void test_pipelineApi_filterNotPartitioned() {
-        Pipeline p = Pipeline.create();
-        p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
-         .withoutTimestamps()
-         .filterUsingServiceAsync(serviceFactory,
-                 transformNotPartitionedFn(i -> i % 2 == 0))
-         .setLocalParallelism(2)
-         .writeTo(Sinks.list(sinkList));
-
-        instance().newJob(p, jobConfig);
-        assertResultEventually(i -> i % 2 == 0 ? Stream.of(i + "") : Stream.empty(), NUM_ITEMS);
-    }
-
-    @Test
     public void test_pipelineApi_flatMapPartitioned() {
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
@@ -247,21 +233,6 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
 
         instance().newJob(p, jobConfig);
         assertResultEventually(i -> Stream.of(i + "-1"), NUM_ITEMS);
-    }
-
-    @Test
-    public void test_pipelineApi_filterPartitioned() {
-        Pipeline p = Pipeline.create();
-        p.readFrom(Sources.mapJournal(journaledMap, START_FROM_OLDEST, EventJournalMapEvent::getNewValue, alwaysTrue()))
-         .withoutTimestamps()
-         .groupingKey(i -> i % 10)
-         .filterUsingServiceAsync(serviceFactory,
-                 transformPartitionedFn(i -> i % 2 == 0))
-         .setLocalParallelism(2)
-         .writeTo(Sinks.list(sinkList));
-
-        instance().newJob(p, jobConfig);
-        assertResultEventually(i -> i % 2 == 0 ? Stream.of(i + "") : Stream.empty(), NUM_ITEMS);
     }
 
     private <R> BiFunctionEx<ExecutorService, Integer, CompletableFuture<R>> transformNotPartitionedFn(

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
@@ -66,6 +66,7 @@ import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.jet.pipeline.ServiceFactories.sharedService;
 import static java.util.Arrays.asList;
@@ -149,8 +150,8 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
         BiFunctionEx<ExecutorService, Integer, CompletableFuture<Traverser<String>>> flatMapAsyncFn =
                 transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"));
         ProcessorSupplier processorSupplier = serviceFactory.hasOrderedAsyncResponses()
-                ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, flatMapAsyncFn)
-                : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, flatMapAsyncFn, identity());
+                ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, MAX_ASYNC_OPS, flatMapAsyncFn)
+                : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, MAX_ASYNC_OPS, flatMapAsyncFn, identity());
         Vertex map = dag.newVertex("map", processorSupplier).localParallelism(2);
         Vertex sink = dag.newVertex("sink", SinkProcessors.writeListP(sinkList.getName()));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/AsyncTransformUsingServiceP_IntegrationTest.java
@@ -66,7 +66,7 @@ import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.TestUtil.throttle;
 import static com.hazelcast.jet.core.processor.SourceProcessors.streamMapP;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_CONCURRENT_OPS;
 import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDEST;
 import static com.hazelcast.jet.pipeline.ServiceFactories.sharedService;
 import static java.util.Arrays.asList;
@@ -147,8 +147,10 @@ public class AsyncTransformUsingServiceP_IntegrationTest extends SimpleTestInClu
         BiFunctionEx<ExecutorService, Integer, CompletableFuture<Traverser<String>>> flatMapAsyncFn =
                 transformNotPartitionedFn(i -> traverseItems(i + "-1", i + "-2", i + "-3", i + "-4", i + "-5"));
         ProcessorSupplier processorSupplier = ordered
-                ? AsyncTransformUsingServiceOrderedP.supplier(serviceFactory, MAX_ASYNC_OPS, flatMapAsyncFn)
-                : AsyncTransformUsingServiceUnorderedP.supplier(serviceFactory, MAX_ASYNC_OPS, flatMapAsyncFn, identity());
+                ? AsyncTransformUsingServiceOrderedP.supplier(
+                        serviceFactory, MAX_CONCURRENT_OPS, flatMapAsyncFn)
+                : AsyncTransformUsingServiceUnorderedP.supplier(
+                        serviceFactory, MAX_CONCURRENT_OPS, flatMapAsyncFn, identity());
         Vertex map = dag.newVertex("map", processorSupplier).localParallelism(2);
         Vertex sink = dag.newVertex("sink", SinkProcessors.writeListP(sinkList.getName()));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -177,35 +177,7 @@ public class ProcessorTransformParallelismTest {
                         stage -> stage
                                 .groupingKey(i -> i)
                                 .flatMapUsingService(NC_SERVICE_FACTORY, (c, k, t) -> Traversers.empty()),
-                        "flatMapUsingPartitionedService"),
-                createParamSet(
-                        stage -> stage
-                                .flatMapUsingServiceAsync(SERVICE_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .flatMapUsingServiceAsync(SERVICE_FACTORY, (c, t) -> supplyAsync(Traversers::empty)),
-                        stage -> stage
-                                .flatMapUsingServiceAsync(NC_SERVICE_FACTORY, (c, t) -> supplyAsync(Traversers::<Integer>empty))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .flatMapUsingServiceAsync(NC_SERVICE_FACTORY, (c, t) -> supplyAsync(Traversers::empty)),
-                        "flatMapUsingServiceAsync"),
-                createParamSet(
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .flatMapUsingServiceAsync(SERVICE_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .flatMapUsingServiceAsync(SERVICE_FACTORY, (c, k, t) -> supplyAsync(Traversers::empty)),
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .flatMapUsingServiceAsync(NC_SERVICE_FACTORY, (c, k, t) -> supplyAsync(Traversers::<Integer>empty))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .flatMapUsingServiceAsync(NC_SERVICE_FACTORY, (c, k, t) -> supplyAsync(Traversers::empty)),
-                        "flatMapUsingPartitionedServiceAsync")
+                        "flatMapUsingPartitionedService")
         );
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -152,34 +152,6 @@ public class ProcessorTransformParallelismTest {
                         "filterUsingPartitionedService"),
                 createParamSet(
                         stage -> stage
-                                .filterUsingServiceAsync(SERVICE_FACTORY, (c, t) -> supplyAsync(() -> false))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .filterUsingServiceAsync(SERVICE_FACTORY, (c, t) -> supplyAsync(() -> false)),
-                        stage -> stage
-                                .filterUsingServiceAsync(NC_SERVICE_FACTORY, (c, t) -> supplyAsync(() -> false))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .filterUsingServiceAsync(NC_SERVICE_FACTORY, (c, t) -> supplyAsync(() -> false)),
-                        "filterUsingServiceAsync"),
-                createParamSet(
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .filterUsingServiceAsync(SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> false))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .filterUsingServiceAsync(SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> false)),
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .filterUsingServiceAsync(NC_SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> false))
-                                .setLocalParallelism(LOCAL_PARALLELISM),
-                        stage -> stage
-                                .groupingKey(i -> i)
-                                .filterUsingServiceAsync(NC_SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> false)),
-                        "filterUsingPartitionedServiceAsync"),
-                createParamSet(
-                        stage -> stage
                                 .flatMapUsingService(SERVICE_FACTORY, (c, t) -> Traversers.<Integer>empty())
                                 .setLocalParallelism(LOCAL_PARALLELISM),
                         stage -> stage

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.jet.impl.pipeline.transform.ProcessorTransform.NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
 import static com.hazelcast.jet.pipeline.ServiceFactory.withCreateContextFn;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.junit.Assert.assertEquals;
@@ -109,18 +110,18 @@ public class ProcessorTransformParallelismTest {
                 createParamSet(
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> t))
+                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t))
                                 .setLocalParallelism(LOCAL_PARALLELISM),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> t)),
+                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t)),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> t))
+                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t))
                                 .setLocalParallelism(LOCAL_PARALLELISM),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, (c, k, t) -> supplyAsync(() -> t)),
+                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t)),
                         "mapUsingPartitionedServiceAsync"),
                 createParamSet(
                         stage -> stage

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 
 import static com.hazelcast.jet.impl.pipeline.transform.ProcessorTransform.NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM;
 import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.ORDERED_ASYNC_RESPONSES;
 import static com.hazelcast.jet.pipeline.ServiceFactory.withCreateContextFn;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.junit.Assert.assertEquals;
@@ -110,18 +111,18 @@ public class ProcessorTransformParallelismTest {
                 createParamSet(
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t))
+                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t))
                                 .setLocalParallelism(LOCAL_PARALLELISM),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t)),
+                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t)),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t))
+                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t))
                                 .setLocalParallelism(LOCAL_PARALLELISM),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, (c, k, t) -> supplyAsync(() -> t)),
+                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t)),
                         "mapUsingPartitionedServiceAsync"),
                 createParamSet(
                         stage -> stage

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/ProcessorTransformParallelismTest.java
@@ -33,8 +33,8 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static com.hazelcast.jet.impl.pipeline.transform.ProcessorTransform.NON_COOPERATIVE_DEFAULT_LOCAL_PARALLELISM;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_ASYNC_OPS;
-import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.ORDERED_ASYNC_RESPONSES;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.MAX_CONCURRENT_OPS;
+import static com.hazelcast.jet.impl.processor.AbstractAsyncTransformUsingServiceP.PRESERVE_ORDER;
 import static com.hazelcast.jet.pipeline.ServiceFactory.withCreateContextFn;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.junit.Assert.assertEquals;
@@ -111,18 +111,18 @@ public class ProcessorTransformParallelismTest {
                 createParamSet(
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t))
+                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_CONCURRENT_OPS, PRESERVE_ORDER, (c, k, t) -> supplyAsync(() -> t))
                                 .setLocalParallelism(LOCAL_PARALLELISM),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t)),
+                                .mapUsingServiceAsync(SERVICE_FACTORY, MAX_CONCURRENT_OPS, PRESERVE_ORDER, (c, k, t) -> supplyAsync(() -> t)),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t))
+                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_CONCURRENT_OPS, PRESERVE_ORDER, (c, k, t) -> supplyAsync(() -> t))
                                 .setLocalParallelism(LOCAL_PARALLELISM),
                         stage -> stage
                                 .groupingKey(i -> i)
-                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_ASYNC_OPS, ORDERED_ASYNC_RESPONSES, (c, k, t) -> supplyAsync(() -> t)),
+                                .mapUsingServiceAsync(NC_SERVICE_FACTORY, MAX_CONCURRENT_OPS, PRESERVE_ORDER, (c, k, t) -> supplyAsync(() -> t)),
                         "mapUsingPartitionedServiceAsync"),
                 createParamSet(
                         stage -> stage

--- a/reference-manual/src/main/asciidoc/work-with-jet/log-debug.adoc
+++ b/reference-manual/src/main/asciidoc/work-with-jet/log-debug.adoc
@@ -250,10 +250,10 @@ the ordinal of the edge or has the value _snapshot_ for output items
 written to state snapshot.
 
 |**numInFlightOps**: The number of pending (in flight) operations when using
-asynchronous flat-mapping processors. +
+asynchronous mapping processors. +
 See
-`{jet-javadoc}/core/processor/Processors.html#flatMapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-com.hazelcast.jet.function.FunctionEx-com.hazelcast.jet.function.BiFunctionEx-[
-Processors.flatMapUsingServiceAsyncP]`.
+`{jet-javadoc}/core/processor/Processors.html#mapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-[
+Processors.mapUsingServiceAsyncP]`.
 
 ** totalKeys **: The number of active keys being tracked by a session window
 processor. +


### PR DESCRIPTION
Add description here

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] Any breaking changes are documented

Fixes mandatory parts of #1909 (optional parts will be in separate PR).

List of breaking changes:
* `filterUsingServiceAsync` operation removed from all stages and processors
* `flatMapUsingServiceAsync` operation removed from all stages and processors
* asynchronous processing specific parameters moved from `ServiceFactory` to `mapUsingServiceAsync` operation of stages & processors
