### PR TITLE
Add toKeyFn/toValueFn to WriteMapP

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -46,6 +46,7 @@ import java.net.Socket;
 import java.nio.charset.Charset;
 import java.sql.PreparedStatement;
 
+import static com.hazelcast.function.FunctionEx.identity;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
@@ -67,7 +68,20 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static <K, V> ProcessorMetaSupplier writeMapP(@Nonnull String mapName) {
-        return HazelcastWriters.writeMapSupplier(mapName, null);
+        return writeMapP(mapName, identity(), identity());
+    }
+
+    /**
+     * Returns a supplier of processors for
+     * {@link Sinks#map(String, FunctionEx, FunctionEx)}.
+     */
+    @Nonnull
+    public static <T, K, V> ProcessorMetaSupplier writeMapP(
+            @Nonnull String mapName,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+    ) {
+        return HazelcastWriters.writeMapSupplier(mapName, null, toKeyFn, toValueFn);
     }
 
     /**
@@ -78,7 +92,21 @@ public final class SinkProcessors {
     public static <K, V> ProcessorMetaSupplier writeRemoteMapP(
         @Nonnull String mapName, @Nonnull ClientConfig clientConfig
     ) {
-        return HazelcastWriters.writeMapSupplier(mapName, clientConfig);
+        return writeRemoteMapP(mapName, clientConfig, identity(), identity());
+    }
+
+    /**
+     * Returns a supplier of processors for
+     * {@link Sinks#remoteMap(String, ClientConfig, FunctionEx, FunctionEx)}.
+     */
+    @Nonnull
+    public static <T, K, V> ProcessorMetaSupplier writeRemoteMapP(
+            @Nonnull String mapName,
+            @Nonnull ClientConfig clientConfig,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+    ) {
+        return HazelcastWriters.writeMapSupplier(mapName, clientConfig, toKeyFn, toValueFn);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -45,6 +45,7 @@ import java.io.OutputStreamWriter;
 import java.net.Socket;
 import java.nio.charset.Charset;
 import java.sql.PreparedStatement;
+import java.util.Map;
 
 import static com.hazelcast.function.FunctionEx.identity;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
@@ -68,7 +69,7 @@ public final class SinkProcessors {
      */
     @Nonnull
     public static <K, V> ProcessorMetaSupplier writeMapP(@Nonnull String mapName) {
-        return writeMapP(mapName, identity(), identity());
+        return writeMapP(mapName, Map.Entry<K, V>::getKey, Map.Entry<K, V>::getValue);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -65,11 +65,13 @@ public final class HazelcastWriters {
     }
 
     @Nonnull
-    public static ProcessorMetaSupplier writeMapSupplier(
+    public static <T, K, V> ProcessorMetaSupplier writeMapSupplier(
             @Nonnull String name,
-            @Nullable ClientConfig clientConfig
+            @Nullable ClientConfig clientConfig,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
     ) {
-        return preferLocalParallelismOne(new WriteMapP.Supplier(asXmlString(clientConfig), name));
+        return preferLocalParallelismOne(new WriteMapP.Supplier<>(asXmlString(clientConfig), name, toKeyFn, toValueFn));
     }
 
     @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
@@ -77,9 +77,9 @@ public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
             };
         } else if (map instanceof ClientMapProxy) {
             // TODO: add strategy/unify after https://github.com/hazelcast/hazelcast/issues/13950 is fixed
-            addToBuffer = entry -> {
-                Data key = serializationService.toData(key(entry));
-                Data value = serializationService.toData(value(entry));
+            addToBuffer = item -> {
+                Data key = serializationService.toData(key(item));
+                Data value = serializationService.toData(value(item));
                 buffer.add(new SimpleEntry<>(key, value));
             };
         } else {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteMapP.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.client.impl.proxy.ClientMapProxy;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.function.FunctionEx;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.serialization.SerializationService;
 import com.hazelcast.jet.config.EdgeConfig;
@@ -31,29 +32,36 @@ import com.hazelcast.partition.PartitioningStrategy;
 
 import javax.annotation.Nonnull;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.Map.Entry;
 import java.util.function.Consumer;
 
 import static java.lang.Integer.max;
 
-public final class WriteMapP<K, V> extends AsyncHazelcastWriterP {
+public final class WriteMapP<T, K, V> extends AsyncHazelcastWriterP {
 
     private static final int BUFFER_LIMIT = 1024;
 
     private final String mapName;
     private final SerializationService serializationService;
     private final ArrayMap<Data, Data> buffer = new ArrayMap<>(EdgeConfig.DEFAULT_QUEUE_SIZE);
+    private final FunctionEx<? super T, ? extends K> toKeyFn;
+    private final FunctionEx<? super T, ? extends V> toValueFn;
 
     private IMap<Data, Data> map;
-    private Consumer<Entry<K, V>> addToBuffer;
+    private Consumer<T> addToBuffer;
 
-    private WriteMapP(@Nonnull HazelcastInstance instance,
-                      int maxParallelAsyncOps,
-                      String mapName,
-                      @Nonnull SerializationService serializationService) {
+    private WriteMapP(
+            @Nonnull HazelcastInstance instance,
+            int maxParallelAsyncOps,
+            String mapName,
+            @Nonnull SerializationService serializationService,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+    ) {
         super(instance, maxParallelAsyncOps);
         this.mapName = mapName;
         this.serializationService = serializationService;
+        this.toKeyFn = toKeyFn;
+        this.toValueFn = toValueFn;
     }
 
     @Override
@@ -62,21 +70,29 @@ public final class WriteMapP<K, V> extends AsyncHazelcastWriterP {
 
         if (map instanceof MapProxyImpl) {
             PartitioningStrategy<?> partitionStrategy = ((MapProxyImpl<K, V>) map).getPartitionStrategy();
-            addToBuffer = entry -> {
-                Data key = serializationService.toData(entry.getKey(), partitionStrategy);
-                Data value = serializationService.toData(entry.getValue());
+            addToBuffer = item -> {
+                Data key = serializationService.toData(key(item), partitionStrategy);
+                Data value = serializationService.toData(value(item));
                 buffer.add(new SimpleEntry<>(key, value));
             };
         } else if (map instanceof ClientMapProxy) {
             // TODO: add strategy/unify after https://github.com/hazelcast/hazelcast/issues/13950 is fixed
             addToBuffer = entry -> {
-                Data key = serializationService.toData(entry.getKey());
-                Data value = serializationService.toData(entry.getValue());
+                Data key = serializationService.toData(key(entry));
+                Data value = serializationService.toData(value(entry));
                 buffer.add(new SimpleEntry<>(key, value));
             };
         } else {
             throw new RuntimeException("Unexpected map class: " + map.getClass().getName());
         }
+    }
+
+    private K key(T item) {
+        return toKeyFn.apply(item);
+    }
+
+    private V value(T item) {
+        return toValueFn.apply(item);
     }
 
     @Override
@@ -104,7 +120,7 @@ public final class WriteMapP<K, V> extends AsyncHazelcastWriterP {
         return true;
     }
 
-    public static class Supplier extends AbstractHazelcastConnectorSupplier {
+    public static class Supplier<T, K, V> extends AbstractHazelcastConnectorSupplier {
 
         private static final long serialVersionUID = 1L;
 
@@ -113,11 +129,19 @@ public final class WriteMapP<K, V> extends AsyncHazelcastWriterP {
         private static final int MAX_PARALLELISM = 16;
 
         private final String mapName;
+        private final FunctionEx<? super T, ? extends K> toKeyFn;
+        private final FunctionEx<? super T, ? extends V> toValueFn;
         private int maxParallelAsyncOps;
 
-        public Supplier(String clientXml, String mapName) {
+        public Supplier(
+                String clientXml, String mapName,
+                @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+                @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+        ) {
             super(clientXml);
             this.mapName = mapName;
+            this.toKeyFn = toKeyFn;
+            this.toValueFn = toValueFn;
         }
 
         @Override
@@ -128,7 +152,7 @@ public final class WriteMapP<K, V> extends AsyncHazelcastWriterP {
 
         @Override
         protected Processor createProcessor(HazelcastInstance instance, SerializationService serializationService) {
-            return new WriteMapP<>(instance, maxParallelAsyncOps, mapName, serializationService);
+            return new WriteMapP<>(instance, maxParallelAsyncOps, mapName, serializationService, toKeyFn, toValueFn);
         }
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
@@ -18,6 +18,8 @@ package com.hazelcast.jet.json;
 
 import com.hazelcast.core.HazelcastJsonValue;
 
+import java.util.Map;
+
 public final class JsonUtil {
 
     private JsonUtil() {
@@ -29,6 +31,23 @@ public final class JsonUtil {
      */
     public static <T> HazelcastJsonValue hazelcastJsonValue(T object) {
         return new HazelcastJsonValue(object.toString());
+    }
+
+
+    /**
+     * Creates a {@link HazelcastJsonValue} by converting the key of the given
+     * entry to string using {@link Object#toString()}.
+     */
+    public static <K> HazelcastJsonValue asJsonKey(Map.Entry<K, ?> entry) {
+        return new HazelcastJsonValue(entry.getKey().toString());
+    }
+
+    /**
+     * Creates a {@link HazelcastJsonValue} by converting the value of the
+     * given entry to string using {@link Object#toString()}.
+     */
+    public static <V> HazelcastJsonValue asJsonValue(Map.Entry<?, V> entry) {
+        return new HazelcastJsonValue(entry.getValue().toString());
     }
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.json;
+
+import com.hazelcast.core.HazelcastJsonValue;
+
+public final class JsonUtil {
+
+    private JsonUtil() {
+    }
+
+    /**
+     * Creates a {@link HazelcastJsonValue} by converting given the object to
+     * string using {@link Object#toString()}.
+     */
+    public static <T> HazelcastJsonValue hazelcastJsonValue(T object) {
+        return new HazelcastJsonValue(object.toString());
+    }
+
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/package-info.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utility classes for JSON.
+ */
+package com.hazelcast.jet.json;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.collection.IList;
-import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.Offloadable;
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.BiFunctionEx;
@@ -30,7 +29,6 @@ import com.hazelcast.jet.Observable;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.impl.pipeline.SinkImpl;
-import com.hazelcast.jet.json.JsonUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.topic.ITopic;
@@ -115,51 +113,6 @@ public final class Sinks {
     }
 
     /**
-     * Returns a sink that converts the key and value of {@code Map.Entry}s it
-     * receives to {@link HazelcastJsonValue} and put them into a Hazelcast
-     * {@code IMap} with the specified name.
-     * <p>
-     * This sink provides the exactly-once guarantee thanks to <i>idempotent
-     * updates</i>. It means that the value with the same key is not appended,
-     * but overwritten. After the job is restarted from snapshot, duplicate
-     * items will not change the state in the target map.
-     * <p>
-     * The default local parallelism for this sink is 1.
-     *
-     * @since 4.1
-     */
-    @Nonnull
-    public static <K, V> Sink<Entry<K, V>> map(@Nonnull String mapName, boolean jsonKey, boolean jsonValue) {
-        return map(mapName,
-                e -> jsonKey ? JsonUtil.hazelcastJsonValue(e.getKey()) : e.getKey(),
-                e -> jsonValue ? JsonUtil.hazelcastJsonValue(e.getValue()) : e.getValue());
-    }
-
-    /**
-     * Returns a sink that uses the supplied functions to extract the key
-     * and value with which to put to a Hazelcast {@code IMap}.
-     * <p>
-     * This sink provides the exactly-once guarantee thanks to <i>idempotent
-     * updates</i>. It means that the value with the same key is not appended,
-     * but overwritten. After the job is restarted from snapshot, duplicate
-     * items will not change the state in the target map.
-     * <p>
-     * The default local parallelism for this sink is 1.
-     *
-     * @since 4.1
-     */
-    @Nonnull
-    public static <T, K, V> Sink<T> map(
-            @Nonnull String mapName,
-            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
-            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
-
-    ) {
-        return new SinkImpl<>("mapSink(" + mapName + ')',
-                writeMapP(mapName, toKeyFn, toValueFn), false, toKeyFn);
-    }
-
-    /**
      * Returns a sink that puts {@code Map.Entry}s it receives into the given
      * Hazelcast {@code IMap}.
      * <p>
@@ -180,6 +133,60 @@ public final class Sinks {
         return map(map.getName());
     }
 
+
+    /**
+     * Returns a sink that uses the supplied functions to extract the key
+     * and value with which to put to a Hazelcast {@code IMap} with the
+     * specified name.
+     * <p>
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
+     * updates</i>. It means that the value with the same key is not appended,
+     * but overwritten. After the job is restarted from snapshot, duplicate
+     * items will not change the state in the target map.
+     * <p>
+     * The default local parallelism for this sink is 1.
+     *
+     * @since 4.2
+     */
+    @Nonnull
+    public static <T, K, V> Sink<T> map(
+            @Nonnull String mapName,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+
+    ) {
+        return new SinkImpl<>("mapSink(" + mapName + ')',
+                writeMapP(mapName, toKeyFn, toValueFn), false, toKeyFn);
+    }
+
+    /**
+     * Returns a sink that uses the supplied functions to extract the key
+     * and value with which to put to given Hazelcast {@code IMap}.
+     * <p>
+     * <strong>NOTE:</strong> Jet only remembers the name of the map you supply
+     * and acquires a map with that name on the local cluster. If you supply a
+     * map instance from another cluster, no error will be thrown to indicate
+     * this.
+     * <p>
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
+     * updates</i>. It means that the value with the same key is not appended,
+     * but overwritten. After the job is restarted from snapshot, duplicate
+     * items will not change the state in the target map.
+     * <p>
+     * The default local parallelism for this sink is 1.
+     *
+     * @since 4.2
+     */
+    @Nonnull
+    public static <T, K, V> Sink<T> map(
+            @Nonnull IMap<? super K, ? super V> map,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+
+    ) {
+        return map(map.getName(), toKeyFn, toValueFn);
+    }
+
     /**
      * Returns a sink that puts {@code Map.Entry}s it receives into a Hazelcast
      * {@code IMap} with the specified name in a remote cluster identified by
@@ -198,33 +205,6 @@ public final class Sinks {
     }
 
     /**
-     * Returns a sink that converts the key and value of {@code Map.Entry}s it
-     * receives to {@link HazelcastJsonValue} and put them into a Hazelcast
-     * {@code IMap} with the specified name in a remote cluster identified by
-     * the supplied {@code ClientConfig}.
-     * <p>
-     * This sink provides the exactly-once guarantee thanks to <i>idempotent
-     * updates</i>. It means that the value with the same key is not appended,
-     * but overwritten. After the job is restarted from snapshot, duplicate
-     * items will not change the state in the target map.
-     * <p>
-     * The default local parallelism for this sink is 1.
-     *
-     * @since 4.1
-     */
-    @Nonnull
-    public static <K, V> Sink<Entry<K, V>> remoteMap(
-            @Nonnull String mapName,
-            @Nonnull ClientConfig clientConfig,
-            boolean jsonKey,
-            boolean jsonValue
-    ) {
-        return remoteMap(mapName, clientConfig,
-                e -> jsonKey ? JsonUtil.hazelcastJsonValue(e.getKey()) : e.getKey(),
-                e -> jsonValue ? JsonUtil.hazelcastJsonValue(e.getValue()) : e.getValue());
-    }
-
-    /**
      * Returns a sink that uses the supplied functions to extract the key
      * and value with which to put to a Hazelcast {@code IMap} in a remote
      * cluster identified by the supplied {@code ClientConfig}.
@@ -236,7 +216,7 @@ public final class Sinks {
      * <p>
      * The default local parallelism for this sink is 1.
      *
-     * @since 4.1
+     * @since 4.2
      */
     @Nonnull
     public static <T, K, V> Sink<T> remoteMap(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -125,6 +125,8 @@ public final class Sinks {
      * items will not change the state in the target map.
      * <p>
      * The default local parallelism for this sink is 1.
+     *
+     * @since 4.1
      */
     @Nonnull
     public static <K, V> Sink<Entry<K, V>> map(@Nonnull String mapName, boolean jsonKey, boolean jsonValue) {
@@ -143,6 +145,8 @@ public final class Sinks {
      * items will not change the state in the target map.
      * <p>
      * The default local parallelism for this sink is 1.
+     *
+     * @since 4.1
      */
     @Nonnull
     public static <T, K, V> Sink<T> map(
@@ -205,6 +209,8 @@ public final class Sinks {
      * items will not change the state in the target map.
      * <p>
      * The default local parallelism for this sink is 1.
+     *
+     * @since 4.1
      */
     @Nonnull
     public static <K, V> Sink<Entry<K, V>> remoteMap(
@@ -229,6 +235,8 @@ public final class Sinks {
      * items will not change the state in the target map.
      * <p>
      * The default local parallelism for this sink is 1.
+     *
+     * @since 4.1
      */
     @Nonnull
     public static <T, K, V> Sink<T> remoteMap(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.collection.IList;
+import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.Offloadable;
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.BiFunctionEx;
@@ -29,6 +30,7 @@ import com.hazelcast.jet.Observable;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.processor.SinkProcessors;
 import com.hazelcast.jet.impl.pipeline.SinkImpl;
+import com.hazelcast.jet.json.JsonUtil;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.hazelcast.topic.ITopic;
@@ -109,7 +111,48 @@ public final class Sinks {
      */
     @Nonnull
     public static <K, V> Sink<Entry<K, V>> map(@Nonnull String mapName) {
-        return new SinkImpl<>("mapSink(" + mapName + ')', writeMapP(mapName), false, entryKey());
+        return map(mapName, Entry::getKey, Entry::getValue);
+    }
+
+    /**
+     * Returns a sink that converts the key and value of {@code Map.Entry}s it
+     * receives to {@link HazelcastJsonValue} and put them into a Hazelcast
+     * {@code IMap} with the specified name.
+     * <p>
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
+     * updates</i>. It means that the value with the same key is not appended,
+     * but overwritten. After the job is restarted from snapshot, duplicate
+     * items will not change the state in the target map.
+     * <p>
+     * The default local parallelism for this sink is 1.
+     */
+    @Nonnull
+    public static <K, V> Sink<Entry<K, V>> map(@Nonnull String mapName, boolean jsonKey, boolean jsonValue) {
+        return map(mapName,
+                e -> jsonKey ? JsonUtil.hazelcastJsonValue(e.getKey()) : e.getKey(),
+                e -> jsonValue ? JsonUtil.hazelcastJsonValue(e.getValue()) : e.getValue());
+    }
+
+    /**
+     * Returns a sink that uses the supplied functions to extract the key
+     * and value with which to put to a Hazelcast {@code IMap}.
+     * <p>
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
+     * updates</i>. It means that the value with the same key is not appended,
+     * but overwritten. After the job is restarted from snapshot, duplicate
+     * items will not change the state in the target map.
+     * <p>
+     * The default local parallelism for this sink is 1.
+     */
+    @Nonnull
+    public static <T, K, V> Sink<T> map(
+            @Nonnull String mapName,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+
+    ) {
+        return new SinkImpl<>("mapSink(" + mapName + ')',
+                writeMapP(mapName, toKeyFn, toValueFn), false, toKeyFn);
     }
 
     /**
@@ -147,7 +190,55 @@ public final class Sinks {
      */
     @Nonnull
     public static <K, V> Sink<Entry<K, V>> remoteMap(@Nonnull String mapName, @Nonnull ClientConfig clientConfig) {
-        return fromProcessor("remoteMapSink(" + mapName + ')', writeRemoteMapP(mapName, clientConfig));
+        return remoteMap(mapName, clientConfig, Entry::getKey, Entry::getValue);
+    }
+
+    /**
+     * Returns a sink that converts the key and value of {@code Map.Entry}s it
+     * receives to {@link HazelcastJsonValue} and put them into a Hazelcast
+     * {@code IMap} with the specified name in a remote cluster identified by
+     * the supplied {@code ClientConfig}.
+     * <p>
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
+     * updates</i>. It means that the value with the same key is not appended,
+     * but overwritten. After the job is restarted from snapshot, duplicate
+     * items will not change the state in the target map.
+     * <p>
+     * The default local parallelism for this sink is 1.
+     */
+    @Nonnull
+    public static <K, V> Sink<Entry<K, V>> remoteMap(
+            @Nonnull String mapName,
+            @Nonnull ClientConfig clientConfig,
+            boolean jsonKey,
+            boolean jsonValue
+    ) {
+        return remoteMap(mapName, clientConfig,
+                e -> jsonKey ? JsonUtil.hazelcastJsonValue(e.getKey()) : e.getKey(),
+                e -> jsonValue ? JsonUtil.hazelcastJsonValue(e.getValue()) : e.getValue());
+    }
+
+    /**
+     * Returns a sink that uses the supplied functions to extract the key
+     * and value with which to put to a Hazelcast {@code IMap} in a remote
+     * cluster identified by the supplied {@code ClientConfig}.
+     * <p>
+     * This sink provides the exactly-once guarantee thanks to <i>idempotent
+     * updates</i>. It means that the value with the same key is not appended,
+     * but overwritten. After the job is restarted from snapshot, duplicate
+     * items will not change the state in the target map.
+     * <p>
+     * The default local parallelism for this sink is 1.
+     */
+    @Nonnull
+    public static <T, K, V> Sink<T> remoteMap(
+            @Nonnull String mapName,
+            @Nonnull ClientConfig clientConfig,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends V> toValueFn
+    ) {
+        return fromProcessor("remoteMapSink(" + mapName + ')',
+                writeRemoteMapP(mapName, clientConfig, toKeyFn, toValueFn));
     }
 
     /**

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -38,6 +38,7 @@ import com.hazelcast.jet.core.test.TestProcessorContext;
 import com.hazelcast.jet.core.test.TestProcessorSupplierContext;
 import com.hazelcast.jet.core.test.TestSupport;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
+import com.hazelcast.jet.json.JsonUtil;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
@@ -240,7 +241,7 @@ public class SinksTest extends PipelineTestSupport {
                 .map(t -> entry(t, t.toString()));
 
         // When
-        sourceStage.writeTo(Sinks.map(sinkName, true, true));
+        sourceStage.writeTo(Sinks.map(sinkName, JsonUtil::asJsonKey, JsonUtil::asJsonValue));
 
         // Then
         execute();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/SinksTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.jet.Job;
@@ -56,10 +57,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.TestContextSupport.adaptSupplier;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.impl.pipeline.AbstractStage.transformOf;
+import static com.hazelcast.jet.json.JsonUtil.hazelcastJsonValue;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
@@ -213,6 +216,38 @@ public class SinksTest extends PipelineTestSupport {
         Set<Entry<String, Integer>> actual = sinkMap.entrySet();
         assertEquals(expected.size(), actual.size());
         expected.forEach(entry -> assertTrue(actual.contains(entry)));
+    }
+
+    @Test
+    public void map_withToKeyValueFunctions() {
+        // Given
+        BatchStage<Integer> sourceStage = p.readFrom(TestSources.items(0, 1, 2, 3, 4));
+
+        // When
+        sourceStage.writeTo(Sinks.map(sinkName, t -> t, Object::toString));
+
+        // Then
+        execute();
+        IMap<Integer, String> sinkMap = jet().getMap(sinkName);
+        assertEquals(5, sinkMap.size());
+        IntStream.range(0, 5).forEach(i -> assertEquals(String.valueOf(i), sinkMap.get(i)));
+    }
+
+    @Test
+    public void map_withJsonKeyValue() {
+        // Given
+        BatchStage<Entry<Integer, String>> sourceStage = p.readFrom(TestSources.items(0, 1, 2, 3, 4))
+                .map(t -> entry(t, t.toString()));
+
+        // When
+        sourceStage.writeTo(Sinks.map(sinkName, true, true));
+
+        // Then
+        execute();
+        IMap<HazelcastJsonValue, HazelcastJsonValue> sinkMap = jet().getMap(sinkName);
+        assertEquals(5, sinkMap.size());
+        IntStream.range(0, 5).forEach(i -> assertEquals(hazelcastJsonValue(String.valueOf(i)),
+                sinkMap.get(hazelcastJsonValue(i))));
     }
 
     @Test


### PR DESCRIPTION
Add toKeyFn/toValueFn to WriteMapP
Add convenience for HazelcastJsonValue

Checklist
- [X] Tags Set
- [X] Milestone Set
- [X] Any breaking changes are documented
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #NNNN

List of breaking changes:

* ..
