### PR TITLE
Improve test for and fix bug related to job lifecycle metrics

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/metrics/MetricNames.java
@@ -225,6 +225,9 @@ public final class MetricNames {
      * Number of job executions started on the Jet cluster. Each job can
      * execute multiple times, for example when it's restarted or suspended
      * and then resumed.
+     * <p>
+     * This metric is zero on non-master members. When a master fails and a new
+     * master takes over, the count is reset.
      *
      * @since 4.0
      */
@@ -234,6 +237,9 @@ public final class MetricNames {
      * Number of job executions finished on the Jet cluster. Each job can
      * execute multiple times, for example when it's restarted or suspended
      * and then resumed.
+     * <p>
+     * This metric is zero on non-master members. When a master fails and a new
+     * master takes over, the count is reset.
      *
      * @since 4.0
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionService.java
@@ -345,6 +345,7 @@ public class JobExecutionService implements DynamicMetricsProvider {
                 com.hazelcast.jet.impl.util.Util.doWithClassLoader(removed, () ->
                     executionContext.completeExecution(error));
             } finally {
+                executionCompleted.inc();
                 removed.shutdown();
                 executionContextJobIds.remove(executionContext.jobId());
                 logger.fine("Completed execution of " + executionContext.jobNameAndExecutionId());
@@ -367,7 +368,6 @@ public class JobExecutionService implements DynamicMetricsProvider {
         executionStarted.inc();
         CompletableFuture<Void> future = execCtx.beginExecution();
         future.whenComplete(withTryCatch(logger, (i, e) -> {
-            executionCompleted.inc();
             if (e instanceof CancellationException) {
                 logger.fine("Execution of " + execCtx.jobNameAndExecutionId() + " was cancelled");
             } else if (e != null) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
@@ -146,6 +146,9 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
         Job job = jetInstances[0].newJob(streamingPipeline());
         assertJobStatusEventually(job, RUNNING);
 
+        assertTrueEventually(() -> assertJobStats(1, 1, 0, 0, 0));
+        assertTrueAllTheTime(() -> assertJobStats(1, 1, 0, 0, 0), 1);
+
         //when
         job.restart();
         assertJobStatusEventually(job, RUNNING);
@@ -159,6 +162,9 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
         //init
         Job job = jetInstances[0].newJob(streamingPipeline());
         assertJobStatusEventually(job, RUNNING);
+
+        assertTrueEventually(() -> assertJobStats(1, 1, 0, 0, 0));
+        assertTrueAllTheTime(() -> assertJobStats(1, 1, 0, 0, 0), 1);
 
         //when
         job.cancel();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
@@ -211,7 +211,8 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
 
     private void assertJobStats(int submitted, int executionsStarted, int executionsTerminated,
                                 int completedSuccessfully, int completedWithFailure) throws Exception {
-        assertJobStatsOnMember(jetInstances[0], submitted, executionsStarted, executionsTerminated, completedSuccessfully, completedWithFailure);
+        assertJobStatsOnMember(jetInstances[0], submitted, executionsStarted, executionsTerminated,
+                completedSuccessfully, completedWithFailure);
         for (int i = 1; i < jetInstances.length; i++) {
             assertJobStatsOnMember(jetInstances[i], 0, executionsStarted, executionsTerminated, 0, 0);
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
@@ -123,18 +123,18 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
     public void jobSuspendedThenResumed() {
         //init
         Job job = jetInstances[0].newJob(streamingPipeline());
-        assertTrueEventually(() -> assertEquals(RUNNING, job.getStatus()));
+        assertJobStatusEventually(job, RUNNING);
 
         //when
         job.suspend();
-        assertTrueEventually(() -> assertEquals(SUSPENDED, job.getStatus()));
+        assertJobStatusEventually(job, SUSPENDED);
 
         //then
         assertTrueEventually(() -> assertJobStats(1, 1, 1, 0, 0));
 
         //when
         job.resume();
-        assertTrueEventually(() -> assertEquals(RUNNING, job.getStatus()));
+        assertJobStatusEventually(job, RUNNING);
 
         //then
         assertTrueEventually(() -> assertJobStats(1, 2, 1, 0, 0));
@@ -144,11 +144,11 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
     public void jobRestarted() {
         //init
         Job job = jetInstances[0].newJob(streamingPipeline());
-        assertTrueEventually(() -> assertEquals(RUNNING, job.getStatus()));
+        assertJobStatusEventually(job, RUNNING);
 
         //when
         job.restart();
-        assertTrueEventually(() -> assertEquals(RUNNING, job.getStatus()));
+        assertJobStatusEventually(job, RUNNING);
 
         //then
         assertTrueEventually(() -> assertJobStats(1, 2, 1, 0, 0));
@@ -158,7 +158,7 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
     public void jobCancelled() {
         //init
         Job job = jetInstances[0].newJob(streamingPipeline());
-        assertTrueEventually(() -> assertEquals(RUNNING, job.getStatus()));
+        assertJobStatusEventually(job, RUNNING);
 
         //when
         job.cancel();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/metrics/JobLifecycleMetricsTest.java
@@ -246,5 +246,4 @@ public class JobLifecycleMetricsTest extends JetTestSupport {
                     expectedAttribute.getValue().longValue(), actualAttribute);
         }
     }
-
 }


### PR DESCRIPTION
Tests for job lifecycle metrics are limited, they only test the values on a single member cluster. 

Checklist
- [x] Tags Set
- [x] Milestone Set
