### PR TITLE
Upgrade spotbugs plugin to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 
         <maven.enforcer.plugin.version>3.0.0-M1</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
-        <maven.spotbugs.plugin.version>3.1.12.2</maven.spotbugs.plugin.version>
+        <maven.spotbugs.plugin.version>4.0.0</maven.spotbugs.plugin.version>
         <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
         <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
         <maven.sonar.plugin.version>3.6.0.1398</maven.sonar.plugin.version>


### PR DESCRIPTION
Removes 'WARNING: An illegal reflective access operation has occurred'
