### PR TITLE
Replace ActiveMQ in tests

### DIFF
--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -128,14 +128,22 @@
         <!--TEST DEPENDENCIES-->
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-all</artifactId>
-            <version>${activemq.version}</version>
-            <scope>test</scope>
+            <artifactId>apache-artemis</artifactId>
+            <version>${activemq-artemis.version}</version>
+            <type>pom</type>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.activemq</groupId>
+                    <artifactId>artemis-jms-client-all</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+
         <dependency>
-            <groupId>org.apache.activemq.tooling</groupId>
-            <artifactId>activemq-junit</artifactId>
-            <version>${activemq.version}</version>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-junit</artifactId>
+            <version>${activemq-artemis.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -930,10 +930,11 @@ public final class Sinks {
      * JmsSinkBuilder} methods for more details.
      * <p>
      * In <b>exactly-once mode</b> the processor uses two-phase XA transactions
-     * to guarantee exactly-once delivery. The transaction is committed after
-     * all processors finished processing the items and stored all data to the
-     * snapshot. Processor is also able to finish the commit after a restart,
-     * should the job fail mid-way of the commit process. This mode
+     * to guarantee exactly-once delivery. The supplier is expected to return
+     * an {@link javax.jms.XAConnectionFactory}. The transaction is committed
+     * after all processors finished processing the items and stored all data
+     * to the snapshot. Processor is also able to finish the commit after a
+     * restart, should the job fail mid-way of the commit process. This mode
      * significantly increases latency because produced messages are visible
      * only after they are committed; if you want to avoid it, you can reduce
      * the guarantee just for this sink. To do so call {@link
@@ -1006,10 +1007,11 @@ public final class Sinks {
      * JmsSinkBuilder} methods for more details.
      * <p>
      * In <b>exactly-once mode</b> the processor uses two-phase XA transactions
-     * to guarantee exactly-once delivery. The transaction is committed after
-     * all processors finished processing the items and stored all data to the
-     * snapshot. Processor is also able to finish the commit after a restart,
-     * should the job fail mid-way of the commit process. This mode
+     * to guarantee exactly-once delivery. The supplier is expected to return
+     * an {@link javax.jms.XAConnectionFactory}. The transaction is committed
+     * after all processors finished processing the items and stored all data
+     * to the snapshot. Processor is also able to finish the commit after a
+     * restart, should the job fail mid-way of the commit process. This mode
      * significantly increases latency because produced messages are visible
      * only after they are committed; if you want to avoid it, you can reduce
      * the guarantee just for this sink. To do so call {@link

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSinkIntegrationTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSinkIntegrationTest.java
@@ -22,9 +22,9 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.ActiveMQXAConnectionFactory;
-import org.apache.activemq.junit.EmbeddedActiveMQBroker;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQXAConnectionFactory;
+import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -46,7 +46,7 @@ import static javax.jms.Session.DUPS_OK_ACKNOWLEDGE;
 public class JmsSinkIntegrationTest extends SimpleTestInClusterSupport {
 
     @ClassRule
-    public static EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker();
+    public static EmbeddedActiveMQResource broker = new EmbeddedActiveMQResource();
 
     private static final int MESSAGE_COUNT = 100;
 
@@ -209,7 +209,8 @@ public class JmsSinkIntegrationTest extends SimpleTestInClusterSupport {
                 .build();
 
         try (
-                Connection connection = broker.createConnectionFactory().createConnection();
+                Connection connection = new ActiveMQConnectionFactory(broker.getVmURL())
+                        .createConnection();
                 Session session = connection.createSession(false, DUPS_OK_ACKNOWLEDGE);
                 MessageConsumer consumer = session.createConsumer(session.createQueue(destinationName))
         ) {
@@ -229,6 +230,6 @@ public class JmsSinkIntegrationTest extends SimpleTestInClusterSupport {
     }
 
     private static ConnectionFactory getConnectionFactory() {
-        return new ActiveMQConnectionFactory(broker.getVmURL());
+        return new ActiveMQXAConnectionFactory(broker.getVmURL());
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_ActiveMqArtemis.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_ActiveMqArtemis.java
@@ -17,16 +17,16 @@
 package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.function.SupplierEx;
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.junit.EmbeddedActiveMQBroker;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.ClassRule;
 
 import javax.jms.ConnectionFactory;
 
-public class JmsSourceIntegrationTest_ActiveMQ extends JmsSourceIntegrationTestBase {
+public class JmsSourceIntegrationTest_ActiveMqArtemis extends JmsSourceIntegrationTestBase {
 
     @ClassRule
-    public static EmbeddedActiveMQBroker broker = new EmbeddedActiveMQBroker();
+    public static EmbeddedActiveMQResource broker = new EmbeddedActiveMQResource();
 
     private static final SupplierEx<ConnectionFactory> FACTORY_SUPPLIER =
             () -> new ActiveMQConnectionFactory(broker.getVmURL());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegration_NonSharedClusterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegration_NonSharedClusterTest.java
@@ -54,10 +54,10 @@ import static org.junit.Assert.assertTrue;
 
 public class JmsSourceIntegration_NonSharedClusterTest extends JetTestSupport {
 
-    private static final int MESSAGE_COUNT = 10_000;
-
     @ClassRule
-    private static EmbeddedActiveMQResource realBroker = new EmbeddedActiveMQResource();
+    public static EmbeddedActiveMQResource realBroker = new EmbeddedActiveMQResource();
+
+    private static final int MESSAGE_COUNT = 10_000;
 
     private static volatile boolean storeFailed;
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegration_NonSharedClusterTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegration_NonSharedClusterTest.java
@@ -30,10 +30,8 @@ import com.hazelcast.jet.impl.JobRepository;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.broker.region.policy.PolicyEntry;
-import org.apache.activemq.broker.region.policy.PolicyMap;
-import org.apache.activemq.junit.EmbeddedActiveMQBroker;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -54,22 +52,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class JmsIntegration_NonSharedClusterTest extends JetTestSupport {
+public class JmsSourceIntegration_NonSharedClusterTest extends JetTestSupport {
 
     private static final int MESSAGE_COUNT = 10_000;
 
     @ClassRule
-    public static EmbeddedActiveMQBroker realBroker = new EmbeddedActiveMQBroker() {
-        @Override
-        protected void configure() {
-            // this is needed to work https://issues.apache.org/jira/browse/AMQ-7369 around
-            PolicyMap destinationPolicy = new PolicyMap();
-            PolicyEntry defaultEntry = new PolicyEntry();
-            defaultEntry.setMaxPageSize(MESSAGE_COUNT);
-            destinationPolicy.setDefaultEntry(defaultEntry);
-            getBrokerService().setDestinationPolicy(destinationPolicy);
-        }
-    };
+    private static EmbeddedActiveMQResource realBroker = new EmbeddedActiveMQResource();
 
     private static volatile boolean storeFailed;
 
@@ -83,7 +71,7 @@ public class JmsIntegration_NonSharedClusterTest extends JetTestSupport {
 
         Pipeline p = Pipeline.create();
         IList<String> sinkList = instance1.getList("sinkList");
-        p.readFrom(Sources.jmsQueueBuilder(JmsIntegration_NonSharedClusterTest::getConnectionFactory)
+        p.readFrom(Sources.jmsQueueBuilder(JmsSourceIntegration_NonSharedClusterTest::getConnectionFactory)
                           .destinationName("queue")
                           .build(msg -> ((TextMessage) msg).getText()))
          .withoutTimestamps()
@@ -133,7 +121,7 @@ public class JmsIntegration_NonSharedClusterTest extends JetTestSupport {
 
         JetInstance instance = createJetMember(config);
         Pipeline p = Pipeline.create();
-        p.readFrom(Sources.jmsQueue("queue", JmsIntegration_NonSharedClusterTest::getConnectionFactory))
+        p.readFrom(Sources.jmsQueue("queue", JmsSourceIntegration_NonSharedClusterTest::getConnectionFactory))
          .withoutTimestamps()
          .writeTo(Sinks.noop());
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/StreamJmsPTest.java
@@ -27,8 +27,8 @@ import com.hazelcast.jet.impl.pipeline.transform.StreamSourceTransform;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.junit.EmbeddedActiveMQBroker;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertEquals;
 public class StreamJmsPTest extends JetTestSupport {
 
     @ClassRule
-    public static EmbeddedActiveMQBroker resource = new EmbeddedActiveMQBroker();
+    public static EmbeddedActiveMQResource resource = new EmbeddedActiveMQResource();
 
     @SuppressWarnings("rawtypes")
     private StreamJmsP processor;

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
 
         <!-- test dependencies -->
         <activemq.version>5.15.11</activemq.version>
+        <activemq-artemis.version>2.11.0</activemq-artemis.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <assertj.version>3.15.0</assertj.version>


### PR DESCRIPTION
Fixes #1954 - the broker sometimes didn't show up in tests.

We also had to change the default `connectionFn` - we relied on particular behavior of ActiveMQ which doesn't exist in Artemis, and IMO Artemis behavior is _more correct_: the `createConnection()` method returned an `XAConnection` when called on an `XAConnectionFactory`. In Artemis, only the `createXaConnection()` returns an `XAConnection`.