### PR TITLE
Handle non-serializable exceptions in AsyncOperation

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
@@ -132,7 +132,7 @@ final class PythonService {
         public void onError(Throwable e) {
             try {
                 if (e instanceof StatusException || e instanceof StatusRuntimeException) {
-                    // not seriazliable exceptions
+                    // not serializable exceptions
                     e = new JetException(ExceptionUtil.stackTraceToString(e));
                 }
 

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
@@ -16,6 +16,7 @@
 package com.hazelcast.jet.python;
 
 import com.hazelcast.jet.JetException;
+import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.jet.python.grpc.InputMessage;
 import com.hazelcast.jet.python.grpc.InputMessage.Builder;
@@ -25,6 +26,8 @@ import com.hazelcast.jet.python.grpc.OutputMessage;
 import com.hazelcast.logging.ILogger;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.grpc.ManagedChannel;
+import io.grpc.StatusException;
+import io.grpc.StatusRuntimeException;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import io.grpc.stub.StreamObserver;
 
@@ -128,6 +131,11 @@ final class PythonService {
         @Override
         public void onError(Throwable e) {
             try {
+                if (e instanceof StatusException || e instanceof StatusRuntimeException) {
+                    // not seriazliable exceptions
+                    e = new JetException(ExceptionUtil.stackTraceToString(e));
+                }
+
                 exceptionInOutputObserver = e;
                 for (CompletableFuture<List<String>> future; (future = futureQueue.poll()) != null;) {
                     future.completeExceptionally(e);

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.CompletionException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -195,7 +194,6 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast-jet/issues/1995")
     public void cleanupExecutedIfPythonFailed() throws IOException {
         // Given
         installFileToBaseDir(FAILING_FUNCTION, "failing.py");

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonServiceTest.java
@@ -49,12 +49,11 @@ public class PythonServiceTest extends SimpleTestInClusterSupport {
     private static final int ITEM_COUNT = 10_000;
     private static final String ECHO_HANDLER_FUNCTION =
             "def handle(input_list):\n" +
- "    return ['echo-%s' % i for i in input_list]\n";
+            "    return ['echo-%s' % i for i in input_list]\n";
 
     private static final String FAILING_FUNCTION
             = "def handle(input_list):\n"
-            + "    assert 1 == 2\n"
-            + "    return ['echo-%s' % i for i in input_list]\n";
+            + "    assert 1 == 2\n";
 
     private File baseDir;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
@@ -25,12 +25,11 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.impl.operationservice.ExceptionAction;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.concurrent.CompletableFuture;
 
 import static com.hazelcast.jet.impl.util.ExceptionUtil.isRestartableException;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.peel;
+import static com.hazelcast.jet.impl.util.ExceptionUtil.stackTraceToString;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.withTryCatch;
 import static com.hazelcast.spi.impl.operationservice.ExceptionAction.THROW_EXCEPTION;
 
@@ -83,9 +82,7 @@ public abstract class AsyncOperation extends Operation implements IdentifiedData
                 Throwable ex = peel(e);
                 if (value instanceof Throwable && ex instanceof HazelcastSerializationException) {
                     // we got a non-serializable exception here
-                    StringWriter caughtStr = new StringWriter();
-                    ((Throwable) value).printStackTrace(new PrintWriter(caughtStr));
-                    sendResponse(new JetException(caughtStr.toString()));
+                    sendResponse(new JetException(stackTraceToString(ex)));
                 } else {
                     throw e;
                 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/AsyncOperation.java
@@ -81,7 +81,12 @@ public abstract class AsyncOperation extends Operation implements IdentifiedData
             } catch (Exception e) {
                 Throwable ex = peel(e);
                 if (value instanceof Throwable && ex instanceof HazelcastSerializationException) {
-                    // we got a non-serializable exception here
+                    // Sometimes exceptions are not serializable, for example on
+                    // https://github.com/hazelcast/hazelcast-jet/issues/1995.
+                    // When sending exception as a response and the serialization fails,
+                    // the response will not be sent and the operation will hang.
+                    // To prevent this from happening, replace the exception with
+                    // another exception that can be serialized.
                     sendResponse(new JetException(stackTraceToString(ex)));
                 } else {
                     throw e;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/ExceptionUtil.java
@@ -40,6 +40,8 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
@@ -188,6 +190,13 @@ public final class ExceptionUtil {
     @Nonnull
     public static <T extends Throwable> RuntimeException sneakyThrow(@Nonnull Throwable t) throws T {
         throw (T) t;
+    }
+
+    @Nonnull
+    public static String stackTraceToString(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
     }
 
     /**


### PR DESCRIPTION
Sometimes the processors may fail with a non-serializable exception.
Convert the exception to a String and fail with a generic exception in
this case.

Checklist
- [x] Tags Set
- [x] Milestone Set

Links to issues fixed (if any):

Fixes #1995
