### PR TITLE
Add retry logic to elastic client calls

### DIFF
--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
@@ -33,6 +33,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 
+import static com.hazelcast.jet.elastic.impl.RetryUtils.withRetry;
 import static com.hazelcast.jet.impl.util.Util.checkNonNullAndSerializable;
 import static java.util.Objects.requireNonNull;
 
@@ -63,10 +64,12 @@ public final class ElasticSinkBuilder<T> implements Serializable {
 
     private static final String DEFAULT_NAME = "elasticSink";
     private static final int DEFAULT_LOCAL_PARALLELISM = 2;
+    private static final int DEFAULT_RETRIES = 5;
 
     private SupplierEx<RestClientBuilder> clientFn;
     private SupplierEx<BulkRequest> bulkRequestFn = BulkRequest::new;
     private FunctionEx<? super T, ? extends DocWriteRequest<?>> mapToRequestFn;
+    private int retries = DEFAULT_RETRIES;
 
     /**
      * Set the client supplier function
@@ -140,6 +143,30 @@ public final class ElasticSinkBuilder<T> implements Serializable {
     }
 
     /**
+     * Number of retries the connector will do in addition to Elastic client
+     * retries
+     *
+     * Elastic client tries to connect to a node only once for each request.
+     * When a request fails the node is marked dead and is not retried again
+     * for the request. This causes problems with single node clusters or in a
+     * situation where whole cluster becomes unavailable at the same time (e.g.
+     * due to a network issue).
+     *
+     * The initial delay is 2s, increasing by factor of 2 with each retry (4s,
+     * 8s, 16s, ..).
+     *
+     * @param retries number of retries, defaults to 5
+     */
+    @Nonnull
+    public ElasticSinkBuilder<T> retries(int retries) {
+        if (retries < 0) {
+            throw new IllegalArgumentException("retries must be positive");
+        }
+        this.retries = retries;
+        return this;
+    }
+
+    /**
      * Create a sink that writes data into Elasticsearch based on this builder configuration
      */
     @Nonnull
@@ -149,7 +176,8 @@ public final class ElasticSinkBuilder<T> implements Serializable {
 
         return SinkBuilder
                 .sinkBuilder(DEFAULT_NAME, ctx ->
-                        new BulkContext(clientFn, bulkRequestFn, ctx.logger()))
+                        new BulkContext(clientFn, bulkRequestFn,
+                                retries, ctx.logger()))
                 .<T>receiveFn((bulkContext, item) -> bulkContext.add(mapToRequestFn.apply(item)))
                 .flushFn(BulkContext::flush)
                 .destroyFn(BulkContext::close)
@@ -165,14 +193,16 @@ public final class ElasticSinkBuilder<T> implements Serializable {
 
         private BulkRequest bulkRequest;
         private final ILogger logger;
+        private final int retries;
 
         BulkContext(SupplierEx<RestClientBuilder> clientBuilder, SupplierEx<BulkRequest> bulkRequestSupplier,
-                    ILogger logger) {
+                    int retries, ILogger logger) {
             restClient = clientBuilder.get().build();
             this.client = new RestHighLevelClient(restClient);
             this.bulkRequestSupplier = bulkRequestSupplier;
 
             this.bulkRequest = bulkRequestSupplier.get();
+            this.retries = retries;
             this.logger = logger;
         }
 
@@ -182,13 +212,20 @@ public final class ElasticSinkBuilder<T> implements Serializable {
 
         void flush() throws IOException {
             if (!bulkRequest.requests().isEmpty()) {
-                BulkResponse response = client.bulk(bulkRequest);
-                if (response.hasFailures()) {
-                    throw new JetException(response.buildFailureMessage());
-                }
-                if (logger.isFineEnabled()) {
-                    logger.fine("BulkRequest with " + bulkRequest.requests().size() + " requests succeeded");
-                }
+                withRetry(
+                        () -> {
+                            BulkResponse response = client.bulk(bulkRequest);
+                            if (response.hasFailures()) {
+                                throw new JetException(response.buildFailureMessage());
+                            }
+                            if (logger.isFineEnabled()) {
+                                logger.fine("BulkRequest with " + bulkRequest.requests().size() + " requests succeeded");
+                            }
+                            return response;
+                        },
+                        retries,
+                        IOException.class, JetException.class
+                );
                 bulkRequest = bulkRequestSupplier.get();
             }
         }

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSourceBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSourceBuilder.java
@@ -57,6 +57,7 @@ import static java.util.Objects.requireNonNull;
 public final class ElasticSourceBuilder<T> {
 
     private static final String DEFAULT_NAME = "elasticSource";
+    private static final int DEFAULT_RETRIES = 5;
 
     private SupplierEx<RestClientBuilder> clientFn;
     private SupplierEx<SearchRequest> searchRequestFn;
@@ -64,6 +65,7 @@ public final class ElasticSourceBuilder<T> {
     private boolean slicing;
     private boolean coLocatedReading;
     private String scrollKeepAlive = "1m"; // Using String because it needs to be Serializable
+    private int retries = DEFAULT_RETRIES;
 
     /**
      * Build Elasticsearch {@link BatchSource} with supplied parameters
@@ -79,7 +81,7 @@ public final class ElasticSourceBuilder<T> {
         ElasticSourceConfiguration<T> configuration = new ElasticSourceConfiguration<>(
                 restHighLevelClientFn(clientFn),
                 searchRequestFn, mapToItemFn, slicing, coLocatedReading,
-                scrollKeepAlive
+                scrollKeepAlive, retries
         );
         ElasticSourcePMetaSupplier<T> metaSupplier = new ElasticSourcePMetaSupplier<>(configuration);
         return Sources.batchFromProcessor(DEFAULT_NAME, metaSupplier);
@@ -201,4 +203,27 @@ public final class ElasticSourceBuilder<T> {
         return this;
     }
 
+    /**
+     * Number of retries the connector will do in addition to Elastic
+     * client retries
+     *
+     * Elastic client tries to connect to a node only once for each
+     * request. When a request fails the node is marked dead and is
+     * not retried again for the request. This causes problems with
+     * single node clusters or in a situation where whole cluster
+     * becomes unavailable at the same time (e.g. due to a network
+     * issue).
+     *
+     * The initial delay is 2s, increasing by factor of 2 with each retry (4s, 8s, 16s, ..).
+     *
+     * @param retries number of retries, defaults to 5
+     */
+    @Nonnull
+    public ElasticSourceBuilder<T> retries(int retries) {
+        if (retries < 0) {
+            throw new IllegalArgumentException("retries must be positive");
+        }
+        this.retries = retries;
+        return this;
+    }
 }

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceConfiguration.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceConfiguration.java
@@ -42,19 +42,22 @@ public class ElasticSourceConfiguration<T> implements Serializable {
     private final boolean slicing;
     private final boolean coLocatedReading;
     private final String scrollKeepAlive;
+    private final int retries;
 
-    public ElasticSourceConfiguration(SupplierEx<RestHighLevelClient> clientFn,
-                                      SupplierEx<SearchRequest> searchRequestFn,
-                                      FunctionEx<? super SearchHit, T> mapToItemFn,
+    public ElasticSourceConfiguration(
+            SupplierEx<RestHighLevelClient> clientFn,
+            SupplierEx<SearchRequest> searchRequestFn,
+            FunctionEx<? super SearchHit, T> mapToItemFn,
                                       boolean slicing, boolean coLocatedReading,
-                                      String scrollKeepAlive) {
-
+                                      String scrollKeepAlive, int retries
+    ) {
         this.clientFn = clientFn;
         this.searchRequestFn = searchRequestFn;
         this.mapToItemFn = mapToItemFn;
         this.slicing = slicing;
         this.coLocatedReading = coLocatedReading;
         this.scrollKeepAlive = scrollKeepAlive;
+        this.retries = retries;
     }
 
     @Nonnull
@@ -82,6 +85,10 @@ public class ElasticSourceConfiguration<T> implements Serializable {
 
     public String scrollKeepAlive() {
         return scrollKeepAlive;
+    }
+
+    public int retries() {
+        return retries;
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceP.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceP.java
@@ -34,9 +34,9 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.slice.SliceBuilder;
 
 import javax.annotation.Nonnull;
-import java.io.IOException;
 import java.util.List;
 
+import static com.hazelcast.jet.elastic.impl.RetryUtils.withRetry;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -146,6 +146,7 @@ final class ElasticSourceP<T> extends AbstractProcessor {
 
         private final RestHighLevelClient client;
         private final String scrollKeepAlive;
+        private final int retries;
 
         private SearchHits hits;
         private int nextHit;
@@ -155,10 +156,11 @@ final class ElasticSourceP<T> extends AbstractProcessor {
                                ILogger logger) {
             this.client = client;
             this.scrollKeepAlive = configuration.scrollKeepAlive();
+            this.retries = configuration.retries();
             this.logger = logger;
 
             try {
-                SearchResponse response = this.client.search(sr);
+                SearchResponse response = withRetry(() -> client.search(sr), retries);
 
                 // These should be always present, even when there are no results
                 hits = requireNonNull(response.getHits(), "null hits in the response");
@@ -170,7 +172,7 @@ final class ElasticSourceP<T> extends AbstractProcessor {
 
                 long totalHits = hits.getTotalHits();
                 logger.fine("Initialized scroll with scrollId " + scrollId + ", total results " + ", " + totalHits);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 throw new JetException("Could not execute SearchRequest to Elastic", e);
             }
         }
@@ -187,13 +189,16 @@ final class ElasticSourceP<T> extends AbstractProcessor {
                     SearchScrollRequest ssr = new SearchScrollRequest(scrollId);
                     ssr.scroll(scrollKeepAlive);
 
-                    SearchResponse searchResponse = client.searchScroll(ssr);
+                    SearchResponse searchResponse = withRetry(
+                            () -> client.searchScroll(ssr),
+                            retries
+                    );
                     hits = searchResponse.getHits();
                     if (hits.getHits().length == 0) {
                         return null;
                     }
                     nextHit = 0;
-                } catch (IOException e) {
+                } catch (Exception e) {
                     throw new JetException("Could not execute SearchScrollRequest to Elastic", e);
                 }
             }
@@ -212,14 +217,17 @@ final class ElasticSourceP<T> extends AbstractProcessor {
             ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
             clearScrollRequest.addScrollId(scrollId);
             try {
-                ClearScrollResponse response = client.clearScroll(clearScrollRequest);
+                ClearScrollResponse response = withRetry(
+                        () -> client.clearScroll(clearScrollRequest),
+                        retries
+                );
 
                 if (response.isSucceeded()) {
                     logger.fine("Succeeded clearing " + response.getNumFreed() + " scrolls");
                 } else {
                     logger.warning("Clearing scroll " + scrollId + " failed");
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 logger.fine("Could not clear scroll with scrollId=" + scrollId, e);
             }
         }

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
@@ -67,7 +67,10 @@ public class ElasticSourcePMetaSupplier<T> implements ProcessorMetaSupplier {
     @Override
     public void init(@Nonnull Context context) throws Exception {
         RestClient restClient = ElasticCatClient.getRestClient(configuration.clientFn().get());
-        try (ElasticCatClient catClient = new ElasticCatClient(restClient)) {
+        try (ElasticCatClient catClient = new ElasticCatClient(
+                restClient,
+                configuration.retries()
+        )) {
             List<Shard> shards = catClient.shards(configuration.searchRequestFn().get().indices());
 
             if (configuration.isCoLocatedReadingEnabled()) {

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/RetryUtils.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/impl/RetryUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic.impl;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
+
+/**
+ * Static utility class to retry operations related to connecting to AWS Services.
+ */
+public final class RetryUtils {
+
+    private static final ILogger LOGGER = Logger.getLogger(RetryUtils.class);
+
+    private static final long MAX_BACKOFF_MS = 5 * 60 * 1000L;
+    private static final long MS_IN_SECOND = 1000L;
+
+    private RetryUtils() {
+    }
+
+    /**
+     * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
+     */
+    public static <T> T withRetry(Callable<T> callable, int retries) {
+        return withRetry(callable, retries, IOException.class);
+    }
+
+    /**
+     * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
+     *
+     */
+    @SafeVarargs
+    public static <T> T withRetry(Callable<T> callable, int retries, Class<? extends Exception> ... exceptions) {
+        int retryCount = 0;
+        while (true) {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                if (anyOf(e, exceptions)) {
+                    retryCount++;
+                    if (retryCount > retries) {
+                        throw sneakyThrow(e);
+                    }
+                    long waitIntervalMs = Math.min(MAX_BACKOFF_MS, MS_IN_SECOND * (1 << retryCount));
+                    LOGGER.fine(String.format("Couldn't connect to Elastic, [%s] retrying in %s seconds...", retryCount,
+                            waitIntervalMs / MS_IN_SECOND));
+                    sleep(waitIntervalMs);
+                } else {
+                    throw sneakyThrow(e);
+                }
+            }
+        }
+    }
+
+    private static boolean anyOf(Exception e, Class<? extends Exception>[] exceptions) {
+        for (Class<? extends Exception> exception : exceptions) {
+            if (exception.isAssignableFrom(e.getClass())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new HazelcastException(e);
+        }
+    }
+}

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
@@ -85,6 +85,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
                 .clientFn(() -> client("elastic", "WrongPassword", containerIp, port))
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
                 .mapToRequestFn((TestItem item) -> new IndexRequest("my-index", "document").source(item.asMap()))
+                .retries(0)
                 .build();
 
         Pipeline p = Pipeline.create();
@@ -106,6 +107,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
                 .clientFn(() -> client(containerIp, port))
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
                 .mapToRequestFn((TestItem item) -> new IndexRequest("my-index", "document").source(item.asMap()))
+                .retries(0)
                 .build();
 
         Pipeline p = Pipeline.create();

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/CommonElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/CommonElasticSinksTest.java
@@ -150,10 +150,11 @@ public abstract class CommonElasticSinksTest extends BaseElasticTest {
     public void given_documentNotInIndex_whenWriteToElasticSinkUpdateRequest_then_jobShouldFail() throws Exception {
         transportClient.admin().indices().create(new CreateIndexRequest("my-index"));
 
-        Sink<TestItem> elasticSink = ElasticSinks.elastic(
-                elasticClientSupplier(),
-                item -> new UpdateRequest("my-index", "document", item.id).doc(item.asMap())
-        );
+        Sink<TestItem> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticClientSupplier())
+                .mapToRequestFn((TestItem item) -> new UpdateRequest("my-index", "document", item.id).doc(item.asMap()))
+                .retries(0)
+                .build();
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items(new TestItem("notExist", "Frantisek")))

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
@@ -269,6 +269,7 @@ public abstract class CommonElasticSourcesTest extends BaseElasticTest {
                 .clientFn(elasticClientSupplier())
                 .searchRequestFn(() -> new SearchRequest("non-existing-index"))
                 .mapToItemFn(SearchHit::getSourceAsString)
+                .retries(0) // we expect the exception -> faster test
                 .build();
         p.readFrom(source)
          .writeTo(Sinks.list(results));

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticCatClientTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.elastic.impl;
 
+import com.hazelcast.jet.JetException;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -42,7 +44,7 @@ public class ElasticCatClientTest {
 
     @Test
     public void shards() throws IOException {
-        ElasticCatClient catClient = new ElasticCatClient(restClient);
+        ElasticCatClient catClient = new ElasticCatClient(restClient, 5);
 
         Response nodesResponse = response("es2node_nodes.json");
         Response shardsResponse = response("es2node_shards.json");
@@ -52,6 +54,34 @@ public class ElasticCatClientTest {
         List<Shard> shards = catClient.shards("my-index");
         assertThat(shards).extracting(Shard::getHttpAddress)
                           .containsOnly("127.0.0.1:9200", "127.0.0.1:9201");
+    }
+
+    @Test
+    public void shouldRetryOnShards() throws IOException {
+        ElasticCatClient catClient = new ElasticCatClient(restClient, 2);
+
+        Response nodesResponse = response("es2node_nodes.json");
+        Response shardsResponse = response("es2node_shards.json");
+        when(restClient.performRequest(any(), any(), any(Map.class)))
+                .thenThrow(new IOException("Could not connect"))
+                .thenReturn(nodesResponse, shardsResponse);
+
+        List<Shard> shards = catClient.shards("my-index");
+        assertThat(shards).extracting(Shard::getHttpAddress)
+                          .containsOnly("127.0.0.1:9200", "127.0.0.1:9201");
+    }
+
+    @Test
+    public void shouldFailAfterFiveAttemptsShards() throws IOException {
+        ElasticCatClient catClient = new ElasticCatClient(restClient, 2);
+
+        when(restClient.performRequest(any(), any(), any(Map.class)))
+                .thenThrow(new IOException("Could not connect"));
+
+        assertThatThrownBy(() -> catClient.shards("my-index"))
+                .isInstanceOf(JetException.class)
+                .hasRootCauseInstanceOf(IOException.class)
+                .hasRootCauseMessage("Could not connect");
     }
 
     private Response response(String json) throws IOException {

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
@@ -97,8 +97,8 @@ public class ElasticSourcePTest {
                 SearchHit::getSourceAsString,
                 slicing,
                 coLocatedReading,
-                KEEP_ALIVE
-        );
+                KEEP_ALIVE,
+                0);
 
         // This constructor calls the client so it has to be called after specific mock setup in each test method
         // rather than in setUp()

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceConfiguration.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceConfiguration.java
@@ -45,14 +45,16 @@ public class ElasticSourceConfiguration<T> implements Serializable {
     private final boolean slicing;
     private final boolean coLocatedReading;
     private final String scrollKeepAlive;
+    private final int retries;
 
-    public ElasticSourceConfiguration(SupplierEx<RestHighLevelClient> clientFn,
-                                      SupplierEx<SearchRequest> searchRequestFn,
-                                      FunctionEx<? super ActionRequest, RequestOptions> optionsFn,
-                                      FunctionEx<? super SearchHit, T> mapToItemFn,
-                                      boolean slicing, boolean coLocatedReading,
-                                      String scrollKeepAlive) {
-
+    public ElasticSourceConfiguration(
+            SupplierEx<RestHighLevelClient> clientFn,
+            SupplierEx<SearchRequest> searchRequestFn,
+            FunctionEx<? super ActionRequest, RequestOptions> optionsFn,
+            FunctionEx<? super SearchHit, T> mapToItemFn,
+            boolean slicing, boolean coLocatedReading,
+            String scrollKeepAlive, int retries
+    ) {
         this.clientFn = clientFn;
         this.searchRequestFn = searchRequestFn;
         this.optionsFn = optionsFn;
@@ -60,6 +62,7 @@ public class ElasticSourceConfiguration<T> implements Serializable {
         this.slicing = slicing;
         this.coLocatedReading = coLocatedReading;
         this.scrollKeepAlive = scrollKeepAlive;
+        this.retries = retries;
     }
 
     @Nonnull
@@ -91,6 +94,10 @@ public class ElasticSourceConfiguration<T> implements Serializable {
 
     public String scrollKeepAlive() {
         return scrollKeepAlive;
+    }
+
+    public int retries() {
+        return retries;
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
@@ -65,7 +65,10 @@ public class ElasticSourcePMetaSupplier<T> implements ProcessorMetaSupplier {
 
     @Override
     public void init(@Nonnull Context context) throws Exception {
-        try (ElasticCatClient catClient = new ElasticCatClient(configuration.clientFn().get().getLowLevelClient())) {
+        try (ElasticCatClient catClient = new ElasticCatClient(
+                configuration.clientFn().get().getLowLevelClient(),
+                configuration.retries()
+        )) {
             List<Shard> shards = catClient.shards(configuration.searchRequestFn().get().indices());
 
             if (configuration.isCoLocatedReadingEnabled()) {

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/RetryUtils.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/impl/RetryUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic.impl;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
+
+/**
+ * Static utility class to retry operations related to connecting to AWS Services.
+ */
+public final class RetryUtils {
+
+    private static final ILogger LOGGER = Logger.getLogger(RetryUtils.class);
+
+    private static final long MAX_BACKOFF_MS = 5 * 60 * 1000L;
+    private static final long MS_IN_SECOND = 1000L;
+
+    private RetryUtils() {
+    }
+
+    /**
+     * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
+     */
+    public static <T> T withRetry(Callable<T> callable, int retries) {
+        return withRetry(callable, retries, IOException.class);
+    }
+
+    /**
+     * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
+     *
+     */
+    @SafeVarargs
+    public static <T> T withRetry(Callable<T> callable, int retries, Class<? extends Exception> ... exceptions) {
+        int retryCount = 0;
+        while (true) {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                if (anyOf(e, exceptions)) {
+                    retryCount++;
+                    if (retryCount > retries) {
+                        throw sneakyThrow(e);
+                    }
+                    long waitIntervalMs = Math.min(MAX_BACKOFF_MS, MS_IN_SECOND * (1 << retryCount));
+                    LOGGER.fine(String.format("Couldn't connect to Elastic, [%s] retrying in %s seconds...", retryCount,
+                            waitIntervalMs / MS_IN_SECOND));
+                    sleep(waitIntervalMs);
+                } else {
+                    throw sneakyThrow(e);
+                }
+            }
+        }
+    }
+
+    private static boolean anyOf(Exception e, Class<? extends Exception>[] exceptions) {
+        for (Class<? extends Exception> exception : exceptions) {
+            if (exception.isAssignableFrom(e.getClass())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new HazelcastException(e);
+        }
+    }
+}

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
@@ -85,6 +85,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
                 .clientFn(() -> client("elastic", "WrongPassword", containerIp, port))
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
                 .mapToRequestFn((TestItem item) -> new IndexRequest("my-index", "document").source(item.asMap()))
+                .retries(0)
                 .build();
 
         Pipeline p = Pipeline.create();
@@ -106,6 +107,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
                 .clientFn(() -> client(containerIp, port))
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
                 .mapToRequestFn((TestItem item) -> new IndexRequest("my-index", "document").source(item.asMap()))
+                .retries(0)
                 .build();
 
         Pipeline p = Pipeline.create();

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/CommonElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/CommonElasticSinksTest.java
@@ -153,10 +153,11 @@ public abstract class CommonElasticSinksTest extends BaseElasticTest {
     public void given_documentNotInIndex_whenWriteToElasticSinkUpdateRequest_then_jobShouldFail() throws Exception {
         elasticClient.indices().create(new CreateIndexRequest("my-index"), RequestOptions.DEFAULT);
 
-        Sink<TestItem> elasticSink = ElasticSinks.elastic(
-                elasticClientSupplier(),
-                item -> new UpdateRequest("my-index", "document", item.id).doc(item.asMap())
-        );
+        Sink<TestItem> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticClientSupplier())
+                .mapToRequestFn((TestItem item) -> new UpdateRequest("my-index", "document", item.id).doc(item.asMap()))
+                .retries(0)
+                .build();
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items(new TestItem("notExist", "Frantisek")))

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
@@ -269,6 +269,7 @@ public abstract class CommonElasticSourcesTest extends BaseElasticTest {
                 .clientFn(elasticClientSupplier())
                 .searchRequestFn(() -> new SearchRequest("non-existing-index"))
                 .mapToItemFn(SearchHit::getSourceAsString)
+                .retries(0) // we expect the exception -> faster test
                 .build();
         p.readFrom(source)
          .writeTo(Sinks.list(results));

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
@@ -102,8 +102,8 @@ public class ElasticSourcePTest {
                 SearchHit::getSourceAsString,
                 slicing,
                 coLocatedReading,
-                KEEP_ALIVE
-        );
+                KEEP_ALIVE,
+                5);
 
         // This constructor calls the client so it has to be called after specific mock setup in each test method
         // rather than in setUp()

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSinkBuilder.java
@@ -34,6 +34,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Serializable;
 
+import static com.hazelcast.jet.elastic.impl.RetryUtils.retry;
 import static com.hazelcast.jet.impl.util.Util.checkNonNullAndSerializable;
 import static java.util.Objects.requireNonNull;
 
@@ -64,11 +65,13 @@ public final class ElasticSinkBuilder<T> implements Serializable {
 
     private static final String DEFAULT_NAME = "elasticSink";
     private static final int DEFAULT_LOCAL_PARALLELISM = 2;
+    private static final int DEFAULT_RETRIES = 5;
 
     private SupplierEx<RestClientBuilder> clientFn;
     private SupplierEx<BulkRequest> bulkRequestFn = BulkRequest::new;
     private FunctionEx<? super T, ? extends DocWriteRequest<?>> mapToRequestFn;
     private FunctionEx<? super ActionRequest, RequestOptions> optionsFn = (request) -> RequestOptions.DEFAULT;
+    private int retries = DEFAULT_RETRIES;
 
     /**
      * Set the client supplier function
@@ -167,6 +170,27 @@ public final class ElasticSinkBuilder<T> implements Serializable {
     }
 
     /**
+     * Number of retries the connector will do in addition to Elastic
+     * client retries
+     *
+     * Elastic client tries to connect to a node only once for each
+     * request. When a request fails the node is marked dead and is
+     * not retried again for the request. This causes problems with
+     * single node clusters or in a situation where whole cluster
+     * becomes unavailable at the same time (e.g. due to a network
+     * issue).
+     *
+     * The initial delay is 2s, increasing by factor of 2 with each retry (4s, 8s, 16s, ..).
+     *
+     * @param retries number of retries, defaults to 5
+     */
+    @Nonnull
+    public ElasticSinkBuilder<T> retries(int retries) {
+        this.retries = retries;
+        return this;
+    }
+
+    /**
      * Create a sink that writes data into Elasticsearch based on this builder configuration
      */
     @Nonnull
@@ -177,7 +201,7 @@ public final class ElasticSinkBuilder<T> implements Serializable {
         return SinkBuilder
                 .sinkBuilder(DEFAULT_NAME, ctx ->
                         new BulkContext(new RestHighLevelClient(clientFn.get()), bulkRequestFn,
-                                optionsFn, ctx.logger()))
+                                optionsFn, retries, ctx.logger()))
                 .<T>receiveFn((bulkContext, item) -> bulkContext.add(mapToRequestFn.apply(item)))
                 .flushFn(BulkContext::flush)
                 .destroyFn(BulkContext::close)
@@ -190,17 +214,21 @@ public final class ElasticSinkBuilder<T> implements Serializable {
         private final RestHighLevelClient client;
         private final SupplierEx<BulkRequest> bulkRequestSupplier;
         private final FunctionEx<? super ActionRequest, RequestOptions> optionsFn;
+        private final int retries;
 
         private BulkRequest bulkRequest;
         private final ILogger logger;
 
-        BulkContext(RestHighLevelClient client, SupplierEx<BulkRequest> bulkRequestSupplier,
-                    FunctionEx<? super ActionRequest, RequestOptions> optionsFn, ILogger logger) {
+        BulkContext(
+                RestHighLevelClient client, SupplierEx<BulkRequest> bulkRequestSupplier,
+                FunctionEx<? super ActionRequest, RequestOptions> optionsFn, int retries, ILogger logger
+        ) {
             this.client = client;
             this.bulkRequestSupplier = bulkRequestSupplier;
             this.optionsFn = optionsFn;
 
             this.bulkRequest = bulkRequestSupplier.get();
+            this.retries = retries;
             this.logger = logger;
         }
 
@@ -210,7 +238,11 @@ public final class ElasticSinkBuilder<T> implements Serializable {
 
         void flush() throws IOException {
             if (!bulkRequest.requests().isEmpty()) {
-                BulkResponse response = client.bulk(bulkRequest, optionsFn.apply(bulkRequest));
+                BulkResponse response = retry(
+                        () -> client.bulk(bulkRequest, optionsFn.apply(bulkRequest)),
+                        retries,
+                        IOException.class
+                );
                 if (response.hasFailures()) {
                     throw new JetException(response.buildFailureMessage());
                 }

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSourceBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSourceBuilder.java
@@ -59,6 +59,7 @@ import static java.util.Objects.requireNonNull;
 public final class ElasticSourceBuilder<T> {
 
     private static final String DEFAULT_NAME = "elasticSource";
+    private static final int DEFAULT_RETRIES = 5;
 
     private SupplierEx<RestClientBuilder> clientFn;
     private SupplierEx<SearchRequest> searchRequestFn;
@@ -67,6 +68,7 @@ public final class ElasticSourceBuilder<T> {
     private boolean slicing;
     private boolean coLocatedReading;
     private String scrollKeepAlive = "1m"; // Using String because it needs to be Serializable
+    private int retries = DEFAULT_RETRIES;
 
     /**
      * Build Elasticsearch {@link BatchSource} with supplied parameters
@@ -82,7 +84,7 @@ public final class ElasticSourceBuilder<T> {
         ElasticSourceConfiguration<T> configuration = new ElasticSourceConfiguration<>(
                 restHighLevelClientFn(clientFn),
                 searchRequestFn, optionsFn, mapToItemFn, slicing, coLocatedReading,
-                scrollKeepAlive
+                scrollKeepAlive, retries
         );
         ElasticSourcePMetaSupplier<T> metaSupplier = new ElasticSourcePMetaSupplier<>(configuration);
         return Sources.batchFromProcessor(DEFAULT_NAME, metaSupplier);
@@ -229,4 +231,24 @@ public final class ElasticSourceBuilder<T> {
         return this;
     }
 
+    /**
+     * Number of retries the connector will do in addition to Elastic
+     * client retries
+     *
+     * Elastic client tries to connect to a node only once for each
+     * request. When a request fails the node is marked dead and is
+     * not retried again for the request. This causes problems with
+     * single node clusters or in a situation where whole cluster
+     * becomes unavailable at the same time (e.g. due to a network
+     * issue).
+     *
+     * The initial delay is 2s, increasing by factor of 2 with each retry (4s, 8s, 16s, ..).
+     *
+     * @param retries number of retries, defaults to 5
+     */
+    @Nonnull
+    public ElasticSourceBuilder<T> retries(int retries) {
+        this.retries = retries;
+        return this;
+    }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSourceBuilder.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSourceBuilder.java
@@ -248,6 +248,9 @@ public final class ElasticSourceBuilder<T> {
      */
     @Nonnull
     public ElasticSourceBuilder<T> retries(int retries) {
+        if (retries < 0) {
+            throw new IllegalArgumentException("retries must be positive");
+        }
         this.retries = retries;
         return this;
     }

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticCatClient.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticCatClient.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.hazelcast.jet.elastic.impl.RetryUtils.retry;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -52,9 +53,11 @@ public class ElasticCatClient implements Closeable {
     private static final ILogger LOG = Logger.getLogger(ElasticCatClient.class);
 
     private final RestClient client;
+    private final int retries;
 
-    public ElasticCatClient(RestClient client) {
+    public ElasticCatClient(RestClient client, int retries) {
         this.client = client;
+        this.retries = retries;
     }
 
     /**
@@ -64,7 +67,7 @@ public class ElasticCatClient implements Closeable {
         try {
             Request r = new Request("GET", "/_cat/master");
             r.addParameter("format", "json");
-            Response res = client.performRequest(r);
+            Response res = retry(() -> client.performRequest(r), retries, IOException.class);
 
             try (InputStreamReader reader = new InputStreamReader(res.getEntity().getContent(), UTF_8)) {
                 JsonArray array = Json.parse(reader).asArray();
@@ -90,7 +93,7 @@ public class ElasticCatClient implements Closeable {
             r.addParameter("format", "json");
             r.addParameter("full_id", "true");
             r.addParameter("h", "id,ip,name,http_address,master");
-            Response res = client.performRequest(r);
+            Response res = retry(() -> client.performRequest(r), retries, IOException.class);
 
             try (InputStreamReader reader = new InputStreamReader(res.getEntity().getContent(), UTF_8)) {
                 JsonArray array = Json.parse(reader).asArray();
@@ -134,7 +137,7 @@ public class ElasticCatClient implements Closeable {
             Request r = new Request("GET", "/_cat/shards/" + String.join(",", indices));
             r.addParameter("format", "json");
             r.addParameter("h", "id,index,shard,prirep,docs,state,ip,node");
-            Response res = client.performRequest(r);
+            Response res = retry(() -> client.performRequest(r), retries, IOException.class);
 
             try (InputStreamReader reader = new InputStreamReader(res.getEntity().getContent(), UTF_8)) {
                 JsonArray array = Json.parse(reader).asArray();
@@ -161,7 +164,7 @@ public class ElasticCatClient implements Closeable {
                     object.get("index").asString(),
                     Integer.parseInt(object.get("shard").asString()),
                     Prirep.valueOf(object.get("prirep").asString()),
-                    Integer.parseInt(object.get("docs").asString()),
+                    object.get("docs") != null ? Integer.parseInt(object.get("docs").asString()) : 0,
                     object.get("state").asString(),
                     object.get("ip").asString(),
                     idToAddress.get(id),

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticCatClient.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticCatClient.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.hazelcast.jet.elastic.impl.RetryUtils.retry;
+import static com.hazelcast.jet.elastic.impl.RetryUtils.withRetry;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -67,7 +67,7 @@ public class ElasticCatClient implements Closeable {
         try {
             Request r = new Request("GET", "/_cat/master");
             r.addParameter("format", "json");
-            Response res = retry(() -> client.performRequest(r), retries, IOException.class);
+            Response res = withRetry(() -> client.performRequest(r), retries);
 
             try (InputStreamReader reader = new InputStreamReader(res.getEntity().getContent(), UTF_8)) {
                 JsonArray array = Json.parse(reader).asArray();
@@ -93,7 +93,7 @@ public class ElasticCatClient implements Closeable {
             r.addParameter("format", "json");
             r.addParameter("full_id", "true");
             r.addParameter("h", "id,ip,name,http_address,master");
-            Response res = retry(() -> client.performRequest(r), retries, IOException.class);
+            Response res = withRetry(() -> client.performRequest(r), retries);
 
             try (InputStreamReader reader = new InputStreamReader(res.getEntity().getContent(), UTF_8)) {
                 JsonArray array = Json.parse(reader).asArray();
@@ -137,7 +137,7 @@ public class ElasticCatClient implements Closeable {
             Request r = new Request("GET", "/_cat/shards/" + String.join(",", indices));
             r.addParameter("format", "json");
             r.addParameter("h", "id,index,shard,prirep,docs,state,ip,node");
-            Response res = retry(() -> client.performRequest(r), retries, IOException.class);
+            Response res = withRetry(() -> client.performRequest(r), retries);
 
             try (InputStreamReader reader = new InputStreamReader(res.getEntity().getContent(), UTF_8)) {
                 JsonArray array = Json.parse(reader).asArray();

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceConfiguration.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceConfiguration.java
@@ -45,14 +45,16 @@ public class ElasticSourceConfiguration<T> implements Serializable {
     private final boolean slicing;
     private final boolean coLocatedReading;
     private final String scrollKeepAlive;
+    private final int retries;
 
-    public ElasticSourceConfiguration(SupplierEx<RestHighLevelClient> clientFn,
-                                      SupplierEx<SearchRequest> searchRequestFn,
-                                      FunctionEx<? super ActionRequest, RequestOptions> optionsFn,
-                                      FunctionEx<? super SearchHit, T> mapToItemFn,
-                                      boolean slicing, boolean coLocatedReading,
-                                      String scrollKeepAlive) {
-
+    public ElasticSourceConfiguration(
+            SupplierEx<RestHighLevelClient> clientFn,
+            SupplierEx<SearchRequest> searchRequestFn,
+            FunctionEx<? super ActionRequest, RequestOptions> optionsFn,
+            FunctionEx<? super SearchHit, T> mapToItemFn,
+            boolean slicing, boolean coLocatedReading,
+            String scrollKeepAlive, int retries
+    ) {
         this.clientFn = clientFn;
         this.searchRequestFn = searchRequestFn;
         this.optionsFn = optionsFn;
@@ -60,6 +62,7 @@ public class ElasticSourceConfiguration<T> implements Serializable {
         this.slicing = slicing;
         this.coLocatedReading = coLocatedReading;
         this.scrollKeepAlive = scrollKeepAlive;
+        this.retries = retries;
     }
 
     @Nonnull
@@ -91,6 +94,10 @@ public class ElasticSourceConfiguration<T> implements Serializable {
 
     public String scrollKeepAlive() {
         return scrollKeepAlive;
+    }
+
+    public int retries() {
+        return retries;
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceP.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourceP.java
@@ -41,6 +41,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
+import static com.hazelcast.jet.elastic.impl.RetryUtils.retry;
 import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
@@ -150,6 +151,7 @@ final class ElasticSourceP<T> extends AbstractProcessor {
         private final RestHighLevelClient client;
         private final FunctionEx<? super ActionRequest, RequestOptions> optionsFn;
         private final String scrollKeepAlive;
+        private final int retries;
 
         private SearchHits hits;
         private int nextHit;
@@ -160,11 +162,12 @@ final class ElasticSourceP<T> extends AbstractProcessor {
             this.client = client;
             this.optionsFn = configuration.optionsFn();
             this.scrollKeepAlive = configuration.scrollKeepAlive();
+            this.retries = configuration.retries();
             this.logger = logger;
 
             try {
                 RequestOptions options = optionsFn.apply(sr);
-                SearchResponse response = this.client.search(sr, options);
+                SearchResponse response = retry(() -> client.search(sr, options), retries, IOException.class);
 
                 // These should be always present, even when there are no results
                 hits = requireNonNull(response.getHits(), "null hits in the response");
@@ -177,7 +180,7 @@ final class ElasticSourceP<T> extends AbstractProcessor {
                 TotalHits totalHits = hits.getTotalHits();
                 logger.fine("Initialized scroll with scrollId " + scrollId + ", total results " +
                         totalHits.relation + ", " + totalHits.value);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 throw new JetException("Could not execute SearchRequest to Elastic", e);
             }
         }
@@ -194,13 +197,17 @@ final class ElasticSourceP<T> extends AbstractProcessor {
                     SearchScrollRequest ssr = new SearchScrollRequest(scrollId);
                     ssr.scroll(scrollKeepAlive);
 
-                    SearchResponse searchResponse = client.scroll(ssr, optionsFn.apply(ssr));
+                    SearchResponse searchResponse = retry(
+                            () -> client.scroll(ssr, optionsFn.apply(ssr)),
+                            retries,
+                            IOException.class
+                    );
                     hits = searchResponse.getHits();
                     if (hits.getHits().length == 0) {
                         return null;
                     }
                     nextHit = 0;
-                } catch (IOException e) {
+                } catch (Exception e) {
                     throw new JetException("Could not execute SearchScrollRequest to Elastic", e);
                 }
             }
@@ -219,15 +226,18 @@ final class ElasticSourceP<T> extends AbstractProcessor {
             ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
             clearScrollRequest.addScrollId(scrollId);
             try {
-                ClearScrollResponse response = client.clearScroll(clearScrollRequest,
-                        optionsFn.apply(clearScrollRequest));
+                ClearScrollResponse response = retry(
+                        () -> client.clearScroll(clearScrollRequest, optionsFn.apply(clearScrollRequest)),
+                        retries,
+                        IOException.class
+                );
 
                 if (response.isSucceeded()) {
                     logger.fine("Succeeded clearing " + response.getNumFreed() + " scrolls");
                 } else {
                     logger.warning("Clearing scroll " + scrollId + " failed");
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 logger.fine("Could not clear scroll with scrollId=" + scrollId, e);
             }
         }

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/ElasticSourcePMetaSupplier.java
@@ -65,7 +65,10 @@ public class ElasticSourcePMetaSupplier<T> implements ProcessorMetaSupplier {
 
     @Override
     public void init(@Nonnull Context context) throws Exception {
-        try (ElasticCatClient catClient = new ElasticCatClient(configuration.clientFn().get().getLowLevelClient())) {
+        try (ElasticCatClient catClient = new ElasticCatClient(
+                configuration.clientFn().get().getLowLevelClient(),
+                configuration.retries()
+        )) {
             List<Shard> shards = catClient.shards(configuration.searchRequestFn().get().indices());
 
             if (configuration.isCoLocatedReadingEnabled()) {

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/RetryUtils.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/impl/RetryUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic.impl;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.util.concurrent.Callable;
+
+import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
+
+/**
+ * Static utility class to retry operations related to connecting to AWS Services.
+ */
+public final class RetryUtils {
+    static final long INITIAL_BACKOFF_MS = 2000L;
+    static final long MAX_BACKOFF_MS = 5 * 60 * 1000L;
+    static final double BACKOFF_MULTIPLIER = 2;
+
+    private static final ILogger LOGGER = Logger.getLogger(RetryUtils.class);
+
+    private static final long MS_IN_SECOND = 1000L;
+
+    private RetryUtils() {
+    }
+
+    /**
+     * Calls {@code callable.call()} until it does not throw an exception (but no more than {@code retries} times).
+     * <p>
+     * If {@code callable} throws an unchecked exception, it is wrapped into {@link HazelcastException}.
+     */
+    @SafeVarargs
+    public static <T> T retry(Callable<T> callable, int retries, Class<? extends Exception> ... exceptions) {
+        int retryCount = 0;
+        while (true) {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                if (anyOf(e, exceptions)) {
+                    retryCount++;
+                    if (retryCount > retries) {
+                        throw sneakyThrow(e);
+                    }
+                    long waitIntervalMs = backoffIntervalForRetry(retryCount);
+                    LOGGER.fine(String.format("Couldn't connect to Elastic, [%s] retrying in %s seconds...", retryCount,
+                            waitIntervalMs / MS_IN_SECOND));
+                    sleep(waitIntervalMs);
+                } else {
+                    throw sneakyThrow(e);
+                }
+            }
+        }
+    }
+
+    private static boolean anyOf(Exception e, Class<? extends Exception>[] exceptions) {
+        for (Class<? extends Exception> exception : exceptions) {
+            if (exception.isAssignableFrom(e.getClass())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static long backoffIntervalForRetry(int retryCount) {
+        long result = INITIAL_BACKOFF_MS;
+        for (int i = 1; i < retryCount; i++) {
+            result *= BACKOFF_MULTIPLIER;
+            if (result > MAX_BACKOFF_MS) {
+                return MAX_BACKOFF_MS;
+            }
+        }
+        return result;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new HazelcastException(e);
+        }
+    }
+}

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/AuthElasticSinksTest.java
@@ -85,6 +85,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
                 .clientFn(() -> client("elastic", "WrongPassword", containerIp, port))
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
                 .mapToRequestFn((TestItem item) -> new IndexRequest("my-index").source(item.asMap()))
+                .retries(0)
                 .build();
 
         Pipeline p = Pipeline.create();
@@ -106,6 +107,7 @@ public class AuthElasticSinksTest extends BaseElasticTest {
                 .clientFn(() -> client(containerIp, port))
                 .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
                 .mapToRequestFn((TestItem item) -> new IndexRequest("my-index").source(item.asMap()))
+                .retries(0)
                 .build();
 
         Pipeline p = Pipeline.create();

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/AuthElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/AuthElasticSourcesTest.java
@@ -21,10 +21,14 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.pipeline.BatchSource;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Test;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -56,7 +60,7 @@ public class AuthElasticSourcesTest extends BaseElasticTest {
         indexDocument("my-index", ImmutableMap.of("name", "Frantisek"));
 
         Pipeline p = Pipeline.create();
-        p.readFrom(ElasticSources.elastic(elasticClientSupplier()))
+        p.readFrom(elasticSource(elasticClientSupplier()))
          .writeTo(Sinks.list(results));
 
         submitJob(p);
@@ -69,7 +73,7 @@ public class AuthElasticSourcesTest extends BaseElasticTest {
         Integer port = container.getMappedPort(PORT);
 
         Pipeline p = Pipeline.create();
-        p.readFrom(ElasticSources.elastic(() -> client("elastic", "WrongPassword", containerIp, port)))
+        p.readFrom(elasticSource(() -> client("elastic", "WrongPassword", containerIp, port)))
          .writeTo(Sinks.list(results));
 
         assertThatThrownBy(() -> submitJob(p))
@@ -84,11 +88,21 @@ public class AuthElasticSourcesTest extends BaseElasticTest {
         Integer port = container.getMappedPort(PORT);
 
         Pipeline p = Pipeline.create();
-        p.readFrom(ElasticSources.elastic(() -> client(containerIp, port)))
+        p.readFrom(elasticSource(() -> client(containerIp, port)))
          .writeTo(Sinks.list(results));
 
         assertThatThrownBy(() -> submitJob(p))
                 .hasRootCauseInstanceOf(ResponseException.class)
                 .hasStackTraceContaining("missing authentication credentials");
+    }
+
+    @NotNull
+    private BatchSource<String> elasticSource(SupplierEx<RestClientBuilder> clientFn) {
+        return ElasticSources.builder()
+                             .clientFn(clientFn)
+                             .searchRequestFn(SearchRequest::new)
+                             .mapToItemFn(SearchHit::getSourceAsString)
+                             .retries(0)
+                             .build();
     }
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSinksTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSinksTest.java
@@ -154,10 +154,11 @@ public abstract class CommonElasticSinksTest extends BaseElasticTest {
     public void given_documentNotInIndex_whenWriteToElasticSinkUpdateRequest_then_jobShouldFail() throws Exception {
         elasticClient.indices().create(new CreateIndexRequest("my-index"), RequestOptions.DEFAULT);
 
-        Sink<TestItem> elasticSink = ElasticSinks.elastic(
-                elasticClientSupplier(),
-                item -> new UpdateRequest("my-index", item.id).doc(item.asMap())
-        );
+        Sink<TestItem> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(elasticClientSupplier())
+                .mapToRequestFn((TestItem item) -> new UpdateRequest("my-index", item.id).doc(item.asMap()))
+                .retries(0)
+                .build();
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items(new TestItem("notExist", "Frantisek")))

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
@@ -269,6 +269,7 @@ public abstract class CommonElasticSourcesTest extends BaseElasticTest {
                 .clientFn(elasticClientSupplier())
                 .searchRequestFn(() -> new SearchRequest("non-existing-index"))
                 .mapToItemFn(SearchHit::getSourceAsString)
+                .retries(0) // we expect the exception -> faster test
                 .build();
         p.readFrom(source)
          .writeTo(Sinks.list(results));

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/impl/ElasticSourcePTest.java
@@ -106,8 +106,8 @@ public class ElasticSourcePTest {
                 SearchHit::getSourceAsString,
                 slicing,
                 coLocatedReading,
-                KEEP_ALIVE
-        );
+                KEEP_ALIVE,
+                5);
 
         // This constructor calls the client so it has to be called after specific mock setup in each test method
         // rather than in setUp()


### PR DESCRIPTION
Elastic client tries to connect to a node only once for each request
(meaning a call to the client here, not actuall HTTP request). When a
request fails the node is marked dead and is not retried for the
request.

This causes issues with single node cluster or small clusters where all
nodes become unreacheble for short amount of time).

For different requests
- the dead nodes are retried after 1 m.
- when all nodes are marked dead one of the dead nodes is retried.

Fixes #2350

Checklist
- [x] Tags Set
- [x] Milestone Set
