### PR TITLE
Re-order jms source parameters to have the lambda as last parameter

### DIFF
--- a/examples/jms/src/main/java/com/hazelcast/jet/examples/jms/JmsQueueSample.java
+++ b/examples/jms/src/main/java/com/hazelcast/jet/examples/jms/JmsQueueSample.java
@@ -45,7 +45,7 @@ public class JmsQueueSample {
 
     private Pipeline buildPipeline() {
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.jmsQueue(() -> new ActiveMQConnectionFactory(ActiveMQBroker.BROKER_URL), INPUT_QUEUE))
+        p.readFrom(Sources.jmsQueue(INPUT_QUEUE, () -> new ActiveMQConnectionFactory(ActiveMQBroker.BROKER_URL)))
          .withoutTimestamps()
          .filter(message -> message.getJMSPriority() > 3)
          .map(message -> (TextMessage) message)

--- a/examples/jms/src/main/java/com/hazelcast/jet/examples/jms/JmsTopicSample.java
+++ b/examples/jms/src/main/java/com/hazelcast/jet/examples/jms/JmsTopicSample.java
@@ -46,7 +46,7 @@ public class JmsTopicSample {
     private static Pipeline buildPipeline() {
         Pipeline p = Pipeline.create();
 
-        p.readFrom(Sources.jmsTopic(() -> new ActiveMQConnectionFactory(ActiveMQBroker.BROKER_URL), INPUT_TOPIC))
+        p.readFrom(Sources.jmsTopic(INPUT_TOPIC, () -> new ActiveMQConnectionFactory(ActiveMQBroker.BROKER_URL)))
          .withoutTimestamps()
          .filter(message -> message.getJMSPriority() > 3)
          .map(message -> (TextMessage) message)

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -1027,13 +1027,13 @@ public final class Sources {
      * that case you can use {@linkplain #jmsQueueBuilder(SupplierEx) the
      * builder} and add a projection.
      *
-     * @param factorySupplier supplier to obtain JMS connection factory
      * @param name            the name of the queue
+     * @param factorySupplier supplier to obtain JMS connection factory
      */
     @Nonnull
     public static StreamSource<Message> jmsQueue(
-            @Nonnull SupplierEx<? extends ConnectionFactory> factorySupplier,
-            @Nonnull String name
+            @Nonnull String name,
+            @Nonnull SupplierEx<? extends ConnectionFactory> factorySupplier
     ) {
         return jmsQueueBuilder(factorySupplier)
                 .destinationName(name)
@@ -1082,13 +1082,13 @@ public final class Sources {
      * that case you can use {@linkplain #jmsQueueBuilder(SupplierEx) the
      * builder} and add a projection.
      *
-     * @param factorySupplier supplier to obtain JMS connection factory
      * @param name            the name of the queue
+     * @param factorySupplier supplier to obtain JMS connection factory
      */
     @Nonnull
     public static StreamSource<Message> jmsTopic(
-            @Nonnull SupplierEx<? extends ConnectionFactory> factorySupplier,
-            @Nonnull String name
+            @Nonnull String name,
+            @Nonnull SupplierEx<? extends ConnectionFactory> factorySupplier
     ) {
         return jmsTopicBuilder(factorySupplier)
                 .destinationName(name)

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -35,8 +35,8 @@ import com.hazelcast.jet.core.processor.SourceProcessors;
 import com.hazelcast.jet.function.ToResultSetFunction;
 import com.hazelcast.jet.impl.pipeline.transform.BatchSourceTransform;
 import com.hazelcast.jet.impl.pipeline.transform.StreamSourceTransform;
-import com.hazelcast.map.IMap;
 import com.hazelcast.map.EventJournalMapEvent;
+import com.hazelcast.map.IMap;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.projection.Projections;
 import com.hazelcast.query.Predicate;
@@ -1013,6 +1013,18 @@ public final class Sources {
     }
 
     /**
+     * @deprecated see {@linkplain #jmsQueue(String, SupplierEx)}.
+     */
+    @Nonnull
+    @Deprecated
+    public static StreamSource<Message> jmsQueue(
+            @Nonnull SupplierEx<? extends ConnectionFactory> factorySupplier,
+            @Nonnull String name
+    ) {
+        return jmsQueue(name, factorySupplier);
+    }
+
+    /**
      * Shortcut equivalent to:
      * <pre>
      *         return jmsQueueBuilder(factorySupplier)
@@ -1063,6 +1075,18 @@ public final class Sources {
     @Nonnull
     public static JmsSourceBuilder jmsQueueBuilder(SupplierEx<? extends ConnectionFactory> factorySupplier) {
         return new JmsSourceBuilder(factorySupplier, false);
+    }
+
+    /**
+     * @deprecated see {@linkplain #jmsTopic(String, SupplierEx)}.
+     */
+    @Nonnull
+    @Deprecated
+    public static StreamSource<Message> jmsTopic(
+            @Nonnull SupplierEx<? extends ConnectionFactory> factorySupplier,
+            @Nonnull String name
+    ) {
+        return jmsTopic(name, factorySupplier);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sources.java
@@ -1041,6 +1041,8 @@ public final class Sources {
      *
      * @param name            the name of the queue
      * @param factorySupplier supplier to obtain JMS connection factory
+     *
+     * @since 4.1
      */
     @Nonnull
     public static StreamSource<Message> jmsQueue(
@@ -1108,6 +1110,8 @@ public final class Sources {
      *
      * @param name            the name of the queue
      * @param factorySupplier supplier to obtain JMS connection factory
+     *
+     * @since 4.1
      */
     @Nonnull
     public static StreamSource<Message> jmsTopic(

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegration_NonSharedClusterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsIntegration_NonSharedClusterTest.java
@@ -133,7 +133,7 @@ public class JmsIntegration_NonSharedClusterTest extends JetTestSupport {
 
         JetInstance instance = createJetMember(config);
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.jmsQueue(JmsIntegration_NonSharedClusterTest::getConnectionFactory, "queue"))
+        p.readFrom(Sources.jmsQueue("queue", JmsIntegration_NonSharedClusterTest::getConnectionFactory))
          .withoutTimestamps()
          .writeTo(Sinks.noop());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTestBase.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTestBase.java
@@ -108,7 +108,7 @@ public abstract class JmsSourceIntegrationTestBase extends SimpleTestInClusterSu
 
     @Test
     public void sourceQueue() throws JMSException {
-        p.readFrom(Sources.jmsQueue(getConnectionFactory(), destinationName))
+        p.readFrom(Sources.jmsQueue(destinationName, getConnectionFactory()))
          .withoutTimestamps()
          .map(TEXT_MESSAGE_FN)
          .writeTo(Sinks.list(sinkList));
@@ -122,7 +122,7 @@ public abstract class JmsSourceIntegrationTestBase extends SimpleTestInClusterSu
 
     @Test
     public void sourceTopic() throws JMSException {
-        p.readFrom(Sources.jmsTopic(getConnectionFactory(), destinationName))
+        p.readFrom(Sources.jmsTopic(destinationName, getConnectionFactory()))
          .withoutTimestamps()
          .map(TEXT_MESSAGE_FN)
          .writeTo(Sinks.list(sinkList));
@@ -216,7 +216,7 @@ public abstract class JmsSourceIntegrationTestBase extends SimpleTestInClusterSu
             return (ConnectionFactory) mockConnectionFactory;
         };
 
-        p.readFrom(Sources.jmsTopic(mockSupplier, destinationName))
+        p.readFrom(Sources.jmsTopic(destinationName, mockSupplier))
          .withoutTimestamps()
          .writeTo(Sinks.logger());
 
@@ -229,7 +229,7 @@ public abstract class JmsSourceIntegrationTestBase extends SimpleTestInClusterSu
 
     @Test
     public void sourceTopic_withNativeTimestamps() throws Exception {
-        p.readFrom(Sources.jmsTopic(getConnectionFactory(), destinationName))
+        p.readFrom(Sources.jmsTopic(destinationName, getConnectionFactory()))
          .withNativeTimestamps(0)
          .map(Message::getJMSTimestamp)
          .window(tumbling(1))
@@ -403,7 +403,7 @@ public abstract class JmsSourceIntegrationTestBase extends SimpleTestInClusterSu
 
         int idleTimeout = 2000;
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.jmsQueue(getConnectionFactory(), destinationName)
+        p.readFrom(Sources.jmsQueue(destinationName, getConnectionFactory())
                           .setPartitionIdleTimeout(idleTimeout))
          .withNativeTimestamps(0)
          .setLocalParallelism(2)
@@ -440,7 +440,7 @@ public abstract class JmsSourceIntegrationTestBase extends SimpleTestInClusterSu
         sendMessages(true, MESSAGE_COUNT);
 
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.jmsQueue(getConnectionFactory(), destinationName))
+        p.readFrom(Sources.jmsQueue(destinationName, getConnectionFactory()))
          .withoutTimestamps()
          .peek()
          .writeTo(Sinks.noop());

--- a/reference-manual/src/main/java/integration/JMS.java
+++ b/reference-manual/src/main/java/integration/JMS.java
@@ -28,8 +28,8 @@ public class JMS {
     static void s1() {
         //tag::s1[]
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.jmsQueue(() -> new ActiveMQConnectionFactory(
-                "tcp://localhost:61616"), "queue"))
+        p.readFrom(Sources.jmsQueue("queue",
+                () -> new ActiveMQConnectionFactory("tcp://localhost:61616")))
          .withoutTimestamps()
          .writeTo(Sinks.logger());
         //end::s1[]


### PR DESCRIPTION
Add description here

Checklist
- [X] Tags Set
- [X] Milestone Set
- [X] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated



List of breaking changes:

- Change of public API for `Sources.jmsQueue` and `Sources.jmsTopic`
