### PR TITLE
Fix handling JET_LICENSE_KEY for jet-start.

### DIFF
--- a/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
+++ b/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
@@ -23,9 +23,9 @@ $JDK_OPTS \
 $JAVA_OPTS \
 )
 
-LICENSING_OPTS_ARRAY=(\
-$LICENSING_OPTS \
-)
+if [ "$JET_LICENSE_KEY" ]; then
+    LICENSING_OPTS_ARRAY=("-Dhazelcast.enterprise.license.key=${JET_LICENSE_KEY}")
+fi
 
 echo "########################################"
 echo "# JAVA=$JAVA"

--- a/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
+++ b/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
@@ -23,6 +23,10 @@ $JDK_OPTS \
 $JAVA_OPTS \
 )
 
+LICENSING_OPTS_ARRAY=(\
+$LICENSING_OPTS \
+)
+
 echo "########################################"
 echo "# JAVA=$JAVA"
 echo "# JAVA_OPTS=${JAVA_OPTS_ARRAY[*]}"
@@ -33,9 +37,9 @@ if [[ "$DAEMON" = "true" ]]; then
     mkdir -p $JET_HOME/logs
     JET_LOG="$JET_HOME/logs/hazelcast-jet.out"
     echo "Starting Hazelcast Jet in daemon mode. Standard out and error will be written to $JET_LOG"
-    nohup $JAVA "${JAVA_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetMemberStarter > "$JET_LOG" 2>&1 &
+    nohup $JAVA "${JAVA_OPTS_ARRAY[@]}" "${LICENSING_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetMemberStarter > "$JET_LOG" 2>&1 &
 else
     echo "Starting Hazelcast Jet"
     set -x
-    $JAVA "${JAVA_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetMemberStarter
+    $JAVA "${JAVA_OPTS_ARRAY[@]}" "${LICENSING_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetMemberStarter
 fi

--- a/hazelcast-jet-distribution/src/bin-regular/common.sh
+++ b/hazelcast-jet-distribution/src/bin-regular/common.sh
@@ -27,8 +27,4 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
     "
 fi
 
-if [ "$JET_LICENSE_KEY" ]; then
-    LICENSING_OPTS="-Dhazelcast.enterprise.license.key=${JET_LICENSE_KEY}"
-fi
-
 CLASSPATH="$JET_HOME/lib/*:$CLASSPATH"

--- a/hazelcast-jet-distribution/src/bin-regular/common.sh
+++ b/hazelcast-jet-distribution/src/bin-regular/common.sh
@@ -28,7 +28,7 @@ if [ "$JAVA_VERSION" -ge "9" ]; then
 fi
 
 if [ "$JET_LICENSE_KEY" ]; then
-  JAVA_OPTS_ARRAY+=("-Dhazelcast.enterprise.license.key=${JET_LICENSE_KEY}")
+    LICENSING_OPTS="-Dhazelcast.enterprise.license.key=${JET_LICENSE_KEY}"
 fi
 
 CLASSPATH="$JET_HOME/lib/*:$CLASSPATH"


### PR DESCRIPTION
Fixed handling `JET_LICENSE_KEY` for Unix `jet-start`.

Checklist
- [x] Tags Set
- [x] Milestone Set

Fixes #1963