### PR TITLE
Enable heap dump on OOM in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
             -Dhazelcast.logging.details.enabled=true
             -Dhazelcast.test.use.network=false
             -Djava.net.preferIPv4Stack=true
+            -XX:+HeapDumpOnOutOfMemoryError
+            -XX:HeapDumpPath=${project.build.directory}
         </argLine>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
We put the setting directly to pom as we want to use it in all builds
and 1G heap should be fine to upload to S3.

The hprof file will be put to root directory of the module which runs
the test.

In case there are multiple heap dumps we can link to the file
to particular test via pid.

Checklist
- [x] Tags Set
- [x] Milestone Set
