### PR TITLE
Fix jet version in docs

### DIFF
--- a/site/docs/api/serialization.md
+++ b/site/docs/api/serialization.md
@@ -341,7 +341,7 @@ dependency to your Jet job's project:
 <!--Gradle-->
 
 ```groovy
-compile "com.hazelcast.jet:hazelcast-jet-protobuf:${hazelcast.jet.version}"
+compile "com.hazelcast.jet:hazelcast-jet-protobuf:${jet-version}"
 ```
 
 <!--Maven-->
@@ -350,7 +350,7 @@ compile "com.hazelcast.jet:hazelcast-jet-protobuf:${hazelcast.jet.version}"
 <dependency>
     <groupId>com.hazelcast.jet</groupId>
     <artifactId>hazelcast-jet-protobuf</artifactId>
-    <version>${hazelcast.jet.version}</version>
+    <version>${jet-version}</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Fixed jet version in docs - replaced {hazelcast.jet.version} with {jet-version.}

Checklist
- [x] Tags Set
- [x] Milestone Set
