### PR TITLE
Bump IMDG dependency to 4.0.1

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestSupport.java
@@ -192,7 +192,7 @@ public final class TestSupport {
     private static final long BLOCKING_TIME_LIMIT_MS_WARN = 10000;
 
     private static final LoggingServiceImpl LOGGING_SERVICE = new LoggingServiceImpl(
-            "test-group", null, BuildInfoProvider.getBuildInfo()
+            "test-group", null, BuildInfoProvider.getBuildInfo(), true
     );
 
     static {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
@@ -47,7 +47,7 @@ public class ReceiverTaskletSendLimitTest {
     @Before
     public void before() {
         tasklet = new ReceiverTasklet(null, RWIN_MULTIPLIER, FLOW_CONTROL_PERIOD_MS,
-                new LoggingServiceImpl(null, null, BuildInfoProvider.getBuildInfo()), new Address(), 0, "");
+                new LoggingServiceImpl(null, null, BuildInfoProvider.getBuildInfo(), false), new Address(), 0, "");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <timestamp>${maven.build.timestamp}</timestamp>
 
         <!-- Main IMDG dependency -->
-        <hazelcast.version>4.0.1-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>4.0.1</hazelcast.version>
         <!-- Dependencies on IMDG modules: must be the same versions IMDG depends on! -->
         <hazelcast.aws.version>3.1</hazelcast.aws.version>
         <hazelcast.kubernetes.version>2.0.1</hazelcast.kubernetes.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <timestamp>${maven.build.timestamp}</timestamp>
 
         <!-- Main IMDG dependency -->
-        <hazelcast.version>4.0</hazelcast.version>
+        <hazelcast.version>4.0.1-SNAPSHOT</hazelcast.version>
         <!-- Dependencies on IMDG modules: must be the same versions IMDG depends on! -->
         <hazelcast.aws.version>3.1</hazelcast.aws.version>
         <hazelcast.kubernetes.version>2.0.1</hazelcast.kubernetes.version>


### PR DESCRIPTION
* Updates IMDG to 4.0.1
* Also include a partial backport of #2041 (tests only; required to fix compilation)

EE counterpart PR: https://github.com/hazelcast/hazelcast-jet-enterprise/pull/113