### PR TITLE
Disable smart routing by default

### DIFF
--- a/hazelcast-jet-distribution/src/root/config/hazelcast-client.yaml
+++ b/hazelcast-jet-distribution/src/root/config/hazelcast-client.yaml
@@ -9,6 +9,10 @@ hazelcast-client:
     # If a port number is not specified, port range 5701-5703 will be tried.
     cluster-members:
       - 127.0.0.1
+    # Whether client should discover and connect other members in the cluster
+    # and route requests to them or only connects to the members listed
+    # above.
+    smart-routing: false
   connection-strategy:
     connection-retry:
       # how long the client should keep trying connecting to the server


### PR DESCRIPTION
To have a better OOTB experience with the CLI when dealing with Kubernetes clusters from outside networks with port-forwarding

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
