### PR TITLE
fix(search): filter on version & language

### DIFF
--- a/site/website/siteConfig.js
+++ b/site/website/siteConfig.js
@@ -92,7 +92,9 @@ const siteConfig = {
     algolia: {
         apiKey: '79d1e4941621b9fd761d279d4d19ed69',
         indexName: 'hazelcast-jet',
-        algoliaOptions: {} // Optional, if provided by Algolia
+        algoliaOptions: {
+            facetFilters: [ "language:LANGUAGE", "version:VERSION" ]
+        }
     },
 
     // On page navigation for the current documentation page.


### PR DESCRIPTION
Enable filter on version and language on the documentation website.


resolves algolia/docsearch-configs#2041
