### PR TITLE
Use exec when starting Jet in jet-start

### DIFF
--- a/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
+++ b/hazelcast-jet-distribution/src/bin-filemode-755/jet-start
@@ -42,5 +42,5 @@ if [[ "$DAEMON" = "true" ]]; then
 else
     echo "Starting Hazelcast Jet"
     set -x
-    $JAVA "${JAVA_OPTS_ARRAY[@]}" "${LICENSING_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetMemberStarter
+    exec $JAVA "${JAVA_OPTS_ARRAY[@]}" "${LICENSING_OPTS_ARRAY[@]}" -cp "$CLASSPATH" com.hazelcast.jet.server.JetMemberStarter
 fi


### PR DESCRIPTION
This replaces the shell process with the Java process.
Due to signal handling in bash we would not be able to
stop Jet using Ctrl+C without this when using jet-start
in Docker container.

Checklist
- [x] Tags Set
- [x] Milestone Set
