### PR TITLE
Change packaging of refman to pom

### DIFF
--- a/reference-manual/pom.xml
+++ b/reference-manual/pom.xml
@@ -20,7 +20,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
     <name>hazelcast-jet-reference-manual</name>
     <description>Hazelcast Jet Reference Manual</description>
 


### PR DESCRIPTION
Reference manual should be packaged same as in `3.x` branch.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated

