### PR TITLE
Various docs fixes

### DIFF
--- a/site/docs/api/pipeline.md
+++ b/site/docs/api/pipeline.md
@@ -24,9 +24,9 @@ called _compute stages_ and expect you to attach further stages to them.
 
 The API differentiates between batch (bounded) and stream (unbounded)
 sources and this is reflected in the naming: there is a
-[BatchStage](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/BatchStage.html)
+[BatchStage](/javadoc/4.0/com/hazelcast/jet/pipeline/BatchStage.html)
 and a
-[StreamStage](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/StreamStage.html)
+[StreamStage](/javadoc/4.0/com/hazelcast/jet/pipeline/StreamStage.html)
 , each offering the operations appropriate to its kind.
 Depending on the data source, your pipeline will end up starting with a
 batch or streaming stage. A batch source still can be used to simulate

--- a/site/docs/api/serialization.md
+++ b/site/docs/api/serialization.md
@@ -157,8 +157,8 @@ types:
 
 - [java.io.Serializable](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html)
 - [java.io.Externalizable](https://docs.oracle.com/javase/8/docs/api/java/io/Externalizable.html)
-- [com.hazelcast.nio.serialization.Portable](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/nio/serialization/Portable.html)
-- [com.hazelcast.nio.serialization.StreamSerializer](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/nio/serialization/StreamSerializer.html)
+- [com.hazelcast.nio.serialization.Portable](/javadoc/4.0/com/hazelcast/nio/serialization/Portable.html)
+- [com.hazelcast.nio.serialization.StreamSerializer](/javadoc/4.0/com/hazelcast/nio/serialization/StreamSerializer.html)
 
 The following table provides a comparison between them to help you in
 deciding which interface to use in your applications.
@@ -215,7 +215,7 @@ not to mention very wasteful with memory.
 
 For the best performance and simplest implementation we recommend using
 the Hazelcast
-[StreamSerializer](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/nio/serialization/StreamSerializer.html)
+[StreamSerializer](/javadoc/4.0/com/hazelcast/nio/serialization/StreamSerializer.html)
 mechanism. Here is a sample implementation for a `Person` class:
 
 ```java

--- a/site/docs/api/sources-sinks.md
+++ b/site/docs/api/sources-sinks.md
@@ -1111,9 +1111,9 @@ processing even with at-least-once sinks.
 
 If Jet doesn’t natively support the data source/sink you need, you can
 build a connector for it yourself by using the
-[SourceBuilder](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/SourceBuilder.html)
+[SourceBuilder](/javadoc/4.0/com/hazelcast/jet/pipeline/SourceBuilder.html)
 and
-[SinkBuilder](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/SinkBuilder.html)
+[SinkBuilder](/javadoc/4.0/com/hazelcast/jet/pipeline/SinkBuilder.html)
 .
 
 ### SourceBuilder

--- a/site/docs/api/stateful-transforms.md
+++ b/site/docs/api/stateful-transforms.md
@@ -61,10 +61,10 @@ in aggregations, such as:
 |`allOf`|Combine multiple aggregations into one aggregation (for example, if you want both sum and average)|
 
 For a complete list, please refer to the
-[AggregateOperations](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/aggregate/AggregateOperations.html)
+[AggregateOperations](/javadoc/4.0/com/hazelcast/jet/aggregate/AggregateOperations.html)
 class. You can also implement your own aggregate operations using the
 builder in
-[AggregateOperation](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/aggregate/AggregateOperation.html)
+[AggregateOperation](/javadoc/4.0/com/hazelcast/jet/aggregate/AggregateOperation.html)
 .
 
 ### groupingKey

--- a/site/docs/concepts/processing-guarantees.md
+++ b/site/docs/concepts/processing-guarantees.md
@@ -47,7 +47,7 @@ processing pipeline:
   *N*, later stages are still working on batches *N - 1*, *N - 2* etc.
 - **Volatile State.** Jet stores aggregation state in plain `HashMap`s
   and only occasionally backs them up to the resilient
-  [`IMap`](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/map/IMap.html)
+  [`IMap`](/javadoc/4.0/com/hazelcast/map/IMap.html)
   storage.
 - **Load Balancing.** Jet often reshapes batches to better match the
   capacity of each stage.

--- a/site/docs/design-docs/index.md
+++ b/site/docs/design-docs/index.md
@@ -7,7 +7,7 @@ This section contains documents detailing technical design of Jet
 features, created during the development process. Design docs for
 features appears under that version's docs. Features developed for the
 upcoming version appears under the [pre-release version
-docs](../next/design-docs).
+docs](/docs/next/design-docs).
 
 Each document is numbered, though since we're just starting this process
 we'll only include features for Jet starting from Jet 4.1.

--- a/site/docs/how-tos/observables.md
+++ b/site/docs/how-tos/observables.md
@@ -62,7 +62,7 @@ observable.destroy();
 ## Clean-up
 
 Observables are backed by
-[Ringbuffers](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/ringbuffer/Ringbuffer.html)
+[Ringbuffers](/javadoc/4.0/com/hazelcast/ringbuffer/Ringbuffer.html)
 stored in the cluster which should be cleaned up by the client, once
 they are no longer necessary. They have a `destroy()` method which does
 just that. If the Observable isn’t destroyed, its memory will be leaked

--- a/site/docs/how-tos/stream-imap.md
+++ b/site/docs/how-tos/stream-imap.md
@@ -3,7 +3,7 @@ title: Receive IMap Change Stream
 description: How to monitor the stream of change events happening to an `IMap.`
 ---
 
-[IMap](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/map/IMap.html)
+[IMap](/javadoc/4.0/com/hazelcast/map/IMap.html)
 is the main data structure in Hazelcast IMDG. Jet can use it as both a
 data source and a data sink. It can serve as both a batch source, giving
 you all the current data, and as a streaming source, giving you a stream

--- a/site/docs/operations/kubernetes.md
+++ b/site/docs/operations/kubernetes.md
@@ -446,7 +446,7 @@ navigate to *Jobs* section on left menu. You should be able to see your
 job running/completed successfully like below and inspect the logs if
 you like.
 
-![minikube-dashboard](../assets/minikube-dashboard.png)
+![minikube-dashboard](/docs/assets/minikube-dashboard.png)
 
 ## Access From Outside The Kubernetes
 

--- a/site/docs/operations/monitoring.md
+++ b/site/docs/operations/monitoring.md
@@ -348,7 +348,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of pending (in flight) operations when using
         asynchronous mapping processors. See
-        <a href="https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/processor/Processors.html#mapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-int-boolean-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-">
+        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#mapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-int-boolean-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-">
         Processors.mapUsingServiceAsyncP</a>.
     </td>
     <td rowspan="9">
@@ -376,7 +376,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of active windows being tracked by a session window
         processor. See
-        <a href="https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/processor/Processors.html#aggregateToSessionWindowP-long-long-java.util.List-java.util.List-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
+        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#aggregateToSessionWindowP-long-long-java.util.List-java.util.List-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
         Processors.aggregateToSessionWindowP</a>.
     </td>
   </tr>
@@ -394,7 +394,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of grouping keys associated with the current active
         frames of a sliding window processor. See
-        <a href="https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/processor/Processors.html#aggregateToSlidingWindowP-java.util.List-java.util.List-com.hazelcast.jet.core.TimestampKind-com.hazelcast.jet.core.SlidingWindowPolicy-long-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
+        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#aggregateToSlidingWindowP-java.util.List-java.util.List-com.hazelcast.jet.core.TimestampKind-com.hazelcast.jet.core.SlidingWindowPolicy-long-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
         Processors.aggregateToSlidingWindowP</a>.
     </td>
   </tr>
@@ -440,7 +440,7 @@ p.readFrom(source)
  .writeTo(sink);
 ```
 
-For further details consult the [Javadoc](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/metrics/Metrics.html).
+For further details consult the [Javadoc](/javadoc/4.0/com/hazelcast/jet/core/metrics/Metrics.html).
 
 User-defined metrics can be used anywhere in pipeline definitions where
 custom code can be added. This means (just to name the most important
@@ -472,16 +472,16 @@ Hazelcast metrics are stored under the
 #### Via Job API
 
 The `Job` class has a
-[`getMetrics()`](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/Job.html#getMetrics--)
+[`getMetrics()`](/javadoc/4.0/com/hazelcast/jet/Job.html#getMetrics--)
 method which returns a
-[JobMetrics](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/metrics/JobMetrics.html)
+[JobMetrics](/javadoc/4.0/com/hazelcast/jet/core/metrics/JobMetrics.html)
 instance. It contains the latest known metric values for the job.
 
 This functionality has been developed primarily to give access to
 metrics of finished jobs, but can in fact be used for jobs in any state.
 
 For details on how to use and filter the metric values consult the
-[JobMetrics API docs](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/metrics/JobMetrics.html)
+[JobMetrics API docs](/javadoc/4.0/com/hazelcast/jet/core/metrics/JobMetrics.html)
 . A simple example for computing the number of data items emitted by a
 certain vertex (let’s call it vertexA), excluding items emitted to the
 snapshot, would look like this:

--- a/site/website/blog/2020-02-20-transactional-processors.md
+++ b/site/website/blog/2020-02-20-transactional-processors.md
@@ -15,7 +15,7 @@ failure, using the latest snapshot to restore the state and continue.
 
 However, the exactly-once guarantee didn't work with most of the
 connectors. Only [replayable
-sources](https://docs.hazelcast.org/docs/jet/latest-dev/manual/#replayable-source),
+sources](/docs/architecture/fault-tolerance),
 such as Apache Kafka or IMap Journal were supported. And no sink
 supported this level of guarantee. Why was that?
 
@@ -104,7 +104,7 @@ don't know if the step 5 was executed or not.
 The 1st phase is common for transactional processors and for processors
 that only save internal state. It is coordinated using the snapshot
 barrier, based on the [Chandy-Lamport
-algorithm](https://docs.hazelcast.org/docs/jet/latest-dev/manual/#distributed-snapshot).
+algorithm](/docs/architecture/fault-tolerance#distributed-snapshot).
 The consequence is that the moment at which internal processors save
 their state and external processors prepare and switch their
 transactions is the same. Therefore you can combine exactly-once stages

--- a/site/website/blog/2020-03-02-jet-40-is-released.md
+++ b/site/website/blog/2020-03-02-jet-40-is-released.md
@@ -235,8 +235,7 @@ Intel Optane DC Support and encryption at rest.
 
 As part of 4.0, we've also done some house cleaning and as a result some
 things have been moved around. All the changes are listed as part of the
-[migration guide in the reference
-manual](https://docs.hazelcast.org/docs/jet/latest-dev/manual/#migration-guides).
+[migration guide blog post](/blog/2020/04/01/upgrading-to-jet-40).
 
 We are committed to backwards compatibility going forward and any
 interfaces or classes which are subject to change will be marked as

--- a/site/website/package.json
+++ b/site/website/package.json
@@ -3,7 +3,7 @@
     "examples": "docusaurus-examples",
     "start": "docusaurus-start",
     "build": "docusaurus-build",
-    "link-check": "concurrently --names 'SERVER,LINK_CHECKER' --prefix-colors 'yellow,red' --kill-others 'docusaurus-start' 'wait-on http://localhost:3000 && blc http://localhost:3000 -ro'",
+    "link-check": "concurrently --names 'SERVER,LINK_CHECKER' --prefix-colors 'yellow,red' --kill-others 'docusaurus-start' 'wait-on http://localhost:3000 && blc http://localhost:3000 -ro -blc http://localhost:3000 -ro --exclude *.tar.gz'",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",

--- a/site/website/versioned_docs/version-4.0/api/pipeline.md
+++ b/site/website/versioned_docs/version-4.0/api/pipeline.md
@@ -26,9 +26,9 @@ called _compute stages_ and expect you to attach further stages to them.
 
 The API differentiates between batch (bounded) and stream (unbounded)
 sources and this is reflected in the naming: there is a
-[BatchStage](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/BatchStage.html)
+[BatchStage](/javadoc/4.0/com/hazelcast/jet/pipeline/BatchStage.html)
 and a
-[StreamStage](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/StreamStage.html)
+[StreamStage](/javadoc/4.0/com/hazelcast/jet/pipeline/StreamStage.html)
 , each offering the operations appropriate to its kind.
 Depending on the data source, your pipeline will end up starting with a
 batch or streaming stage. A batch source still can be used to simulate

--- a/site/website/versioned_docs/version-4.0/api/serialization.md
+++ b/site/website/versioned_docs/version-4.0/api/serialization.md
@@ -159,10 +159,10 @@ types:
 
 - [java.io.Serializable](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html)
 - [java.io.Externalizable](https://docs.oracle.com/javase/8/docs/api/java/io/Externalizable.html)
-- [com.hazelcast.nio.serialization.Portable](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/nio/serialization/Portable.html)
-- [com.hazelcast.nio.serialization.StreamSerializer](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/nio/serialization/StreamSerializer.html)
+- [com.hazelcast.nio.serialization.Portable](/javadoc/4.0/com/hazelcast/nio/serialization/Portable.html)
+- [com.hazelcast.nio.serialization.StreamSerializer](/javadoc/4.0/com/hazelcast/nio/serialization/StreamSerializer.html)
   &
-  [com.hazelcast.nio.serialization.ByteArraySerializer](https://docs.hazelcast.org/docs/4.0/javadoc/com/hazelcast/nio/serialization/ByteArraySerializer.html)
+  [com.hazelcast.nio.serialization.ByteArraySerializer](/javadoc/4.0/com/hazelcast/nio/serialization/ByteArraySerializer.html)
 
 The following table provides a comparison between them to help you in
 deciding which interface to use in your applications.

--- a/site/website/versioned_docs/version-4.0/api/sources-sinks.md
+++ b/site/website/versioned_docs/version-4.0/api/sources-sinks.md
@@ -1113,9 +1113,9 @@ processing even with at-least-once sinks.
 
 If Jet doesn’t natively support the data source/sink you need, you can
 build a connector for it yourself by using the
-[SourceBuilder](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/SourceBuilder.html)
+[SourceBuilder](/javadoc/4.0/com/hazelcast/jet/pipeline/SourceBuilder.html)
 and
-[SinkBuilder](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/pipeline/SinkBuilder.html)
+[SinkBuilder](/javadoc/4.0/com/hazelcast/jet/pipeline/SinkBuilder.html)
 .
 
 ### SourceBuilder

--- a/site/website/versioned_docs/version-4.0/api/stateful-transforms.md
+++ b/site/website/versioned_docs/version-4.0/api/stateful-transforms.md
@@ -63,10 +63,10 @@ in aggregations, such as:
 |`allOf`|Combine multiple aggregations into one aggregation (for example, if you want both sum and average)|
 
 For a complete list, please refer to the
-[AggregateOperations](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/aggregate/AggregateOperations.html)
+[AggregateOperations](/javadoc/4.0/com/hazelcast/jet/aggregate/AggregateOperations.html)
 class. You can also implement your own aggregate operations using the
 builder in
-[AggregateOperation](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/aggregate/AggregateOperation.html)
+[AggregateOperation](/javadoc/4.0/com/hazelcast/jet/aggregate/AggregateOperation.html)
 .
 
 ### groupingKey

--- a/site/website/versioned_docs/version-4.0/operations/monitoring.md
+++ b/site/website/versioned_docs/version-4.0/operations/monitoring.md
@@ -350,7 +350,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of pending (in flight) operations when using
         asynchronous mapping processors. See
-        <a href="https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/processor/Processors.html#mapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-int-boolean-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-">
+        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#mapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-int-boolean-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-">
         Processors.mapUsingServiceAsyncP</a>.
     </td>
     <td rowspan="9">
@@ -378,7 +378,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of active windows being tracked by a session window
         processor. See
-        <a href="https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/processor/Processors.html#aggregateToSessionWindowP-long-long-java.util.List-java.util.List-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
+        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#aggregateToSessionWindowP-long-long-java.util.List-java.util.List-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
         Processors.aggregateToSessionWindowP</a>.
     </td>
   </tr>
@@ -396,7 +396,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of grouping keys associated with the current active
         frames of a sliding window processor. See
-        <a href="https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/processor/Processors.html#aggregateToSlidingWindowP-java.util.List-java.util.List-com.hazelcast.jet.core.TimestampKind-com.hazelcast.jet.core.SlidingWindowPolicy-long-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
+        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#aggregateToSlidingWindowP-java.util.List-java.util.List-com.hazelcast.jet.core.TimestampKind-com.hazelcast.jet.core.SlidingWindowPolicy-long-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
         Processors.aggregateToSlidingWindowP</a>.
     </td>
   </tr>
@@ -442,7 +442,7 @@ p.readFrom(source)
  .writeTo(sink);
 ```
 
-For further details consult the [Javadoc](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/metrics/Metrics.html).
+For further details consult the [Javadoc](/javadoc/4.0/com/hazelcast/jet/core/metrics/Metrics.html).
 
 User-defined metrics can be used anywhere in pipeline definitions where
 custom code can be added. This means (just to name the most important
@@ -474,16 +474,16 @@ Hazelcast metrics are stored under the
 #### Via Job API
 
 The `Job` class has a
-[`getMetrics()`](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/Job.html#getMetrics--)
+[`getMetrics()`](/javadoc/4.0/com/hazelcast/jet/Job.html#getMetrics--)
 method which returns a
-[JobMetrics](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/metrics/JobMetrics.html)
+[JobMetrics](/javadoc/4.0/com/hazelcast/jet/core/metrics/JobMetrics.html)
 instance. It contains the latest known metric values for the job.
 
 This functionality has been developed primarily to give access to
 metrics of finished jobs, but can in fact be used for jobs in any state.
 
 For details on how to use and filter the metric values consult the
-[JobMetrics API docs](https://docs.hazelcast.org/docs/jet/4.0/javadoc/com/hazelcast/jet/core/metrics/JobMetrics.html)
+[JobMetrics API docs](/javadoc/4.0/com/hazelcast/jet/core/metrics/JobMetrics.html)
 . A simple example for computing the number of data items emitted by a
 certain vertex (let’s call it vertexA), excluding items emitted to the
 snapshot, would look like this:

--- a/site/website/versioned_sidebars/version-4.0-sidebars.json
+++ b/site/website/versioned_sidebars/version-4.0-sidebars.json
@@ -59,9 +59,6 @@
     ],
     "Design Documents": [
       "version-4.0-design-docs/index",
-      "version-4.0-design-docs/006-declarative-serialization",
-      "version-4.0-design-docs/005-cdc-sources",
-      "version-4.0-design-docs/004-spring-boot-starter",
       "version-4.0-design-docs/003-elasticsearch-connector",
       "version-4.0-design-docs/002-job-level-serialization",
       "version-4.0-design-docs/001-code-deployment-improvements"


### PR DESCRIPTION
* Fix some broken links
* don't invoke download links for link-checker
* Use local javadoc instead of old URL
* 4.0 sidebar included invalid links
