### PR TITLE
Do not skip deploy for trade-source

### DIFF
--- a/examples/trade-source/pom.xml
+++ b/examples/trade-source/pom.xml
@@ -27,4 +27,16 @@
         <version>4.2-SNAPSHOT</version>
     </parent>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
`trade-source` artifacts are currently not deployed to snapshot repositories.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated

