### PR TITLE
Inner join distinction

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -192,6 +192,23 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     }
 
     @Nonnull @Override
+    public <K1, K2, T1_IN, T2_IN, T1, T2, R> BatchStage<R> innerHashJoin2(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BatchStage<T2_IN> stage2,
+            @Nonnull JoinClause<K2, ? super T, ? super T2_IN, ? extends T2> joinClause2,
+            @Nonnull TriFunction<T, T1, T2, R> mapToOutputFn
+    ) {
+        TriFunction<T, T1, T2, R> finalOutputFn = (leftSide, middle, rightSide) -> {
+            if (leftSide == null || middle == null || rightSide == null) {
+                return null;
+            }
+            return mapToOutputFn.apply(leftSide, middle, rightSide);
+        };
+        return attachHashJoin2(stage1, joinClause1, stage2, joinClause2, finalOutputFn);
+    }
+
+    @Nonnull @Override
     public <R> BatchStage<R> aggregate(@Nonnull AggregateOperation1<? super T, ?, ? extends R> aggrOp) {
         return attach(new AggregateTransform<>(singletonList(transform), aggrOp), fnAdapter);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/BatchStageImpl.java
@@ -166,6 +166,21 @@ public class BatchStageImpl<T> extends ComputeStageImplBase<T> implements BatchS
     }
 
     @Nonnull @Override
+    public <K, T1_IN, T1, R> BatchStage<R> innerHashJoin(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BiFunctionEx<T, T1, R> mapToOutputFn
+    ) {
+        BiFunctionEx<T, T1, R> finalOutputFn = (leftSide, rightSide) -> {
+            if (leftSide == null || rightSide == null) {
+                return null;
+            }
+            return mapToOutputFn.apply(leftSide, rightSide);
+        };
+        return attachHashJoin(stage1, joinClause1, finalOutputFn);
+    }
+
+    @Nonnull @Override
     public <K1, K2, T1_IN, T2_IN, T1, T2, R> BatchStage<R> hashJoin2(
             @Nonnull BatchStage<T1_IN> stage1,
             @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -191,6 +191,23 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
     }
 
     @Nonnull @Override
+    public <K1, K2, T1_IN, T2_IN, T1, T2, R> StreamStage<R> innerHashJoin2(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BatchStage<T2_IN> stage2,
+            @Nonnull JoinClause<K2, ? super T, ? super T2_IN, ? extends T2> joinClause2,
+            @Nonnull TriFunction<T, T1, T2, R> mapToOutputFn
+    ) {
+        TriFunction<T, T1, T2, R> finalOutputFn = (leftSide, middle, rightSide) -> {
+            if (leftSide == null || middle == null || rightSide == null) {
+                return null;
+            }
+            return mapToOutputFn.apply(leftSide, middle, rightSide);
+        };
+        return attachHashJoin2(stage1, joinClause1, stage2, joinClause2, finalOutputFn);
+    }
+
+    @Nonnull @Override
     public StreamStage<T> peek(
             @Nonnull PredicateEx<? super T> shouldLogFn,
             @Nonnull FunctionEx<? super T, ? extends CharSequence> toStringFn

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/StreamStageImpl.java
@@ -165,6 +165,21 @@ public class StreamStageImpl<T> extends ComputeStageImplBase<T> implements Strea
     }
 
     @Nonnull @Override
+    public <K, T1_IN, T1, R> StreamStage<R> innerHashJoin(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BiFunctionEx<T, T1, R> mapToOutputFn
+    ) {
+        BiFunctionEx<T, T1, R> finalOutputFn = (leftSide, rightSide) -> {
+            if (leftSide == null || rightSide == null) {
+                return null;
+            }
+            return mapToOutputFn.apply(leftSide, rightSide);
+        };
+        return attachHashJoin(stage1, joinClause1, finalOutputFn);
+    }
+
+    @Nonnull @Override
     public <K1, K2, T1_IN, T2_IN, T1, T2, R> StreamStage<R> hashJoin2(
             @Nonnull BatchStage<T1_IN> stage1,
             @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
@@ -151,11 +151,11 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
         }
     }
 
