### PR TITLE
Add timestamp to stdout filename

### DIFF
--- a/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
+++ b/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
@@ -35,7 +35,8 @@ echo "########################################"
 
 if [[ "$DAEMON" = "true" ]]; then
     mkdir -p $JET_HOME/logs
-    JET_LOG="$JET_HOME/logs/hazelcast-jet.out"
+    DATE=`date "+%Y-%m-%d.%H.%M.%S"`
+    JET_LOG="$JET_HOME/logs/hazelcast-jet.$DATE.out"
     echo "Starting Hazelcast Jet in daemon mode. Standard out and error will be written to $JET_LOG"
     nohup $JAVA "${JAVA_OPTS_ARRAY[@]}" "${LICENSING_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetMemberStarter > "$JET_LOG" 2>&1 &
 else


### PR DESCRIPTION
When you start the node in daemon mode, the output filename will now have the timestamp appended to it to create a unique filename.

Checklist
- [x] Tags Set
- [x] Milestone Set

Links to issues fixed (if any):

Fixes #1964 