### PR TITLE
add shade plugin to examples pom.xml

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -87,6 +87,19 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Adding shade config so that the examples can run via `jet submit` 

**Before:** 
```
$ jet submit -v -c com.hazelcast.jet.examples.earlyresults.TradingVolumeOverTime hazelcast-jet-examples-early-window-results-4.2-SNAPSHOT.jar 
...
Caused by: java.lang.NoClassDefFoundError: org/jfree/chart/renderer/category/BarRenderer
	at com.hazelcast.jet.examples.earlyresults.TradingVolumeOverTime.main(TradingVolumeOverTime.java:75)
	... 18 more
Caused by: java.lang.ClassNotFoundException: org.jfree.chart.renderer.category.BarRenderer
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:435)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 19 more
```

**After:**
```
$ jet submit -v -c com.hazelcast.jet.examples.earlyresults.TradingVolumeOverTime hazelcast-jet-examples-early-window-results-4.2-SNAPSHOT.jar 
Verbose mode is on, setting logging level to INFO
Submitting JAR 'hazelcast-jet-examples-early-window-results-4.2-SNAPSHOT.jar' with arguments []
19:41:53.717 [ INFO] [c.h.i.c.AbstractConfigLocator] Loading configuration '[redacted]/hazelcast-client.yaml' from System property 'hazelcast.client.config'
19:41:53.729 [ INFO] [c.h.i.c.AbstractConfigLocator] Using configuration file at [redacted]/hazelcast-client.yaml
19:41:53.988 [ INFO] [c.h.c.i.s.ClientInvocationService] hz.client_1 [jet] [4.1] [4.0.1] Running with 2 response threads, dynamic=true
19:41:54.039 [ INFO] [c.h.c.LifecycleService] hz.client_1 [jet] [4.1] [4.0.1] HazelcastClient 4.0.1 (20200409 - e086b9c) is STARTING
19:41:54.040 [ INFO] [c.h.c.LifecycleService] hz.client_1 [jet] [4.1] [4.0.1] HazelcastClient 4.0.1 (20200409 - e086b9c) is STARTED
19:41:54.075 [ INFO] [c.h.c.i.c.ClientConnectionManager] hz.client_1 [jet] [4.1] [4.0.1] Trying to connect to cluster: jet
19:41:54.079 [ INFO] [c.h.c.i.c.ClientConnectionManager] hz.client_1 [jet] [4.1] [4.0.1] Trying to connect to [127.0.0.1]:5701
19:41:54.114 [ INFO] [c.h.c.LifecycleService] hz.client_1 [jet] [4.1] [4.0.1] HazelcastClient 4.0.1 (20200409 - e086b9c) is CLIENT_CONNECTED
19:41:54.114 [ INFO] [c.h.c.i.c.ClientConnectionManager] hz.client_1 [jet] [4.1] [4.0.1] Authenticated with server [192.168.86.99]:5701:c58edad7-7329-4fcf-842c-81221eab6299, server version: 4.0.1, local address: /127.0.0.1:53586
19:41:54.118 [ INFO] [c.h.i.d.Diagnostics] hz.client_1 [jet] [4.1] [4.0.1] Diagnostics disabled. To enable add -Dhazelcast.diagnostics.enabled=true to the JVM arguments.
19:41:54.122 [ INFO] [c.h.c.i.s.ClientClusterService] hz.client_1 [jet] [4.1] [4.0.1] 

Members [1] {
	Member [192.168.86.99]:5701 - c58edad7-7329-4fcf-842c-81221eab6299
}

19:41:54.191 [ INFO] [c.h.c.i.s.ClientStatisticsService] Client statistics is enabled with period 5 seconds.
```

Checklist
- [ ] Tags Set
- [ ] Milestone Set
- [ ] Any breaking changes are documented
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #2000 

List of breaking changes:

* ..
