### PR TITLE
Bump Classgraph version to 4.8.66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <grpc.version>1.26.0</grpc.version>
         <protobuf.version>3.11.3</protobuf.version>
         <picocli.version>3.9.0</picocli.version>
-        <classgraph.version>4.8.62</classgraph.version>
+        <classgraph.version>4.8.66</classgraph.version>
 
         <!-- test dependencies -->
         <activemq.version>5.15.11</activemq.version>


### PR DESCRIPTION
Bumped Classgraph version to 4.8.66.

Checklist
- [x] Tags Set
- [x] Milestone Set

Fixes https://github.com/hazelcast/hazelcast-jet/issues/2130 by https://github.com/classgraph/classgraph/issues/400