-    private static BiFunctionEx<List<Tag>, Object[], ItemsByTag> tupleToItemsByTag(List<Boolean> nullsAllowed) {
+    private static BiFunctionEx<List<Tag>, Object[], ItemsByTag> tupleToItemsByTag(List<Boolean> nullsNotAllowed) {
         return (tagList, tuple) -> {
             ItemsByTag res = new ItemsByTag();
             for (int i = 0; i < tagList.size(); i++) {
-                if (tuple[i] == null && !nullsAllowed.get(i)) {
+                if (tuple[i] == null && nullsNotAllowed.get(i)) {
                     return null;
                 }
                 res.put(tagList.get(i), tuple[i]);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
@@ -31,7 +31,6 @@ import com.hazelcast.jet.pipeline.JoinClause;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.core.Edge.from;
 import static com.hazelcast.jet.impl.pipeline.Planner.tailList;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/HashJoinTransform.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.pipeline.transform;
 import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.datamodel.ItemsByTag;
 import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.impl.pipeline.Planner;
@@ -30,6 +31,7 @@ import com.hazelcast.jet.pipeline.JoinClause;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.hazelcast.jet.core.Edge.from;
 import static com.hazelcast.jet.impl.pipeline.Planner.tailList;
@@ -44,6 +46,8 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
     private final BiFunctionEx mapToOutputBiFn;
     @Nullable
     private final TriFunction mapToOutputTriFn;
+    @Nullable
+    private final List<Boolean> whereNullsNotAllowed;
 
     public HashJoinTransform(
             @Nonnull List<Transform> upstream,
@@ -56,6 +60,7 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
         this.tags = tags;
         this.mapToOutputBiFn = mapToOutputBiFn;
         this.mapToOutputTriFn = null;
+        this.whereNullsNotAllowed = null;
     }
 
     public <T1, T2> HashJoinTransform(
@@ -69,6 +74,21 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
         this.tags = tags;
         this.mapToOutputBiFn = null;
         this.mapToOutputTriFn = mapToOutputTriFn;
+        this.whereNullsNotAllowed = null;
+    }
+    public HashJoinTransform(
+            @Nonnull List<Transform> upstream,
+            @Nonnull List<JoinClause<?, ? super T0, ?, ?>> clauses,
+            @Nonnull List<Tag> tags,
+            @Nonnull BiFunctionEx mapToOutputBiFn,
+            @Nonnull List<Boolean> whereNullsNotAllowed
+    ) {
+        super(upstream.size() + "-way hash-join", upstream);
+        this.clauses = clauses;
+        this.tags = tags;
+        this.mapToOutputBiFn = mapToOutputBiFn;
+        this.mapToOutputTriFn = null;
+        this.whereNullsNotAllowed = whereNullsNotAllowed;
     }
 
     //         ---------           ----------           ----------
@@ -101,8 +121,12 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
         List<Tag> tags = this.tags;
         BiFunctionEx mapToOutputBiFn = this.mapToOutputBiFn;
         TriFunction mapToOutputTriFn = this.mapToOutputTriFn;
+
+        // must be extracted to variable, probably because of serialization bug
+        BiFunctionEx<List<Tag>, Object[], ItemsByTag> tupleToItems = tupleToItemsByTag(whereNullsNotAllowed);
+
         Vertex joiner = p.addVertex(this, name() + "-joiner", localParallelism(),
-                () -> new HashJoinP<>(keyFns, tags, mapToOutputBiFn, mapToOutputTriFn)).v;
+                () -> new HashJoinP<>(keyFns, tags, mapToOutputBiFn, mapToOutputTriFn, tupleToItems)).v;
         p.dag.edge(from(primary.v, primary.nextAvailableOrdinal()).to(joiner, 0));
 
         String collectorName = name() + "-collector";
@@ -125,5 +149,18 @@ public class HashJoinTransform<T0, R> extends AbstractTransform {
                     .broadcast().priority(-1));
             collectorOrdinal++;
         }
+    }
+
+    private static BiFunctionEx<List<Tag>, Object[], ItemsByTag> tupleToItemsByTag(List<Boolean> nullsAllowed) {
+        return (tagList, tuple) -> {
+            ItemsByTag res = new ItemsByTag();
+            for (int i = 0; i < tagList.size(); i++) {
+                if (tuple[i] == null && !nullsAllowed.get(i)) {
+                    return null;
+                }
+                res.put(tagList.get(i), tuple[i]);
+            }
+            return res;
+        };
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.processor;
 
+import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.core.AbstractProcessor;
 import com.hazelcast.jet.datamodel.ItemsByTag;
@@ -28,11 +29,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -79,7 +76,8 @@ public class HashJoinP<E0> extends AbstractProcessor {
             @Nonnull List<Function<E0, Object>> keyFns,
             @Nonnull List<Tag> tags,
             @Nullable BiFunction mapToOutputBiFn,
-            @Nullable TriFunction mapToOutputTriFn
+            @Nullable TriFunction mapToOutputTriFn,
+            @Nullable BiFunctionEx<List<Tag>, Object[], ItemsByTag> tupleToItemsByTag
     ) {
         this.keyFns = keyFns;
         this.lookupTables = new ArrayList<>(Collections.nCopies(keyFns.size(), null));
@@ -89,11 +87,10 @@ public class HashJoinP<E0> extends AbstractProcessor {
         if (!tags.isEmpty()) {
             requireNonNull(mapToOutputBiFn, "mapToOutputBiFn required with tags");
             mapTupleToOutputFn = (item, tuple) -> {
-                ItemsByTag res = new ItemsByTag();
-                for (int i = 0; i < tags.size(); i++) {
-                    res.put(tags.get(i), tuple[i]);
-                }
-                return mapToOutputBiFn.apply(item, res);
+                ItemsByTag res = tupleToItemsByTag.apply(tags, tuple);
+                return res == null
+                        ? null
+                        : mapToOutputBiFn.apply(item, res);
             };
         } else if (keyFns.size() == 1) {
             BiFunction mapToOutput = requireNonNull(mapToOutputBiFn,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/HashJoinP.java
@@ -29,7 +29,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -214,6 +214,15 @@ public interface BatchStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
+    <K1, K2, T1_IN, T2_IN, T1, T2, R> BatchStage<R> innerHashJoin2(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BatchStage<T2_IN> stage2,
+            @Nonnull JoinClause<K2, ? super T, ? super T2_IN, ? extends T2> joinClause2,
+            @Nonnull TriFunction<T, T1, T2, R> mapToOutputFn
+    );
+
+    @Nonnull @Override
     default HashJoinBuilder<T> hashJoinBuilder() {
         return new HashJoinBuilder<>(this);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -198,6 +198,13 @@ public interface BatchStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
+    <K, T1_IN, T1, R> BatchStage<R> innerHashJoin(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BiFunctionEx<T, T1, R> mapToOutputFn
+    );
+
+    @Nonnull @Override
     <K1, K2, T1_IN, T2_IN, T1, T2, R> BatchStage<R> hashJoin2(
             @Nonnull BatchStage<T1_IN> stage1,
             @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
@@ -82,7 +82,24 @@ public abstract class GeneralHashJoinBuilder<T0> {
      */
     public <K, T1_IN, T1> Tag<T1> add(BatchStage<T1_IN> stage, JoinClause<K, T0, T1_IN, T1> joinClause) {
         Tag<T1> tag = tag(clauses.size());
-        clauses.put(tag, new TransformAndClause<>(stage, joinClause));
+        clauses.put(tag, new TransformAndClause<>(stage, joinClause, false));
+        return tag;
+    }
+
+    /**
+     * Adds another contributing pipeline stage to the hash-join operation.
+     *
+     * @param stage the contributing stage
+     * @param joinClause specifies how to join the contributing stage
+     * @param <K> the type of the join key
+     * @param <T1_IN> the type of the contributing stage's data
+     * @param <T1> the type of result after applying the projecting transformation
+     *             to the contributing stage's data
+     * @return the tag that refers to the contributing stage
+     */
+    public <K, T1_IN, T1> Tag<T1> addInner(BatchStage<T1_IN> stage, JoinClause<K, T0, T1_IN, T1> joinClause) {
+        Tag<T1> tag = tag(clauses.size());
+        clauses.put(tag, new TransformAndClause<>(stage, joinClause, true));
         return tag;
     }
 
@@ -98,17 +115,23 @@ public abstract class GeneralHashJoinBuilder<T0> {
                         orderedClauses.stream().map(e -> e.getValue().transform())
                 ).collect(toList());
         // A probable javac bug forced us to extract this variable
+        // and not using method reference
         Stream<JoinClause<?, T0, ?, ?>> joinClauses = orderedClauses
                 .stream()
                 .map(e -> e.getValue().clause())
-                .map(fnAdapter::adaptJoinClause);
+                .map(joinClause -> fnAdapter.adaptJoinClause(joinClause));
+        Stream<Boolean> nullabilityPossibility = orderedClauses
+                .stream()
+                .map(e -> e.getValue().inner);
+        BiFunctionEx<?, ? super ItemsByTag, ?> mapToOutputBiFn = fnAdapter.adaptHashJoinOutputFn(mapToOutputFn);
         HashJoinTransform<T0, R> hashJoinTransform = new HashJoinTransform<>(
                 upstream,
                 joinClauses.collect(toList()),
                 orderedClauses.stream()
                               .map(Entry::getKey)
                               .collect(toList()),
-                fnAdapter.adaptHashJoinOutputFn(mapToOutputFn));
+                mapToOutputBiFn,
+                nullabilityPossibility.collect(toList()));
         pipelineImpl.connect(upstream, hashJoinTransform);
         return createOutStageFn.get(hashJoinTransform, fnAdapter, pipelineImpl);
     }
@@ -122,10 +145,12 @@ public abstract class GeneralHashJoinBuilder<T0> {
     private static class TransformAndClause<K, E0, T1, T1_OUT> {
         private final Transform transform;
         private final JoinClause<K, E0, T1, T1_OUT> joinClause;
+        private final boolean inner;
 
-        TransformAndClause(GeneralStage<T1> stage, JoinClause<K, E0, T1, T1_OUT> joinClause) {
+        TransformAndClause(GeneralStage<T1> stage, JoinClause<K, E0, T1, T1_OUT> joinClause, boolean inner) {
             this.transform = transformOf(stage);
             this.joinClause = joinClause;
+            this.inner = inner;
         }
 
         Transform transform() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
@@ -124,9 +124,6 @@ public abstract class GeneralHashJoinBuilder<T0> {
                 .stream()
                 .map(e -> e.getValue().clause())
                 .map(joinClause -> fnAdapter.adaptJoinClause(joinClause));
-        Stream<Boolean> whereNullNotAllowed = orderedClauses
-                .stream()
-                .map(e -> e.getValue().inner);
         BiFunctionEx<?, ? super ItemsByTag, ?> mapToOutputBiFn = fnAdapter.adaptHashJoinOutputFn(mapToOutputFn);
         HashJoinTransform<T0, R> hashJoinTransform = new HashJoinTransform<>(
                 upstream,
@@ -135,7 +132,10 @@ public abstract class GeneralHashJoinBuilder<T0> {
                               .map(Entry::getKey)
                               .collect(toList()),
                 mapToOutputBiFn,
-                whereNullNotAllowed.collect(toList()));
+                orderedClauses
+                        .stream()
+                        .map(e -> e.getValue().inner)
+                        .collect(toList()));
         pipelineImpl.connect(upstream, hashJoinTransform);
         return createOutStageFn.get(hashJoinTransform, fnAdapter, pipelineImpl);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
@@ -89,8 +89,8 @@ public abstract class GeneralHashJoinBuilder<T0> {
     /**
      * Adds another contributing pipeline stage to the hash-join operation.
      *
-     * If no matching items for returned {@linkplain Tag tag} is found, no records
-     * for given key will be added.
+     * If no matching items for returned {@linkplain Tag tag} is found, no
+     * records for given key will be added.
      *
      * @param stage the contributing stage
      * @param joinClause specifies how to join the contributing stage

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
@@ -89,7 +89,8 @@ public abstract class GeneralHashJoinBuilder<T0> {
     /**
      * Adds another contributing pipeline stage to the hash-join operation.
      *
-     * If no matching items for returned {@linkplain Tag tag} is found, all records for given key won't be added.
+     * If no matching items for returned {@linkplain Tag tag} is found, no records
+     * for given key will be added.
      *
      * @param stage the contributing stage
      * @param joinClause specifies how to join the contributing stage

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
@@ -89,6 +89,8 @@ public abstract class GeneralHashJoinBuilder<T0> {
     /**
      * Adds another contributing pipeline stage to the hash-join operation.
      *
+     * If no matching items for returned {@linkplain Tag tag} is found, all records for given key won't be added.
+     *
      * @param stage the contributing stage
      * @param joinClause specifies how to join the contributing stage
      * @param <K> the type of the join key
@@ -120,7 +122,7 @@ public abstract class GeneralHashJoinBuilder<T0> {
                 .stream()
                 .map(e -> e.getValue().clause())
                 .map(joinClause -> fnAdapter.adaptJoinClause(joinClause));
-        Stream<Boolean> nullabilityPossibility = orderedClauses
+        Stream<Boolean> whereNullNotAllowed = orderedClauses
                 .stream()
                 .map(e -> e.getValue().inner);
         BiFunctionEx<?, ? super ItemsByTag, ?> mapToOutputBiFn = fnAdapter.adaptHashJoinOutputFn(mapToOutputFn);
@@ -131,7 +133,7 @@ public abstract class GeneralHashJoinBuilder<T0> {
                               .map(Entry::getKey)
                               .collect(toList()),
                 mapToOutputBiFn,
-                nullabilityPossibility.collect(toList()));
+                whereNullNotAllowed.collect(toList()));
         pipelineImpl.connect(upstream, hashJoinTransform);
         return createOutStageFn.get(hashJoinTransform, fnAdapter, pipelineImpl);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralHashJoinBuilder.java
@@ -98,6 +98,7 @@ public abstract class GeneralHashJoinBuilder<T0> {
      * @param <T1> the type of result after applying the projecting transformation
      *             to the contributing stage's data
      * @return the tag that refers to the contributing stage
+     * @since 4.1
      */
     public <K, T1_IN, T1> Tag<T1> addInner(BatchStage<T1_IN> stage, JoinClause<K, T0, T1_IN, T1> joinClause) {
         Tag<T1> tag = tag(clauses.size());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -751,8 +751,9 @@ public interface GeneralStage<T> extends Stage {
     );
 
     /**
-     * Attaches to both this and the supplied stage a inner-hash-joining stage and
-     * returns it. This stage plays the role of the <em>primary stage</em> in
+     * Attaches to both this and the supplied stage
+     * an inner-hash-joining stage and  returns it.
+     * This stage plays the role of the <em>primary stage</em> in
      * the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
      * package javadoc} for a detailed description of the hash-join transform.
      * <p>
@@ -771,10 +772,10 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      *
      * <p>
-     *     This metod is similar to {@link #hashJoin(BatchStage, JoinClause, BiFunctionEx)} method,
-     *     but it guarantees that both input items will be not-null.
-     *     Nulls will be filtered out before reaching {@code #mapToOutputFn}.
-     * </p>
+     * This method is similar
+     * to {@link #hashJoin(BatchStage, JoinClause, BiFunctionEx)} method,
+     * but it guarantees that both input items will be not-null.
+     * Nulls will be filtered out before reaching {@code #mapToOutputFn}.
      *
      * @param stage1        the stage to hash-join with this one
      * @param joinClause1   specifies how to join the two streams

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -752,7 +752,7 @@ public interface GeneralStage<T> extends Stage {
 
     /**
      * Attaches to both this and the supplied stage an inner hash-joining stage
-     * and  returns it. This stage plays the role of the <em>primary stage</em>
+     * and returns it. This stage plays the role of the <em>primary stage</em>
      * in the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
      * package javadoc} for a detailed description of the hash-join transform.
      * <p>
@@ -771,9 +771,9 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      *
      * <p>
-     * This method is similar to {@link #hashJoin(BatchStage, JoinClause, BiFunctionEx)}
-     * method, but it guarantees that both input items will be not-null. Nulls will
-     * be filtered out before reaching {@code #mapToOutputFn}.
+     * This method is similar to {@link #hashJoin} method, but it guarantees
+     * that both input items will be not-null. Nulls will be filtered out
+     * before reaching {@code #mapToOutputFn}.
      *
      * @param stage1        the stage to hash-join with this one
      * @param joinClause1   specifies how to join the two streams
@@ -839,9 +839,9 @@ public interface GeneralStage<T> extends Stage {
     );
 
     /**
-     * Attaches to this and the two supplied stages a inner hash-joining stage and
-     * returns it. This stage plays the role of the <em>primary stage</em> in
-     * the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
+     * Attaches to this and the two supplied stages a inner hash-joining stage
+     * and returns it. This stage plays the role of the <em>primary stage</em>
+     * in the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
      * package javadoc} for a detailed description of the hash-join transform.
      * <p>
      * This sample joins a stream of users to streams of countries and
@@ -861,9 +861,9 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      *
      * <p>
-     * This method is similar to {@link #hashJoin2(BatchStage, JoinClause, BatchStage, JoinClause, TriFunction)}
-     * method, but it guarantees that both input items will be not-null. Nulls will
-     * be filtered out before reaching {@code #mapToOutputFn}.
+     * This method is similar to {@link #hashJoin2} method, but it guarantees
+     * that both input items will be not-null. Nulls will be filtered out
+     * before reaching {@code #mapToOutputFn}.
      *
      * @param stage1        the first stage to join
      * @param joinClause1   specifies how to join with {@code stage1}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -751,10 +751,9 @@ public interface GeneralStage<T> extends Stage {
     );
 
     /**
-     * Attaches to both this and the supplied stage
-     * an inner-hash-joining stage and  returns it.
-     * This stage plays the role of the <em>primary stage</em> in
-     * the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
+     * Attaches to both this and the supplied stage an inner hash-joining stage
+     * and  returns it. This stage plays the role of the <em>primary stage</em>
+     * in the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
      * package javadoc} for a detailed description of the hash-join transform.
      * <p>
      * This sample joins a stream of users to a stream of countries and outputs
@@ -772,10 +771,9 @@ public interface GeneralStage<T> extends Stage {
      * }</pre>
      *
      * <p>
-     * This method is similar
-     * to {@link #hashJoin(BatchStage, JoinClause, BiFunctionEx)} method,
-     * but it guarantees that both input items will be not-null.
-     * Nulls will be filtered out before reaching {@code #mapToOutputFn}.
+     * This method is similar to {@link #hashJoin(BatchStage, JoinClause, BiFunctionEx)}
+     * method, but it guarantees that both input items will be not-null. Nulls will
+     * be filtered out before reaching {@code #mapToOutputFn}.
      *
      * @param stage1        the stage to hash-join with this one
      * @param joinClause1   specifies how to join the two streams
@@ -861,6 +859,11 @@ public interface GeneralStage<T> extends Stage {
      *     (user, country, company) -> user.setCountry(country).setCompany(company)
      * )
      * }</pre>
+     *
+     * <p>
+     * This method is similar to {@link #hashJoin2(BatchStage, JoinClause, BatchStage, JoinClause, TriFunction)}
+     * method, but it guarantees that both input items will be not-null. Nulls will
+     * be filtered out before reaching {@code #mapToOutputFn}.
      *
      * @param stage1        the first stage to join
      * @param joinClause1   specifies how to join with {@code stage1}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -875,6 +875,8 @@ public interface GeneralStage<T> extends Stage {
      * @param <T2>          the result type of projection of {@code stage2} items
      * @param <R>           the resulting output type
      * @return the newly attached stage
+     *
+     * @since 4.1
      */
     @Nonnull
     <K1, K2, T1_IN, T2_IN, T1, T2, R> GeneralStage<R> innerHashJoin2(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -785,6 +785,8 @@ public interface GeneralStage<T> extends Stage {
      * @param <T1>          the result type of projection on {@code stage1} items
      * @param <R>           the resulting output type
      * @return the newly attached stage
+     *
+     * @since 4.1
      */
     @Nonnull
     <K, T1_IN, T1, R> GeneralStage<R> innerHashJoin(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -841,6 +841,51 @@ public interface GeneralStage<T> extends Stage {
     );
 
     /**
+     * Attaches to this and the two supplied stages a inner hash-joining stage and
+     * returns it. This stage plays the role of the <em>primary stage</em> in
+     * the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
+     * package javadoc} for a detailed description of the hash-join transform.
+     * <p>
+     * This sample joins a stream of users to streams of countries and
+     * companies, and outputs a stream of users with the {@code country} and
+     * {@code company} fields set:
+     * <pre>{@code
+     * // Types of the input stages:
+     * BatchStage<User> users;
+     * BatchStage<Map.Entry<Long, Country>> idAndCountry;
+     * BatchStage<Map.Entry<Long, Company>> idAndCompany;
+     *
+     * users.innerHashJoin2(
+     *     idAndCountry, JoinClause.joinMapEntries(User::getCountryId),
+     *     idAndCompany, JoinClause.joinMapEntries(User::getCompanyId),
+     *     (user, country, company) -> user.setCountry(country).setCompany(company)
+     * )
+     * }</pre>
+     *
+     * @param stage1        the first stage to join
+     * @param joinClause1   specifies how to join with {@code stage1}
+     * @param stage2        the second stage to join
+     * @param joinClause2   specifies how to join with {@code stage2}
+     * @param mapToOutputFn function to map the joined items to the output value
+     * @param <K1>          the type of key for {@code stage1}
+     * @param <T1_IN>       the type of {@code stage1} items
+     * @param <T1>          the result type of projection of {@code stage1} items
+     * @param <K2>          the type of key for {@code stage2}
+     * @param <T2_IN>       the type of {@code stage2} items
+     * @param <T2>          the result type of projection of {@code stage2} items
+     * @param <R>           the resulting output type
+     * @return the newly attached stage
+     */
+    @Nonnull
+    <K1, K2, T1_IN, T2_IN, T1, T2, R> GeneralStage<R> innerHashJoin2(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BatchStage<T2_IN> stage2,
+            @Nonnull JoinClause<K2, ? super T, ? super T2_IN, ? extends T2> joinClause2,
+            @Nonnull TriFunction<T, T1, T2, R> mapToOutputFn
+    );
+
+    /**
      * Returns a fluent API builder object to construct a hash join operation
      * with any number of contributing stages. It is mainly intended for
      * hash-joins with three or more enriching stages. For one or two stages

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -750,6 +750,41 @@ public interface GeneralStage<T> extends Stage {
             @Nonnull BiFunctionEx<T, T1, R> mapToOutputFn
     );
 
+    /**
+     * Attaches to both this and the supplied stage a inner-hash-joining stage and
+     * returns it. This stage plays the role of the <em>primary stage</em> in
+     * the hash-join. Please refer to the {@link com.hazelcast.jet.pipeline
+     * package javadoc} for a detailed description of the hash-join transform.
+     * <p>
+     * This sample joins a stream of users to a stream of countries and outputs
+     * a stream of users with the {@code country} field set:
+     * <pre>{@code
+     * // Types of the input stages:
+     * BatchStage<User> users;
+     * BatchStage<Map.Entry<Long, Country>> idAndCountry;
+     *
+     * users.innerHashJoin(
+     *     idAndCountry,
+     *     JoinClause.joinMapEntries(User::getCountryId),
+     *     (user, country) -> user.setCountry(country)
+     * )
+     * }</pre>
+     *
+     * <p>
+     *     This metod is similar to {@link #hashJoin(BatchStage, JoinClause, BiFunctionEx)} method,
+     *     but it guarantees that both input items will be not-null.
+     *     Nulls will be filtered out before reaching {@code #mapToOutputFn}.
+     * </p>
+     *
+     * @param stage1        the stage to hash-join with this one
+     * @param joinClause1   specifies how to join the two streams
+     * @param mapToOutputFn function to map the joined items to the output value
+     * @param <K>           the type of the join key
+     * @param <T1_IN>       the type of {@code stage1} items
+     * @param <T1>          the result type of projection on {@code stage1} items
+     * @param <R>           the resulting output type
+     * @return the newly attached stage
+     */
     @Nonnull
     <K, T1_IN, T1, R> GeneralStage<R> innerHashJoin(
             @Nonnull BatchStage<T1_IN> stage1,
@@ -772,7 +807,7 @@ public interface GeneralStage<T> extends Stage {
      * BatchStage<Map.Entry<Long, Country>> idAndCountry;
      * BatchStage<Map.Entry<Long, Company>> idAndCompany;
      *
-     * users.hashJoin(
+     * users.hashJoin2(
      *     idAndCountry, JoinClause.joinMapEntries(User::getCountryId),
      *     idAndCompany, JoinClause.joinMapEntries(User::getCompanyId),
      *     (user, country, company) -> user.setCountry(country).setCompany(company)

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -750,6 +750,13 @@ public interface GeneralStage<T> extends Stage {
             @Nonnull BiFunctionEx<T, T1, R> mapToOutputFn
     );
 
+    @Nonnull
+    <K, T1_IN, T1, R> GeneralStage<R> innerHashJoin(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BiFunctionEx<T, T1, R> mapToOutputFn
+    );
+
     /**
      * Attaches to this and the two supplied stages a hash-joining stage and
      * returns it. This stage plays the role of the <em>primary stage</em> in

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -202,6 +202,15 @@ public interface StreamStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
+    <K1, K2, T1_IN, T2_IN, T1, T2, R> StreamStage<R> innerHashJoin2(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BatchStage<T2_IN> stage2,
+            @Nonnull JoinClause<K2, ? super T, ? super T2_IN, ? extends T2> joinClause2,
+            @Nonnull TriFunction<T, T1, T2, R> mapToOutputFn
+    );
+
+    @Nonnull @Override
     default StreamHashJoinBuilder<T> hashJoinBuilder() {
         return new StreamHashJoinBuilder<>(this);
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/StreamStage.java
@@ -186,6 +186,13 @@ public interface StreamStage<T> extends GeneralStage<T> {
     );
 
     @Nonnull @Override
+    <K, T1_IN, T1, R> StreamStage<R> innerHashJoin(
+            @Nonnull BatchStage<T1_IN> stage1,
+            @Nonnull JoinClause<K, ? super T, ? super T1_IN, ? extends T1> joinClause1,
+            @Nonnull BiFunctionEx<T, T1, R> mapToOutputFn
+    );
+
+    @Nonnull @Override
     <K1, K2, T1_IN, T2_IN, T1, T2, R> StreamStage<R> hashJoin2(
             @Nonnull BatchStage<T1_IN> stage1,
             @Nonnull JoinClause<K1, ? super T, ? super T1_IN, ? extends T1> joinClause1,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/package-info.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/package-info.java
@@ -81,8 +81,8 @@
  * {@code innerHashJoin} function, in which for each primary item with
  * at least one match, there are N output items, one for each matching
  * item in the enriching set. If an enriching set doesn't have a matching
- * item, there will be no records with given primary item. In this case
- * output function's arguments are always non-null.
+ * item, there will be no records with the given primary item. In this case
+ * the output function's arguments are always non-null.
  *
  * <p>
  * The join also allows duplicate keys on both enriching and primary inputs:

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/package-info.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/package-info.java
@@ -72,24 +72,21 @@
  * hashtables (hence the name). It consumes the enriching streams in full
  * before ingesting any data from the primary stream.
  * <p>
- * The output of {@code hashJoin} is just like an SQL left-outer join:
- * for each primary item there are N output items,
- * one for each matching item in the enriching set.
- * If an enriching set doesn't have a matching item, the output will
- * have a {@code null} instead of the enriching item.
+ * The output of {@code hashJoin} is just like an SQL left outer join:
+ * for each primary item there are N output items,  one for each matching
+ * item in the enriching set. If an enriching set doesn't have a matching
+ * item, the output will have a {@code null} instead of the enriching item.
  * <p>
- * If SQL inner-join is needed,
- * then specialised {@code innerHashJoin} can be used, in which
- * for each primary item with at least one match, there are N output items,
- * one for each matching item in the enriching set.
- * If an enriching set doesn't have a matching item,
- * there will be no records with given primary item.
- * In this case output function's arguments are always non-null.
+ * If you need SQL inner join, then you can use the specialised
+ * {@code innerHashJoin} function, in which for each primary item with
+ * at least one match, there are N output items, one for each matching
+ * item in the enriching set. If an enriching set doesn't have a matching
+ * item, there will be no records with given primary item. In this case
+ * output function's arguments are always non-null.
  *
  * <p>
- * The join also allows
- * duplicate keys on both enriching and primary inputs: the output is a
- * cartesian product of all the matching entries.
+ * The join also allows duplicate keys on both enriching and primary inputs:
+ * the output is a cartesian product of all the matching entries.
 
  * <p>
  * Example:<pre>

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/package-info.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/package-info.java
@@ -72,12 +72,25 @@
  * hashtables (hence the name). It consumes the enriching streams in full
  * before ingesting any data from the primary stream.
  * <p>
- * The output is just like an SQL left-outer join: for each primary item
- * there are N output items, one for each matching item in the enriching
- * set. If an enriching set doesn't have a matching item, the output will
- * have a {@code null} instead of the enriching item. The join also allows
+ * The output of {@code hashJoin} is just like an SQL left-outer join:
+ * for each primary item there are N output items,
+ * one for each matching item in the enriching set.
+ * If an enriching set doesn't have a matching item, the output will
+ * have a {@code null} instead of the enriching item.
+ * <p>
+ * If SQL inner-join is needed,
+ * then specialised {@code innerHashJoin} can be used, in which
+ * for each primary item with at least one match, there are N output items,
+ * one for each matching item in the enriching set.
+ * If an enriching set doesn't have a matching item,
+ * there will be no records with given primary item.
+ * In this case output function's arguments are always non-null.
+ *
+ * <p>
+ * The join also allows
  * duplicate keys on both enriching and primary inputs: the output is a
  * cartesian product of all the matching entries.
+
  * <p>
  * Example:<pre>
  * +------------------------+-----------------+---------------------------+

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.impl.processor;
 
 import com.hazelcast.function.BiFunctionEx;
-import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Processor;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/processor/HashJoinPTest.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.jet.impl.processor;
 
+import com.hazelcast.function.BiFunctionEx;
+import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.datamodel.ItemsByTag;
+import com.hazelcast.jet.datamodel.Tag;
 import com.hazelcast.jet.datamodel.Tuple2;
 import com.hazelcast.jet.datamodel.Tuple3;
 import com.hazelcast.jet.function.TriFunction;
@@ -62,6 +65,7 @@ public class HashJoinPTest extends JetTestSupport {
                 singletonList(e -> e),
                 emptyList(),
                 mapToOutputBiFn,
+                null,
                 null
         );
 
@@ -89,6 +93,7 @@ public class HashJoinPTest extends JetTestSupport {
                 singletonList(enrichingSideKeyFn),
                 emptyList(),
                 mapToOutputBiFn,
+                null,
                 null
         );
 
@@ -116,7 +121,8 @@ public class HashJoinPTest extends JetTestSupport {
                 asList(e -> e, e -> e),
                 emptyList(),
                 null,
-                mapToOutputTriFn
+                mapToOutputTriFn,
+                null
         );
 
         verifyProcessor(supplier)
@@ -145,7 +151,8 @@ public class HashJoinPTest extends JetTestSupport {
                 asList(e -> e, e -> e),
                 emptyList(),
                 null,
-                mapToOutputTriFn
+                mapToOutputTriFn,
+                null
         );
 
         verifyProcessor(supplier)
@@ -183,7 +190,8 @@ public class HashJoinPTest extends JetTestSupport {
                 asList(e -> e, e -> e),
                 asList(tag0(), tag1()),
                 mapToOutputBiFn,
-                null
+                null,
+                tupleToItemsByTag()
         );
 
         verifyProcessor(supplier)
@@ -212,7 +220,8 @@ public class HashJoinPTest extends JetTestSupport {
                 asList(e -> e, e -> e),
                 asList(tag0(), tag1()),
                 mapToOutputBiFn,
-                null
+                null,
+                tupleToItemsByTag()
         );
 
         verifyProcessor(supplier)
@@ -250,6 +259,7 @@ public class HashJoinPTest extends JetTestSupport {
                 singletonList(e -> e),
                 emptyList(),
                 (l, r) -> r == null ? null : tuple2(l, r),
+                null,
                 null
         );
 
@@ -271,7 +281,8 @@ public class HashJoinPTest extends JetTestSupport {
                 asList(e -> e, e -> e),
                 emptyList(),
                 null,
-                (l, r1, r2) -> r1 == null || r2 == null ? null : tuple3(l, r1, r2)
+                (l, r1, r2) -> r1 == null || r2 == null ? null : tuple3(l, r1, r2),
+                null
         );
 
         verifyProcessor(supplier)
@@ -297,7 +308,8 @@ public class HashJoinPTest extends JetTestSupport {
                 asList(e -> e, e -> e),
                 asList(tag0(), tag1()),
                 (item, itemsByTag) -> ((ItemsByTag) itemsByTag).get(tag0()) == null ? null : tuple2(item, itemsByTag),
-                null
+                null,
+                tupleToItemsByTag()
         );
 
         verifyProcessor(supplier)
@@ -326,6 +338,7 @@ public class HashJoinPTest extends JetTestSupport {
                 singletonList(e -> e),
                 emptyList(),
                 mapToOutputBiFn,
+                null,
                 null
         );
 
@@ -359,5 +372,15 @@ public class HashJoinPTest extends JetTestSupport {
     @SafeVarargs
     private static <K, V> Map<K, Object> toMap(Tuple2<K, Object>... entries) {
         return Stream.of(entries).collect(Collectors.toMap(Tuple2::f0, Tuple2::f1));
+    }
+
+    private static BiFunctionEx<List<Tag>, Object[], ItemsByTag> tupleToItemsByTag() {
+        return (tagList, tuple) -> {
+            ItemsByTag res = new ItemsByTag();
+            for (int i = 0; i < tagList.size(); i++) {
+                res.put(tagList.get(i), tuple[i]);
+            }
+            return res;
+        };
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
@@ -1041,8 +1041,11 @@ public class BatchStageTest extends PipelineTestSupport {
         int invalidIdStart = itemCount * 2;
         List<Integer> input = sequence(itemCount);
         String prefix = "value-";
-        BatchStage<Entry<Integer, String>> enrichingStageMatching = batchStageFromList(input).map(i -> entry(i, prefix + i));
-        BatchStage<Entry<Integer, String>> enrichingStageNonMatching = batchStageFromList(input).map(i -> entry(invalidIdStart + i, "nope"));
+        BatchStage<Entry<Integer, String>> enrichingStageMatching = batchStageFromList(input)
+                .map(i -> entry(i, prefix + i));
+        BatchStage<Entry<Integer, String>> enrichingStageNonMatching = batchStageFromList(input)
+                .map(i -> entry(invalidIdStart + i, "nope"));
+
         BatchStage<Entry<Integer, String>> enrichingStage = enrichingStageMatching.merge(enrichingStageNonMatching);
 
         // When

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
@@ -1080,8 +1080,8 @@ public class BatchStageTest extends PipelineTestSupport {
 
         // When
         HashJoinBuilder<Integer> b = batchStageFromList(input).hashJoinBuilder();
-        Tag<String> tagA = b.add(enrichingStage1, joinMapEntries(wholeItem()));
-        Tag<String> tagB = b.add(enrichingStage2, joinMapEntries(wholeItem()));
+        Tag<String> tagA = b.addInner(enrichingStage1, joinMapEntries(wholeItem()));
+        Tag<String> tagB = b.addInner(enrichingStage2, joinMapEntries(wholeItem()));
         GeneralStage<Tuple2<Integer, ItemsByTag>> joined =
                 b.build(Tuple2::tuple2);
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchStageTest.java
@@ -143,7 +143,7 @@ public class BatchStageTest extends PipelineTestSupport {
         List<Integer> input = sequence(itemCount);
         FunctionEx<BatchStage<? extends Number>, BatchStage<String>> transformFn = stage ->
                 stage.map(formatFn)
-                     .map(String::toUpperCase);
+                        .map(String::toUpperCase);
 
         // When
         BatchStage<String> mapped = batchStageFromList(input)
@@ -775,10 +775,10 @@ public class BatchStageTest extends PipelineTestSupport {
         assertEquals(
                 streamToString(
                         input.stream()
-                             .filter(i -> {
-                                 int sum = i * (i + 1) / 2;
-                                 return sum % 2 == 0;
-                             }),
+                                .filter(i -> {
+                                    int sum = i * (i + 1) / 2;
+                                    return sum % 2 == 0;
+                                }),
                         formatFn),
                 streamToString(sinkStreamOf(Integer.class), formatFn)
         );
@@ -804,14 +804,14 @@ public class BatchStageTest extends PipelineTestSupport {
         assertEquals(
                 streamToString(
                         input.stream()
-                             .map(i -> {
-                                 // Using direct formula to sum the sequence of even/odd numbers:
-                                 int first = i % 2;
-                                 long count = i / 2 + 1;
-                                 long sum = (first + i) * count / 2;
-                                 return sum % 2 == 0 ? i : null;
-                             })
-                             .filter(Objects::nonNull),
+                                .map(i -> {
+                                    // Using direct formula to sum the sequence of even/odd numbers:
+                                    int first = i % 2;
+                                    long count = i / 2 + 1;
+                                    long sum = (first + i) * count / 2;
+                                    return sum % 2 == 0 ? i : null;
+                                })
+                                .filter(Objects::nonNull),
                         formatFn),
                 streamToString(sinkStreamOf(Integer.class), formatFn)
         );
@@ -836,10 +836,10 @@ public class BatchStageTest extends PipelineTestSupport {
         assertEquals(
                 streamToString(
                         input.stream()
-                             .flatMap(i -> {
-                                 long sum = i * (i + 1) / 2;
-                                 return Stream.of(sum, sum);
-                             }),
+                                .flatMap(i -> {
+                                    long sum = i * (i + 1) / 2;
+                                    return Stream.of(sum, sum);
+                                }),
                         formatFn),
                 streamToString(sinkStreamOf(Long.class), formatFn)
         );
@@ -923,8 +923,8 @@ public class BatchStageTest extends PipelineTestSupport {
         assertEquals(0, itemCount % 2);
         Stream<Entry<Integer, Long>> expectedStream =
                 LongStream.range(1, itemCount / 2 + 1)
-                          .boxed()
-                          .flatMap(i -> Stream.of(entry(0, i), entry(1, i)));
+                        .boxed()
+                        .flatMap(i -> Stream.of(entry(0, i), entry(1, i)));
         Function<Entry<Integer, Long>, String> formatFn =
                 e -> String.format("(%04d, %04d)", e.getKey(), e.getValue());
         assertEquals(
@@ -955,8 +955,8 @@ public class BatchStageTest extends PipelineTestSupport {
     public void distinct() {
         // Given
         List<Integer> input = IntStream.range(0, 2 * itemCount)
-                                       .map(i -> i % itemCount)
-                                       .boxed().collect(toList());
+                .map(i -> i % itemCount)
+                .boxed().collect(toList());
         Collections.shuffle(input);
 
         // When
@@ -1058,6 +1058,50 @@ public class BatchStageTest extends PipelineTestSupport {
         assertEquals(
                 streamToString(input.stream().filter(e -> e % 2 == 0).map(i -> tuple2(i, prefix + i)), formatFn),
                 streamToString(sinkStreamOfEntry(), formatFn));
+    }
+
+    @Test
+    public void when_hashJoinBuilderAddInner_then_filterOutNulls() {
+        // Given
+        int itemCountLocal = itemCount;
+        List<Integer> input = sequence(itemCountLocal);
+        String prefixA = "A-";
+        String prefixB = "B-";
+        String prefixC = "C-";
+        String prefixD = "D-";
+        BatchStage<Entry<Integer, String>> enrichingStage1 =
+                batchStageFromList(input)
+                        .filter(e -> e <= itemCountLocal / 2)
+                        .flatMap(i -> traverseItems(entry(i, prefixA + i), entry(i, prefixB + i)));
+        BatchStage<Entry<Integer, String>> enrichingStage2 =
+                batchStageFromList(input)
+                        .filter(e -> e <= itemCountLocal / 4)
+                        .flatMap(i -> traverseItems(entry(i, prefixC + i), entry(i, prefixD + i)));
+
+        // When
+        HashJoinBuilder<Integer> b = batchStageFromList(input).hashJoinBuilder();
+        Tag<String> tagA = b.add(enrichingStage1, joinMapEntries(wholeItem()));
+        Tag<String> tagB = b.add(enrichingStage2, joinMapEntries(wholeItem()));
+        GeneralStage<Tuple2<Integer, ItemsByTag>> joined =
+                b.build(Tuple2::tuple2);
+
+        // Then
+        joined.writeTo(sink);
+        execute();
+        TriFunction<Integer, String, String, String> formatFn =
+                (i, v1, v2) -> String.format("(%04d, %s, %s)", i, v1, v2);
+        assertEquals(
+                streamToString(input.stream()
+                                .filter(i ->  i <= itemCountLocal / 4)
+                                .flatMap(i -> Stream.of(
+                                        tuple3(i, prefixA, prefixC),
+                                        tuple3(i, prefixA, prefixD),
+                                        tuple3(i, prefixB, prefixC),
+                                        tuple3(i, prefixB, prefixD))),
+                        t -> formatFn.apply(t.f0(), t.f1() + t.f0(), t.f2() + t.f0())),
+                streamToString(sinkList.stream().map(o -> (Tuple2<Integer, ItemsByTag>) o),
+                        t2 -> formatFn.apply(t2.f0(), t2.f1().get(tagA), t2.f1().get(tagB)))
+        );
     }
 
     @Test
@@ -1213,8 +1257,8 @@ public class BatchStageTest extends PipelineTestSupport {
 
         // When
         p.readFrom(source)
-         .addTimestamps(o -> 0L, 0)
-         .writeTo(assertOrdered(items));
+                .addTimestamps(o -> 0L, 0)
+                .writeTo(assertOrdered(items));
 
         // Then
         execute();
@@ -1228,8 +1272,8 @@ public class BatchStageTest extends PipelineTestSupport {
         // When
         p.readFrom(Sources.batchFromProcessor("src",
                 ProcessorMetaSupplier.of(lp, ProcessorSupplier.of(noopP()))))
-         .addTimestamps(o -> 0L, 0)
-         .writeTo(Sinks.noop());
+                .addTimestamps(o -> 0L, 0)
+                .writeTo(Sinks.noop());
         DAG dag = p.toDag();
 
         // Then
@@ -1244,9 +1288,9 @@ public class BatchStageTest extends PipelineTestSupport {
 
         // When
         p.readFrom(source)
-         .setLocalParallelism(lp)
-         .addTimestamps(t -> System.currentTimeMillis(), 1000)
-         .writeTo(Sinks.noop());
+                .setLocalParallelism(lp)
+                .addTimestamps(t -> System.currentTimeMillis(), 1000)
+                .writeTo(Sinks.noop());
         DAG dag = p.toDag();
 
         // Then
@@ -1262,8 +1306,8 @@ public class BatchStageTest extends PipelineTestSupport {
 
         // When
         p.readFrom(src)
-         .addTimestamps(o -> 0L, 0)
-         .writeTo(Sinks.noop());
+                .addTimestamps(o -> 0L, 0)
+                .writeTo(Sinks.noop());
         DAG dag = p.toDag();
 
         // Then
@@ -1281,9 +1325,9 @@ public class BatchStageTest extends PipelineTestSupport {
 
         // When
         p.readFrom(source)
-         .addTimestamps(o -> 0L, 0)
-         .setLocalParallelism(lp)
-         .writeTo(Sinks.noop());
+                .addTimestamps(o -> 0L, 0)
+                .setLocalParallelism(lp)
+                .writeTo(Sinks.noop());
     }
 
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -1259,8 +1259,9 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         // Given
         List<Integer> input = sequence(itemCount);
         String prefixA = "A";
-        // entry(0, "A-0000"), entry(1, "A-0001"), ...
-        BatchStage<Entry<Integer, String>> enrichingStage = enrichingStage(input, prefixA);
+        // entry(0, "A-0000"), entry(2, "A-0002"), ...
+        List<Integer> enrichingInputList = input.stream().filter(e -> e % 2 == 0).collect(toList());
+        BatchStage<Entry<Integer, String>> enrichingStage = enrichingStage(enrichingInputList, prefixA);
 
         // When
         @SuppressWarnings("Convert2MethodRef")
@@ -1275,10 +1276,10 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         hashJoined.writeTo(sink);
         execute();
         BiFunction<Integer, String, String> formatFn = (i, value) -> String.format("(%04d, %s)", i, value);
-        // sinkList: tuple2(0, "A-0000"), tuple2(1, "A-0001"), ...
+        // sinkList: tuple2(0, "A-0000"), tuple2(2, "A-0002"), ...
         assertEquals(
                 streamToString(
-                        input.stream().map(i -> formatFn.apply(i, ENRICHING_FORMAT_FN.apply(prefixA, i))),
+                        input.stream().filter(e -> e % 2 == 0).map(i -> formatFn.apply(i, ENRICHING_FORMAT_FN.apply(prefixA, i))),
                         identity()),
                 streamToString(
                         sinkList.stream().map(t2 -> (Tuple2<Integer, String>) t2),

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -1255,6 +1255,39 @@ public class StreamStageTest extends PipelineStreamTestSupport {
 
     @Test
     @SuppressWarnings("unchecked")
+    public void innerHashJoin() {
+        // Given
+        List<Integer> input = sequence(itemCount);
+        String prefixA = "A";
+        // entry(0, "A-0000"), entry(1, "A-0001"), ...
+        BatchStage<Entry<Integer, String>> enrichingStage = enrichingStage(input, prefixA);
+
+        // When
+        @SuppressWarnings("Convert2MethodRef")
+        // there's a method ref bug in JDK
+        StreamStage<Tuple2<Integer, String>> hashJoined = streamStageFromList(input).innerHashJoin(
+                enrichingStage,
+                joinMapEntries(wholeItem()),
+                (i, valueA) -> tuple2(i, valueA)
+        );
+
+        // Then
+        hashJoined.writeTo(sink);
+        execute();
+        BiFunction<Integer, String, String> formatFn = (i, value) -> String.format("(%04d, %s)", i, value);
+        // sinkList: tuple2(0, "A-0000"), tuple2(1, "A-0001"), ...
+        assertEquals(
+                streamToString(
+                        input.stream().map(i -> formatFn.apply(i, ENRICHING_FORMAT_FN.apply(prefixA, i))),
+                        identity()),
+                streamToString(
+                        sinkList.stream().map(t2 -> (Tuple2<Integer, String>) t2),
+                        t2 -> formatFn.apply(t2.f0(), t2.f1()))
+        );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void hashJoin2() {
         // Given
         List<Integer> input = sequence(itemCount);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/StreamStageTest.java
@@ -1279,7 +1279,7 @@ public class StreamStageTest extends PipelineStreamTestSupport {
         // sinkList: tuple2(0, "A-0000"), tuple2(2, "A-0002"), ...
         assertEquals(
                 streamToString(
-                        input.stream().filter(e -> e % 2 == 0).map(i -> formatFn.apply(i, ENRICHING_FORMAT_FN.apply(prefixA, i))),
+                        enrichingInputList.stream().map(i -> formatFn.apply(i, ENRICHING_FORMAT_FN.apply(prefixA, i))),
                         identity()),
                 streamToString(
                         sinkList.stream().map(t2 -> (Tuple2<Integer, String>) t2),


### PR DESCRIPTION
As discussed on Gitter and mentioned in #1238, new users often don't know that hashJoin is not inner join (like their intuition says). Adding innerHashJoin with pre-filtering will reduce filtering in user apps and make API more clear for new users.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] No breaking changes

Fixes #1238 
