### PR TITLE
Add MissingJavadoc checks to checkstyle

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -121,7 +121,13 @@
             <property name="allowMissingReturnTag" value="true"/>
             <property name="validateThrows" value="false"/>
         </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="public"/>
+        </module>
         <module name="JavadocType">
+            <property name="scope" value="public"/>
+        </module>
+        <module name="MissingJavadocType">
             <property name="scope" value="public"/>
         </module>
         <module name="JavadocVariable">

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
@@ -28,6 +28,18 @@ import java.util.Map;
 
 import static com.hazelcast.jet.impl.util.Util.uncheckCall;
 
+/**
+ * Util class to parse JSON formatted input to various object types or
+ * convert objects to JSON strings.
+ * <p>
+ * We use the lightweight JSON library `jackson-jr` to parse the given
+ * input or convert the given objects to JSON string. If
+ * `jackson-annotations` library present on the classpath, we register
+ * {@link JacksonAnnotationExtension} to so that the JSON conversion can
+ * make us of annotations.
+ *
+ * @since 4.2
+ */
 public final class JsonUtil {
 
     private static final JSON JSON_JR;


### PR DESCRIPTION
Original checkstyle `JavadocType` and `JavadocMethod` was split into those and `MissingJavadocType` and `MissingJavadocMethod` in checkstyle version 8.20. We started to use version 8.29 instead of 8.18 which means that this functionality is currently missing in our checkstyle.

For more details see https://checkstyle.sourceforge.io/releasenotes.html#Release_8.20

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
