### PR TITLE
Enable job-level serializer for IMDG Observables

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Inbox.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Inbox.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * A subset of {@code Queue<Object>} API restricted to the consumer side,
@@ -98,6 +99,26 @@ public interface Inbox extends Iterable<Object> {
         int drained = 0;
         for (E o; drained < limit && (o = (E) poll()) != null; drained++) {
             target.add(o);
+        }
+        return drained;
+    }
+
+    /**
+     * Drains and maps at most {@code limit} elements into the provided
+     * {@link Collection}.
+     *
+     * @param target the collection to drain this object's items into
+     * @param limit the maximum amount of items to drain
+     * @param mapper mapping function to apply to this object's items
+     * @return the number of elements actually drained
+     *
+     * @since 4.1
+     */
+    @SuppressWarnings("unchecked")
+    default <E, M> int drainTo(@Nonnull Collection<M> target, int limit, @Nonnull Function<E, M> mapper) {
+        int drained = 0;
+        for (E o; drained < limit && (o = (E) poll()) != null; drained++) {
+            target.add(mapper.apply(o));
         }
         return drained;
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ArrayDequeInboxTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/ArrayDequeInboxTest.java
@@ -24,8 +24,10 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.Function;
 
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -33,6 +35,7 @@ import static org.junit.Assert.assertNull;
 public class ArrayDequeInboxTest {
 
     private static final List<Integer> ITEMS = asList(1, 2);
+    private static final Function<Object, Integer> DOUBLE_INT = n -> (int) n * 2;
 
     private ArrayDequeInbox inbox = new ArrayDequeInbox(new ProgressTracker());
 
@@ -95,6 +98,32 @@ public class ArrayDequeInboxTest {
         ArrayList<Object> sink = new ArrayList<>();
         inbox.drainTo(sink, n);
         assertEquals(ITEMS.subList(0, Math.min(n, ITEMS.size())), sink);
+    }
+
+    @Test
+    public void test_drainToCollectionWithLimitAndMapper_0() {
+        test_drainToCollectionWithLimitAndMapper(0);
+    }
+
+    @Test
+    public void test_drainToCollectionWithLimitAndMapper_1() {
+        test_drainToCollectionWithLimitAndMapper(1);
+    }
+
+    @Test
+    public void test_drainToCollectionWithLimitAndMapper_2() {
+        test_drainToCollectionWithLimitAndMapper(2);
+    }
+
+    @Test
+    public void test_drainToCollectionWithLimitAndMapper_3() {
+        test_drainToCollectionWithLimitAndMapper(3);
+    }
+
+    private void test_drainToCollectionWithLimitAndMapper(int n) {
+        List<Integer> sink = new ArrayList<>();
+        inbox.drainTo(sink, n, DOUBLE_INT);
+        assertEquals(ITEMS.stream().limit(n).map(DOUBLE_INT).collect(toList()), sink);
     }
 
     @Test


### PR DESCRIPTION
Allowed job-level serializers to be used with IMDG `Observable`s.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc