### PR TITLE
Increase python test coverage

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceConfig.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceConfig.java
@@ -93,6 +93,7 @@ import java.util.StringJoiner;
  * under the {@code com.hazelcast.jet.python} log category. This includes
  * all the output from launched subprocesses.
  *
+ * @since 4.0
  */
 public class PythonServiceConfig implements Serializable {
     private static final String HANDLER_FUNCTION_DEFAULT = "transform_list";
@@ -142,6 +143,7 @@ public class PythonServiceConfig implements Serializable {
      * If all you need to deploy to Jet is in a single file, you can call {@link
      * #setHandlerFile} instead.
      */
+    @Nonnull
     public PythonServiceConfig setBaseDir(@Nonnull String baseDir) {
         if (handlerFile != null) {
             throw new IllegalArgumentException(
@@ -174,6 +176,7 @@ public class PythonServiceConfig implements Serializable {
      * #setHandlerFunction handler function}. If your Python work is in more
      * than one file, call {@link #setBaseDir} instead.
      */
+    @Nonnull
     public PythonServiceConfig setHandlerFile(@Nonnull String handlerFile) {
         if (baseDir != null) {
             throw new IllegalStateException(
@@ -204,6 +207,7 @@ public class PythonServiceConfig implements Serializable {
     /**
      * Returns the {@linkplain #setHandlerModule handler module} name.
      * */
+    @Nullable
     public String handlerModule() {
         return handlerModule;
     }
@@ -212,6 +216,7 @@ public class PythonServiceConfig implements Serializable {
      * Sets the name of the Python module that has the function that
      * transforms Jet pipeline data.
      */
+    @Nonnull
     public PythonServiceConfig setHandlerModule(@Nonnull String handlerModule) {
         if (handlerFile != null) {
             throw new IllegalStateException(
@@ -225,6 +230,7 @@ public class PythonServiceConfig implements Serializable {
      * Returns the name of the {@linkplain #setHandlerFunction handler
      * function}. The default value is {@code transform_list}.
      */
+    @Nonnull
     public String handlerFunction() {
         return handlerFunction;
     }
@@ -238,6 +244,7 @@ public class PythonServiceConfig implements Serializable {
      * transforming each item in the input list. There must be a strict
      * one-to-one match between the input and output lists.
      */
+    @Nonnull
     public PythonServiceConfig setHandlerFunction(@Nonnull String handlerFunction) {
         this.handlerFunction = requireNonBlank(handlerFunction, "handlerFunction");
         return this;

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonTransforms.java
@@ -85,7 +85,7 @@ public final class PythonTransforms {
     ) {
         return s -> s
                 .mapUsingServiceAsyncBatched(PythonService.factory(cfg), Integer.MAX_VALUE, PythonService::sendRequest)
-                .setName("mapUsingPython");
+                .setName("mapUsingPythonBatch");
     }
 
     /**
@@ -107,6 +107,6 @@ public final class PythonTransforms {
         return s -> s
                 .groupingKey(keyFn)
                 .mapUsingServiceAsyncBatched(PythonService.factory(cfg), Integer.MAX_VALUE, PythonService::sendRequest)
-                .setName("mapUsingPython");
+                .setName("mapUsingPythonBatch");
     }
 }

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/package-info.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/package-info.java
@@ -19,6 +19,8 @@
  * transform that allows you to transform Jet pipeline data using a Python
  * function. See {@link com.hazelcast.jet.python.PythonServiceConfig} for
  * more details.
+ *
+ * @since 4.0
  */
 @EvolvingApi
 package com.hazelcast.jet.python;

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.jet.python;
+
+import com.hazelcast.internal.nio.IOUtil;
+import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.annotation.NightlyTest;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletionException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static com.hazelcast.jet.python.PythonTransforms.mapUsingPythonBatch;
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatNoWindowsOS;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@Category({NightlyTest.class})
+public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
+
+    private static final String ECHO_HANDLER_FUNCTION
+            = "def handle(input_list):\n"
+            + "    return ['echo-%s' % i for i in input_list]\n";
+
+    private static final String FAILING_FUNCTION
+            = "def handle(input_list):\n"
+            + "    assert 1 == 2\n"
+            + "    return ['echo-%s' % i for i in input_list]\n";
+
+    private File baseDir;
+
+    @BeforeClass
+    public static void beforeClass() {
+        initialize(2, null);
+        assumeThatNoWindowsOS();
+    }
+
+    @Before
+    public void before() throws Exception {
+        baseDir = createTempDirectory();
+        installFileToBaseDir(ECHO_HANDLER_FUNCTION, "echo.py");
+    }
+
+    @After
+    public void after() {
+        IOUtil.delete(baseDir);
+    }
+
+    @Test
+    public void initIsRunBeforeJob() throws IOException {
+        // Given
+        String baseDirStr = baseDir.toString();
+        String outcomeFilename = "init_outcome.txt";
+        installFileToBaseDir(String.format(
+                "echo 'Init script running'%n"
+                + "sleep 10%n"
+                + "echo 'init.sh' executed > %s/%s%n",
+                baseDirStr, outcomeFilename), "init.sh");
+
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        // When
+        p.readFrom(TestSources.items("1"))
+                .map(t -> {
+                    Path expectedInitFile = Paths.get(baseDirStr, outcomeFilename);
+                    // Then
+                    assertTrue("file which should be created by init.sh does not exist",
+                            Files.exists(expectedInitFile));
+                    return t;
+                })
+                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        instance().newJob(p).join();
+    }
+
+    @Test
+    public void cleanupIsRunAfterJob() throws IOException {
+        // Given
+        String baseDirStr = baseDir.toString();
+        String outcomeFilename = "cleanup_outcome.txt";
+        installFileToBaseDir(
+                prepareSimpleCleanupSh(baseDirStr, outcomeFilename),
+                "cleanup.sh");
+
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        // When
+        p.readFrom(TestSources.items("1"))
+                .map(t -> {
+                    Thread.sleep(5_000);
+                    Path expectedInitFile = Paths.get(baseDirStr, outcomeFilename);
+                    // Then
+                    assertFalse("file which should be created by cleanup.sh exists during job execution",
+                            Files.exists(expectedInitFile));
+                    return t;
+                })
+                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        instance().newJob(p).join();
+
+        assertTrue("Cleanup script didn't run", new File(baseDir, outcomeFilename).isFile());
+    }
+
+    @Test
+    public void initFailureCausesJobFailure() throws IOException {
+        // Given
+        installFileToBaseDir("exit 1", "init.sh");
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        // When
+        p.readFrom(TestSources.items("1"))
+                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        // Then
+        try {
+            instance().newJob(p).join();
+            fail();
+        } catch (CompletionException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void cleanupExecutedIfInitFailed() throws IOException {
+        // Given
+        installFileToBaseDir("exit 1", "init.sh");
+        String baseDirStr = baseDir.toString();
+        String outcomeFilename = "cleanup_outcome.txt";
+        installFileToBaseDir(
+                prepareSimpleCleanupSh(baseDirStr, outcomeFilename),
+                "cleanup.sh");
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(TestSources.items("1"))
+                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        // When
+        try {
+            instance().newJob(p).join();
+            fail();
+        } catch (CompletionException ex) {
+            // expected
+        }
+
+        // Then
+        assertTrue("Cleanup script didn't run", new File(baseDir, outcomeFilename).isFile());
+    }
+
+    @Test
+    @Ignore("https://github.com/hazelcast/hazelcast-jet/issues/1995")
+    public void cleanupExecutedIfPythonFailed() throws IOException {
+        // Given
+        installFileToBaseDir(FAILING_FUNCTION, "failing.py");
+        String baseDirStr = baseDir.toString();
+        String outcomeFilename = "cleanup_outcome.txt";
+        installFileToBaseDir(
+                prepareSimpleCleanupSh(baseDirStr, outcomeFilename),
+                "cleanup.sh");
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("failing")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(TestSources.items("1"))
+                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        // When
+        try {
+            instance().newJob(p).join();
+            fail();
+        } catch (CompletionException ex) {
+            // expected
+        }
+
+        // Then
+        assertTrue("Cleanup script didn't run", new File(baseDir, outcomeFilename).isFile());
+    }
+
+    @Test
+    public void cleanupExecutedIfJobFailed() throws IOException {
+        // Given
+        String baseDirStr = baseDir.toString();
+        String outcomeFilename = "cleanup_outcome.txt";
+        installFileToBaseDir(
+                prepareSimpleCleanupSh(baseDirStr, outcomeFilename),
+                "cleanup.sh");
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(TestSources.items("1"))
+                .map(t -> {
+                    assertTrue("expected failure", false);
+                    return t;
+                })
+                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        // When
+        try {
+            instance().newJob(p).join();
+            fail();
+        } catch (CompletionException ex) {
+            // expected
+        }
+
+        // Then
+        assertTrue("Cleanup script didn't run", new File(baseDir, outcomeFilename).isFile());
+    }
+
+    @Test
+    public void initAndCleanupNotExecutedIfHandlerFileIsUsed() throws IOException {
+        // Given
+        String baseDirStr = baseDir.toString();
+        String outcomeInitFilename = "init_outcome.txt";
+        installFileToBaseDir(
+                prepareSimpleInitSh(baseDirStr, outcomeInitFilename),
+                "init.sh");
+        String outcomeCleanupFilename = "cleanup_outcome.txt";
+        installFileToBaseDir(
+                prepareSimpleCleanupSh(baseDirStr, outcomeCleanupFilename),
+                "cleanup.sh");
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setHandlerFile(baseDir + "/echo.py")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(TestSources.items("1"))
+                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        // When
+        instance().newJob(p).join();
+
+        // Then
+        assertFalse("init script ran", new File(baseDir, outcomeCleanupFilename).exists());
+        assertFalse("Cleanup script ran", new File(baseDir, outcomeCleanupFilename).exists());
+    }
+
+    private String prepareSimpleInitSh(String baseDirStr, String outcomeFilename) {
+        return String.format(
+                "echo 'Init script running'%n"
+                + "echo 'init.sh' executed > %s/%s%n", baseDirStr, outcomeFilename);
+    }
+
+    private String prepareSimpleCleanupSh(String baseDirStr, String outcomeFilename) {
+        return String.format(
+                "echo 'Cleanup script running'%n"
+                + "echo 'cleanup.sh' executed > %s/%s%n", baseDirStr, outcomeFilename);
+    }
+
+    private void installFileToBaseDir(String contents, String filename) throws IOException {
+        try (InputStream in = new ByteArrayInputStream(contents.getBytes(UTF_8))) {
+            Files.copy(in, new File(baseDir, filename).toPath());
+        }
+    }
+
+}

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.python;
 import com.hazelcast.jet.SimpleTestInClusterSupport;
 import com.hazelcast.jet.pipeline.BatchStage;
 import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.python.PythonTransforms.mapUsingPython;
@@ -40,6 +42,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class PythonServiceTest extends SimpleTestInClusterSupport {
 
@@ -226,6 +229,52 @@ public class PythonServiceTest extends SimpleTestInClusterSupport {
         ));
         instance().newJob(p).join();
         assertTrue("Cleanup script didn't run", new File(baseDir, outcomeFilename).isFile());
+    }
+
+    @Test
+    public void batchStage_mapUsingPythonFailure() {
+        // Given
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("notExistsFunction");
+        Pipeline p = Pipeline.create();
+        BatchStage<String> stage = p.readFrom(TestSources.items("1"));
+
+        // When
+        stage.apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        // Then
+        try {
+            instance().newJob(p).join();
+            fail();
+        } catch (CompletionException ex) {
+            // expected
+        }
+    }
+
+    @Test
+    public void streamStage_mapUsingPythonFailure() {
+        // Given
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("notExistsFunction");
+        Pipeline p = Pipeline.create();
+        StreamStage<String> stage = p.readFrom(TestSources.items("1")).addTimestamps(x -> 0, 0);
+
+        // When
+        stage.apply(mapUsingPython(cfg)).setLocalParallelism(2)
+                .writeTo(Sinks.logger());
+
+        // Then
+        try {
+            instance().newJob(p).join();
+            fail();
+        } catch (CompletionException ex) {
+            // expected
+        }
     }
 
     private void installFileToBaseDir(String contents, String filename) throws IOException {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -99,7 +99,7 @@ public interface GeneralStage<T> extends Stage {
      * This sample takes a stream of sentences and outputs a stream of
      * individual words in them:
      * <pre>{@code
-     * stage.map(sentence -> traverseArray(sentence.split("\\W+")))
+     * stage.flatMap(sentence -> traverseArray(sentence.split("\\W+")))
      * }</pre>
      *
      * @param flatMapFn a stateless flatmapping function, whose result type is


### PR DESCRIPTION
Added some test cases for python. `PythonInitCleanupTest` is executed in nightly profile since it takes some non-trivial time (~85seconds). Here is the result for nightly profile run with this branch - http://jenkins.hazelcast.com/view/Jet/job/jet-oss-master-nightly-temp/2/testReport/com.hazelcast.jet.python/PythonInitCleanupTest/

One of tests is ignored due to https://github.com/hazelcast/hazelcast-jet/issues/1995

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated