### PR TITLE
Create gRPC servers with fixed thread pool

### DIFF
--- a/examples/grpc/src/main/java/com/hazelcast/jet/examples/grpc/GRPCEnrichment.java
+++ b/examples/grpc/src/main/java/com/hazelcast/jet/examples/grpc/GRPCEnrichment.java
@@ -37,6 +37,7 @@ import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 import static com.hazelcast.function.Functions.entryValue;
@@ -86,6 +87,7 @@ public final class GRPCEnrichment {
                 .collect(toMap(Entry::getKey, e -> new Broker(e.getKey(), e.getValue())));
 
         ServerBuilder.forPort(PORT)
+                     .executor(Executors.newFixedThreadPool(4))
                      .addService(new ProductServiceImpl(productMap))
                      .addService(new BrokerServiceImpl(brokerMap))
                      .build()

--- a/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcServiceTest.java
+++ b/extensions/grpc/src/test/java/com/hazelcast/jet/grpc/GrpcServiceTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
@@ -236,7 +237,10 @@ public class GrpcServiceTest extends SimpleTestInClusterSupport {
     }
 
     private static Server createServer(BindableService service) throws IOException {
-        Server server = ServerBuilder.forPort(0).addService(service).build();
+        Server server = ServerBuilder.forPort(0)
+                                     .executor(Executors.newFixedThreadPool(4))
+                                     .addService(service)
+                                     .build();
         server.start();
         return server;
     }


### PR DESCRIPTION
The default cached thread pool is not suitable as it creates a new
thread when there is no available thread, leading to high amount of
threads.

Fixes #2162

Checklist
- [x] Tags Set
- [x] Milestone Set
