### PR TITLE
Improve default log experience

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -71,6 +71,7 @@ public final class Jet {
     private static final ILogger LOGGER = Logger.getLogger(Jet.class);
 
     static {
+        JetBootstrap.configureLogging();
         assertHazelcastVersion();
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetBootstrap.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetBootstrap.java
@@ -49,6 +49,7 @@ import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.jar.JarFile;
 import java.util.logging.LogManager;
@@ -73,6 +74,7 @@ public final class JetBootstrap {
     private static ConcurrentMemoizingSupplier<JetInstance> supplier;
 
     private static final ILogger LOGGER = Logger.getLogger(Jet.class.getName());
+    private static final AtomicBoolean LOGGING_CONFIGURED = new AtomicBoolean(false);
 
     private JetBootstrap() {
     }
@@ -167,8 +169,10 @@ public final class JetBootstrap {
     }
 
     public static void configureLogging() {
-        InputStream input = JetBootstrap.class.getClassLoader().getResourceAsStream("logging.properties");
-        Util.uncheckRun(() -> LogManager.getLogManager().readConfiguration(input));
+        if (LOGGING_CONFIGURED.compareAndSet(false, true)) {
+            InputStream input = JetBootstrap.class.getClassLoader().getResourceAsStream("logging.properties");
+            Util.uncheckRun(() -> LogManager.getLogManager().readConfiguration(input));
+        }
     }
 
     private static class InstanceProxy extends AbstractJetInstance {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetBootstrap.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetBootstrap.java
@@ -41,6 +41,7 @@ import com.hazelcast.topic.ITopic;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -170,8 +171,11 @@ public final class JetBootstrap {
 
     public static void configureLogging() {
         if (LOGGING_CONFIGURED.compareAndSet(false, true)) {
-            InputStream input = JetBootstrap.class.getClassLoader().getResourceAsStream("logging.properties");
-            Util.uncheckRun(() -> LogManager.getLogManager().readConfiguration(input));
+            try (InputStream input = JetBootstrap.class.getClassLoader().getResourceAsStream("logging.properties")) {
+                Util.uncheckRun(() -> LogManager.getLogManager().readConfiguration(input));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.util;
+
+import com.hazelcast.instance.BuildInfoProvider;
+
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+import java.util.logging.StreamHandler;
+
+public class JetLogHandler extends StreamHandler {
+
+    public JetLogHandler() {
+        super(System.out, new JetLogFormatter());
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        // sync method call, we should implement own logger here.
+        super.publish(record);
+        flush();
+    }
+
+    private static class JetLogFormatter extends Formatter {
+
+        /**
+         * Temporary, remove after https://github.com/hazelcast/hazelcast/pull/16622 is merged
+         * Currently the filtering doesn't work for client, because it uses IMDG version.
+         */
+        private static final String VERSION_STR =
+                "[" + BuildInfoProvider.getBuildInfo().getJetBuildInfo().getVersion() + "]";
+
+        private static final boolean ENABLE_DETAILS = Boolean.parseBoolean(
+                getDetailsProperty());
+
+        private static String getDetailsProperty() {
+            return System.getProperties().getProperty("hazelcast.logging.details.enabled", "false");
+        }
+
+        @Override
+        public String format(LogRecord record) {
+            String loggerName = record.getLoggerName();
+            int idx = loggerName.lastIndexOf((int) '.');
+            if (idx > 0 && loggerName.length() > idx + 1) {
+                loggerName = loggerName.substring(idx + 1);
+            }
+            String message = record.getMessage();
+            if (!ENABLE_DETAILS) {
+                int versionIdx = message.indexOf(VERSION_STR);
+                if (versionIdx > 0) {
+                    message = message.substring(versionIdx + VERSION_STR.length() + 1);
+                }
+            }
+            return String.format("%s [%7s] [%25s] %s%n",
+                    Util.toLocalTime(record.getMillis()),
+                    record.getLevel(),
+                    loggerName,
+                    message);
+        }
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
@@ -94,7 +94,7 @@ public class JetLogHandler extends StreamHandler {
         private static String getLoggerName(String name) {
             // abbreviate package names, credit Martin Ender:
             // https://codegolf.stackexchange.com/questions/119126/shorten-the-java-package/119133#119133
-            return name.replaceAll("\\B\\w+(\\.[a-zA-Z])","$1");
+            return name.replaceAll("\\B\\w+(\\.[a-zA-Z])", "$1");
         }
 
         private static String getExceptionString(LogRecord record) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
@@ -62,6 +62,8 @@ public class JetLogHandler extends StreamHandler {
         private static final int ERROR_LEVEL = 1000;
         private static final int WARNING_LEVEL = 900;
         private static final int INFO_LEVEL = 800;
+        private static final int DEBUG_LEVEL = 500;
+        private static final int TRACE_LEVEL = 400;
 
         private static String getDetailsProperty() {
             return System.getProperties().getProperty("hazelcast.logging.details.enabled", "false");
@@ -69,11 +71,7 @@ public class JetLogHandler extends StreamHandler {
 
         @Override
         public String format(LogRecord record) {
-            String loggerName = record.getLoggerName();
-            int idx = loggerName.lastIndexOf((int) '.');
-            if (idx > 0 && loggerName.length() > idx + 1) {
-                loggerName = loggerName.substring(idx + 1);
-            }
+            String loggerName = getLoggerName(record.getLoggerName());
             String message = record.getMessage();
             if (!ENABLE_DETAILS) {
                 int versionIdx = message.indexOf(VERSION_STR);
@@ -81,10 +79,10 @@ public class JetLogHandler extends StreamHandler {
                     message = message.substring(versionIdx + VERSION_STR.length() + 1);
                 }
             }
-            return String.format("%s [%s%7s%s] [%s%25s%s] %s%s",
+            return String.format("%s [%s%5s%s] [%s%s%s] %s%s",
                     Util.toLocalTime(record.getMillis()),
-                    getColor(record.getLevel()),
-                    record.getLevel(),
+                    getLevelColor(record.getLevel()),
+                    getLevel(record.getLevel()),
                     ANSI_RESET,
                     ANSI_BLUE,
                     loggerName,
@@ -93,7 +91,13 @@ public class JetLogHandler extends StreamHandler {
                     record.getThrown() == null ? System.lineSeparator() : getExceptionString(record));
         }
 
-        private String getExceptionString(LogRecord record) {
+        private static String getLoggerName(String name) {
+            // abbreviate package names, credit Martin Ender:
+            // https://codegolf.stackexchange.com/questions/119126/shorten-the-java-package/119133#119133
+            return name.replaceAll("\\B\\w+(\\.[a-z])","$1");
+        }
+
+        private static String getExceptionString(LogRecord record) {
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
             pw.write(System.lineSeparator());
@@ -103,7 +107,7 @@ public class JetLogHandler extends StreamHandler {
             return sw.toString();
         }
 
-        private String getColor(Level level) {
+        private static String getLevelColor(Level level) {
             switch (level.intValue()) {
                 case ERROR_LEVEL:
                     return ANSI_RED;
@@ -113,6 +117,23 @@ public class JetLogHandler extends StreamHandler {
                     return ANSI_GREEN;
                 default:
                     return ANSI_RESET;
+            }
+        }
+
+        private static String getLevel(Level level) {
+            switch (level.intValue()) {
+                case ERROR_LEVEL:
+                    return  "ERROR";
+                case WARNING_LEVEL:
+                    return  "WARN";
+                case INFO_LEVEL:
+                    return  "INFO";
+                case DEBUG_LEVEL:
+                    return  "DEBUG";
+                case TRACE_LEVEL:
+                    return  "TRACE";
+                default:
+                    return level.toString();
             }
         }
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
@@ -19,10 +19,21 @@ package com.hazelcast.jet.impl.util;
 import com.hazelcast.instance.BuildInfoProvider;
 
 import java.util.logging.Formatter;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.StreamHandler;
 
 public class JetLogHandler extends StreamHandler {
+
+    public static final String ANSI_RESET = "\u001B[0m";
+    public static final String ANSI_BLACK = "\u001B[30m";
+    public static final String ANSI_RED = "\u001B[31m";
+    public static final String ANSI_GREEN = "\u001B[32m";
+    public static final String ANSI_YELLOW = "\u001B[33m";
+    public static final String ANSI_BLUE = "\u001B[34m";
+    public static final String ANSI_PURPLE = "\u001B[35m";
+    public static final String ANSI_CYAN = "\u001B[36m";
+    public static final String ANSI_WHITE = "\u001B[37m";
 
     public JetLogHandler() {
         super(System.out, new JetLogFormatter());
@@ -65,11 +76,28 @@ public class JetLogHandler extends StreamHandler {
                     message = message.substring(versionIdx + VERSION_STR.length() + 1);
                 }
             }
-            return String.format("%s [%7s] [%25s] %s%n",
+            return String.format("%s [%s%7s%s] [%s%25s%s] %s%n",
                     Util.toLocalTime(record.getMillis()),
+                    getColor(record.getLevel()),
                     record.getLevel(),
+                    ANSI_RESET,
+                    ANSI_BLUE,
                     loggerName,
+                    ANSI_RESET,
                     message);
+        }
+
+        private String getColor(Level level) {
+            switch (level.intValue()) {
+                case 1000: // ERROR
+                    return ANSI_RED;
+                case 900: // WARN
+                    return ANSI_YELLOW;
+                case 800: // INFO
+                    return ANSI_GREEN;
+                default:
+                    return ANSI_RESET;
+            }
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
@@ -71,7 +71,7 @@ public class JetLogHandler extends StreamHandler {
 
         @Override
         public String format(LogRecord record) {
-            String loggerName = getLoggerName(record.getLoggerName());
+            String loggerName = abbreviateLoggerName(record.getLoggerName());
             String message = record.getMessage();
             if (!ENABLE_DETAILS) {
                 int versionIdx = message.indexOf(VERSION_STR);
@@ -91,10 +91,8 @@ public class JetLogHandler extends StreamHandler {
                     record.getThrown() == null ? System.lineSeparator() : getExceptionString(record));
         }
 
-        private static String getLoggerName(String name) {
-            // abbreviate package names, credit Martin Ender:
-            // https://codegolf.stackexchange.com/questions/119126/shorten-the-java-package/119133#119133
-            return name.replaceAll("\\B\\w+(\\.[a-zA-Z])", "$1");
+        private static String abbreviateLoggerName(String name) {
+            return name.replaceAll("\\B\\w+\\.", ".");
         }
 
         private static String getExceptionString(LogRecord record) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
@@ -94,7 +94,7 @@ public class JetLogHandler extends StreamHandler {
         private static String getLoggerName(String name) {
             // abbreviate package names, credit Martin Ender:
             // https://codegolf.stackexchange.com/questions/119126/shorten-the-java-package/119133#119133
-            return name.replaceAll("\\B\\w+(\\.[a-z])","$1");
+            return name.replaceAll("\\B\\w+(\\.[a-zA-Z])","$1");
         }
 
         private static String getExceptionString(LogRecord record) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetLogHandler.java
@@ -57,9 +57,7 @@ public class JetLogHandler extends StreamHandler {
         private static final String VERSION_STR =
                 "[" + BuildInfoProvider.getBuildInfo().getJetBuildInfo().getVersion() + "]";
 
-        private static final boolean ENABLE_DETAILS = Boolean.parseBoolean(
-                getDetailsProperty());
-
+        private static final boolean ENABLE_DETAILS = Boolean.parseBoolean(getDetailsProperty());
 
         private static final int ERROR_LEVEL = 1000;
         private static final int WARNING_LEVEL = 900;
@@ -107,11 +105,11 @@ public class JetLogHandler extends StreamHandler {
 
         private String getColor(Level level) {
             switch (level.intValue()) {
-                case ERROR_LEVEL: // ERROR
+                case ERROR_LEVEL:
                     return ANSI_RED;
-                case WARNING_LEVEL: // WARN
+                case WARNING_LEVEL:
                     return ANSI_YELLOW;
-                case INFO_LEVEL: // INFO
+                case INFO_LEVEL:
                     return ANSI_GREEN;
                 default:
                     return ANSI_RESET;

--- a/hazelcast-jet-core/src/main/resources/logging.properties
+++ b/hazelcast-jet-core/src/main/resources/logging.properties
@@ -14,7 +14,5 @@
 # limitations under the License.
 #
 
-handlers=java.util.logging.ConsoleHandler
+handlers=com.hazelcast.jet.impl.util.JetLogHandler
 .level=INFO
-java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
-java.util.logging.SimpleFormatter.format=[%1$tF %1$tT.%1$tL] [%4$-7s] %2$s - %5$s %6$s %n


### PR DESCRIPTION
Improve log experience when you don’t have log4j:

* print to stdout instead of stderr
* remove ip/cluster name/version information
* improved formatting

We should also consider not using java.util.logging at all
since every call is synchronized.

Add description here

Checklist
- [x] Tags Set
- [x] Milestone Set

See also: https://github.com/hazelcast/hazelcast/pull/16622