### PR TITLE
Remove destroying Observables on JetInstance shutdown

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
@@ -170,7 +170,6 @@ public abstract class AbstractJetInstance implements JetInstance {
 
     @Override
     public void shutdown() {
-        observables.values().forEach(Observable::destroy);
         hazelcastInstance.shutdown();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -274,14 +274,14 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
      * Clean up the cluster and make it ready to run a next test. If we fail
      * to, shut it down so that next tests don't run on a messed-up cluster.
      *
-     * @param instancesToShutDown cluster instances, must contain at least
+     * @param instances cluster instances, must contain at least
      *                            one instance
      */
-    public void cleanUpCluster(JetInstance ... instancesToShutDown) {
-        for (Job job : instancesToShutDown[0].getJobs()) {
-            ditchJob(job, instancesToShutDown);
+    public void cleanUpCluster(JetInstance ... instances) {
+        for (Job job : instances[0].getJobs()) {
+            ditchJob(job, instances);
         }
-        for (DistributedObject o : instancesToShutDown[0].getHazelcastInstance().getDistributedObjects()) {
+        for (DistributedObject o : instances[0].getHazelcastInstance().getDistributedObjects()) {
             o.destroy();
         }
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetInstance;
-import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.Observable;
 import com.hazelcast.jet.function.Observer;
@@ -26,28 +25,20 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.jet.pipeline.test.SimpleEvent;
 import com.hazelcast.jet.pipeline.test.TestSources;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nonnull;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
-import static com.hazelcast.jet.core.JetTestSupport.assertJobStatusEventually;
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static com.hazelcast.test.HazelcastTestSupport.spawn;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class ObservableShutdownTest {
+public class ObservableShutdownTest extends JetTestSupport {
 
     private static final int MEMBER_COUNT = 3;
-
-    private JetTestInstanceFactory factory;
 
     private JetInstance[] members;
     private JetInstance client;
@@ -60,9 +51,8 @@ public class ObservableShutdownTest {
 
     @Before
     public void before() {
-        factory = new JetTestInstanceFactory();
-        members = Stream.generate(factory::newMember).limit(MEMBER_COUNT).toArray(JetInstance[]::new);
-        client = factory.newClient();
+        members = createJetMembers(MEMBER_COUNT);
+        client = createJetClient();
 
         memberObserver = new TestObserver();
         memberObservable = members[members.length - 1].newObservable();
@@ -71,12 +61,6 @@ public class ObservableShutdownTest {
         clientObserver = new TestObserver();
         clientObservable = client.newObservable();
         clientObservable.addObserver(clientObserver);
-    }
-
-    @After
-    public void after() throws Exception {
-        spawn(() -> factory.terminateAll())
-                .get(1, TimeUnit.MINUTES);
     }
 
     @Test

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
@@ -25,8 +25,10 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamStage;
 import com.hazelcast.jet.pipeline.test.SimpleEvent;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@RunWith(HazelcastParallelClassRunner.class)
 public class ObservableShutdownTest extends JetTestSupport {
 
     private static final int MEMBER_COUNT = 3;
@@ -64,7 +67,7 @@ public class ObservableShutdownTest extends JetTestSupport {
     }
 
     @Test
-    public void cleanup() {
+    public void when_jetInstanceIsShutDown_then_ObservablesStopReceivingEvents() {
         Pipeline pipeline = Pipeline.create();
         StreamStage<Long> stage = pipeline.readFrom(TestSources.itemStream(100))
                 .withoutTimestamps()

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
@@ -1,0 +1,123 @@
+package com.hazelcast.jet.core;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.Observable;
+import com.hazelcast.jet.function.Observer;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.StreamStage;
+import com.hazelcast.jet.pipeline.test.SimpleEvent;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static com.hazelcast.jet.core.JetTestSupport.assertJobStatusEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.spawn;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ObservableShutdownTest {
+
+    private static final int MEMBER_COUNT = 3;
+
+    private JetTestInstanceFactory factory;
+    private JetInstance[] members;
+    private JetInstance client;
+    private Observable<Long> memberObservable, clientObservable;
+    private TestObserver memberObserver, clientObserver;
+
+    @Before
+    public void before() {
+        factory = new JetTestInstanceFactory();
+        members = Stream.generate(factory::newMember).limit(MEMBER_COUNT).toArray(JetInstance[]::new);
+        client = factory.newClient();
+
+        memberObserver = new TestObserver();
+        memberObservable = members[members.length - 1].newObservable();
+        memberObservable.addObserver(memberObserver);
+
+        clientObserver = new TestObserver();
+        clientObservable = client.newObservable();
+        clientObservable.addObserver(clientObserver);
+    }
+
+    @After
+    public void after() throws Exception {
+        spawn(() -> factory.terminateAll())
+                .get(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void cleanup() {
+        Pipeline pipeline = Pipeline.create();
+        StreamStage<Long> stage = pipeline.readFrom(TestSources.itemStream(100))
+                .withoutTimestamps()
+                .map(SimpleEvent::sequence);
+
+        stage.writeTo(Sinks.observable(clientObservable));
+        stage.writeTo(Sinks.observable(memberObservable));
+
+        //when
+        Job job = client.newJob(pipeline);
+        //then
+        assertTrueEventually(() -> assertTrue(clientObserver.getNoOfValues() > 10));
+        assertTrueEventually(() -> assertTrue(memberObserver.getNoOfValues() > 10));
+
+        //when
+        client.shutdown();
+        //then
+        assertObserverStopsReceivingValues(clientObserver);
+
+        //when
+        long jobId = job.getId();
+        members[members.length - 1].shutdown();
+        //then
+        assertJobStatusEventually(members[0].getJob(jobId), JobStatus.RUNNING);
+        assertObserverStopsReceivingValues(memberObserver);
+    }
+
+    private void assertObserverStopsReceivingValues(TestObserver observer) {
+        assertTrueEventually(() -> {
+            int values1 = observer.getNoOfValues();
+            MILLISECONDS.sleep(1000);
+            int values2 = observer.getNoOfValues();
+            assertEquals(values1, values2);
+        });
+    }
+
+    private static final class TestObserver implements Observer<Long> {
+
+        private final AtomicInteger values = new AtomicInteger();
+
+        @Override
+        public void onNext(@Nonnull Long value) {
+            values.incrementAndGet();
+        }
+
+        @Override
+        public void onError(@Nonnull Throwable throwable) {
+            fail("Errors aren't expected: " +throwable.getMessage());
+        }
+
+        @Override
+        public void onComplete() {
+            fail("Completions aren't expected");
+        }
+
+        int getNoOfValues() {
+            return values.get();
+        }
+    }
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableShutdownTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.JetInstance;
@@ -32,10 +48,15 @@ public class ObservableShutdownTest {
     private static final int MEMBER_COUNT = 3;
 
     private JetTestInstanceFactory factory;
+
     private JetInstance[] members;
     private JetInstance client;
-    private Observable<Long> memberObservable, clientObservable;
-    private TestObserver memberObserver, clientObserver;
+
+    private Observable<Long> memberObservable;
+    private Observable<Long> clientObservable;
+
+    private TestObserver memberObserver;
+    private TestObserver clientObserver;
 
     @Before
     public void before() {
@@ -107,7 +128,7 @@ public class ObservableShutdownTest {
 
         @Override
         public void onError(@Nonnull Throwable throwable) {
-            fail("Errors aren't expected: " +throwable.getMessage());
+            fail("Errors aren't expected: " + throwable.getMessage());
         }
 
         @Override


### PR DESCRIPTION
Triggering `Observable.destroy()` on `JetInstance` shutdown has some unexpected consequences (for example: you kill a client, the client destroys an observable, job execution terminates a bit later and it re-creates the observable in the meantime, next execution starts with a few left-over results). This is also related to the fact that observables aren't job specific and that we allow them to be reused in multiple executions... But anyways, better to not destroy them in such unexpected ways (especially since it's not even documented). Leave all destroys be explicitly triggered by users.

Fixes [#2059 ](https://github.com/hazelcast/hazelcast-jet/issues/2059)

Checklist
- [x] Tags Set
- [x] Milestone Set