### PR TITLE
Bump protobuf-maven-plugin from 0.5.1 to 0.6.1

### DIFF
--- a/examples/grpc/pom.xml
+++ b/examples/grpc/pom.xml
@@ -63,7 +63,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.1</version>
+                <version>0.6.1</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>

--- a/extensions/python/pom.xml
+++ b/extensions/python/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.1</version>
+                <version>0.6.1</version>
                 <executions>
                     <execution>
                         <id>java</id>
@@ -112,7 +112,7 @@
                     <plugin>
                         <groupId>org.xolstice.maven.plugins</groupId>
                         <artifactId>protobuf-maven-plugin</artifactId>
-                        <version>0.5.1</version>
+                        <version>0.6.1</version>
                         <executions>
                             <execution>
                                 <id>python</id>


### PR DESCRIPTION
Copy of https://github.com/hazelcast/hazelcast-jet/pull/2018 because PR builder is not able to be executed for given PR for any reason.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
