### PR TITLE
Generate javadoc in distribution module

### DIFF
--- a/hazelcast-jet-all/pom.xml
+++ b/hazelcast-jet-all/pom.xml
@@ -109,45 +109,6 @@
         </plugins>
     </build>
 
-    <profiles>
-        <profile>
-            <id>unshaded</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <configuration>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>com.hazelcast:hazelcast:*</exclude>
-                                </excludes>
-                            </artifactSet>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>test-enterprise</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <configuration>
-                            <includeDependencySources>true</includeDependencySources>
-                            <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
-                            <dependencySourceIncludes>
-                                <dependencySourceInclude>com.hazelcast.jet</dependencySourceInclude>
-                            </dependencySourceIncludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <dependencies>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
@@ -157,7 +118,7 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>3.9.0</version>
+            <version>${picocli.version}</version>
         </dependency>
 
         <!-- These dependencies are otherwise optional, but we include them in the
@@ -241,4 +202,43 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>unshaded</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>com.hazelcast:hazelcast:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-enterprise</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <includeDependencySources>true</includeDependencySources>
+                            <includeTransitiveDependencySources>true</includeTransitiveDependencySources>
+                            <dependencySourceIncludes>
+                                <dependencySourceInclude>com.hazelcast.jet</dependencySourceInclude>
+                            </dependencySourceIncludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/hazelcast-jet-distribution/pom.xml
+++ b/hazelcast-jet-distribution/pom.xml
@@ -79,6 +79,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceIncludes>
+                        <dependencySourceInclude>com.hazelcast:*</dependencySourceInclude>
+                        <dependencySourceInclude>com.hazelcast.jet:*</dependencySourceInclude>
+                    </dependencySourceIncludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -87,6 +105,12 @@
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <!-- workaround, otherwise javadoc from core module is not included -->
+        <dependency>
+            <groupId>com.hazelcast.jet</groupId>
+            <artifactId>hazelcast-jet-core</artifactId>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/hazelcast-jet-distribution/pom.xml
+++ b/hazelcast-jet-distribution/pom.xml
@@ -95,6 +95,65 @@
                         <dependencySourceInclude>com.hazelcast:*</dependencySourceInclude>
                         <dependencySourceInclude>com.hazelcast.jet:*</dependencySourceInclude>
                     </dependencySourceIncludes>
+                    <excludePackageNames>*.picocli.*:*.com.fasterxml:*.org.snakeyaml</excludePackageNames>
+                    <additionalDependencies>
+                        <!-- provided deps are required for javadoc generation -->
+                        <dependency>
+                            <groupId>javax.cache</groupId>
+                            <artifactId>cache-api</artifactId>
+                            <version>${jsr107.api.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.jms</groupId>
+                            <artifactId>javax.jms-api</artifactId>
+                            <version>${jms.api.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-beans</artifactId>
+                            <version>${spring.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-context</artifactId>
+                            <version>${spring.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-core</artifactId>
+                            <version>${spring.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-tx</artifactId>
+                            <version>${spring.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>info.picocli</groupId>
+                            <artifactId>picocli</artifactId>
+                            <version>${picocli.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.hadoop</groupId>
+                            <artifactId>hadoop-hdfs</artifactId>
+                            <version>${hadoop.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.hadoop</groupId>
+                            <artifactId>hadoop-common</artifactId>
+                            <version>${hadoop.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.hadoop</groupId>
+                            <artifactId>hadoop-mapreduce-client-core</artifactId>
+                            <version>${hadoop.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.annotation</groupId>
+                            <artifactId>javax.annotation-api</artifactId>
+                            <version>${jsr250.api.version}</version>
+                        </dependency>
+                    </additionalDependencies>
                 </configuration>
             </plugin>
         </plugins>
@@ -105,12 +164,6 @@
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <!-- workaround, otherwise javadoc from core module is not included -->
-        <dependency>
-            <groupId>com.hazelcast.jet</groupId>
-            <artifactId>hazelcast-jet-core</artifactId>
-            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -161,6 +214,7 @@
             <artifactId>hazelcast-jet-examples-hello-world</artifactId>
             <version>${project.version}</version>
         </dependency>
+
     </dependencies>
 </project>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,11 @@
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
         <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
-        <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
-        <maven.shade.plugin.version>3.2.1</maven.shade.plugin.version>
+        <maven.shade.plugin.version>3.2.2</maven.shade.plugin.version>
         <maven.dependency.plugin.version>2.6</maven.dependency.plugin.version>
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
@@ -112,6 +112,7 @@
         <kafka.version>2.2.0</kafka.version>
         <grpc.version>1.26.0</grpc.version>
         <protobuf.version>3.11.3</protobuf.version>
+        <picocli.version>3.9.0</picocli.version>
 
         <!-- test dependencies -->
         <activemq.version>5.15.11</activemq.version>
@@ -408,7 +409,7 @@
                     <maxmemory>1024</maxmemory>
                     <detectJavaApiLink>true</detectJavaApiLink>
                     <excludePackageNames>
-                        *.impl:*.internal:*.com.fasterxml:*.org.snakeyaml
+                        *.impl:*.internal
                     </excludePackageNames>
 
                     <!-- see https://bugs.openjdk.java.net/browse/JDK-8212233

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <maven.jar.plugin.version>2.4</maven.jar.plugin.version>
         <maven.source.plugin.version>2.2.1</maven.source.plugin.version>
-        <maven.javadoc.plugin.version>3.1.1</maven.javadoc.plugin.version>
+        <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <maven.assembly.plugin.version>3.0.0</maven.assembly.plugin.version>
         <maven.bundle.plugin.version>2.4.0</maven.bundle.plugin.version>
@@ -408,7 +408,7 @@
                     <maxmemory>1024</maxmemory>
                     <detectJavaApiLink>true</detectJavaApiLink>
                     <excludePackageNames>
-                        *.impl:*.internal
+                        *.impl:*.internal:*.com.fasterxml:*.org.snakeyaml
                     </excludePackageNames>
 
                     <!-- see https://bugs.openjdk.java.net/browse/JDK-8212233


### PR DESCRIPTION
Javadoc for Jet+IMDG is currently not generated anywhere in Jet repo. In `3.x` version it was generated in `hazelcast-jet-distribution` but it is not working now since that module is packaged as `pom`.

After this PR javadoc for Jet+IMDG is generated by command `mvn javadoc:aggregate -DskipTests` called from `hazelcast-jet-distribution` module (not from root module).

Moreover version of `maven-javadoc-plugin` is downgraded back to `3.0.1`. Version `3.1.x` has some issue during javadoc generation, version `3.0.1` works correctly. 

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated

