### PR TITLE
Add test for elastic and update/delete for non existing document

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
@@ -76,7 +76,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
     }
 
     @Test
-    public void given_clientWithWrongPassword_whenReadFromElasticSource_thenFailWithAuthenticationException() {
+    public void given_clientWithWrongPassword_whenWriteToElasticSink_thenFailWithAuthenticationException() {
         ElasticsearchContainer container = ElasticSupport.secureElastic.get();
         String containerIp = container.getContainerIpAddress();
         Integer port = container.getMappedPort(PORT);
@@ -97,7 +97,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
     }
 
     @Test
-    public void given_clientWithoutAuthentication_whenReadFromElasticSource_thenFailWithAuthenticationException() {
+    public void given_clientWithoutAuthentication_whenWriteToElasticSink_thenFailWithAuthenticationException() {
         ElasticsearchContainer container = ElasticSupport.secureElastic.get();
         String containerIp = container.getContainerIpAddress();
         Integer port = container.getMappedPort(PORT);


### PR DESCRIPTION
Behavior of delete/update non existing document for elastic sink is not ideal now. It fails job if this happen. However it can be a problem when job is restarted (and the same delete request should be executed again) etc. Fixing this can be complicated - for Jet 4.2 this will be covered by documentation and eventually changed/fixed in the future. This PR adds regression tests for checking that behavior was not changed unexpectedly.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
