### PR TITLE
[004] Add IMDG configuration options for Jet Spring Boot Starter

### DIFF
--- a/site/docs/api/spring.md
+++ b/site/docs/api/spring.md
@@ -342,16 +342,16 @@ create a client instance you need to put `hazelcast-client.yaml` or
 `hazelcast-client.xml` to the classpath or to the root directory.
 
 If your configuration files are available with different names then you
-can point to them by system properties, `hazelcast.jet.config`  for
-server and `hazelcast.client.config` for client. You can also use
-config properties, `hazelcast.jet.server.config` for server and
-`hazelcast.jet.client.config` for client.
+can point to them by config properties, `hazelcast.jet.server.config`
+for server and `hazelcast.jet.client.config` for client. You can also
+use system properties, `hazelcast.jet.config` for server and
+`hazelcast.client.config` for client.
 
 If you want to configure the underlying `HazelcastInstance`, you need
 to put `hazelcast.yaml` or `hazelcast.xml` to the classpath or to the
-root directory. You can use the system property `hazelcast.config` or
-config property `hazelcast.jet.imdg.config` to explicitly set the
-configuration file.
+root directory. You can use the config property
+`hazelcast.jet.server.config` or system property
+`hazelcast.config` to explicitly set the configuration file.
 
 If no configuration file is present or explicitly specified, the
 starter creates a server instance using the default configuration file

--- a/site/docs/api/spring.md
+++ b/site/docs/api/spring.md
@@ -343,7 +343,15 @@ create a client instance you need to put `hazelcast-client.yaml` or
 
 If your configuration files are available with different names then you
 can point to them by system properties, `hazelcast.jet.config`  for
-server and `hazelcast.client.config` for client.
+server and `hazelcast.client.config` for client. You can also use
+config properties, `hazelcast.jet.server.config` for server and
+`hazelcast.jet.client.config` for client.
+
+If you want to configure the underlying `HazelcastInstance`, you need
+to put `hazelcast.yaml` or `hazelcast.xml` to the classpath or to the
+root directory. You can use the system property `hazelcast.config` or
+config property `hazelcast.jet.imdg.config` to explicitly set the
+configuration file.
 
 If no configuration file is present or explicitly specified, the
 starter creates a server instance using the default configuration file

