### PR TITLE
Replace Supplier<Schema> with Schema for Avro sink

### DIFF
--- a/examples/files/src/main/java/com/hazelcast/jet/examples/files/SalesCsvAnalyzer.java
+++ b/examples/files/src/main/java/com/hazelcast/jet/examples/files/SalesCsvAnalyzer.java
@@ -45,10 +45,9 @@ public class SalesCsvAnalyzer {
         Pipeline p = Pipeline.create();
 
         BatchSource<SalesRecordLine> source = Sources.filesBuilder(sourceDir)
-                                                     .glob("*.csv")
-                                                     .build(path -> Files.lines(path)
-                                                                         .skip(1)
-                                                                         .map(SalesRecordLine::parse));
+             .glob("*.csv")
+             .build(path -> Files.lines(path).skip(1).map(SalesRecordLine::parse));
+
         p.readFrom(source)
          .filter(record -> record.getPrice() < 30)
          .groupingKey(SalesRecordLine::getPaymentType)

--- a/examples/files/src/main/java/com/hazelcast/jet/examples/files/avro/AvroSink.java
+++ b/examples/files/src/main/java/com/hazelcast/jet/examples/files/avro/AvroSink.java
@@ -48,9 +48,10 @@ public class AvroSink {
     private static Pipeline buildPipeline() {
         Pipeline p = Pipeline.create();
 
+        Schema schema = schemaForUser();
         p.readFrom(Sources.<String, User>map(MAP_NAME))
          .map(Map.Entry::getValue)
-         .writeTo(AvroSinks.files(DIRECTORY_NAME, AvroSink::schemaForUser, User.class));
+         .writeTo(AvroSinks.files(DIRECTORY_NAME, User.class, schema));
 
         return p;
     }

--- a/extensions/avro/src/main/java/com/hazelcast/jet/avro/AvroSinks.java
+++ b/extensions/avro/src/main/java/com/hazelcast/jet/avro/AvroSinks.java
@@ -58,45 +58,45 @@ public final class AvroSinks {
      *
      * @param directoryName directory to create the files in. Will be created
      *                      if it doesn't exist. Must be the same on all members.
-     * @param schemaSupplier the record schema supplier
+     * @param schema the record schema
      * @param datumWriterSupplier the record writer supplier
      * @param <R> the type of the record
      */
     @Nonnull
     public static <R> Sink<R> files(
             @Nonnull String directoryName,
-            @Nonnull SupplierEx<Schema> schemaSupplier,
+            @Nonnull Schema schema,
             @Nonnull SupplierEx<DatumWriter<R>> datumWriterSupplier
     ) {
 
         return Sinks.fromProcessor("avroFilesSink(" + directoryName + ')',
-                AvroProcessors.writeFilesP(directoryName, schemaSupplier, datumWriterSupplier));
+                AvroProcessors.writeFilesP(directoryName, schema, datumWriterSupplier));
     }
 
     /**
-     * Convenience for {@link #files(String, SupplierEx,
+     * Convenience for {@link #files(String, Schema,
      * SupplierEx)} which uses either {@link SpecificDatumWriter} or
      * {@link ReflectDatumWriter} depending on the supplied {@code recordClass}.
      */
     @Nonnull
     public static <R> Sink<R> files(
             @Nonnull String directoryName,
-            @Nonnull SupplierEx<Schema> schemaSupplier,
-            @Nonnull Class<R> recordClass
+            @Nonnull Class<R> recordClass,
+            @Nonnull Schema schema
     ) {
-        return files(directoryName, schemaSupplier, () -> SpecificRecord.class.isAssignableFrom(recordClass) ?
+        return files(directoryName, schema, () -> SpecificRecord.class.isAssignableFrom(recordClass) ?
                 new SpecificDatumWriter<>(recordClass) : new ReflectDatumWriter<>(recordClass));
     }
 
     /**
-     * Convenience for {@link #files(String, SupplierEx,
+     * Convenience for {@link #files(String, Schema,
      * SupplierEx)} which uses {@link GenericDatumWriter}.
      */
     @Nonnull
     public static Sink<IndexedRecord> files(
             @Nonnull String directoryName,
-            @Nonnull SupplierEx<Schema> schemaSupplier
+            @Nonnull Schema schema
     ) {
-        return files(directoryName, schemaSupplier, GenericDatumWriter::new);
+        return files(directoryName, schema, GenericDatumWriter::new);
     }
 }

--- a/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSinkTest.java
+++ b/extensions/avro/src/test/java/com/hazelcast/jet/avro/AvroSinkTest.java
@@ -80,7 +80,7 @@ public class AvroSinkTest extends JetTestSupport {
     public void testReflectWriter() throws IOException {
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.list(list))
-         .writeTo(AvroSinks.files(directory.getPath(), User::classSchema, User.class));
+         .writeTo(AvroSinks.files(directory.getPath(), User.class, User.classSchema()));
 
         jet.newJob(p).join();
 
@@ -92,7 +92,7 @@ public class AvroSinkTest extends JetTestSupport {
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.list(list))
          .map(user -> new SpecificUser(user.getName(), user.getFavoriteNumber()))
-         .writeTo(AvroSinks.files(directory.getPath(), SpecificUser::getClassSchema, SpecificUser.class));
+         .writeTo(AvroSinks.files(directory.getPath(), SpecificUser.class, SpecificUser.getClassSchema()));
 
         jet.newJob(p).join();
 
@@ -104,7 +104,7 @@ public class AvroSinkTest extends JetTestSupport {
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.list(list))
          .map(AvroSinkTest::toRecord)
-         .writeTo(AvroSinks.files(directory.getPath(), User::classSchema));
+         .writeTo(AvroSinks.files(directory.getPath(), User.classSchema()));
 
         jet.newJob(p).join();
 

--- a/reference-manual/src/main/java/integration/Avro.java
+++ b/reference-manual/src/main/java/integration/Avro.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
 import org.apache.avro.generic.GenericRecord;
 
 public class Avro {
@@ -40,10 +41,11 @@ public class Avro {
         String schemaString = "{\"type\":\"record\",\"name\":\"Person\"," +
                 "\"namespace\":\"datamodel\",\"fields\":[{" +
                 "\"name\":\"id\",\"type\":\"int\"}]}";
+        Schema schema = new Parser().parse(schemaString);
         Pipeline p = Pipeline.create();
         p.readFrom(Sources.<GenericRecord>list("inputList"))
          .writeTo(AvroSinks.files("/home/jet/output",
-                 () -> new Schema.Parser().parse(schemaString)));
+                 schema));
         //end::s2[]
     }
 }


### PR DESCRIPTION
The sink unnecessarily required a supplier, where a simple Schema object would be enough.

Note: it also needs backporting to 4.0 release branch.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] Any breaking changes are documented

List of breaking changes:

* `AvroSinks.files` takes `Schema` now instead of `Supplier<Schema>`
