### PR TITLE
Fix sliding-windows TopNStocks code sample

### DIFF
--- a/examples/sliding-windows/src/main/java/com/hazelcast/jet/examples/slidingwindow/TopNStocks.java
+++ b/examples/sliding-windows/src/main/java/com/hazelcast/jet/examples/slidingwindow/TopNStocks.java
@@ -73,7 +73,7 @@ public class TopNStocks {
                 topN(5, comparingValue.reversed()),
                 TopNResult::new);
 
-        p.readFrom(TradeSource.tradeStream(6_000))
+        p.readFrom(TradeSource.tradeStream(500, 6_000))
          .withNativeTimestamps(1_000)
          .groupingKey(Trade::getTicker)
          .window(sliding(10_000, 1_000))
@@ -116,9 +116,9 @@ public class TopNStocks {
         public String toString() {
             return String.format(
                     "Top rising stocks:%n%s\nTop falling stocks:%n%s",
-                    topIncrease.stream().map(kwr -> String.format("   %s by %.2f", kwr.key(), kwr.result()))
+                    topIncrease.stream().map(kwr -> String.format("   %s by %.5f", kwr.key(), kwr.result()))
                                .collect(joining("\n")),
-                    topDecrease.stream().map(kwr -> String.format("   %s by %.2f", kwr.key(), kwr.result()))
+                    topDecrease.stream().map(kwr -> String.format("   %s by %.5f", kwr.key(), kwr.result()))
                                .collect(joining("\n"))
             );
         }

--- a/examples/sliding-windows/src/main/java/com/hazelcast/jet/examples/slidingwindow/TopNStocks.java
+++ b/examples/sliding-windows/src/main/java/com/hazelcast/jet/examples/slidingwindow/TopNStocks.java
@@ -116,9 +116,9 @@ public class TopNStocks {
         public String toString() {
             return String.format(
                     "Top rising stocks:%n%s\nTop falling stocks:%n%s",
-                    topIncrease.stream().map(kwr -> String.format("   %s by %.5f", kwr.key(), kwr.result()))
+                    topIncrease.stream().map(kwr -> String.format("   %s by %.2f%%", kwr.key(), 100d * kwr.result()))
                                .collect(joining("\n")),
-                    topDecrease.stream().map(kwr -> String.format("   %s by %.5f", kwr.key(), kwr.result()))
+                    topDecrease.stream().map(kwr -> String.format("   %s by %.2f%%", kwr.key(), 100d * kwr.result()))
                                .collect(joining("\n"))
             );
         }

--- a/examples/trade-source/src/main/java/com/hazelcast/jet/examples/tradesource/TradeSource.java
+++ b/examples/trade-source/src/main/java/com/hazelcast/jet/examples/tradesource/TradeSource.java
@@ -139,7 +139,7 @@ public final class TradeSource {
     private static final class TradeGenerator {
 
         private static final int LOT = 100;
-        private static final long PRICE_UNITS_PER_CENT = 1000L;
+        private static final long PRICE_PARTS_PER_UNIT = 1000L;
 
         private final List<String> tickers;
         private final long emitPeriodNanos;
@@ -154,7 +154,8 @@ public final class TradeSource {
             this.tickers = loadTickers(numTickers);
             this.maxLagNanos = MILLISECONDS.toNanos(maxLagMillis);
             this.pricesAndTrends = tickers.stream()
-                    .collect(toMap(t -> t, t -> new LongLongAccumulator(500, 5)));
+                    .collect(toMap(t -> t, t -> new LongLongAccumulator(50 * PRICE_PARTS_PER_UNIT,
+                            PRICE_PARTS_PER_UNIT / 10)));
             this.emitPeriodNanos = SECONDS.toNanos(1) / tradesPerSec;
             this.startTimeNanos = this.scheduledTimeNanos = System.nanoTime();
             this.startTimeMillis = System.currentTimeMillis();
@@ -166,7 +167,7 @@ public final class TradeSource {
             while (scheduledTimeNanos <= nowNanos) {
                 String ticker = tickers.get(rnd.nextInt(tickers.size()));
                 LongLongAccumulator priceAndDelta = pricesAndTrends.get(ticker);
-                long price = getNextPrice(priceAndDelta, rnd) / PRICE_UNITS_PER_CENT;
+                long price = getNextPrice(priceAndDelta, rnd) / PRICE_PARTS_PER_UNIT;
                 long tradeTimeNanos = scheduledTimeNanos - (maxLagNanos > 0 ? rnd.nextLong(maxLagNanos) : 0L);
                 long tradeTimeMillis = startTimeMillis + NANOSECONDS.toMillis(tradeTimeNanos - startTimeNanos);
                 Trade trade = new Trade(tradeTimeMillis, ticker, rnd.nextInt(1, 10) * LOT, price);
@@ -187,7 +188,7 @@ public final class TradeSource {
                 delta = -delta;
             }
             price = price + delta;
-            delta = delta + rnd.nextLong(101) - 50;
+            delta = delta + rnd.nextLong(PRICE_PARTS_PER_UNIT + 1) - PRICE_PARTS_PER_UNIT / 2;
 
             priceAndDelta.set1(price);
             priceAndDelta.set2(delta);

--- a/examples/trade-source/src/main/java/com/hazelcast/jet/examples/tradesource/TradeSource.java
+++ b/examples/trade-source/src/main/java/com/hazelcast/jet/examples/tradesource/TradeSource.java
@@ -139,7 +139,7 @@ public final class TradeSource {
     private static final class TradeGenerator {
 
         private static final int LOT = 100;
-        private static final long PRICE_PARTS_PER_UNIT = 1000L;
+        private static final long MONEY_SCALE_FACTOR = 1000L;
 
         private final List<String> tickers;
         private final long emitPeriodNanos;
@@ -154,8 +154,8 @@ public final class TradeSource {
             this.tickers = loadTickers(numTickers);
             this.maxLagNanos = MILLISECONDS.toNanos(maxLagMillis);
             this.pricesAndTrends = tickers.stream()
-                    .collect(toMap(t -> t, t -> new LongLongAccumulator(50 * PRICE_PARTS_PER_UNIT,
-                            PRICE_PARTS_PER_UNIT / 10)));
+                    .collect(toMap(t -> t, t -> new LongLongAccumulator(50 * MONEY_SCALE_FACTOR,
+                            MONEY_SCALE_FACTOR / 10)));
             this.emitPeriodNanos = SECONDS.toNanos(1) / tradesPerSec;
             this.startTimeNanos = this.scheduledTimeNanos = System.nanoTime();
             this.startTimeMillis = System.currentTimeMillis();
@@ -167,7 +167,7 @@ public final class TradeSource {
             while (scheduledTimeNanos <= nowNanos) {
                 String ticker = tickers.get(rnd.nextInt(tickers.size()));
                 LongLongAccumulator priceAndDelta = pricesAndTrends.get(ticker);
-                long price = getNextPrice(priceAndDelta, rnd) / PRICE_PARTS_PER_UNIT;
+                long price = getNextPrice(priceAndDelta, rnd) / MONEY_SCALE_FACTOR;
                 long tradeTimeNanos = scheduledTimeNanos - (maxLagNanos > 0 ? rnd.nextLong(maxLagNanos) : 0L);
                 long tradeTimeMillis = startTimeMillis + NANOSECONDS.toMillis(tradeTimeNanos - startTimeNanos);
                 Trade trade = new Trade(tradeTimeMillis, ticker, rnd.nextInt(1, 10) * LOT, price);
@@ -188,7 +188,7 @@ public final class TradeSource {
                 delta = -delta;
             }
             price = price + delta;
-            delta = delta + rnd.nextLong(PRICE_PARTS_PER_UNIT + 1) - PRICE_PARTS_PER_UNIT / 2;
+            delta = delta + rnd.nextLong(MONEY_SCALE_FACTOR + 1) - MONEY_SCALE_FACTOR / 2;
 
             priceAndDelta.set1(price);
             priceAndDelta.set2(delta);


### PR DESCRIPTION
`TopNStocks` code sample does not have any valuable output after migration to new `TradeSource` generator. There were two issues:
* it started to use all tickers instead of limited number (`500`)
* changes in price started to be too low that display cents of double was not sufficient (fixed by using `5f` instead of original `2f`)

Original output looks like:
```
Top rising stocks:
   AMCX by 0.04
   ASML by 0.04
   BIIB by 0.04
   ALTY by 0.03
   ACIA by 0.03
Top falling stocks:
   AGNC by -0.04
   AXSM by -0.04
   ACRX by -0.03
   AREX by -0.03
   ACGLP by -0.03
```

Not valuable output after TradeSource migration looks like:
```
Top rising stocks:
   HMTA by 0.00
   MSDIW by 0.00
   SQBG by 0.00
   ELOS by 0.00
   CLRBW by 0.00
Top falling stocks:
   INVT by -0.00
   DBVT by -0.00
   ADRA by -0.00
   OFED by -0.00
   WFM by -0.00
```

Output after this PR:
```
Top rising stocks:
   CDC by 4.44%
   ABCD by 3.86%
   CBMG by 3.86%
   ASTE by 3.86%
   AGLE by 3.79%
Top falling stocks:
   ATNI by -1.99%
   AGII by -1.92%
   AMAG by -1.74%
   AGIIL by -1.73%
   BATRA by -1.73%
```

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
