### PR TITLE
Add javac param to stop package info files sabotaging incremental compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,9 @@
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                    <compilerArgs>
+                        <arg>-Xpkginfo:always</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Maven compile plugin has a [bug](https://issues.apache.org/jira/browse/MCOMPILER-368) dues to which our `package-info.java` files are always considered dirty and most modules are always recompiled, even if there aren't actual changes in them. 

Will try a workaround for this by setting the `javac` param `pkginfo`.

Checklist
- [x] Tags Set
- [x] Milestone Set