### PR TITLE
Set license of extension modules in pom

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -45,6 +45,14 @@
         <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderHazelcastCommunity.txt</checkstyle.headerLocation>
     </properties>
 
+    <licenses>
+        <license>
+            <name>Hazelcast Community License</name>
+            <url>http://hazelcast.com/hazelcast-community-license</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <dependencies>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>


### PR DESCRIPTION
The licenses section is the standard way to provide information
about a license of a module. This is used by tools such as
license-maven-plugin.

It is inherited by child modules by default, so with the current
setting the extensions inherit the Apache 2 license of the root
module (this can be verified by running `mvn help:effective-pom`
in a module directory).

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] Any breaking changes are documented
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] For code samples, code sample main readme is updated

List of breaking changes:

* None
