### PR TITLE
Align order of serialization interface in benchmark

### DIFF
--- a/site/docs/api/serialization.md
+++ b/site/docs/api/serialization.md
@@ -200,10 +200,10 @@ with different number of bytes depending on used strategy:
 
 ```text
 Strategy                                        Number of Bytes  Overhead %
-com.hazelcast.nio.serialization.StreamSerializer             26           0
-com.hazelcast.nio.serialization.Portable                    104         300
-java.io.Externalizable                                       87         234
 java.io.Serializable                                        162         523
+java.io.Externalizable                                       87         234
+com.hazelcast.nio.serialization.Portable                    104         300
+com.hazelcast.nio.serialization.StreamSerializer             26           0
 ```
 
 You can see that using plain `Serializable` can easily become a


### PR DESCRIPTION
Align order of Serialization interface in benchmark with previous benchmark and Serialization interface table. It's more simple to read if it has the same order.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated

