### PR TITLE
Exclude classgraph from javadocs

### DIFF
--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>io.github.classgraph</groupId>
             <artifactId>classgraph</artifactId>
-            <version>4.8.62</version>
+            <version>${classgraph.version}</version>
         </dependency>
 
         <dependency>

--- a/hazelcast-jet-distribution/pom.xml
+++ b/hazelcast-jet-distribution/pom.xml
@@ -96,7 +96,7 @@
                         <dependencySourceInclude>com.hazelcast.jet:*</dependencySourceInclude>
                     </dependencySourceIncludes>
                     <excludePackageNames>
-                        *.impl:*.impl.*:*.internal:*.internal.*:*.picocli:*.picocli.*:*.com.fasterxml:*.com.fasterxml.*:*.org.snakeyaml:*.org.snakeyaml.*
+                        *.impl:*.impl.*:*.internal:*.internal.*:*.picocli:*.picocli.*:*.com.fasterxml:*.com.fasterxml.*:*.org.snakeyaml:*.org.snakeyaml.*:*.io.github.*
                     </excludePackageNames>
                     <additionalDependencies>
                         <!-- provided deps are required for javadoc generation -->
@@ -134,6 +134,11 @@
                             <groupId>info.picocli</groupId>
                             <artifactId>picocli</artifactId>
                             <version>${picocli.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.github.classgraph</groupId>
+                            <artifactId>classgraph</artifactId>
+                            <version>${classgraph.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <grpc.version>1.26.0</grpc.version>
         <protobuf.version>3.11.3</protobuf.version>
         <picocli.version>3.9.0</picocli.version>
+        <classgraph.version>4.8.62</classgraph.version>
 
         <!-- test dependencies -->
         <activemq.version>5.15.11</activemq.version>


### PR DESCRIPTION
It was leftover in the generated javadoc

Checklist
- [x] Tags Set
- [x] Milestone Set
