### PR TITLE
Fix flaky test in ExecutionLifecycleTest

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -31,6 +31,7 @@ import com.hazelcast.jet.core.metrics.JobMetrics;
 import com.hazelcast.jet.impl.deployment.IMapOutputStream;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.jet.impl.metrics.RawJobMetrics;
+import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
@@ -473,9 +474,13 @@ public class JobRepository {
             return null;
         }
         if (error.getClass().equals(JetException.class) && error.getMessage() != null) {
-            return error.getMessage();
+            String stackTrace = ExceptionUtil.stackTraceToString(error);
+            // The error message is later thrown as JetException
+            // Remove leading 'com.hazelcast.jet.JetException: ' from the stack trace to avoid double JetException
+            // in the final stacktrace
+            return stackTrace.substring(stackTrace.indexOf(' '));
         }
-        return error.toString();
+        return ExceptionUtil.stackTraceToString(error);
     }
 
     private static long jobIdFromMapName(String map, String prefix) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -478,7 +478,7 @@ public class JobRepository {
             // The error message is later thrown as JetException
             // Remove leading 'com.hazelcast.jet.JetException: ' from the stack trace to avoid double JetException
             // in the final stacktrace
-            return stackTrace.substring(stackTrace.indexOf(' '));
+            return stackTrace.substring(stackTrace.indexOf(' ') + 1);
         }
         return ExceptionUtil.stackTraceToString(error);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ExecutionLifecycleTest.java
@@ -545,7 +545,7 @@ public class ExecutionLifecycleTest extends SimpleTestInClusterSupport {
         Throwable causeAfter = excAfterComplete.getCause();
 
         assertEquals(causeBefore.getClass(), causeAfter.getClass());
-        assertEquals(causeBefore.getMessage(), causeAfter.getMessage());
+        assertContains(causeAfter.getMessage(), causeBefore.getMessage());
     }
 
     private void when_deserializationOnMasterFails_then_jobSubmissionFails(JetInstance instance) throws Throwable {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SuspendResumeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SuspendResumeTest.java
@@ -228,7 +228,7 @@ public class SuspendResumeTest extends JetTestSupport {
         assertTrueEventually(() -> {
             assertNull("JobRecord", jobRepository.getJobRecord(job.getId()));
             JobResult jobResult = jobRepository.getJobResult(job.getId());
-            assertEquals(CancellationException.class.getName(), jobResult.getFailureText());
+            assertContains(jobResult.getFailureText(), CancellationException.class.getName());
             assertFalse("Job result successful", jobResult.isSuccessful());
         });
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
@@ -59,7 +59,9 @@ public final class TestUtil {
     /**
      * Asserts that {@code caught} exception is equal to {@code expected} or one of its causes.
      * <p>
-     * Exceptions are considered equal, if their {@code message}s and classes are equal.
+     * Exceptions are considered equal, if their {@code message}s and classes are equal OR if the caught exception
+     * contains expected message and exception class name (this covers cases where exception is reported as a string
+     * from already completed job).
      *
      * @param expected Expected exception
      * @param caught   Caught exception

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TestUtil.java
@@ -69,7 +69,9 @@ public final class TestUtil {
         boolean found = false;
         Throwable t = caught;
         while (!found && t != null) {
-            found = Objects.equals(t.getMessage(), expected.getMessage()) && t.getClass() == expected.getClass();
+            found = Objects.equals(t.getMessage(), expected.getMessage()) && t.getClass() == expected.getClass() ||
+                    (t.getMessage().contains(expected.getMessage()) &&
+                            t.getMessage().contains(expected.getClass().getName()));
             t = t.getCause();
         }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/JobSummaryTest.java
@@ -175,7 +175,7 @@ public class JobSummaryTest extends JetTestSupport {
         assertEquals(1, list.size());
         JobSummary jobSummary = list.get(0);
 
-        assertEquals(msg, new JetException(jobSummary.getFailureText()).toString());
+        assertContains(new JetException(jobSummary.getFailureText()).toString(), msg);
         assertNotEquals(0, jobSummary.getCompletionTime());
     }
 


### PR DESCRIPTION
Fix flaky test where job can be completed from JobResult

Reproducible by adding delay to doInvokeJoinJob in AbstractJobProxy.
Fixes #2072

Add stacktrace to failureText in JobResult, stack trace is useful for debugging

Checklist
- [x] Tags Set
- [x] Milestone Set


