### PR TITLE
Standardize how extension modules import hazelcast-jet

### DIFF
--- a/extensions/avro/pom.xml
+++ b/extensions/avro/pom.xml
@@ -87,12 +87,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.hazelcast.jet</groupId>
-            <artifactId>hazelcast-jet</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>${avro.version}</version>

--- a/extensions/hadoop/pom.xml
+++ b/extensions/hadoop/pom.xml
@@ -50,13 +50,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.hazelcast.jet</groupId>
-            <artifactId>hazelcast-jet</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
             <version>${hadoop.version}</version>

--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -69,12 +69,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.hazelcast.jet</groupId>
-            <artifactId>hazelcast-jet</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <version>${kafka.version}</version>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -50,6 +50,7 @@
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
             <version>${project.parent.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/extensions/python/pom.xml
+++ b/extensions/python/pom.xml
@@ -137,12 +137,6 @@
     </profiles>
 
     <dependencies>
-        <dependency>
-            <groupId>com.hazelcast.jet</groupId>
-            <artifactId>hazelcast-jet-core</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- Generated gRPC code uses an annotation which was renamed in Java 11 -->
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -87,12 +87,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.hazelcast.jet</groupId>
-            <artifactId>hazelcast-jet</artifactId>
-            <version>${project.parent.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>s3</artifactId>
         </dependency>


### PR DESCRIPTION
Python module also had an extra dependency which caused it to be shaded 
into the distribution jar
