### PR TITLE
Add Evolving API annotation, and move TestSources/Sinks out of Beta

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
@@ -16,9 +16,9 @@
 package com.hazelcast.jet.python;
 
 import com.hazelcast.function.FunctionEx;
+import com.hazelcast.jet.annotation.EvolvingApi;
 import com.hazelcast.jet.pipeline.BatchStage;
 import com.hazelcast.jet.pipeline.StreamStage;
-import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 
@@ -32,7 +32,7 @@ import javax.annotation.Nonnull;
  *
  * @since 4.0
  */
-@Beta
+@EvolvingApi
 public final class PythonTransforms {
 
     private PythonTransforms() {

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/package-info.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/package-info.java
@@ -20,4 +20,7 @@
  * function. See {@link com.hazelcast.jet.python.PythonServiceConfig} for
  * more details.
  */
+@EvolvingApi
 package com.hazelcast.jet.python;
+
+import com.hazelcast.jet.annotation.EvolvingApi;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/annotation/EvolvingApi.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/annotation/EvolvingApi.java
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 
-/**
- * This package contains various mock sources to help with pipeline testing
- * and development.
- *
- * @since 3.2
- */
-package com.hazelcast.jet.pipeline.test;
+package com.hazelcast.jet.annotation;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the annotated class, method or interface has stable
+ * implementation but its API may change between minor versions.
+ *
+ * @since 4.0
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD, ElementType.FIELD})
+public @interface EvolvingApi {
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/annotation/package-info.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/annotation/package-info.java
@@ -15,10 +15,8 @@
  */
 
 /**
- * This package contains various mock sources to help with pipeline testing
- * and development.
+ * Annotations used for describing public API stability.
  *
- * @since 3.2
+ * @since 4.0
  */
-package com.hazelcast.jet.pipeline.test;
-
+package com.hazelcast.jet.annotation;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/AssertionCompletedException.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/AssertionCompletedException.java
@@ -17,7 +17,7 @@
 package com.hazelcast.jet.pipeline.test;
 
 import com.hazelcast.jet.Job;
-import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.jet.annotation.EvolvingApi;
 
 /**
  * An exception which indicates that an assertion passed successfully. It is
@@ -26,7 +26,7 @@ import com.hazelcast.spi.annotation.Beta;
  *
  * @since 3.2
  */
-@Beta
+@EvolvingApi
 public final class AssertionCompletedException extends RuntimeException {
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/AssertionSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/AssertionSinkBuilder.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.jet.impl.pipeline.SinkImpl;
 import com.hazelcast.jet.impl.pipeline.test.AssertionP;
 import com.hazelcast.jet.pipeline.Sink;
-import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 
@@ -37,7 +36,6 @@ import static com.hazelcast.jet.impl.util.Util.checkSerializable;
  *
  * @since 3.2
  */
-@Beta
 public final class AssertionSinkBuilder<S, T> {
 
     private final SupplierEx<? extends S> createFn;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/AssertionSinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/AssertionSinks.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.pipeline.test;
 
 import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.jet.pipeline.Sink;
-import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -43,7 +42,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  *
  * @since 3.2
  */
-@Beta
 public final class AssertionSinks {
 
     private AssertionSinks() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/Assertions.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/Assertions.java
@@ -20,7 +20,6 @@ import com.hazelcast.function.ConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.pipeline.BatchStage;
 import com.hazelcast.jet.pipeline.StreamStage;
-import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,7 +37,6 @@ import java.util.List;
  *
  * @since 3.2
  */
-@Beta
 public final class Assertions {
 
     private Assertions() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/GeneratorFunction.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/GeneratorFunction.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.pipeline.test;
 
-import com.hazelcast.spi.annotation.Beta;
-
 import java.io.Serializable;
 
 /**
@@ -28,7 +26,6 @@ import java.io.Serializable;
  * @since 3.2
  */
 @FunctionalInterface
-@Beta
 public interface GeneratorFunction<R> extends Serializable {
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/SimpleEvent.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/SimpleEvent.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.pipeline.test;
 
 import com.hazelcast.jet.impl.util.Util;
-import com.hazelcast.spi.annotation.Beta;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -27,7 +26,6 @@ import java.util.Objects;
  *
  * @since 3.2
  */
-@Beta
 public class SimpleEvent implements Serializable {
 
     private final long timestamp;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/TestSources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/test/TestSources.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.jet.pipeline.test;
 
+import com.hazelcast.jet.annotation.EvolvingApi;
 import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.SourceBuilder.TimestampedSourceBuffer;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.jet.pipeline.StreamSourceStage;
-import com.hazelcast.spi.annotation.Beta;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
@@ -36,7 +36,7 @@ import static com.hazelcast.jet.impl.util.Util.checkSerializable;
  *
  * @since 3.2
  */
-@Beta
+@EvolvingApi
 public final class TestSources {
 
     private TestSources() {
@@ -74,11 +74,12 @@ public final class TestSources {
      * Returns a streaming source which generates events of type {@link SimpleEvent} at
      * the specified rate infinitely.
      * <p>
-     * This source is not fault-tolerant. The sequence will be reset once a job
-     * is restarted. The source supports {@linkplain
+     * The source supports {@linkplain
      * StreamSourceStage#withNativeTimestamps(long) native timestamps}. The
      * timestamp is the current system time at the moment they are
-     * generated.
+     * generated. The source is not distributed and all the items are
+     * generated on the same node. This source is not fault-tolerant.
+     * The sequence will be reset once a job is restarted.
      * <p>
      * <b>Note:</b>
      * There is no absolute guarantee that the actual rate of emitted
@@ -89,6 +90,7 @@ public final class TestSources {
      *
      * @since 3.2
      */
+    @EvolvingApi
     @Nonnull
     public static StreamSource<SimpleEvent> itemStream(int itemsPerSecond) {
         return itemStream(itemsPerSecond, SimpleEvent::new);
@@ -98,11 +100,12 @@ public final class TestSources {
      * Returns a streaming source which generates events created by the {@code
      * generatorFn} at the specified rate infinitely.
      * <p>
-     * This source is not fault-tolerant. The sequence will be reset once a job
-     * is restarted. The source supports {@linkplain
+     * The source supports {@linkplain
      * StreamSourceStage#withNativeTimestamps(long) native timestamps}. The
      * timestamp is the current system time at the moment they are
-     * generated.
+     * generated. The source is not distributed and all the items are
+     * generated on the same node. This source is not fault-tolerant.
+     * The sequence will be reset once a job is restarted.
      * <p>
      * <b>Note:</b>
      * There is no absolute guarantee that the actual rate of emitted
@@ -115,6 +118,7 @@ public final class TestSources {
      *
      * @since 3.2
      */
+    @EvolvingApi
     @Nonnull
     public static <T> StreamSource<T> itemStream(
         int itemsPerSecond,

--- a/reference-manual/src/main/asciidoc/appendix.adoc
+++ b/reference-manual/src/main/asciidoc/appendix.adoc
@@ -20,8 +20,11 @@ However some exceptions apply:
 
 * Classes in `com.hazelcast.jet.core` package which form the
 <<expert-zone, Core API>> of Jet only provide PATCH level compatibility guarantee.
+* Types and methods annotated with `@EvolvingApi` only provide PATCH level
+compatibility guarantee. These are typically new features where the API is
+subject to further changes.
 * Classes in `impl` packages do not provide any compatibility
-guarantees between versions.
+guarantees between versions and should not be used.
 
 == Summary Table
 

--- a/reference-manual/src/main/asciidoc/pipeline-api/pipeline-api.adoc
+++ b/reference-manual/src/main/asciidoc/pipeline-api/pipeline-api.adoc
@@ -1048,9 +1048,6 @@ in a convenient way. Jet's Pipeline API offers some tools to help
 testing a pipeline without having to integrate with a real data source
 or sink.
 
-NOTE: These APIs are currently marked as `@Beta` and are not covered
-by the <<jet-version-compatibility, backward-compatibility guarantees>>.
-
 == Test Sources
 
 Jet provides some {jet-javadoc}/pipeline/test/TestSources.html[test and development sources]


### PR DESCRIPTION
* mark PythonTransforms as EvolvingAPI instead of Beta
* TestSinks/Sources are moved out of beta, except streaming source which is marked with EvolvingAPI

Checklist
- [x] Tags Set
- [x] Milestone Set