--- a/site/docs/design-docs/004-spring-boot-starter.md
+++ b/site/docs/design-docs/004-spring-boot-starter.md
@@ -30,8 +30,9 @@ public class HazelcastJetAutoConfiguration {
 Spring Boot has a feature named `ConfigurationProperties` which makes
 external configuration easily accessible. We've defined configuration
 properties for server and client. User can point the starter to the
-desired configuration file by defining `hazelcast.jet.config` for
-server or `hazelcast.jet.client.config` for client.
+desired configuration file by defining `hazelcast.jet.server.config`
+for server, `hazelcast.jet.imdg.config` for imdg, and
+`hazelcast.jet.client.config` for client.
 
 ### Conditional
 
@@ -62,7 +63,7 @@ class first.
 - If `hazelcast.jet.config` system property is defined, a member will
   be created using the defined configuration file.
 
-- If `hazelcast.jet.config` configuration property is defined, a member
+- If `hazelcast.jet.server.config` config property is defined, a member
   will be created using the defined configuration file.
 
 - If `ClientConfig` is available as a bean, a client will be created
@@ -71,8 +72,8 @@ class first.
 - If `hazelcast.client.config` system property is defined, a client
   will be created using the defined configuration file.
 
-- If `hazelcast.jet.client.config` configuration property is defined, a
-  client will be created using the defined configuration file.
+- If `hazelcast.jet.client.config` config property is defined, a client
+  will be created using the defined configuration file.
 
 - If `hazelcast-jet.(yaml|yml|xml)` found on the classpath or at the
   root directory, a member will be created with that configuration file.

--- a/site/docs/design-docs/004-spring-boot-starter.md
+++ b/site/docs/design-docs/004-spring-boot-starter.md
@@ -59,20 +59,20 @@ class first.
 
 - If `JetConfig` is available as a bean, a member will be created using
   the bean.
-
-- If `hazelcast.jet.config` system property is defined, a member will
-  be created using the defined configuration file.
+  
+- If `ClientConfig` is available as a bean, a client will be created
+  using the bean.
 
 - If `hazelcast.jet.server.config` config property is defined, a member
   will be created using the defined configuration file.
 
-- If `ClientConfig` is available as a bean, a client will be created
-  using the bean.
-
-- If `hazelcast.client.config` system property is defined, a client
-  will be created using the defined configuration file.
+- If `hazelcast.jet.config` system property is defined, a member will
+  be created using the defined configuration file.
 
 - If `hazelcast.jet.client.config` config property is defined, a client
+  will be created using the defined configuration file.
+
+- If `hazelcast.client.config` system property is defined, a client
   will be created using the defined configuration file.
 
 - If `hazelcast-jet.(yaml|yml|xml)` found on the classpath or at the

--- a/site/docs/tutorials/spring-boot.md
+++ b/site/docs/tutorials/spring-boot.md
@@ -158,7 +158,7 @@ You can also set configuration files using system property:
 
 ```java
 System.setProperty("hazelcast.jet.config", "config/hazelcast-jet-tutorial.yaml");
-System.setProperty("hazelcast.config", "config/hazelcast-jet-tutorial.yaml");
+System.setProperty("hazelcast.config", "config/hazelcast-tutorial.yaml");
 ```
 
 This will work if your configuration files are at the working

--- a/site/docs/tutorials/spring-boot.md
+++ b/site/docs/tutorials/spring-boot.md
@@ -100,7 +100,7 @@ member is started and the default configuration file is used:
 ...
 c.h.i.config.AbstractConfigLocator       : Loading 'hazelcast-jet-default.xml' from the classpath.
 ...
-com.hazelcast.core.LifecycleService      : [127.0.0.1]:5701 [jet] [4.0] [127.0.0.1]:5701 is STARTED
+c.h.i.config.AbstractConfigLocator       : Loading 'hazelcast-jet-member-default.xml' from the classpath.
 ...
 ```
 
@@ -117,32 +117,53 @@ hazelcast-jet:
     queue-size: 2048
 ```
 
+To configure the underlying `HazelcastInstance` we'll define a
+configuration file named `hazelcast.yaml` at the root directory.
+
+```yaml
+hazelcast:
+  cluster-name: tutorial-jet-starter
+```
+
 When you stop and re-run the main class you should now see that the
-configuration file we've just created is used to start the member:
+configuration files we've just created is used to start the member:
 
 ```text
 ...
 c.h.i.config.AbstractConfigLocator       : Loading 'hazelcast-jet.yaml' from the working directory.
 ...
+c.h.i.config.AbstractConfigLocator       : Loading 'hazelcast.yaml' from the working directory.
+...
 ```
 
 ### Using Properties File
 
-If your configuration file is not at the root directory or you want to
+If your configuration files are not at the root directory or you want to
 use a different name then you can create an `application.properties`
-file and set the `hazelcast.jet.config` like below:
+file and set the `hazelcast.jet.server.config` and `hazelcast.jet.imdg.config`
+like below:
 
 ```properties
-hazelcast.jet.config=file:config/hazelcast-jet-tutorial.yaml
+hazelcast.jet.server.config=file:config/hazelcast-jet-tutorial.yaml
+hazelcast.jet.imdg.config=file:config/hazelcast-tutorial.yaml
 ```
+
+Since Spring Boot converts these config properties to resource URLs,
+you need to use `file:` prefix for files at the working directory and
+`classpath:` for files on the classpath.
 
 ### Using System Properties
 
-You can also set configuration file using system property:
+You can also set configuration files using system property:
 
 ```java
-System.setProperty("hazelcast.jet.config", "file:config/hazelcast-jet-tutorial.yaml");
+System.setProperty("hazelcast.jet.config", "config/hazelcast-jet-tutorial.yaml");
+System.setProperty("hazelcast.config", "config/hazelcast-jet-tutorial.yaml");
 ```
+
+This will work if your configuration files are at the working
+directory. If they are on the classpath you should use `classpath:`
+prefix.
 
 ## 4. Jet Client
 
@@ -169,9 +190,16 @@ file and set the `hazelcast.jet.client.config` like below:
 hazelcast.jet.client.config=file:config/hazelcast-client-tutorial.yaml
 ```
 
+You need to use `file:` prefix for files at the working directory and
+`classpath:` for files on the classpath.
+
 ### Using System Properties
 
 You can also set configuration file using system property:
 
 ```java
-System.setProperty("hazelcast.client.config", "file:config/hazelcast-client-tutorial.yaml");
+System.setProperty("hazelcast.client.config", "config/hazelcast-client-tutorial.yaml");
+```
+
+If configuration file is on the classpath you should use `classpath:`
+prefix.


### PR DESCRIPTION
Add IMDG configuration options for Jet Spring Boot Starter

Checklist
- [X] Tags Set
- [X] Milestone Set
- [NA] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Related to https://github.com/hazelcast/hazelcast-jet-contrib/pull/75
