### PR TITLE
Use SerialTest for Elasticsearch integration tests

### DIFF
--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -39,6 +40,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.search.SearchHit;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -64,6 +66,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
  * Subclasses are free to cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
+@Category(SerialTest.class)
 public abstract class BaseElasticTest {
 
     protected static final int BATCH_SIZE = 42;


### PR DESCRIPTION
Having parallel tests causes multiple Elasticsearch containers to start,
making the tests slower on low-core machines (4C).

The main time consuming part of the tests now is the container start,
which can't be avoided - we already reuse containers between test
classes.