### PR TITLE
Remove the deprecated gradle object from the tutorial documents

### DIFF
--- a/site/docs/tutorials/map-join.md
+++ b/site/docs/tutorials/map-join.md
@@ -77,7 +77,7 @@ dependencies {
 
 jar {
     enabled = false
-    dependsOn(shadowJar { classifier = null })
+    dependsOn(shadowJar{archiveClassifier.set("")})
     manifest.attributes 'Main-Class': 'org.example.JoinUsingMapJob'
 }
 

--- a/site/docs/tutorials/pulsar.md
+++ b/site/docs/tutorials/pulsar.md
@@ -92,7 +92,7 @@ dependencies {
 
 jar {
     enabled = false
-    dependsOn(shadowJar { classifier = null })
+    dependsOn(shadowJar{archiveClassifier.set("")})
     manifest.attributes 'Main-Class': 'org.example.JetJob'
 }
 

--- a/site/docs/tutorials/windowing.md
+++ b/site/docs/tutorials/windowing.md
@@ -73,7 +73,7 @@ dependencies {
 
 jar {
     enabled = false
-    dependsOn(shadowJar { classifier = null })
+    dependsOn(shadowJar{archiveClassifier.set("")})
     manifest.attributes 'Main-Class': 'org.example.TradeMonitor'
 }
 


### PR DESCRIPTION
Replace the deprecated usage of gradle obj `classifier` with `archiveClassifier` in the tutorials.

Checklist
- [X] Tags Set
