### PR TITLE
Fix link in Jet JavaDoc

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -93,7 +93,7 @@ public final class Jet {
      * doesn't have all the classes you use in the job.
      * <p>
      * Normally you would have to explicitly add all the dependency classes to
-     * the {@link JobConfig#addClass JobConfig}, either one by one or packaged
+     * the {@link JobConfig#addClass(Class[]) JobConfig}, either one by one or packaged
      * into a JAR. If you're submitting a job using the command-line tool {@code
      * jet submit}, the JAR to attach is the same JAR that contains the code
      * that submits the job.


### PR DESCRIPTION
Fix link in `Jet`'s JavaDoc, straightforward.