### PR TITLE
Add checkNonNullAndSerializable util method

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -32,7 +32,6 @@ import com.hazelcast.spi.impl.NodeEngine;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.io.NotSerializableException;
@@ -167,8 +166,7 @@ public final class Util {
      * @return given object
      * @throws IllegalArgumentException if {@code object} is not serializable
      */
-    @Nullable
-    public static <T> T checkSerializable(@Nullable T object, @Nonnull String objectName) {
+    public static <T> T checkSerializable(T object, String objectName) {
         if (object == null) {
             return null;
         }
@@ -204,8 +202,7 @@ public final class Util {
      * @return given object
      * @throws IllegalArgumentException if {@code object} is not serializable
      */
-    @Nonnull
-    public static <T> T checkNonNullAndSerializable(@Nullable T object, @Nonnull String objectName) {
+    public static <T> T checkNonNullAndSerializable(T object, String objectName) {
         if (object == null) {
             throw new IllegalArgumentException('"' + objectName + "\" must not be null");
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -183,6 +183,32 @@ public final class Util {
     }
 
     /**
+     * Checks that the {@code object} is not null and  implements
+     * {@link Serializable} and is correctly serializable by actually
+     * trying to serialize it. This will reveal some non-serializable
+     * field early.
+     * <p>
+     * Usage:
+     * <pre>{@code
+     * void setValue(@Nonnull Object value) {
+     *     this.value = checkNonNullAndSerializable(value, "value");
+     * }
+     * }</pre>
+     *
+     * @param object     object to check
+     * @param objectName object description for the exception
+     * @return given object
+     * @throws IllegalArgumentException if {@code object} is not serializable
+     */
+    public static <T> T checkNonNullAndSerializable(T object, String objectName) {
+        if (object == null) {
+            throw new IllegalArgumentException('"' + objectName + "\" must not be null");
+        }
+        checkSerializable(object, objectName);
+        return object;
+    }
+
+    /**
      * Distributes the {@code objects} to {@code count} processors in a
      * round-robin fashion. If the object count is smaller than processor
      * count, an empty list is put for the rest of the processors.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -187,7 +187,7 @@ public final class Util {
     }
 
     /**
-     * Checks that the {@code object} is not null and  implements
+     * Checks that the {@code object} is not null and implements
      * {@link Serializable} and is correctly serializable by actually
      * trying to serialize it. This will reveal some non-serializable
      * field early.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.impl.NodeEngine;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.io.NotSerializableException;
@@ -166,7 +167,8 @@ public final class Util {
      * @return given object
      * @throws IllegalArgumentException if {@code object} is not serializable
      */
-    public static <T> T checkSerializable(T object, String objectName) {
+    @Nullable
+    public static <T> T checkSerializable(@Nullable T object, @Nonnull String objectName) {
         if (object == null) {
             return null;
         }
@@ -202,7 +204,9 @@ public final class Util {
      * @return given object
      * @throws IllegalArgumentException if {@code object} is not serializable
      */
-    public static <T> T checkNonNullAndSerializable(T object, String objectName) {
+    @Nonnull
+    public static <T> T checkNonNullAndSerializable(@Nonnull T object, @Nonnull String objectName) {
+        //noinspection ConstantConditions
         if (object == null) {
             throw new IllegalArgumentException('"' + objectName + "\" must not be null");
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.impl.NodeEngine;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InvalidClassException;
 import java.io.NotSerializableException;
@@ -163,11 +164,13 @@ public final class Util {
      *
      * @param object     object to check
      * @param objectName object description for the exception
+     * @return given object
      * @throws IllegalArgumentException if {@code object} is not serializable
      */
-    public static void checkSerializable(Object object, String objectName) {
+    @Nullable
+    public static <T> T checkSerializable(@Nullable T object, @Nonnull String objectName) {
         if (object == null) {
-            return;
+            return null;
         }
         if (!(object instanceof Serializable)) {
             throw new IllegalArgumentException('"' + objectName + "\" must implement Serializable");
@@ -180,6 +183,7 @@ public final class Util {
             // never really thrown, as the underlying stream never throws it
             throw new JetException(e);
         }
+        return object;
     }
 
     /**
@@ -200,7 +204,8 @@ public final class Util {
      * @return given object
      * @throws IllegalArgumentException if {@code object} is not serializable
      */
-    public static <T> T checkNonNullAndSerializable(T object, String objectName) {
+    @Nonnull
+    public static <T> T checkNonNullAndSerializable(@Nullable T object, @Nonnull String objectName) {
         if (object == null) {
             throw new IllegalArgumentException('"' + objectName + "\" must not be null");
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -36,6 +37,8 @@ import static com.hazelcast.jet.impl.util.Util.gcd;
 import static com.hazelcast.jet.impl.util.Util.memoizeConcurrent;
 import static com.hazelcast.jet.impl.util.Util.roundRobinPart;
 import static com.hazelcast.jet.impl.util.Util.subtractClamped;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -167,5 +170,26 @@ public class UtilTest {
         assertEquals(AT_LEAST_ONCE, Util.min(AT_LEAST_ONCE, EXACTLY_ONCE));
         assertEquals(NONE, Util.min(NONE, EXACTLY_ONCE));
         assertEquals(NONE, Util.min(NONE, NONE));
+    }
+
+    @Test
+    public void whenNullToCheckNonNullAndSerializable_thenThrowException() {
+        assertThatThrownBy(() -> Util.checkNonNullAndSerializable(null, "object"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("\"object\" must not be null");
+    }
+
+    @Test
+    public void whenNonSerializableToCheckNonNullAndSerializable_thenThrowException() {
+        assertThatThrownBy(() -> Util.checkNonNullAndSerializable(new HashMap<>().entrySet(), "object"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("\"object\" must implement Serializable");
+    }
+
+    @Test
+    public void whenObjectToCheckNonNullAndSerializable_thenReturnObject() {
+        String s = "s";
+        String returned = Util.checkNonNullAndSerializable(s, "s");
+        assertThat(returned).isSameAs(s);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/UtilTest.java
@@ -173,6 +173,26 @@ public class UtilTest {
     }
 
     @Test
+    public void whenNullToCheckSerializable_thenReturnNull() {
+        Object returned = Util.checkSerializable(null, "object");
+        assertThat(returned).isNull();
+    }
+
+    @Test
+    public void whenSerializableObjectToCheckSerializable_thenReturnObject() {
+        Object o = "o";
+        Object returned = Util.checkSerializable(o, "object");
+        assertThat(returned).isSameAs(o);
+    }
+
+    @Test
+    public void whenNonSerializableObjectToCheckSerializable_thenThrowException() {
+        assertThatThrownBy(() -> Util.checkSerializable(new HashMap<>().entrySet(), "object"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("\"object\" must implement Serializable");
+    }
+
+    @Test
     public void whenNullToCheckNonNullAndSerializable_thenThrowException() {
         assertThatThrownBy(() -> Util.checkNonNullAndSerializable(null, "object"))
                 .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
This combines Objects.requireNonNull with our Util.checkSerializable
into single method call. Useful in source/sink builders for checking
parameters.

Checklist
- [x] Tags Set
- [x] Milestone Set