### PR TITLE
Remove dependency to nodeEngine from Jet tasks.

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobConfigMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobConfigMessageTask.java
@@ -20,10 +20,9 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.jet.impl.client.protocol.codec.JetGetJobConfigCodec;
 import com.hazelcast.jet.impl.operation.GetJobConfigOperation;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 public class JetGetJobConfigMessageTask extends AbstractJetMessageTask<JetGetJobConfigCodec.RequestParameters, Data>
@@ -40,11 +39,9 @@ public class JetGetJobConfigMessageTask extends AbstractJetMessageTask<JetGetJob
         return new GetJobConfigOperation(parameters.jobId);
     }
 
-
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        SerializationService serializationService = nodeEngine.getSerializationService();
-        return serializationService.toData(response);
+        return toData(response);
     }
 
     @Override
@@ -56,5 +53,4 @@ public class JetGetJobConfigMessageTask extends AbstractJetMessageTask<JetGetJob
     public Object[] getParameters() {
         return new Object[0];
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobSummaryListMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobSummaryListMessageTask.java
@@ -19,10 +19,9 @@ package com.hazelcast.jet.impl.client.protocol.task;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
-import com.hazelcast.internal.serialization.SerializationService;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.jet.impl.client.protocol.codec.JetGetJobSummaryListCodec;
 import com.hazelcast.jet.impl.operation.GetJobSummaryListOperation;
-import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 public class JetGetJobSummaryListMessageTask
@@ -41,8 +40,7 @@ public class JetGetJobSummaryListMessageTask
 
     @Override
     protected Object processResponseBeforeSending(Object response) {
-        SerializationService serializationService = nodeEngine.getSerializationService();
-        return serializationService.toData(response);
+        return toData(response);
     }
 
     @Override


### PR DESCRIPTION
Removed dependency to `nodeEngine` and used already defined/inherited `toData()` in `JetGetJobConfigMessageTask` & `JetGetJobSummaryListMessageTask`.

Checklist
- [x] Tags Set
- [x] Milestone Set