### PR TITLE
Introduce version replacement tags

### DIFF
--- a/site/docs/api/data-structures.md
+++ b/site/docs/api/data-structures.md
@@ -244,7 +244,7 @@ coordination tasks.
 ## ICache
 
 `ICache` is a fully compliant
-[JCache](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#jcache-overview)
+[JCache](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#jcache-overview)
 implementation. The features offered are mostly similar to `IMap`, but
 are limited to what's offered by the `JCache` specification, so many of
 `IMap`s features such as `EntryProcessor` and querying aren't available
@@ -252,7 +252,7 @@ on `ICache`.
 
 ## CP Subsystem
 
-[CP subsystem](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#cp-subsystem)
+[CP subsystem](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#cp-subsystem)
 builds a strongly consistent layer inside Hazelcast Jet which can be
 used for distributed coordination use cases, such as distributed locking
 and synchronization. The CP subsystem is based on a full RAFT

--- a/site/docs/api/pipeline.md
+++ b/site/docs/api/pipeline.md
@@ -24,9 +24,9 @@ called _compute stages_ and expect you to attach further stages to them.
 
 The API differentiates between batch (bounded) and stream (unbounded)
 sources and this is reflected in the naming: there is a
-[BatchStage](/javadoc/4.0/com/hazelcast/jet/pipeline/BatchStage.html)
+[BatchStage](/javadoc/{jet-version}/com/hazelcast/jet/pipeline/BatchStage.html)
 and a
-[StreamStage](/javadoc/4.0/com/hazelcast/jet/pipeline/StreamStage.html)
+[StreamStage](/javadoc/{jet-version}/com/hazelcast/jet/pipeline/StreamStage.html)
 , each offering the operations appropriate to its kind.
 Depending on the data source, your pipeline will end up starting with a
 batch or streaming stage. A batch source still can be used to simulate

--- a/site/docs/api/serialization.md
+++ b/site/docs/api/serialization.md
@@ -157,8 +157,8 @@ types:
 
 - [java.io.Serializable](https://docs.oracle.com/javase/8/docs/api/java/io/Serializable.html)
 - [java.io.Externalizable](https://docs.oracle.com/javase/8/docs/api/java/io/Externalizable.html)
-- [com.hazelcast.nio.serialization.Portable](/javadoc/4.0/com/hazelcast/nio/serialization/Portable.html)
-- [com.hazelcast.nio.serialization.StreamSerializer](/javadoc/4.0/com/hazelcast/nio/serialization/StreamSerializer.html)
+- [com.hazelcast.nio.serialization.Portable](/javadoc/{imdg-version}/com/hazelcast/nio/serialization/Portable.html)
+- [com.hazelcast.nio.serialization.StreamSerializer](/javadoc/{imdg-version}/com/hazelcast/nio/serialization/StreamSerializer.html)
 
 The following table provides a comparison between them to help you in
 deciding which interface to use in your applications.
@@ -215,7 +215,7 @@ not to mention very wasteful with memory.
 
 For the best performance and simplest implementation we recommend using
 the Hazelcast
-[StreamSerializer](/javadoc/4.0/com/hazelcast/nio/serialization/StreamSerializer.html)
+[StreamSerializer](/javadoc/{imdg-version}/com/hazelcast/nio/serialization/StreamSerializer.html)
 mechanism. Here is a sample implementation for a `Person` class:
 
 ```java

--- a/site/docs/api/sources-sinks.md
+++ b/site/docs/api/sources-sinks.md
@@ -95,7 +95,7 @@ dependency to your application:
 <!--Gradle-->
 
 ```groovy
-compile 'com.hazelcast.jet:hazelcast-jet-avro:4.0'
+compile 'com.hazelcast.jet:hazelcast-jet-avro:{jet-version}'
 ```
 
 <!--Maven-->
@@ -104,7 +104,7 @@ compile 'com.hazelcast.jet:hazelcast-jet-avro:4.0'
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-avro</artifactId>
-  <version>4.0</version>
+  <version>{jet-version}</version>
 </dependency>
 ```
 
@@ -202,7 +202,7 @@ dependency to your application:
 <!--Gradle-->
 
 ```groovy
-compile 'com.hazelcast.jet:hazelcast-jet-hadoop:4.0'
+compile 'com.hazelcast.jet:hazelcast-jet-hadoop:{jet-version}'
 ```
 
 <!--Maven-->
@@ -211,7 +211,7 @@ compile 'com.hazelcast.jet:hazelcast-jet-hadoop:4.0'
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-hadoop</artifactId>
-  <version>4.0</version>
+  <version>{jet-version}</version>
 </dependency>
 ```
 
@@ -279,7 +279,7 @@ application:
 <!--Gradle-->
 
 ```groovy
-compile 'com.hazelcast.jet:hazelcast-jet-s3:4.0'
+compile 'com.hazelcast.jet:hazelcast-jet-s3:{jet-version}'
 ```
 
 <!--Maven-->
@@ -288,7 +288,7 @@ compile 'com.hazelcast.jet:hazelcast-jet-s3:4.0'
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-s3</artifactId>
-  <version>4.0</version>
+  <version>{jet-version}</version>
 </dependency>
 ```
 
@@ -353,7 +353,7 @@ dependency to your application:
 
 ```groovy
 
-compile 'com.hazelcast.jet:hazelcast-jet-kafka:4.0'
+compile 'com.hazelcast.jet:hazelcast-jet-kafka:{jet-version}'
 ```
 
 <!--Maven-->
@@ -362,7 +362,7 @@ compile 'com.hazelcast.jet:hazelcast-jet-kafka:4.0'
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-kafka</artifactId>
-  <version>4.0</version>
+  <version>{jet-version}</version>
 </dependency>
 ```
 
@@ -1220,9 +1220,9 @@ processing even with at-least-once sinks.
 
 If Jet doesn’t natively support the data source/sink you need, you can
 build a connector for it yourself by using the
-[SourceBuilder](/javadoc/4.0/com/hazelcast/jet/pipeline/SourceBuilder.html)
+[SourceBuilder](/javadoc/{jet-version}/com/hazelcast/jet/pipeline/SourceBuilder.html)
 and
-[SinkBuilder](/javadoc/4.0/com/hazelcast/jet/pipeline/SinkBuilder.html)
+[SinkBuilder](/javadoc/{jet-version}/com/hazelcast/jet/pipeline/SinkBuilder.html)
 .
 
 ### SourceBuilder

--- a/site/docs/api/spring.md
+++ b/site/docs/api/spring.md
@@ -187,9 +187,9 @@ Here’s how your namespace and schema instance declarations may look:
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-{imdg-version}.xsd
         http://www.hazelcast.com/schema/jet-spring
-        http://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-4.0.xsd">
+        http://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-{jet-version}.xsd">
         <!-- ... -->
  </beans>
 ```
@@ -258,9 +258,9 @@ beans:
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-{imdg-version}.xsd
         http://www.hazelcast.com/schema/jet-spring
-        http://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-4.0.xsd">
+        http://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-{jet-version}.xsd">
 
     <!-- Obtain Hazelcast IMDG instance from Hazelcast Jet instance-->
     <jet:hazelcast jet-instance-ref="jet-instance" id="hazelcast-instance"/>
@@ -319,7 +319,7 @@ attributes.
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
         http://www.hazelcast.com/schema/jet-spring
-        http://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-4.0.xsd">
+        http://www.hazelcast.com/schema/jet-spring/hazelcast-jet-spring-{jet-version}.xsd">
     <jet:instance id="instance" lazy-init="true" scope="singleton">
     <!-- ... -->
     </jet:instance>

--- a/site/docs/api/stateful-transforms.md
+++ b/site/docs/api/stateful-transforms.md
@@ -61,10 +61,10 @@ in aggregations, such as:
 |`allOf`|Combine multiple aggregations into one aggregation (for example, if you want both sum and average)|
 
 For a complete list, please refer to the
-[AggregateOperations](/javadoc/4.0/com/hazelcast/jet/aggregate/AggregateOperations.html)
+[AggregateOperations](/javadoc/{jet-version}/com/hazelcast/jet/aggregate/AggregateOperations.html)
 class. You can also implement your own aggregate operations using the
 builder in
-[AggregateOperation](/javadoc/4.0/com/hazelcast/jet/aggregate/AggregateOperation.html)
+[AggregateOperation](/javadoc/{jet-version}/com/hazelcast/jet/aggregate/AggregateOperation.html)
 .
 
 ### groupingKey

--- a/site/docs/api/testing.md
+++ b/site/docs/api/testing.md
@@ -21,8 +21,8 @@ project:
 <!--Gradle-->
 
 ```bash
-compile 'com.hazelcast.jet:hazelcast-jet-core:4.0:tests'
-compile 'com.hazelcast:hazelcast:4.0:tests'
+compile 'com.hazelcast.jet:hazelcast-jet-core:{jet-version}:tests'
+compile 'com.hazelcast:hazelcast:{imdg-version}:tests'
 ```
 
 <!--Maven-->
@@ -31,13 +31,13 @@ compile 'com.hazelcast:hazelcast:4.0:tests'
 <dependency>
   <groupId>com.hazelcast.jet</groupId>
   <artifactId>hazelcast-jet-core</artifactId>
-  <version>4.0</version>
+  <version>{jet-version}</version>
   <classifier>tests</classifier>
 </dependency>
 <dependency>
   <groupId>com.hazelcast</groupId>
   <artifactId>hazelcast</artifactId>
-  <version>4.0</version>
+  <version>{imdg-version}</version>
   <classifier>tests</classifier>
 </dependency>
 ```
@@ -151,7 +151,7 @@ Members {size:2, ver:2} [
  Member [127.0.0.1]:5702 - 920d1b0c-0898-4b6e-9009-8f29889d6a77 this
 ]
 ....
-10:45:04.890 [ INFO] [c.h.c.i.s.ClientClusterService] [4.0]
+10:45:04.890 [ INFO] [c.h.c.i.s.ClientClusterService] [{imdg-version}]
 
 Members [2] {
  Member [127.0.0.1]:5701 - 93328d97-0975-4dfa-bf56-4d46e8a469a1

--- a/site/docs/architecture/execution-engine.md
+++ b/site/docs/architecture/execution-engine.md
@@ -105,11 +105,11 @@ This lightweight contract allows us to implement `Traverser` with just a
 lambda expression. If you look at the source code of Jet processor,
 you may encounter quite complex code inside `Traverser` transforms. A
 good example is the
-[`SlidingWindowP`](https://github.com/hazelcast/hazelcast-jet/blob/v4.0/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java#L207)
+[`SlidingWindowP`](https://github.com/hazelcast/hazelcast-jet/blob/v{jet-version}/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/SlidingWindowP.java#L207)
 processor.
 
 At the
-[`ProcessorTasklet`](https://github.com/hazelcast/hazelcast-jet/blob/v4.0/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java#L259)
+[`ProcessorTasklet`](https://github.com/hazelcast/hazelcast-jet/blob/v{jet-version}/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ProcessorTasklet.java#L259)
 level we needed a full state machine implementation, basically
 implementing the [CPS
 transformation](https://github.com/Kotlin/KEEP/blob/master/proposals/coroutines.md#implementation-details)

--- a/site/docs/concepts/processing-guarantees.md
+++ b/site/docs/concepts/processing-guarantees.md
@@ -47,7 +47,7 @@ processing pipeline:
   *N*, later stages are still working on batches *N - 1*, *N - 2* etc.
 - **Volatile State.** Jet stores aggregation state in plain `HashMap`s
   and only occasionally backs them up to the resilient
-  [`IMap`](/javadoc/4.0/com/hazelcast/map/IMap.html)
+  [`IMap`](/javadoc/{imdg-version}/com/hazelcast/map/IMap.html)
   storage.
 - **Load Balancing.** Jet often reshapes batches to better match the
   capacity of each stage.

--- a/site/docs/design-docs/004-spring-boot-starter.md
+++ b/site/docs/design-docs/004-spring-boot-starter.md
@@ -123,7 +123,7 @@ The health indicator for Jet actually uses the wrapped
 `HazelcastHealthIndicator` which is already available in Spring Boot
 distribution instead of creating a Jet specific one. The problem is
 Spring Boot still uses IMDG `3.12.x` and `com.hazelcast.core.Endpoint`
-is moved to `com.hazelcast.cluster.Endpoint` in `4.0`. Since this class
-is used in `HazelcastHealthIndicator` we should wait for Spring Boot to
-upgrade to IMDG `4.0` to continue this unification. See the
-[issue](https://github.com/hazelcast/hazelcast-jet-contrib/issues/63).
+is moved to `com.hazelcast.cluster.Endpoint` in `{imdg-version}`. Since
+this class is used in `HazelcastHealthIndicator` we should wait for
+Spring Boot to upgrade to IMDG `{imdg-version}` to continue this
+unification. See the [issue](https://github.com/hazelcast/hazelcast-jet-contrib/issues/63).

--- a/site/docs/design-docs/004-spring-boot-starter.md
+++ b/site/docs/design-docs/004-spring-boot-starter.md
@@ -123,7 +123,7 @@ The health indicator for Jet actually uses the wrapped
 `HazelcastHealthIndicator` which is already available in Spring Boot
 distribution instead of creating a Jet specific one. The problem is
 Spring Boot still uses IMDG `3.12.x` and `com.hazelcast.core.Endpoint`
-is moved to `com.hazelcast.cluster.Endpoint` in `{imdg-version}`. Since
-this class is used in `HazelcastHealthIndicator` we should wait for
-Spring Boot to upgrade to IMDG `{imdg-version}` to continue this
-unification. See the [issue](https://github.com/hazelcast/hazelcast-jet-contrib/issues/63).
+is moved to `com.hazelcast.cluster.Endpoint` in `4.0`. Since this class
+is used in `HazelcastHealthIndicator` we should wait for Spring Boot to
+upgrade to IMDG `4.0` to continue this unification. See the
+[issue](https://github.com/hazelcast/hazelcast-jet-contrib/issues/63).

--- a/site/docs/design-docs/006-declarative-serialization.md
+++ b/site/docs/design-docs/006-declarative-serialization.md
@@ -7,7 +7,7 @@ description: Out of box support for additional serialization types such as Avro 
 
 ## Problem statement
 
-In Jet 4.0 we support 4 interfaces to serialize custom types. However,
+In Jet {jet-version} we support 4 interfaces to serialize custom types. However,
 either implementations are slow (`java.io.Serializable` &
 `java.io.Externalizable`) or must depend on IMDG specific classes and
 require hand crafted code from the user which is cumbersome and error

--- a/site/docs/design-docs/006-declarative-serialization.md
+++ b/site/docs/design-docs/006-declarative-serialization.md
@@ -7,7 +7,7 @@ description: Out of box support for additional serialization types such as Avro 
 
 ## Problem statement
 
-In Jet {jet-version} we support 4 interfaces to serialize custom types. However,
+In Jet 4.0 we support 4 interfaces to serialize custom types. However,
 either implementations are slow (`java.io.Serializable` &
 `java.io.Externalizable`) or must depend on IMDG specific classes and
 require hand crafted code from the user which is cumbersome and error

--- a/site/docs/enterprise/blue-green.md
+++ b/site/docs/enterprise/blue-green.md
@@ -56,4 +56,4 @@ failures in the cluster You can also force a client to specifically
 disconnect from one cluster and connect to the other one through
 blacklisting. For a list of detailed features and options for Blue/Green
 configuration options see the
-[Hazelcast IMDG documentation on Blue-Green Deployment](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#blue-green-deployment-and-disaster-recovery).
+[Hazelcast IMDG documentation on Blue-Green Deployment](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#blue-green-deployment-and-disaster-recovery).

--- a/site/docs/enterprise/installation.md
+++ b/site/docs/enterprise/installation.md
@@ -8,15 +8,15 @@ Hazelcast Jet Enterprise requires a license key to run. You can get a
 
 ## Download Hazelcast Jet
 
-Once you have a license key, download Hazelcast Jet from [here](https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.0.tar.gz).
+Once you have a license key, download Hazelcast Jet from [here](https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-{jet-version}.tar.gz).
 
 Hazelcast Jet requires a minimum of JDK 8, which can be acquired from
 [AdoptOpenJDK](https://adoptopenjdk.net/). Once you have the download,
 unzip it to a folder which we will refer from now on as `JET_HOME`.
 
 ```bash
-tar zxvf hazelcast-jet-enterprise-4.0.tar.gz
-cd hazelcast-jet-enterprise-4.0
+tar zxvf hazelcast-jet-enterprise-{jet-version}.tar.gz
+cd hazelcast-jet-enterprise-{jet-version}
 ```
 
 ## Set License Key
@@ -79,7 +79,7 @@ repositories {
     }
 }
 
-compile 'com.hazelcast.jet:hazelcast-jet-enterprise:4.0'
+compile 'com.hazelcast.jet:hazelcast-jet-enterprise:{jet-version}'
 ```
 
 <!--Maven-->
@@ -94,7 +94,7 @@ compile 'com.hazelcast.jet:hazelcast-jet-enterprise:4.0'
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-jet-enterprise</artifactId>
-    <version>4.0</version>
+    <version>{jet-version}</version>
 </dependency>
 ```
 
@@ -134,11 +134,11 @@ below instead of our example's `172.17.0.2`. Let's submit the Hello
 World application from the distribution package:
 
 ```bash
-cd hazelcast-jet-enterprise-4.0
+cd hazelcast-jet-enterprise-{jet-version}
 docker run -it -v "$(pwd)"/examples:/examples hazelcast/hazelcast-jet-enterprise jet -a 172.17.0.2 submit /examples/hello-world.jar
 ```
 
-The command mounts the local `examples` directory from `hazelcast-jet-enterprise-4.0`
+The command mounts the local `examples` directory from `hazelcast-jet-enterprise-{jet-version}`
 to the container and uses `jet submit` to submit the example JAR. While
 the job is running, it should produce output like this:
 

--- a/site/docs/enterprise/lossless-restart.md
+++ b/site/docs/enterprise/lossless-restart.md
@@ -41,7 +41,7 @@ hazelcast:
 ```
 
 See the
-[docs](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#hot-restart-persistence)
+[docs](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#hot-restart-persistence)
 for detailed description including fine-tuning.
 
 ## Safely Shutting Down A Jet Cluster

--- a/site/docs/enterprise/management-center.md
+++ b/site/docs/enterprise/management-center.md
@@ -8,12 +8,12 @@ used to monitor a Jet cluster and manage the lifecycle of the jobs
 
 ## Download Management Center
 
-You can download Hazelcast Jet Management Center [here](https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-4.0.tar.gz).
+You can download Hazelcast Jet Management Center [here](https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-{jet-version}.tar.gz).
 
 Once you have downloaded it, unzip it to a folder:
 
 ```bash
-tar zxvf hazelcast-jet-enterprise-4.0.tar.gz
+tar zxvf hazelcast-jet-enterprise-{jet-version}.tar.gz
 ```
 
 ## Setting License Key
@@ -120,7 +120,7 @@ below:
 2020-03-17 14:31:18.947  INFO 1 --- [           main] c.h.j.management.service.LicenseService  : License Info : License{allowedNumberOfNodes=NNN, expiryDate=MM/DD/YYYY 23:59:59, featureList=[ Management Center, Clustered JMX, Clustered Rest, Security, Hot Restart, Jet Management Center, Jet Lossless Recovery, Jet Rolling Job Upgrade, Jet Enterprise ], type=Enterprise HD, companyName=null, ownerEmail=null, keyHash=NNN, No Version Restriction}
 
 ...
-2020-03-17 14:31:17.523  INFO 1 --- [-center.event-5] c.h.c.impl.spi.ClientClusterService      : jet-management-center [jet] [4.0] [4.0]
+2020-03-17 14:31:17.523  INFO 1 --- [-center.event-5] c.h.c.impl.spi.ClientClusterService      : jet-management-center [jet] [{jet-version}] [{jet-version}]
 
 Members [1] {
     Member [172.17.0.2]:5701 - 32349cdf-8c9a-413f-8dad-80f2ef7bbcd6

--- a/site/docs/enterprise/off-heap.md
+++ b/site/docs/enterprise/off-heap.md
@@ -10,7 +10,7 @@ pauses in the application, leading to unpredictable spikes in latency
 and drops in throughput.
 
 To avoid this, Jet supports storing data in `IMap` in what's called
-_native_ or _off-heap_ memory using the [High-Density Memory](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#using-high-density-memory-store-with-map)
+_native_ or _off-heap_ memory using the [High-Density Memory](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#using-high-density-memory-store-with-map)
 feature of Hazelcast. This allows JVM to operate with smaller heaps and
 do garbage collection more efficiently, while allowing Jet to store
 large amount of data.
@@ -41,7 +41,7 @@ hazelcast:
       in-memory-format: NATIVE
 ```
 
-For additional configuration options, see [configuring high-density memory](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#configuring-high-density-memory-store)
+For additional configuration options, see [configuring high-density memory](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#configuring-high-density-memory-store)
 section of the Hazelcast manual.
 
 ## Persistent Memory
@@ -52,6 +52,6 @@ Depending on the value size, this offers almost similar performance to
 memory at a lower cost, making it attractive for storing large amounts
 of data efficiently.
 
-Please refer to the [configuring persistent memory](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#using-persistent-memory)
+Please refer to the [configuring persistent memory](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#using-persistent-memory)
 section of the Hazelcast manual for details on how to enable persistent
 memory.

--- a/site/docs/enterprise/security.md
+++ b/site/docs/enterprise/security.md
@@ -93,7 +93,7 @@ traffic. Detailed benchmarks are available upon request.
 By default Jet uses the Java implementation of SSL. For better
 performance, it is also possible to use Jet with OpenSSL instead. For
 configuring OpenSSL we recommend going through the guide in
-[Hazelcast 4.0 Reference Manual](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#integrating-openssl-boringssl).
+[Hazelcast {imdg-version} Reference Manual](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#integrating-openssl-boringssl).
 
 ## Remote Hazelcast Sources and Sinks
 

--- a/site/docs/get-started/first-job.md
+++ b/site/docs/get-started/first-job.md
@@ -26,7 +26,7 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    compile 'com.hazelcast.jet:hazelcast-jet:4.0'
+    compile 'com.hazelcast.jet:hazelcast-jet:{jet-version}'
 }
 
 application {
@@ -57,7 +57,7 @@ application {
       <dependency>
         <groupId>com.hazelcast.jet</groupId>
         <artifactId>hazelcast-jet</artifactId>
-        <version>4.0</version>
+        <version>{jet-version}</version>
       </dependency>
     </dependencies>
 

--- a/site/docs/get-started/installation.md
+++ b/site/docs/get-started/installation.md
@@ -13,7 +13,7 @@ There are two main approaches to setting up a local Hazelcast Jet
 cluster: as a classic Java process or as a Docker instance. In order to
 follow the tutorial, in both cases you'll need the Hazelcast Jet
 distribution package. Download it from
-[here](https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz)
+[here](https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}/hazelcast-jet-{jet-version}.tar.gz)
 and unzip it to a directory we'll refer to as `<jet_home>`.
 
 ## As a Java Process
@@ -38,7 +38,7 @@ command. For example, let's check the cluster state:
 ```bash
 $ bin/jet cluster
 State: ACTIVE
-Version: 4.0
+Version: {jet-version}
 Size: 1
 
 ADDRESS                  UUID

--- a/site/docs/how-tos/observables.md
+++ b/site/docs/how-tos/observables.md
@@ -62,7 +62,7 @@ observable.destroy();
 ## Clean-up
 
 Observables are backed by
-[Ringbuffers](/javadoc/4.0/com/hazelcast/ringbuffer/Ringbuffer.html)
+[Ringbuffers](/javadoc/{imdg-version}/com/hazelcast/ringbuffer/Ringbuffer.html)
 stored in the cluster which should be cleaned up by the client, once
 they are no longer necessary. They have a `destroy()` method which does
 just that. If the Observable isn’t destroyed, its memory will be leaked

--- a/site/docs/how-tos/stream-imap.md
+++ b/site/docs/how-tos/stream-imap.md
@@ -3,7 +3,7 @@ title: Receive IMap Change Stream
 description: How to monitor the stream of change events happening to an `IMap.`
 ---
 
-[IMap](/javadoc/4.0/com/hazelcast/map/IMap.html)
+[IMap](/javadoc/{imdg-version}/com/hazelcast/map/IMap.html)
 is the main data structure in Hazelcast IMDG. Jet can use it as both a
 data source and a data sink. It can serve as both a batch source, giving
 you all the current data, and as a streaming source, giving you a stream

--- a/site/docs/operations/cluster-sizing.md
+++ b/site/docs/operations/cluster-sizing.md
@@ -74,7 +74,7 @@ To tolerate the failure of one member, we recommend to size your cluster
 to operate with ```n-1``` members setup.
 
 You can use Hazelcast [IMap and ICache Event
-Journal](https://docs.hazelcast.org/docs/jet/4.0/manual/#connector-imdg-journal)
+Journal](https://docs.hazelcast.org/docs/jet/{jet-version}/manual/#connector-imdg-journal)
 
 to ingest the streaming data. Journal is an in-memory structure with a
 fixed capacity. If the jobs consuming the journal can't keep up there is
@@ -82,7 +82,7 @@ a risk of data loss.  The pace of the data producers and the capacity of
 the Journal therefore determine the length of an error window of your
 application. If you can't afford losing data, consider increasing the
 journal size or ingest streaming data using a persistent storage such as
-[Apache Kafka](https://docs.hazelcast.org/docs/jet/4.0/manual/#kafka)
+[Apache Kafka](https://docs.hazelcast.org/docs/jet/{jet-version}/manual/#kafka)
 or Apache Pulsar.
 
 Another approach to increase the fault-tolerance is splitting the Jet
@@ -217,7 +217,7 @@ Consider using more performant disks when:
 
 * You use the cluster file system as a source or sink - faster disks
  improve the performance
-* Using disk persistence for [Lossless Cluster Restart](https://docs.hazelcast.org/docs/jet/4.0/manual/#configure-lossless-cluster-restart-enterprise-only)
+* Using disk persistence for [Lossless Cluster Restart](https://docs.hazelcast.org/docs/jet/{jet-version}/manual/#configure-lossless-cluster-restart-enterprise-only)
 
 ## Data flow
 
@@ -339,7 +339,7 @@ machines, each of 8 CPU, 16 GB RAM, 10 Gbps network.
 ### Fault-Tolerance
 
 The [Event
-Journal](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#event-journal)
+Journal](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#event-journal)
 capacity was set to 1.5 million items. With a input data production rate
 of 50k events each second, the data are kept for 30 seconds before being
 overwritten. The job snapshot frequency was set to 1 second.
@@ -351,5 +351,5 @@ snapshot) giving the job enough time to reprocess the 3 seconds (~ 150k
 events) of data it missed.
 
 More aggressive [failure
-detector](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#failure-detector-configuration)
+detector](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#failure-detector-configuration)
 and a larger event journal can be used to stretch the error window.

--- a/site/docs/operations/installation.md
+++ b/site/docs/operations/installation.md
@@ -111,6 +111,6 @@ be output during note startup as below:
 # JAVA=/usr/bin/java
 # JAVA_OPTS=--add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
 ..
-# CLASSPATH=/home/jet/hazelcast-jet-4.0/lib/*:
+# CLASSPATH=/home/jet/hazelcast-jet-{jet-version}/lib/*:
 ########################################
 ```

--- a/site/docs/operations/kubernetes.md
+++ b/site/docs/operations/kubernetes.md
@@ -233,15 +233,15 @@ $ kubectl logs hazelcast-jet-0
 ...
 ...
 ...
-2020-03-05 10:02:44,698  INFO [c.h.i.c.ClusterService] [main] - [172.17.0.6]:5701 [dev] [4.0]
+2020-03-05 10:02:44,698  INFO [c.h.i.c.ClusterService] [main] - [172.17.0.6]:5701 [dev] [{imdg-version}]
 
 Members {size:1, ver:1} [
  Member [172.17.0.6]:5701 - 03a22d3c-d88a-40bf-81b0-8f85e16acb0f this
 ]
 
-2020-03-05 10:02:44,725  INFO [c.h.c.LifecycleService] [main] - [172.17.0.6]:5701 [dev] [4.0] [172.17.0.6]:5701 is STARTED
-2020-03-05 10:03:20,387  INFO [c.h.i.n.t.TcpIpConnection] [hz.distracted_bartik.IO.thread-in-2] - [172.17.0.6]:5701 [dev] [4.0] Initialized new cluster connection between /172.17.0.6:5701 and /172.17.0.7:49103
-2020-03-05 10:03:27,381  INFO [c.h.i.c.ClusterService] [hz.distracted_bartik.priority-generic-operation.thread-0] - [172.17.0.6]:5701 [dev] [4.0]
+2020-03-05 10:02:44,725  INFO [c.h.c.LifecycleService] [main] - [172.17.0.6]:5701 [dev] [{imdg-version}] [172.17.0.6]:5701 is STARTED
+2020-03-05 10:03:20,387  INFO [c.h.i.n.t.TcpIpConnection] [hz.distracted_bartik.IO.thread-in-2] - [172.17.0.6]:5701 [dev] [{imdg-version}] Initialized new cluster connection between /172.17.0.6:5701 and /172.17.0.7:49103
+2020-03-05 10:03:27,381  INFO [c.h.i.c.ClusterService] [hz.distracted_bartik.priority-generic-operation.thread-0] - [172.17.0.6]:5701 [dev] [{imdg-version}]
 
 Members {size:2, ver:2} [
  Member [172.17.0.6]:5701 - 03a22d3c-d88a-40bf-81b0-8f85e16acb0f this

--- a/site/docs/operations/monitoring.md
+++ b/site/docs/operations/monitoring.md
@@ -71,8 +71,8 @@ Let’s look at these 3 broad categories of metrics in detail.
 
 There is a wide range of metrics and statistics provided by Hazelcast:
 
-* statistics of distributed data structures (see [Reference Manual](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#getting-member-statistics))
-* executor statistics (see [Reference Manual](https://docs.hazelcast.org/docs/4.0/manual/html-single/index.html#executor-statistics))
+* statistics of distributed data structures (see [Reference Manual](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#getting-member-statistics))
+* executor statistics (see [Reference Manual](https://docs.hazelcast.org/docs/{imdg-version}/manual/html-single/index.html#executor-statistics))
 * partition related statistics (state, migration, replication)
 * garbage collection statistics
 * memory statistics for the JVM which current IMDG member belongs to
@@ -348,7 +348,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of pending (in flight) operations when using
         asynchronous mapping processors. See
-        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#mapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-int-boolean-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-">
+        <a href="/javadoc/{jet-version}/com/hazelcast/jet/core/processor/Processors.html#mapUsingServiceAsyncP-com.hazelcast.jet.pipeline.ServiceFactory-int-boolean-com.hazelcast.function.FunctionEx-com.hazelcast.function.BiFunctionEx-">
         Processors.mapUsingServiceAsyncP</a>.
     </td>
     <td rowspan="9">
@@ -376,7 +376,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of active windows being tracked by a session window
         processor. See
-        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#aggregateToSessionWindowP-long-long-java.util.List-java.util.List-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
+        <a href="/javadoc/{jet-version}/com/hazelcast/jet/core/processor/Processors.html#aggregateToSessionWindowP-long-long-java.util.List-java.util.List-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
         Processors.aggregateToSessionWindowP</a>.
     </td>
   </tr>
@@ -394,7 +394,7 @@ then the `source` or `sink` tags will also be set to true.
     <td>
         The number of grouping keys associated with the current active
         frames of a sliding window processor. See
-        <a href="/javadoc/4.0/com/hazelcast/jet/core/processor/Processors.html#aggregateToSlidingWindowP-java.util.List-java.util.List-com.hazelcast.jet.core.TimestampKind-com.hazelcast.jet.core.SlidingWindowPolicy-long-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
+        <a href="/javadoc/{jet-version}/com/hazelcast/jet/core/processor/Processors.html#aggregateToSlidingWindowP-java.util.List-java.util.List-com.hazelcast.jet.core.TimestampKind-com.hazelcast.jet.core.SlidingWindowPolicy-long-com.hazelcast.jet.aggregate.AggregateOperation-com.hazelcast.jet.core.function.KeyedWindowResultFunction-">
         Processors.aggregateToSlidingWindowP</a>.
     </td>
   </tr>
@@ -440,7 +440,7 @@ p.readFrom(source)
  .writeTo(sink);
 ```
 
-For further details consult the [Javadoc](/javadoc/4.0/com/hazelcast/jet/core/metrics/Metrics.html).
+For further details consult the [Javadoc](/javadoc/{jet-version}/com/hazelcast/jet/core/metrics/Metrics.html).
 
 User-defined metrics can be used anywhere in pipeline definitions where
 custom code can be added. This means (just to name the most important
@@ -472,16 +472,16 @@ Hazelcast metrics are stored under the
 #### Via Job API
 
 The `Job` class has a
-[`getMetrics()`](/javadoc/4.0/com/hazelcast/jet/Job.html#getMetrics--)
+[`getMetrics()`](/javadoc/{jet-version}/com/hazelcast/jet/Job.html#getMetrics--)
 method which returns a
-[JobMetrics](/javadoc/4.0/com/hazelcast/jet/core/metrics/JobMetrics.html)
+[JobMetrics](/javadoc/{jet-version}/com/hazelcast/jet/core/metrics/JobMetrics.html)
 instance. It contains the latest known metric values for the job.
 
 This functionality has been developed primarily to give access to
 metrics of finished jobs, but can in fact be used for jobs in any state.
 
 For details on how to use and filter the metric values consult the
-[JobMetrics API docs](/javadoc/4.0/com/hazelcast/jet/core/metrics/JobMetrics.html)
+[JobMetrics API docs](/javadoc/{jet-version}/com/hazelcast/jet/core/metrics/JobMetrics.html)
 . A simple example for computing the number of data items emitted by a
 certain vertex (let’s call it vertexA), excluding items emitted to the
 snapshot, would look like this:

--- a/site/docs/tutorials/cdc.md
+++ b/site/docs/tutorials/cdc.md
@@ -24,7 +24,7 @@ CDC connectors for a
 The [Kafka Connect API](http://kafka.apache.org/documentation.html#connect)
 is an interface developed for Kafka, that simplifies and automates the
 integration of a new data source (or sink) with your Kafka cluster.
-Since version {jet-version} Jet includes a generic Kafka Connect Source,
+Since version 4.0 Jet includes a generic Kafka Connect Source,
 thus making the integration of Debezium's connectors easy.
 
 Let's see an example, how to process change events from a MySQL database

--- a/site/docs/tutorials/cdc.md
+++ b/site/docs/tutorials/cdc.md
@@ -24,8 +24,8 @@ CDC connectors for a
 The [Kafka Connect API](http://kafka.apache.org/documentation.html#connect)
 is an interface developed for Kafka, that simplifies and automates the
 integration of a new data source (or sink) with your Kafka cluster.
-Since version 4.0 Jet includes a generic Kafka Connect Source, thus
-making the integration of Debezium's connectors easy.
+Since version {jet-version} Jet includes a generic Kafka Connect Source,
+thus making the integration of Debezium's connectors easy.
 
 Let's see an example, how to process change events from a MySQL database
 in Jet.
@@ -168,15 +168,15 @@ mysql> SELECT * FROM customers;
 
 ## 4. Start Hazelcast Jet
 
-1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz)
+1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}/hazelcast-jet-{jet-version}.tar.gz)
   Hazelcast Jet
 
 2. Unzip it:
 
 ```bash
 cd <where_you_downloaded_it>
-tar zxvf hazelcast-jet-4.0.tar.gz
-cd hazelcast-jet-4.0
+tar zxvf hazelcast-jet-{jet-version}.tar.gz
+cd hazelcast-jet-{jet-version}
 ```
 
 3. Start Jet:
@@ -214,7 +214,7 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    compile 'com.hazelcast.jet:hazelcast-jet:4.0'
+    compile 'com.hazelcast.jet:hazelcast-jet:{jet-version}'
     compile 'com.hazelcast.jet.contrib:debezium:0.1'
     compile 'io.debezium:debezium-connector-mysql:1.0.0.Final'
 }
@@ -227,7 +227,7 @@ jar {
 
 shadowJar {
     dependencies {
-        exclude(dependency('com.hazelcast.jet:hazelcast-jet:4.0'))
+        exclude(dependency('com.hazelcast.jet:hazelcast-jet:{jet-version}'))
     }
 }
 ```
@@ -253,7 +253,7 @@ shadowJar {
        <dependency>
            <groupId>com.hazelcast.jet</groupId>
            <artifactId>hazelcast-jet</artifactId>
-           <version>4.0</version>
+           <version>{jet-version}</version>
        </dependency>
        <dependency>
            <groupId>com.hazelcast.jet.contrib</groupId>

--- a/site/docs/tutorials/kafka.md
+++ b/site/docs/tutorials/kafka.md
@@ -19,15 +19,15 @@ From now on we assume Kafka is running on your machine.
 
 ## 2. Start Hazelcast Jet
 
-1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz)
+1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}/hazelcast-jet-{jet-version}.tar.gz)
   Hazelcast Jet
 
 2. Unzip it:
 
 ```bash
 cd <where_you_downloaded_it>
-tar zxvf hazelcast-jet-4.0.tar.gz
-cd hazelcast-jet-4.0
+tar zxvf hazelcast-jet-{jet-version}.tar.gz
+cd hazelcast-jet-{jet-version}
 ```
 
 If you already have Jet and you skipped the above steps, make sure to
@@ -36,7 +36,7 @@ follow from here on.
 3. Activate the Apache Kafka Connector plugin:
 
 ```bash
-mv opt/hazelcast-jet-kafka-4.0.jar lib/
+mv opt/hazelcast-jet-kafka-{jet-version}.jar lib/
 ```
 
 4. Start Jet:
@@ -75,8 +75,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    compile 'com.hazelcast.jet:hazelcast-jet:4.0'
-    compile 'com.hazelcast.jet:hazelcast-jet-kafka:4.0'
+    compile 'com.hazelcast.jet:hazelcast-jet:{jet-version}'
+    compile 'com.hazelcast.jet:hazelcast-jet-kafka:{jet-version}'
 }
 
 jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
@@ -103,12 +103,12 @@ jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-kafka</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
     </dependencies>
 

--- a/site/docs/tutorials/map-join.md
+++ b/site/docs/tutorials/map-join.md
@@ -24,15 +24,15 @@ We will use the ticker to lookup the full company name in a replicated map.
 
 ## 1. Start Hazelcast Jet
 
-1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz)
+1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}/hazelcast-jet-{jet-version}.tar.gz)
   Hazelcast Jet
 
 2. Unzip it:
 
 ```bash
 cd <where_you_downloaded_it>
-tar zxvf hazelcast-jet-4.0.tar.gz
-cd hazelcast-jet-4.0
+tar zxvf hazelcast-jet-{jet-version}.tar.gz
+cd hazelcast-jet-{jet-version}
 ```
 
 3. Start Jet:
@@ -72,8 +72,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    compile 'com.hazelcast.jet:hazelcast-jet:4.0'
-    compile 'com.hazelcast.jet.examples:hazelcast-jet-examples-trade-source:4.0'
+    compile 'com.hazelcast.jet:hazelcast-jet:{jet-version}'
+    compile 'com.hazelcast.jet.examples:hazelcast-jet-examples-trade-source:{jet-version}'
 }
 
 jar {
@@ -84,7 +84,7 @@ jar {
 
 shadowJar {
     dependencies {
-        exclude(dependency('com.hazelcast.jet:hazelcast-jet:4.0'))
+        exclude(dependency('com.hazelcast.jet:hazelcast-jet:{jet-version}'))
     }
 }
 ```
@@ -110,12 +110,12 @@ shadowJar {
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet.examples</groupId>
             <artifactId>hazelcast-jet-examples-trade-source</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
     </dependencies>
 

--- a/site/docs/tutorials/pulsar.md
+++ b/site/docs/tutorials/pulsar.md
@@ -34,15 +34,15 @@ localhost:6650.
 
 ## 2. Start Hazelcast Jet
 
-1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz)
+1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}/hazelcast-jet-{jet-version}.tar.gz)
    Hazelcast Jet
 
 2. Unzip it:
 
 ```bash
 cd <where_you_downloaded_it>
-tar zxvf hazelcast-jet-4.0.tar.gz
-cd hazelcast-jet-4.0
+tar zxvf hazelcast-jet-{jet-version}.tar.gz
+cd hazelcast-jet-{jet-version}
 ```
 
 If you already have Jet and you skipped the above steps, make sure to
@@ -89,7 +89,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.hazelcast.jet:hazelcast-jet:4.0'
+    compile 'com.hazelcast.jet:hazelcast-jet:{jet-version}'
     compile 'com.hazelcast.jet-contrib:pulsar:0.1-SNAPSHOT'
     compile 'org.apache.pulsar:pulsar-client:2.5.0'
 }
@@ -102,7 +102,7 @@ jar {
 
 shadowJar {
     dependencies {
-        exclude(dependency('com.hazelcast.jet:hazelcast-jet:4.0'))
+        exclude(dependency('com.hazelcast.jet:hazelcast-jet:{jet-version}'))
     }
 }
 ```
@@ -128,7 +128,7 @@ shadowJar {
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet.contrib</groupId>

--- a/site/docs/tutorials/python.md
+++ b/site/docs/tutorials/python.md
@@ -45,15 +45,15 @@ Python 3 on your machine.
 
 ## 3. Start Hazelcast Jet
 
-1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz)
+1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}/hazelcast-jet-{jet-version}.tar.gz)
   Hazelcast Jet
 
 2. Unzip it:
 
 ```bash
 cd <where_you_downloaded_it>
-tar zxvf hazelcast-jet-4.0.tar.gz
-cd hazelcast-jet-4.0
+tar zxvf hazelcast-jet-{jet-version}.tar.gz
+cd hazelcast-jet-{jet-version}
 ```
 
 If you already have Jet and you skipped the above steps, make sure to
@@ -62,7 +62,7 @@ follow from here on.
 3. Activate the Python plugin:
 
 ```bash
-mv opt/hazelcast-jet-python-4.0.jar lib/
+mv opt/hazelcast-jet-python-{jet-version}.jar lib/
 ```
 
 4. Start Jet:
@@ -101,8 +101,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    compile 'com.hazelcast.jet:hazelcast-jet:4.0'
-    compile 'com.hazelcast.jet:hazelcast-jet-python:4.0'
+    compile 'com.hazelcast.jet:hazelcast-jet:{jet-version}'
+    compile 'com.hazelcast.jet:hazelcast-jet-python:{jet-version}'
 }
 
 jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
@@ -129,12 +129,12 @@ jar.manifest.attributes 'Main-Class': 'org.example.JetJob'
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet-python</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
     </dependencies>
 

--- a/site/docs/tutorials/windowing.md
+++ b/site/docs/tutorials/windowing.md
@@ -19,15 +19,15 @@ financial exchange's most actively traded stocks.
 
 ## 1. Start Hazelcast Jet
 
-1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v4.0/hazelcast-jet-4.0.tar.gz)
+1. [Download](https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}/hazelcast-jet-{jet-version}.tar.gz)
   Hazelcast Jet
 
 2. Unzip it:
 
 ```bash
 cd <where_you_downloaded_it>
-tar zxvf hazelcast-jet-4.0.tar.gz
-cd hazelcast-jet-4.0
+tar zxvf hazelcast-jet-{jet-version}.tar.gz
+cd hazelcast-jet-{jet-version}
 ```
 
 3. Start Jet:
@@ -68,8 +68,8 @@ version '1.0-SNAPSHOT'
 repositories.mavenCentral()
 
 dependencies {
-    compile 'com.hazelcast.jet:hazelcast-jet:4.0'
-    compile 'com.hazelcast.jet.examples:hazelcast-jet-examples-trade-source:4.0'
+    compile 'com.hazelcast.jet:hazelcast-jet:{jet-version}'
+    compile 'com.hazelcast.jet.examples:hazelcast-jet-examples-trade-source:{jet-version}'
 }
 
 jar {
@@ -80,7 +80,7 @@ jar {
 
 shadowJar {
     dependencies {
-        exclude(dependency('com.hazelcast.jet:hazelcast-jet:4.0'))
+        exclude(dependency('com.hazelcast.jet:hazelcast-jet:{jet-version}'))
     }
 }
 ```
@@ -106,12 +106,12 @@ shadowJar {
         <dependency>
             <groupId>com.hazelcast.jet</groupId>
             <artifactId>hazelcast-jet</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.jet.examples</groupId>
             <artifactId>hazelcast-jet-examples-trade-source</artifactId>
-            <version>4.0</version>
+            <version>{jet-version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Applies the version replacement tags created in #2179.

Those tags get replaced before deploying a new version. The process can be run manually by issuing the `npm run replace-version` command in the `site/website` folder. It will run and replace the tags with actual versions in all the files. 

This makes checking the changes automatically possible, because after you run the above command all the content should be identical with what's on the `master` branch. And it is (well, almost, but few differences, simple to check)!

Checklist
- [x] Tags Set
- [x] Milestone Set
