### PR TITLE
Turn off linkXRef option to remove build warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -481,7 +481,7 @@
                     <suppressionsLocation>${maven.multiModuleProjectDirectory}/checkstyle/suppressions.xml</suppressionsLocation>
                     <headerLocation>${checkstyle.headerLocation}</headerLocation>
                     <enableRSS>false</enableRSS>
-                    <linkXRef>true</linkXRef>
+                    <linkXRef>false</linkXRef>
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <failOnViolation>true</failOnViolation>


### PR DESCRIPTION
This option is useful when a checkstyle report is generated,
it adds links to the source code directly from the checkstyle
html report.

We fail the build so the only report we ever get is empty report,
making this option not useful.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [x] Any breaking changes are documented
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [x] For code samples, code sample main readme is updated
