### PR TITLE
Add test for non-existing package for JobConfig

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/ResourceConfigTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/ResourceConfigTest.java
@@ -88,6 +88,16 @@ public class ResourceConfigTest extends JetTestSupport {
     }
 
     @Test
+    public void when_addResourcesWithNonExistingPackage() {
+        // When
+        config.addPackage("thispackage.does.not.exist");
+
+        // Then
+        Collection<ResourceConfig> resourceConfigs = config.getResourceConfigs().values();
+        assertTrue(resourceConfigs.isEmpty());
+    }
+
+    @Test
     public void when_addJarWithUrl() throws Exception {
         // Given
         String resourceId = "jarfile";

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/NestedClassIsLoaded.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/deployment/NestedClassIsLoaded.java
@@ -35,7 +35,7 @@ public class NestedClassIsLoaded extends AbstractProcessor {
             Method method = clazz.getMethod("map", String.class);
             // We invoke the method so that the lambda inside of it is executed.
             // We check the lambda is loaded with the outer class.
-            assertEquals(method.invoke(clazz.getDeclaredConstructor().newInstance(), "some-string"), "some-string");
+            assertEquals("some-string", method.invoke(clazz.getDeclaredConstructor().newInstance(), "some-string"));
         } catch (Exception e) {
             fail(e.getMessage());
         }


### PR DESCRIPTION
Added regression test for non-existing package passed in `JobConfif.addPackage()`.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
