### PR TITLE
Fix rolling log filename

### DIFF
--- a/hazelcast-jet-distribution/src/root/config/log4j2.properties
+++ b/hazelcast-jet-distribution/src/root/config/log4j2.properties
@@ -21,7 +21,7 @@ appender.console.layout.pattern=%d [%highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=
 appender.rolling.type=RollingFile
 appender.rolling.name=RollingFile
 appender.rolling.fileName=${sys:jet.home}/logs/hazelcast-jet.log
-appender.rolling.filePattern='.'%d{yyyy-MM-dd}
+appender.rolling.filePattern=${sys:jet.home}/logs/hazelcast-jet.log.%d{yyyy-MM-dd}
 appender.rolling.layout.type=PatternLayout
 appender.rolling.layout.pattern=%d [%5p] [%t] [%c{.1}]: %m%n
 appender.rolling.policies.type = Policies


### PR DESCRIPTION
it was creating some files like `'.'2020-05-20` when rolling the logs