### PR TITLE
Update equalsverifier version to 3.1.13

### DIFF
--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.1.4</version>
+            <version>3.1.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Tests fail with older version on Java 14.

```
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 58
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.jar.asm.ClassReader.<init>(ClassReader.java:184)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.jar.asm.ClassReader.<init>(ClassReader.java:166)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.jar.asm.ClassReader.<init>(ClassReader.java:152)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.utility.OpenedClassReader.of(OpenedClassReader.java:82)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$Default.parse(TypePool.java:1174)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$Default.doDescribe(TypePool.java:1160)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$AbstractBase.describe(TypePool.java:408)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$AbstractBase$Hierarchical.describe(TypePool.java:471)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$Default$LazyTypeDescription$TokenizedGenericType.toErasure(TypePool.java:6503)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$Default$LazyTypeDescription$GenericTypeToken$Resolution$Raw$RawAnnotatedType.of(TypePool.java:3905)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$Default$LazyTypeDescription$GenericTypeToken$Resolution$Raw.resolveFieldType(TypePool.java:3785)
	at nl.jqno.equalsverifier.internal.lib.bytebuddy.pool.TypePool$Default$LazyTypeDescription$LazyFieldDescription.getType(TypePool.java:6838)
	at nl.jqno.equalsverifier.internal.reflection.annotations.AnnotationCacheBuilder.lambda$visitFields$8(AnnotationCacheBuilder.java:99)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at nl.jqno.equalsverifier.internal.reflection.annotations.AnnotationCacheBuilder.visitFields(AnnotationCacheBuilder.java:91)
	at nl.jqno.equalsverifier.internal.reflection.annotations.AnnotationCacheBuilder.visitType(AnnotationCacheBuilder.java:47)
	at nl.jqno.equalsverifier.internal.reflection.annotations.AnnotationCacheBuilder.build(AnnotationCacheBuilder.java:35)
	at nl.jqno.equalsverifier.internal.util.Configuration.buildAnnotationCache(Configuration.java:79)
	at nl.jqno.equalsverifier.internal.util.Configuration.build(Configuration.java:67)
	at nl.jqno.equalsverifier.EqualsVerifierApi.buildConfig(EqualsVerifierApi.java:354)
	at nl.jqno.equalsverifier.EqualsVerifierApi.performVerification(EqualsVerifierApi.java:346)
	at nl.jqno.equalsverifier.EqualsVerifierApi.verify(EqualsVerifierApi.java:302)
```


Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] Any breaking changes are documented
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] For code samples, code sample main readme is updated
