### PR TITLE
Change default local parallelism from 2 to 4 for avro/file/json sources

### DIFF
--- a/extensions/avro/src/main/java/com/hazelcast/jet/avro/AvroSourceBuilder.java
+++ b/extensions/avro/src/main/java/com/hazelcast/jet/avro/AvroSourceBuilder.java
@@ -92,8 +92,8 @@ public final class AvroSourceBuilder<D> {
      * Any {@code IOException} will cause the job to fail. The files must not
      * change while being read; if they do, the behavior is unspecified.
      * <p>
-     * The default local parallelism for this processor is 2 (or 1 if just 1
-     * CPU is available).
+     * The default local parallelism for this processor is 4 (or available CPU
+     * count if it is less than 4).
      *
      * @param mapOutputFn the function which creates output object from each
      *                    record. Gets the filename and record read by {@code

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadFilesP.java
@@ -48,6 +48,8 @@ import static com.hazelcast.jet.impl.util.Util.checkSerializable;
  */
 public final class ReadFilesP<T> extends AbstractProcessor {
 
+    private static final int DEFAULT_LOCAL_PARALLELISM = 4;
+
     private final Path directory;
     private final String glob;
     private final boolean sharedFileSystem;
@@ -141,7 +143,7 @@ public final class ReadFilesP<T> extends AbstractProcessor {
     ) {
         checkSerializable(readFileFn, "readFileFn");
 
-        return ProcessorMetaSupplier.of(2, () -> new ReadFilesP<>(
+        return ProcessorMetaSupplier.of(DEFAULT_LOCAL_PARALLELISM, () -> new ReadFilesP<>(
                 directory, glob, sharedFileSystem, readFileFn)
         );
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/FileSourceBuilder.java
@@ -118,8 +118,8 @@ public final class FileSourceBuilder {
      * Any {@code IOException} will cause the job to fail. The files must not
      * change while being read; if they do, the behavior is unspecified.
      * <p>
-     * The default local parallelism for this processor is 2 (or 1 if just 1
-     * CPU is available).
+     * The default local parallelism for this processor is 4 (or available CPU
+     * count if it is less than 4).
      *
      * @param mapOutputFn the function which creates output object from each
      *                    line. Gets the filename and line as parameters
@@ -148,8 +148,8 @@ public final class FileSourceBuilder {
      * Any {@code IOException} will cause the job to fail. The files must not
      * change while being read; if they do, the behavior is unspecified.
      * <p>
-     * The default local parallelism for this processor is 2 (or 1 if just 1
-     * CPU is available).
+     * The default local parallelism for this processor is 4 (or available CPU
+     * count if it is less than 4).
      *
      * @param readFileFn the function to read objects from a file. Gets file
      *                   {@code Path} as parameter and returns a {@code Stream}


### PR DESCRIPTION
Change default local parallelism from 2 to 4 for avro/file/json sources


Checklist
- [X] Tags Set
- [X] Milestone Set
- [X] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #2352

List of breaking changes:

* Change default preferedLocalParallelism from 2 to 4

