### PR TITLE
Disable logging details by default

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -43,7 +43,9 @@ import com.hazelcast.jet.impl.JetService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
@@ -283,6 +285,16 @@ public final class Jet {
         if (!jetProps.containsKey(JET_SHUTDOWNHOOK_ENABLED)) {
             jetProps.setProperty(JET_SHUTDOWNHOOK_ENABLED.getName(), hzHookEnabled);
         }
+
+        // this property should behave as if false is the default
+        HazelcastProperty loggingDetails = ClusterProperty.LOGGING_ENABLE_DETAILS;
+        if (loggingDetails.getSystemProperty() == null
+                && !jetProps.containsKey(loggingDetails)
+                && !hzProperties.containsKey(loggingDetails)
+        ) {
+            jetProps.setProperty(loggingDetails.getName(), "false");
+        }
+
         hzConfig.setProperty(SHUTDOWNHOOK_ENABLED.getName(), "false");
 
         // copy Jet properties to HZ properties

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetConsoleLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetConsoleLogHandler.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.jet.impl.util;
 
-import com.hazelcast.instance.BuildInfoProvider;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.logging.Formatter;
@@ -50,35 +48,16 @@ public class JetConsoleLogHandler extends StreamHandler {
 
     private static class JetLogFormatter extends Formatter {
 
-        /**
-         * Temporary, remove after https://github.com/hazelcast/hazelcast/pull/16622 is merged
-         * Currently the filtering doesn't work for client, because it uses IMDG version.
-         */
-        private static final String VERSION_STR =
-                "[" + BuildInfoProvider.getBuildInfo().getJetBuildInfo().getVersion() + "]";
-
-        private static final boolean ENABLE_DETAILS = Boolean.parseBoolean(getDetailsProperty());
-
         private static final int ERROR_LEVEL = 1000;
         private static final int WARNING_LEVEL = 900;
         private static final int INFO_LEVEL = 800;
         private static final int DEBUG_LEVEL = 500;
         private static final int TRACE_LEVEL = 400;
 
-        private static String getDetailsProperty() {
-            return System.getProperties().getProperty("hazelcast.logging.details.enabled", "false");
-        }
-
         @Override
         public String format(LogRecord record) {
             String loggerName = abbreviateLoggerName(record.getLoggerName());
             String message = record.getMessage();
-            if (!ENABLE_DETAILS) {
-                int versionIdx = message.indexOf(VERSION_STR);
-                if (versionIdx > 0) {
-                    message = message.substring(versionIdx + VERSION_STR.length() + 1);
-                }
-            }
             return String.format("%s [%s%5s%s] [%s%s%s] %s%s",
                     Util.toLocalTime(record.getMillis()),
                     getLevelColor(record.getLevel()),

--- a/hazelcast-jet-core/src/main/resources/hazelcast-jet-member-default.xml
+++ b/hazelcast-jet-core/src/main/resources/hazelcast-jet-member-default.xml
@@ -18,9 +18,7 @@
 <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-4.0.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <cluster-name>
-        jet
-    </cluster-name>
+    <cluster-name>jet</cluster-name>
     <network>
         <port auto-increment="true" port-count="100">5701</port>
         <join>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
             -XX:+AlwaysPreTouch
             -Dhazelcast.phone.home.enabled=false
             -Dhazelcast.logging.type=log4j2
+            -Dhazelcast.logging.details.enabled=true
             -Dhazelcast.test.use.network=false
             -Djava.net.preferIPv4Stack=true
         </argLine>


### PR DESCRIPTION
Do not write version number, ip and cluster name on every log message by default

This option can be turned on again by  setting `hazelcast.logging.details.enabled` to `true`

Checklist
- [x] Tags Set
- [x] Milestone Set

