### PR TITLE
Shutdown gRPC channels cleanly

### DIFF
--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
@@ -30,6 +30,7 @@ import io.grpc.stub.StreamObserver;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides {@link ServiceFactory} implementations for calling gRPC
@@ -107,7 +108,7 @@ public final class GrpcServices {
                 .withCreateContextFn(ctx -> channelFn.get().build())
                 .withCreateServiceFn((ctx, channel) -> new UnaryService<>(channel, callStubFn))
                 .withDestroyServiceFn(UnaryService::destroy)
-                .withDestroyContextFn(ManagedChannel::shutdown);
+                .withDestroyContextFn(channel -> channel.shutdown().awaitTermination(5, TimeUnit.SECONDS));
     }
 
     /**
@@ -170,6 +171,6 @@ public final class GrpcServices {
                 .withCreateContextFn(ctx -> channelFn.get().build())
                 .withCreateServiceFn((ctx, channel) -> new BidirectionalStreamingService<>(ctx, channel, callStubFn))
                 .withDestroyServiceFn(BidirectionalStreamingService::destroy)
-                .withDestroyContextFn(ManagedChannel::shutdown);
+                .withDestroyContextFn(channel -> channel.shutdown().awaitTermination(5, TimeUnit.SECONDS));
     }
 }

--- a/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcServiceTest.java
+++ b/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcServiceTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.grpc.GrpcServices.bidirectionalStreamingService;
@@ -61,9 +62,10 @@ public class GrpcServiceTest extends SimpleTestInClusterSupport {
     }
 
     @After
-    public void teardown() {
+    public void teardown() throws InterruptedException {
         if (server != null) {
-            server.shutdown() ;
+            server.shutdown();
+            server.awaitTermination(5, TimeUnit.SECONDS);
         }
     }
 
@@ -192,7 +194,7 @@ public class GrpcServiceTest extends SimpleTestInClusterSupport {
     @Test
     public void when_unary_with_faultyService() throws IOException {
         // Given
-        Server server = createServer(new FaultyGreeterServiceImpl());
+        server = createServer(new FaultyGreeterServiceImpl());
         final int port = server.getPort();
 
         Pipeline p = Pipeline.create();
@@ -256,7 +258,7 @@ public class GrpcServiceTest extends SimpleTestInClusterSupport {
 
                 @Override
                 public void onCompleted() {
-
+                    responseObserver.onCompleted();
                 }
             };
         }

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
@@ -158,12 +158,7 @@ final class PythonService {
             if (!completionLatch.await(1, SECONDS)) {
                 logger.info("gRPC call has not completed on time");
             }
-            if (!chan.shutdown().awaitTermination(1, SECONDS)) {
-                logger.info("gRPC client has not shut down on time");
-            }
-            if (!chan.shutdownNow().awaitTermination(1, SECONDS)) {
-                logger.info("gRPC client has not shut down on time, even after forceful shutdown");
-            }
+            GrpcUtil.shutdownChannel(chan, logger);
             server.stop();
         } catch (Exception e) {
             throw new JetException("PythonService.destroy() failed: " + e, e);


### PR DESCRIPTION
Several fixes
- closing channels doesn't happen imediatelly - added awatTermination
- Server stored in local variable not shutdown at end of test
- onCompleted should call onCompleted on responseObserver

Checklist
- [x] Tags Set
- [x] Milestone Set
