### PR TITLE
Fix graceful atLeastOnce stress tests for JMS and JDBC sink

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JdbcSinkBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/JdbcSinkBuilder.java
@@ -30,7 +30,7 @@ import java.sql.PreparedStatement;
  *
  * @param <T> type of the items the sink accepts
  *
- * @since 4.0
+ * @since 4.1
  */
 public class JdbcSinkBuilder<T> {
     private String updateQuery;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -1161,7 +1161,7 @@ public final class Sinks {
      * The default local parallelism for this sink is 1.
      *
      * @param <T> type of the items the sink accepts
-     * @since 4.0
+     * @since 4.1
      */
     @Nonnull
     public static <T> JdbcSinkBuilder<T> jdbcBuilder() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSinkIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSinkIntegrationTest.java
@@ -190,7 +190,7 @@ public class JmsSinkIntegrationTest extends SimpleTestInClusterSupport {
 
     @Test
     public void test_transactional_withRestarts_graceful_atLeastOnce() throws Exception {
-        test_transactional_withRestarts(false, false);
+        test_transactional_withRestarts(true, false);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/SinkStressTestUtil.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/SinkStressTestUtil.java
@@ -102,7 +102,7 @@ public final class SinkStressTestUtil {
                         && System.nanoTime() < endTime);
                 lastCount = distinctActualItems.size();
                 logger.info("number of committed items in the sink so far: " + lastCount);
-                if (exactlyOnce || graceful) {
+                if (exactlyOnce) {
                     String actualItemsStr = actualItems.stream()
                             .collect(groupingBy(identity(), TreeMap::new, counting()))
                             .entrySet().stream()

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -129,7 +129,6 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
          ));
 
         instance().newJob(p).join();
-        assertEquals(PERSON_COUNT, rowCount());
     }
 
     @Test
@@ -247,7 +246,7 @@ public class WriteJdbcPTest extends SimpleTestInClusterSupport {
 
     @Test
     public void test_transactional_withRestarts_graceful_atLeastOnce() throws Exception {
-        test_transactional_withRestarts(false, false);
+        test_transactional_withRestarts(true, false);
     }
 
     @Test


### PR DESCRIPTION
Changes:
- Fix incorrect usage of forceful instead of graceful shutdown in `JmsSinkIntegrationTest` and `WriteJdbcPTest`. 
- Removed unused assertion from `testFailJob_withNonTransientException()` in `WriteJdbcPTest`.
- Fix `since` for `jdbcBuilder`

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
