### PR TITLE
Improve log formatting, fix bad folder name

### DIFF
--- a/hazelcast-jet-distribution/src/root/config/log4j.properties
+++ b/hazelcast-jet-distribution/src/root/config/log4j.properties
@@ -17,12 +17,12 @@ log4j.rootLogger=INFO, stdout, rollingFile
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d %5p [%c{1}] [%t] - %m%n
+log4j.appender.stdout.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d %5p [%c{1.}] [%t] - %m%n
 
 log4j.appender.rollingFile=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.rollingFile.DatePattern='.'yyyy-MM-dd
-log4j.appender.rollingFile.File=@jet.home@/logs/hazelcast-jet.log
+log4j.appender.rollingFile.File=${jet.home}/logs/hazelcast-jet.log
 log4j.appender.rollingFile.layout=org.apache.log4j.PatternLayout
 log4j.appender.rollingFile.layout.ConversionPattern=%d %5p [%c{1}] [%t] - %m%n
 


### PR DESCRIPTION
logs were being written to a `@jet.home@` folder. Also use abbreviated class names for the logger.