### PR TITLE
Make sure mapUsingServiceAsyncBatched can do filtering

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -389,9 +389,8 @@ public interface GeneralStage<T> extends Stage {
      * a list of input items and returns a {@code CompletableFuture<List<R>>}.
      * The size of the input list is limited by the given {@code maxBatchSize}.
      * <p>
-     * As opposed to the non-batched variant, this transform cannot perform
-     * filtering. The output list's items must match one-to-one with the input
-     * list's.
+     * This transform can perform filtering by putting {@code null} elements into
+     * the output list.
      * <p>
      * The latency of the async call will add to the total latency of the
      * output.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStageWithKey.java
@@ -323,9 +323,8 @@ public interface GeneralStageWithKey<T, K> {
      * a list of input items and returns a {@code CompletableFuture<List<R>>}.
      * The size of list is limited by the given {@code maxBatchSize}.
      * <p>
-     * As opposed to the non-batched variant, this transform cannot perform
-     * filtering. The output list's items must match one-to-one with the input
-     * lists'.
+     * This transform can perform filtering by putting {@code null} elements into
+     * the output list.
      * <p>
      * The latency of the async call will add to the total latency of the
      * output.
@@ -372,8 +371,8 @@ public interface GeneralStageWithKey<T, K> {
      * {@code maxBatchSize}. The key at index N corresponds to the input item
      * at index N.
      * <p>
-     * As opposed to the non-batched variant, this transform cannot perform
-     * filtering. The output list's items must match one-to-one with the input
+     * This transform can perform filtering by putting {@code null} elements into
+     * the output list.
      * lists'.
      * <p>
      * The latency of the async call will add to the total latency of the

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
@@ -470,11 +470,6 @@ public class BatchStageTest extends PipelineTestSupport {
                             assertTrue("list size", items.size() <= batchSize && items.size() > 0);
                             assertEquals("lists size equality", items.size(), keys.size());
                             executor.schedule(() -> {
-                                /*List<String> results = new ArrayList<>(items.size());
-                                for (int i = 0; i < items.size(); i++) {
-                                    results.set(i, i % 13 == 0 || keys.get(i) == 0 ? null : formatFn.apply(suffix, items.get(i)));
-                                }
-                                f.complete(results);*/
                                 List<String> results = items.isEmpty() ? Collections.emptyList() : new ArrayList<>();
                                 for (int i = 0; i < items.size(); i++) {
                                     Integer item = items.get(i);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
@@ -276,6 +276,43 @@ public class BatchStageTest extends PipelineTestSupport {
     }
 
     @Test
+    public void mapUsingServiceAsyncBatched_withFiltering() {
+        ServiceFactory<?, ScheduledExecutorService> serviceFactory = sharedService(
+                pctx -> Executors.newScheduledThreadPool(8), ExecutorService::shutdown
+        );
+
+        // Given
+        List<Integer> input = sequence(itemCount);
+        BiFunctionEx<String, Integer, String> formatFn = (suffix, i) -> String.format("%04d%s", i, suffix);
+        String suffix = "-context";
+
+        // When
+        int batchSize = 4;
+        BatchStage<String> mapped = batchStageFromList(input).mapUsingServiceAsyncBatched(serviceFactory, batchSize,
+                (executor, list) -> {
+                    CompletableFuture<List<String>> f = new CompletableFuture<>();
+                    assertTrue("list size", list.size() <= batchSize && list.size() > 0);
+                    executor.schedule(() -> {
+                        List<String> result = list.stream()
+                                .map(i -> i % 13 == 0 ? null : formatFn.apply(suffix, i))
+                                .collect(toList());
+                        f.complete(result);
+                    }, 10, TimeUnit.MILLISECONDS);
+                    return f;
+                }
+        );
+
+        // Then
+        mapped.writeTo(sink);
+        execute();
+        assertEquals(
+                streamToString(input.stream()
+                        .filter(i -> i % 13 != 0)
+                        .map(i -> formatFn.apply(suffix, i)), identity()),
+                streamToString(sinkList.stream(), Object::toString));
+    }
+
+    @Test
     public void mapUsingService_keyed() {
         // Given
         List<Integer> input = sequence(itemCount);
@@ -407,6 +444,56 @@ public class BatchStageTest extends PipelineTestSupport {
         execute();
         assertEquals(
                 streamToString(input.stream(), i -> formatFn.apply(suffix, i)),
+                streamToString(sinkStreamOf(String.class), identity()));
+    }
+
+    @Test
+    public void mapUsingServiceAsyncBatched_keyed_withFiltering() {
+        ServiceFactory<?, ScheduledExecutorService> serviceFactory = sharedService(
+                pctx -> Executors.newScheduledThreadPool(8), ExecutorService::shutdown
+        );
+
+        // Given
+        List<Integer> input = sequence(itemCount);
+        BiFunctionEx<String, Integer, String> formatFn = (suffix, i) -> String.format("%04d%s", i, suffix);
+        String suffix = "-context";
+
+        // When
+        int batchSize = 32;
+        BatchStage<String> mapped = batchStageFromList(input)
+                .groupingKey(i -> i % 23)
+                .mapUsingServiceAsyncBatched(
+                        serviceFactory,
+                        batchSize,
+                        (executor, keys, items) -> {
+                            CompletableFuture<List<String>> f = new CompletableFuture<>();
+                            assertTrue("list size", items.size() <= batchSize && items.size() > 0);
+                            assertEquals("lists size equality", items.size(), keys.size());
+                            executor.schedule(() -> {
+                                /*List<String> results = new ArrayList<>(items.size());
+                                for (int i = 0; i < items.size(); i++) {
+                                    results.set(i, i % 13 == 0 || keys.get(i) == 0 ? null : formatFn.apply(suffix, items.get(i)));
+                                }
+                                f.complete(results);*/
+                                List<String> results = items.isEmpty() ? Collections.emptyList() : new ArrayList<>();
+                                for (int i = 0; i < items.size(); i++) {
+                                    Integer item = items.get(i);
+                                    Integer key = keys.get(i);
+                                    results.add(item % 13 == 0 || key == 0 ? null : formatFn.apply(suffix, item));
+                                }
+                                f.complete(results);
+                            }, 10, TimeUnit.MILLISECONDS);
+                            return f;
+                        }
+                );
+
+        // Then
+        mapped.writeTo(sink);
+        execute();
+        assertEquals(
+                streamToString(input.stream()
+                        .filter(i -> i % 13 != 0 && i % 23 != 0)
+                        .map(i -> formatFn.apply(suffix, i)), identity()),
                 streamToString(sinkStreamOf(String.class), identity()));
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -640,11 +640,6 @@ public class StreamStageTest extends PipelineStreamTestSupport {
                             assertTrue("list size", items.size() <= batchSize && items.size() > 0);
                             assertEquals("lists size equality", items.size(), keys.size());
                             executor.schedule(() -> {
-                                /*List<String> results = new ArrayList<>(items.size());
-                                for (int i = 0; i < items.size(); i++) {
-                                    results.set(i, i % 13 == 0 || keys.get(i) == 0 ? null : formatFn.apply(suffix, items.get(i)));
-                                }
-                                f.complete(results);*/
                                 List<String> results = items.isEmpty() ? Collections.emptyList() : new ArrayList<>();
                                 for (int i = 0; i < items.size(); i++) {
                                     Integer item = items.get(i);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -40,6 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -446,6 +447,43 @@ public class StreamStageTest extends PipelineStreamTestSupport {
     }
 
     @Test
+    public void mapUsingServiceAsyncBatched_withFiltering() {
+        ServiceFactory<?, ScheduledExecutorService> serviceFactory = sharedService(
+                pctx -> Executors.newScheduledThreadPool(8), ExecutorService::shutdown
+        );
+
+        // Given
+        List<Integer> input = sequence(itemCount);
+        BiFunctionEx<String, Integer, String> formatFn = (suffix, i) -> String.format("%04d%s", i, suffix);
+        String suffix = "-context";
+
+        // When
+        int batchSize = 4;
+        StreamStage<String> mapped = streamStageFromList(input).mapUsingServiceAsyncBatched(serviceFactory, batchSize,
+                (executor, list) -> {
+                    CompletableFuture<List<String>> f = new CompletableFuture<>();
+                    assertTrue("list size", list.size() <= batchSize && list.size() > 0);
+                    executor.schedule(() -> {
+                        List<String> result = list.stream()
+                                .map(i -> i % 13 == 0 ? null : formatFn.apply(suffix, i))
+                                .collect(toList());
+                        f.complete(result);
+                    }, 10, TimeUnit.MILLISECONDS);
+                    return f;
+                }
+        );
+
+        // Then
+        mapped.writeTo(sink);
+        execute();
+        assertEquals(
+                streamToString(input.stream()
+                        .filter(i -> i % 13 != 0)
+                        .map(i -> formatFn.apply(suffix, i)), identity()),
+                streamToString(sinkList.stream(), Object::toString));
+    }
+
+    @Test
     public void mapUsingService_keyed() {
         // Given
         List<Integer> input = sequence(itemCount);
@@ -577,6 +615,56 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         assertEquals(
                 streamToString(input.stream().map(i -> formatFn.apply(suffix, i)), identity()),
                 streamToString(sinkList.stream(), Object::toString));
+    }
+
+    @Test
+    public void mapUsingServiceAsyncBatched_keyed_withFiltering() {
+        ServiceFactory<?, ScheduledExecutorService> serviceFactory = sharedService(
+                pctx -> Executors.newScheduledThreadPool(8), ExecutorService::shutdown
+        );
+
+        // Given
+        List<Integer> input = sequence(itemCount);
+        BiFunctionEx<String, Integer, String> formatFn = (suffix, i) -> String.format("%04d%s", i, suffix);
+        String suffix = "-context";
+
+        // When
+        int batchSize = 32;
+        StreamStage<String> mapped = streamStageFromList(input)
+                .groupingKey(i -> i % 23)
+                .mapUsingServiceAsyncBatched(
+                        serviceFactory,
+                        batchSize,
+                        (executor, keys, items) -> {
+                            CompletableFuture<List<String>> f = new CompletableFuture<>();
+                            assertTrue("list size", items.size() <= batchSize && items.size() > 0);
+                            assertEquals("lists size equality", items.size(), keys.size());
+                            executor.schedule(() -> {
+                                /*List<String> results = new ArrayList<>(items.size());
+                                for (int i = 0; i < items.size(); i++) {
+                                    results.set(i, i % 13 == 0 || keys.get(i) == 0 ? null : formatFn.apply(suffix, items.get(i)));
+                                }
+                                f.complete(results);*/
+                                List<String> results = items.isEmpty() ? Collections.emptyList() : new ArrayList<>();
+                                for (int i = 0; i < items.size(); i++) {
+                                    Integer item = items.get(i);
+                                    Integer key = keys.get(i);
+                                    results.add(item % 13 == 0 || key == 0 ? null : formatFn.apply(suffix, item));
+                                }
+                                f.complete(results);
+                            }, 10, TimeUnit.MILLISECONDS);
+                            return f;
+                        }
+                );
+
+        // Then
+        mapped.writeTo(sink);
+        execute();
+        assertEquals(
+                streamToString(input.stream()
+                        .filter(i -> i % 13 != 0 && i % 23 != 0)
+                        .map(i -> formatFn.apply(suffix, i)), identity()),
+                streamToString(sinkStreamOf(String.class), identity()));
     }
 
     @Test


### PR DESCRIPTION
`mapUsingServiceAsyncBatched` should be able to be used for filtering to, by setting `null` values in the output lists.

Checklist
- [x] Tags Set
- [x] Milestone Set

Fixes #1909