### PR TITLE
Fix ref manual link in README

### DIFF
--- a/hazelcast-jet-distribution/src/root/README.md
+++ b/hazelcast-jet-distribution/src/root/README.md
@@ -90,4 +90,4 @@ Additional Information
 
 * [Hazelcast Jet on GitHub](https://github.com/hazelcast-jet), the repo includes [code examples](https://github.com/hazelcast/hazelcast-jet/tree/master/examples)
 * [Hazelcast Jet Homepage](https://jet.hazelcast.org)
-* [Hazelcast Jet Reference Manual](https://docs.hazelcast.org/docs/jet/latest/manual/)
+* [Hazelcast Jet Reference Manual](https://jet-start.sh/docs)


### PR DESCRIPTION
Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated

