### PR TITLE
Improve gRPC module

### DIFF
--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcProperties.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcProperties.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.hazelcast.jet.grpc.impl;
+package com.hazelcast.jet.grpc;
 
+import com.hazelcast.jet.grpc.impl.BidirectionalStreamingService;
 import com.hazelcast.spi.properties.HazelcastProperty;
 import io.grpc.stub.StreamObserver;
 
@@ -23,6 +24,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Properties of the grpc module
+ *
+ * @since 4.2
  */
 public final class GrpcProperties {
 
@@ -32,21 +35,17 @@ public final class GrpcProperties {
      * You may want to increase this value when your gRPC calls take longer than 1 s to cleanly shutdown the service.
      * <p>
      * The default value is 1 s
-     *
-     * @since 4.2
      */
     public static final HazelcastProperty DESTROY_TIMEOUT
-            = new HazelcastProperty("jet.grpc.destroy.timeout", 1, SECONDS);
+            = new HazelcastProperty("jet.grpc.destroy.timeout.seconds", 1, SECONDS);
 
     /**
      * Time to wait for clean shutdown of a {@link io.grpc.ManagedChannel}
      * <p>
      * The default value is 1 s
-     *
-     * @since 4.2
      */
     public static final HazelcastProperty SHUTDOWN_TIMEOUT
-            = new HazelcastProperty("jet.grpc.shutdown.timeout", 1, SECONDS);
+            = new HazelcastProperty("jet.grpc.shutdown.timeout.seconds", 1, SECONDS);
 
     private GrpcProperties() {
     }

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
@@ -31,6 +31,7 @@ import io.grpc.stub.StreamObserver;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ForkJoinPool;
 
 /**
  * Provides {@link ServiceFactory} implementations for calling gRPC
@@ -105,7 +106,7 @@ public final class GrpcServices {
             @Nonnull FunctionEx<? super ManagedChannel, ? extends BiConsumerEx<T, StreamObserver<R>>> callStubFn
     ) {
         return ServiceFactories.nonSharedService(
-                ctx -> new UnaryService<>(ctx, channelFn.get().build(), callStubFn),
+                ctx -> new UnaryService<>(ctx, channelFn.get().executor(ForkJoinPool.commonPool()).build(), callStubFn),
                 UnaryService::destroy
         );
     }
@@ -168,7 +169,7 @@ public final class GrpcServices {
                     callStubFn
     ) {
         return ServiceFactories.nonSharedService(
-                ctx -> new BidirectionalStreamingService<>(ctx, channelFn.get().build(), callStubFn),
+                ctx -> new BidirectionalStreamingService<>(ctx, channelFn.get().executor(ForkJoinPool.commonPool()).build(), callStubFn),
                 BidirectionalStreamingService::destroy
         );
     }

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
@@ -92,8 +92,7 @@ public final class GrpcServices {
      * will be completed with that exception. To catch and handle it, use the
      * {@code CompletableFuture} API.
      *
-     * @param channelFn creates the channel builder. A single channel is created per Jet member
-     *                  and shared among the processor instances.
+     * @param channelFn creates the channel builder. A single channel is created per processor instance.
      * @param callStubFn a function which, given a channel, creates the stub and returns a
      *                   function that calls the stub given the input item and the observer.
      *                   It will be called once per input item.
@@ -154,8 +153,7 @@ public final class GrpcServices {
      * will be completed with that exception. To catch and handle it, use the
      * {@code CompletableFuture} API.
      *
-     * @param channelFn creates the channel builder. A single channel is created per Jet member
-     *                  and shared among the processor instances.
+     * @param channelFn creates the channel builder. A single channel is created per processor instance.
      * @param callStubFn a function which, given a channel, creates the stub and returns a
      *                   function that calls the stub given the input item and the observer.
      *                   It will be called once per input item.

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
@@ -167,7 +167,11 @@ public final class GrpcServices {
                     callStubFn
     ) {
         return ServiceFactories.nonSharedService(
-                ctx -> new BidirectionalStreamingService<>(ctx, channelFn.get().executor(ForkJoinPool.commonPool()).build(), callStubFn),
+                ctx -> new BidirectionalStreamingService<>(
+                        ctx,
+                        channelFn.get().executor(ForkJoinPool.commonPool()).build(),
+                        callStubFn
+                ),
                 BidirectionalStreamingService::destroy
         );
     }

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/GrpcServices.java
@@ -21,9 +21,9 @@ import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.grpc.impl.BidirectionalStreamingService;
-import com.hazelcast.jet.grpc.impl.GrpcUtil;
 import com.hazelcast.jet.grpc.impl.UnaryService;
 import com.hazelcast.jet.pipeline.GeneralStage;
+import com.hazelcast.jet.pipeline.ServiceFactories;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -31,8 +31,6 @@ import io.grpc.stub.StreamObserver;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.CompletableFuture;
-
-import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 
 /**
  * Provides {@link ServiceFactory} implementations for calling gRPC
@@ -106,11 +104,10 @@ public final class GrpcServices {
             @Nonnull SupplierEx<? extends ManagedChannelBuilder<?>> channelFn,
             @Nonnull FunctionEx<? super ManagedChannel, ? extends BiConsumerEx<T, StreamObserver<R>>> callStubFn
     ) {
-        return ServiceFactory
-                .withCreateContextFn(ctx -> tuple2(channelFn.get().build(), ctx.logger()))
-                .withCreateServiceFn((ctx, tuple) -> new UnaryService<>(tuple.f0(), callStubFn))
-                .withDestroyServiceFn(UnaryService::destroy)
-                .withDestroyContextFn(tuple -> GrpcUtil.shutdownChannel(tuple.f0(), tuple.f1()));
+        return ServiceFactories.nonSharedService(
+                ctx -> new UnaryService<>(ctx, channelFn.get().build(), callStubFn),
+                UnaryService::destroy
+        );
     }
 
     /**
@@ -170,10 +167,9 @@ public final class GrpcServices {
             @Nonnull FunctionEx<? super ManagedChannel, ? extends FunctionEx<StreamObserver<R>, StreamObserver<T>>>
                     callStubFn
     ) {
-        return ServiceFactory
-                .withCreateContextFn(ctx -> tuple2(channelFn.get().build(), ctx.logger()))
-                .withCreateServiceFn((ctx, tuple) -> new BidirectionalStreamingService<>(ctx, tuple.f0(), callStubFn))
-                .withDestroyServiceFn(BidirectionalStreamingService::destroy)
-                .withDestroyContextFn(tuple -> GrpcUtil.shutdownChannel(tuple.f0(), tuple.f1()));
+        return ServiceFactories.nonSharedService(
+                ctx -> new BidirectionalStreamingService<>(ctx, channelFn.get().build(), callStubFn),
+                BidirectionalStreamingService::destroy
+        );
     }
 }

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/BidirectionalStreamingService.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/BidirectionalStreamingService.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.Processor.Context;
 import com.hazelcast.jet.grpc.GrpcService;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
 
@@ -39,15 +40,25 @@ public final class BidirectionalStreamingService<T, R> implements GrpcService<T,
     private final Queue<CompletableFuture<R>> futureQueue = new ConcurrentLinkedQueue<>();
     private final CountDownLatch completionLatch = new CountDownLatch(1);
     private final ILogger logger;
+    private final ManagedChannel channel;
     private volatile Throwable exceptionInOutputObserver;
 
+    private final long destroyTimeout;
+    private final long shutdownTimeout;
+
     public BidirectionalStreamingService(
-            Context context,
-            ManagedChannel channel,
-            FunctionEx<? super ManagedChannel, ? extends FunctionEx<StreamObserver<R>, StreamObserver<T>>> callStubFn
+            @Nonnull Context context,
+            @Nonnull ManagedChannel channel,
+            @Nonnull FunctionEx<? super ManagedChannel, ? extends FunctionEx<StreamObserver<R>, StreamObserver<T>>>
+                    callStubFn
     ) {
         logger = context.logger();
+        this.channel = channel;
         sink = callStubFn.apply(channel).apply(new OutputMessageObserver());
+
+        HazelcastProperties properties = new HazelcastProperties(context.jetInstance().getConfig().getProperties());
+        destroyTimeout = properties.getSeconds(GrpcProperties.DESTROY_TIMEOUT);
+        shutdownTimeout = properties.getSeconds(GrpcProperties.SHUTDOWN_TIMEOUT);
     }
 
     @Nonnull @Override
@@ -67,9 +78,11 @@ public final class BidirectionalStreamingService<T, R> implements GrpcService<T,
 
     public void destroy() throws InterruptedException {
         sink.onCompleted();
-        if (!completionLatch.await(1, SECONDS)) {
+
+        if (!completionLatch.await(destroyTimeout, SECONDS)) {
             logger.info("gRPC call has not completed on time");
         }
+        GrpcUtil.shutdownChannel(channel, logger, shutdownTimeout);
     }
 
     private class OutputMessageObserver implements StreamObserver<R> {

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/BidirectionalStreamingService.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/BidirectionalStreamingService.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.grpc.impl;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.Processor.Context;
+import com.hazelcast.jet.grpc.GrpcProperties;
 import com.hazelcast.jet.grpc.GrpcService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.HazelcastProperties;

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/GrpcProperties.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/GrpcProperties.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.grpc.impl;
+
+import com.hazelcast.spi.properties.HazelcastProperty;
+import io.grpc.stub.StreamObserver;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Properties of the grpc module
+ */
+public final class GrpcProperties {
+
+    /**
+     * Time to wait for {@link StreamObserver#onCompleted()} confirmation when destroying a
+     * {@link BidirectionalStreamingService}
+     * You may want to increase this value when your gRPC calls take longer than 1 s to cleanly shutdown the service.
+     * <p>
+     * The default value is 1 s
+     *
+     * @since 4.2
+     */
+    public static final HazelcastProperty DESTROY_TIMEOUT
+            = new HazelcastProperty("jet.grpc.destroy.timeout", 1, SECONDS);
+
+    /**
+     * Time to wait for clean shutdown of a {@link io.grpc.ManagedChannel}
+     * <p>
+     * The default value is 1 s
+     *
+     * @since 4.2
+     */
+    public static final HazelcastProperty SHUTDOWN_TIMEOUT
+            = new HazelcastProperty("jet.grpc.shutdown.timeout", 1, SECONDS);
+
+    private GrpcProperties() {
+    }
+}

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/GrpcUtil.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/GrpcUtil.java
@@ -52,8 +52,8 @@ public final class GrpcUtil {
      * Tries orderly shutdown first {@link ManagedChannel#shutdown()}, then forceful shutdown
      * {@link ManagedChannel#shutdownNow()}.
      */
-    public static void shutdownChannel(ManagedChannel channel, ILogger logger) throws InterruptedException {
-        if (!channel.shutdown().awaitTermination(1, SECONDS)) {
+    public static void shutdownChannel(ManagedChannel channel, ILogger logger, long timeout) throws InterruptedException {
+        if (!channel.shutdown().awaitTermination(timeout, SECONDS)) {
             logger.info("gRPC client has not shut down on time");
 
             if (!channel.shutdownNow().awaitTermination(1, SECONDS)) {

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/GrpcUtil.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/GrpcUtil.java
@@ -47,14 +47,15 @@ public final class GrpcUtil {
     }
 
     /**
-     * Shutdowns {@link ManagedChannel}
+     * Shuts down a {@link ManagedChannel}
      * <p>
      * Tries orderly shutdown first {@link ManagedChannel#shutdown()}, then forceful shutdown
      * {@link ManagedChannel#shutdownNow()}.
      */
     public static void shutdownChannel(ManagedChannel channel, ILogger logger, long timeout) throws InterruptedException {
         if (!channel.shutdown().awaitTermination(timeout, SECONDS)) {
-            logger.info("gRPC client has not shut down on time");
+            logger.info("gRPC client has not shut down within " + timeout + " seconds, you can override the timeout " +
+                    "by setting the `jet.grpc.shutdown.timeout.seconds` system property");
 
             if (!channel.shutdownNow().awaitTermination(1, SECONDS)) {
                 logger.info("gRPC client has not shut down on time, even after forceful shutdown");

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/UnaryService.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/UnaryService.java
@@ -18,7 +18,10 @@ package com.hazelcast.jet.grpc.impl;
 
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.FunctionEx;
+import com.hazelcast.jet.core.Processor.Context;
 import com.hazelcast.jet.grpc.GrpcService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import io.grpc.ManagedChannel;
 import io.grpc.stub.StreamObserver;
 
@@ -28,12 +31,21 @@ import java.util.concurrent.CompletableFuture;
 public final class UnaryService<T, R> implements GrpcService<T, R> {
 
     private final BiConsumerEx<? super T, ? super StreamObserver<R>> callFn;
+    private final ManagedChannel channel;
+    private final ILogger logger;
+    private final long shutdownTimeout;
 
     public UnaryService(
+            @Nonnull Context context,
             @Nonnull ManagedChannel channel,
             @Nonnull FunctionEx<? super ManagedChannel, ? extends BiConsumerEx<T, StreamObserver<R>>> callStubFn
     ) {
+        this.logger = context.logger();
+        this.channel = channel;
         callFn = callStubFn.apply(channel);
+
+        HazelcastProperties properties = new HazelcastProperties(context.jetInstance().getConfig().getProperties());
+        shutdownTimeout = properties.getSeconds(GrpcProperties.SHUTDOWN_TIMEOUT);
     }
 
     @Override @Nonnull
@@ -43,7 +55,8 @@ public final class UnaryService<T, R> implements GrpcService<T, R> {
         return o.future;
     }
 
-    public void destroy() {
+    public void destroy() throws InterruptedException {
+        GrpcUtil.shutdownChannel(channel, logger, shutdownTimeout);
     }
 
     private static class Observer<R> implements StreamObserver<R> {

--- a/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/UnaryService.java
+++ b/extensions/grpc/src/main/java/com/hazelcast/jet/grpc/impl/UnaryService.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.grpc.impl;
 import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.jet.core.Processor.Context;
+import com.hazelcast.jet.grpc.GrpcProperties;
 import com.hazelcast.jet.grpc.GrpcService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.properties.HazelcastProperties;

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
@@ -158,7 +158,7 @@ final class PythonService {
             if (!completionLatch.await(1, SECONDS)) {
                 logger.info("gRPC call has not completed on time");
             }
-            GrpcUtil.shutdownChannel(chan, logger);
+            GrpcUtil.shutdownChannel(chan, logger, 1);
             server.stop();
         } catch (Exception e) {
             throw new JetException("PythonService.destroy() failed: " + e, e);

--- a/site/docs/how-tos/grpc.md
+++ b/site/docs/how-tos/grpc.md
@@ -246,6 +246,15 @@ stage.mapUsingServiceAsyncBatched(bidiService,
 })
 ```
 
+If your batch takes close to or more than 1 s (including the network
+overhead) you should increase the value for following properties to
+perform clean shutdown:
+
+```
+jet.grpc.destroy.timeout
+jet.grpc.shutdown.timeout
+```
+
 See the [grpc
 example](https://github.com/hazelcast/hazelcast-jet/tree/master/examples/grpc)
 module for a complete code example.

--- a/site/docs/how-tos/grpc.md
+++ b/site/docs/how-tos/grpc.md
@@ -246,15 +246,17 @@ stage.mapUsingServiceAsyncBatched(bidiService,
 })
 ```
 
-If your batch takes close to or more than 1 s (including the network
-overhead) you should increase the value for following properties to
-perform clean shutdown:
+If your batch takes more than ~0.8 seconds (including the network
+overhead), you should increase the value of the following properties
+so that the clean shutdown succeeds:
 
-```
-jet.grpc.destroy.timeout
-jet.grpc.shutdown.timeout
+```text
+jet.grpc.destroy.timeout.seconds
+jet.grpc.shutdown.timeout.seconds
 ```
 
-See the [grpc
-example](https://github.com/hazelcast/hazelcast-jet/tree/master/examples/grpc)
+The [GrpcProperties](/javadoc/{jet-version}/com/hazelcast/jet/grpc/GrpcProperties.html)
+JavaDoc provides more details about these properties.
+
+See the [grpc example](https://github.com/hazelcast/hazelcast-jet/tree/master/examples/grpc)
 module for a complete code example.


### PR DESCRIPTION
Changes:
- create channel per processor
- make service destroy timeout and channel shutdown timeout configurable
- Use common ForkJoinPool as executor for the channel

Checklist
- [x] Tags Set
- [x] Milestone Set
