### PR TITLE
Add test for CDC join scenario

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/RecordPartImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/RecordPartImpl.java
@@ -73,6 +73,23 @@ class RecordPartImpl implements RecordPart {
     }
 
     @Override
+    public int hashCode() {
+        return json.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RecordPartImpl other = (RecordPartImpl) obj;
+        return Objects.equals(json, other.json);
+    }
+
+    @Override
     public String toString() {
         return toJson();
     }

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -16,13 +16,18 @@
 
 package com.hazelcast.jet.cdc.postgres;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
 import org.junit.Rule;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Date;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
@@ -47,6 +52,153 @@ public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcInte
         try (Connection connection = DriverManager.getConnection(postgres.getJdbcUrl(), postgres.getUsername(),
                 postgres.getPassword())) {
             connection.createStatement().execute("CREATE SCHEMA " + schema);
+        }
+    }
+
+    protected static class Customer implements Serializable {
+
+        @JsonProperty("id")
+        public int id;
+
+        @JsonProperty("first_name")
+        public String firstName;
+
+        @JsonProperty("last_name")
+        public String lastName;
+
+        @JsonProperty("email")
+        public String email;
+
+        Customer() {
+        }
+
+        public Customer(int id, String firstName, String lastName, String email) {
+            this.id = id;
+            this.firstName = firstName;
+            this.lastName = lastName;
+            this.email = email;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(email, firstName, id, lastName);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Customer other = (Customer) obj;
+            return id == other.id
+                    && Objects.equals(firstName, other.firstName)
+                    && Objects.equals(lastName, other.lastName)
+                    && Objects.equals(email, other.email);
+        }
+
+        @Override
+        public String toString() {
+            return "Customer {id=" + id + ", firstName=" + firstName + ", lastName=" + lastName + ", email=" + email + '}';
+        }
+    }
+
+    protected static class Order implements Serializable {
+
+        @JsonProperty("id")
+        public int orderNumber;
+
+        @JsonProperty("order_date")
+        public Date orderDate;
+
+        @JsonProperty("purchaser")
+        public int purchaser;
+
+        @JsonProperty("quantity")
+        public int quantity;
+
+        @JsonProperty("product_id")
+        public int productId;
+
+        Order() {
+        }
+
+        public Order(int orderNumber, Date orderDate, int purchaser, int quantity, int productId) {
+            this.orderNumber = orderNumber;
+            this.orderDate = orderDate;
+            this.purchaser = purchaser;
+            this.quantity = quantity;
+            this.productId = productId;
+        }
+
+        public void setOrderDate(Date orderDate) {
+            long days = orderDate.getTime();
+            this.orderDate = new Date(TimeUnit.DAYS.toMillis(days));
+        }
+
+        public int getOrderNumber() {
+            return orderNumber;
+        }
+
+        public Date getOrderDate() {
+            return orderDate;
+        }
+
+        public int getPurchaser() {
+            return purchaser;
+        }
+
+        public int getQuantity() {
+            return quantity;
+        }
+
+        public int getProductId() {
+            return productId;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(orderNumber, orderDate, purchaser, quantity, productId);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Order other = (Order) obj;
+            return orderNumber == other.orderNumber
+                    && Objects.equals(orderDate, other.orderDate)
+                    && Objects.equals(purchaser, other.purchaser)
+                    && Objects.equals(quantity, other.quantity)
+                    && Objects.equals(productId, other.productId);
+        }
+
+        @Override
+        public String toString() {
+            return "Order {orderNumber=" + orderNumber + ", orderDate=" + orderDate + ", purchaser=" + purchaser +
+                    ", quantity=" + quantity + ", productId=" + productId + '}';
         }
     }
 

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.cdc.postgres;
+
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.cdc.ChangeRecord;
+import com.hazelcast.jet.cdc.Operation;
+import com.hazelcast.jet.cdc.ParsingException;
+import com.hazelcast.jet.cdc.RecordPart;
+import com.hazelcast.jet.cdc.impl.ChangeRecordImpl;
+import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import com.hazelcast.jet.pipeline.StreamSource;
+import com.hazelcast.jet.pipeline.StreamStage;
+import com.hazelcast.map.EntryProcessor;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
+
+public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrationTest {
+
+    private static final int MAX_CONCURRENT_OPERATIONS = 1;
+    private static final String CACHE = "cache";
+    private static final int REPEATS = 1000;
+
+    @Test
+    public void ordersOfCustomers() throws Exception {
+        StreamSource<ChangeRecord> source = sourceBuilder("source")
+                .setTableWhitelist("inventory.customers", "inventory.orders")
+                .build();
+
+        Pipeline pipeline = Pipeline.create();
+        StreamStage<ChangeRecord> allRecords = pipeline.readFrom(source)
+                .withNativeTimestamps(0);
+
+        allRecords.filter(r -> r.table().equals("customers"))
+                .apply(this::fixOrdering)
+                .writeTo(Sinks.mapWithEntryProcessor(MAX_CONCURRENT_OPERATIONS, CACHE,
+                        record -> (Integer) record.key().toMap().get("id"),
+                        CustomerEntryProcessor::new
+                ));
+
+        allRecords.filter(r -> r.table().equals("orders"))
+                .apply(this::fixOrdering)
+                .writeTo(Sinks.mapWithEntryProcessor(MAX_CONCURRENT_OPERATIONS, CACHE,
+                        record -> (Integer) record.value().toMap().get("purchaser"),
+                        OrderEntryProcessor::new
+                ));
+
+        // when
+        JetInstance jet = createJetMembers(1)[0];
+        Job job = jet.newJob(pipeline);
+        //then
+        Map<Integer, OrdersOfCustomer> expected = toMap(
+        new OrdersOfCustomer(
+                new Customer(1001, "Sally", "Thomas", "sally.thomas@acme.com"),
+                new Order(10001, new Date(1452902400000L), 1001, 1, 102)),
+        new OrdersOfCustomer(
+                new Customer(1002, "George", "Bailey", "gbailey@foobar.com"),
+                new Order(10002, new Date(1452988800000L) , 1002, 2, 105),
+                new Order(10003, new Date(1455840000000L), 1002, 2, 106)),
+        new OrdersOfCustomer(
+                new Customer(1003, "Edward", "Walker", "ed@walker.com"),
+                new Order(10004, new Date(1456012800000L), 1003, 1, 107)),
+        new OrdersOfCustomer(
+                new Customer(1004, "Anne", "Kretchmar", "annek@noanswer.org")));
+        assertEqualsEventually(() -> getIMapContent(jet, CACHE), expected);
+
+        //when
+        try (Connection connection = DriverManager.getConnection(postgres.getJdbcUrl(), postgres.getUsername(),
+                postgres.getPassword())) {
+            connection.setSchema("inventory");
+            Statement statement = connection.createStatement();
+            for (int i = 1; i <= REPEATS; i++) {
+                statement.addBatch("UPDATE customers SET first_name='Anne" + i + "' WHERE id=1004");
+
+                statement.addBatch("INSERT INTO customers VALUES (1005, 'Jason', 'Bourne', 'jason@bourne.org')");
+                statement.addBatch("DELETE FROM customers WHERE id=1005");
+
+                statement.addBatch("UPDATE orders SET quantity='" + i + "' WHERE id=10004");
+
+                statement.addBatch("DELETE FROM orders WHERE id=10003");
+                statement.addBatch("INSERT INTO orders VALUES (10003, '2016-02-19', 1002, 2, 106)");
+            }
+            statement.executeBatch();
+        }
+        //then
+        expected = toMap(
+                new OrdersOfCustomer(
+                        new Customer(1001, "Sally", "Thomas", "sally.thomas@acme.com"),
+                        new Order(10001, new Date(1452902400000L), 1001, 1, 102)),
+                new OrdersOfCustomer(
+                        new Customer(1002, "George", "Bailey", "gbailey@foobar.com"),
+                        new Order(10002, new Date(1452988800000L) , 1002, 2, 105),
+                        new Order(10003, new Date(1455840000000L), 1002, 2, 106)),
+                new OrdersOfCustomer(
+                        new Customer(1003, "Edward", "Walker", "ed@walker.com"),
+                        new Order(10004, new Date(1456012800000L), 1003, REPEATS, 107)),
+                new OrdersOfCustomer(
+                        new Customer(1004, "Anne" + REPEATS, "Kretchmar", "annek@noanswer.org")));
+        expected.put(1005, new OrdersOfCustomer());
+        assertEqualsEventually(() -> getIMapContent(jet, CACHE), expected);
+    }
+
+    private StreamStage<ChangeRecord> fixOrdering(StreamStage<ChangeRecord> input) {
+        return input
+                .groupingKey(ChangeRecord::key)
+                .mapStateful(
+                        TimeUnit.SECONDS.toMillis(10),
+                        () -> new Sequence(0, 0),
+                        (lastSequence, key, record) -> {
+                            ChangeRecordImpl recordImpl = (ChangeRecordImpl) record;
+                            long source = recordImpl.getSequenceSource();
+                            long sequence = recordImpl.getSequenceValue();
+                            if (lastSequence.update(source, sequence)) {
+                                return record;
+                            }
+                            return null;
+                        },
+                        (TriFunction<Sequence, RecordPart, Long, ChangeRecord>) (sequence, recordPart, aLong) -> null);
+    }
+
+    @NotNull
+    private static Map<Integer, OrdersOfCustomer> getIMapContent(JetInstance jet, String name) {
+        return jet.<Integer, OrdersOfCustomer>getMap(name).entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    }
+
+    @NotNull
+    private static Map<Integer, OrdersOfCustomer> toMap(OrdersOfCustomer... ordersOfCustomers) {
+        return Arrays.stream(ordersOfCustomers).collect(Collectors.toMap(
+                orders -> orders.getCustomer().getId(), Function.identity()));
+    }
+
+    private static class Sequence {
+
+        private long source;
+        private long sequence;
+
+        Sequence(long source, long sequence) {
+            this.source = source;
+            this.sequence = sequence;
+        }
+
+        boolean update(long source, long sequence) {
+            if (this.source != source) { //sequence source changed for key
+                this.source = source;
+                this.sequence = sequence;
+                return true;
+            }
+
+            if (this.sequence < sequence) { //sequence is newer than previous for key
+                this.sequence = sequence;
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "source=" + source + ", sequence=" + sequence;
+        }
+    }
+
+    private static class OrdersOfCustomer implements Serializable {
+
+        private final Map<Integer, Order> orders;
+        private Customer customer;
+
+        OrdersOfCustomer() {
+            this.customer = null;
+            this.orders = new HashMap<>();
+        }
+
+        OrdersOfCustomer(Customer customer, Order... orders) {
+            this.customer = customer;
+            this.orders = Arrays.stream(orders).collect(Collectors.toMap(Order::getOrderNumber, Function.identity()));
+        }
+
+        public Customer getCustomer() {
+            return customer;
+        }
+
+        public void setCustomer(Customer customer) {
+            this.customer = customer;
+        }
+
+        public void deleteOrder(Order order) {
+            orders.remove(order.getOrderNumber());
+        }
+
+        public void addOrUpdateOrder(Order order) {
+            orders.put(order.getOrderNumber(), order);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(customer, orders);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            OrdersOfCustomer other = (OrdersOfCustomer) obj;
+            return Objects.equals(customer, other.customer)
+                    && Objects.equals(orders, other.orders);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Customer: %s, Orders: %s", customer, orders);
+        }
+    }
+
+    private static class CustomerEntryProcessor implements EntryProcessor<Integer, OrdersOfCustomer, Object> {
+
+        private final ChangeRecord record;
+
+        CustomerEntryProcessor(ChangeRecord record) {
+            this.record = record;
+        }
+
+        @Override
+        public Object process(Entry<Integer, OrdersOfCustomer> entry) {
+            try {
+                boolean deletion = Operation.DELETE.equals(record.operation());
+                OrdersOfCustomer value = entry.getValue();
+                if (deletion) {
+                    if (value != null) {
+                        value.setCustomer(null);
+                    }
+                } else {
+                    if (value == null) {
+                        value = new OrdersOfCustomer();
+                    }
+                    value.setCustomer(record.value().toObject(Customer.class));
+                }
+                entry.setValue(value);
+            } catch (ParsingException e) {
+                throw rethrow(e);
+            }
+            return null;
+        }
+    }
+
+    private static class OrderEntryProcessor implements EntryProcessor<Integer, OrdersOfCustomer, Object> {
+
+        private final ChangeRecord record;
+
+        OrderEntryProcessor(ChangeRecord record) {
+            this.record = record;
+        }
+
+        @Override
+        public Object process(Entry<Integer, OrdersOfCustomer> entry) {
+            try {
+                boolean deletion = Operation.DELETE.equals(record.operation());
+                OrdersOfCustomer value = entry.getValue();
+                if (deletion) {
+                    if (value != null) {
+                        value.deleteOrder(record.value().toObject(Order.class));
+                    }
+                } else {
+                    if (value == null) {
+                        value = new OrdersOfCustomer();
+                    }
+                    value.addOrUpdateOrder(record.value().toObject(Order.class));
+                }
+                entry.setValue(value);
+            } catch (ParsingException e) {
+                throw rethrow(e);
+            }
+            return null;
+        }
+    }
+
+}

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -153,8 +153,7 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
 
     @NotNull
     private static Map<Integer, OrdersOfCustomer> getIMapContent(JetInstance jet, String name) {
-        return jet.<Integer, OrdersOfCustomer>getMap(name).entrySet().stream()
-                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        return new HashMap<>(jet.getMap(name));
     }
 
     @NotNull

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
@@ -43,9 +43,7 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.jet.Util.entry;
 
@@ -56,13 +54,13 @@ public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTe
     public void customers() throws Exception {
         // given
         List<String> expectedRecords = Arrays.asList(
-                "1001/0:SYNC:Customer {id=1001, firstName=Sally, lastName=Thomas, email=sally.thomas@acme.com}",
-                "1002/0:SYNC:Customer {id=1002, firstName=George, lastName=Bailey, email=gbailey@foobar.com}",
-                "1003/0:SYNC:Customer {id=1003, firstName=Edward, lastName=Walker, email=ed@walker.com}",
-                "1004/0:SYNC:Customer {id=1004, firstName=Anne, lastName=Kretchmar, email=annek@noanswer.org}",
-                "1004/1:UPDATE:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}",
-                "1005/0:INSERT:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}",
-                "1005/1:DELETE:Customer {id=1005, firstName=Jason, lastName=Bourne, email=jason@bourne.org}"
+                "1001/0:SYNC:" + new Customer(1001, "Sally", "Thomas", "sally.thomas@acme.com"),
+                "1002/0:SYNC:" + new Customer(1002, "George", "Bailey", "gbailey@foobar.com"),
+                "1003/0:SYNC:" + new Customer(1003, "Edward", "Walker", "ed@walker.com"),
+                "1004/0:SYNC:" + new Customer(1004, "Anne", "Kretchmar", "annek@noanswer.org"),
+                "1004/1:UPDATE:" + new Customer(1004, "Anne Marie", "Kretchmar", "annek@noanswer.org"),
+                "1005/0:INSERT:" + new Customer(1005, "Jason", "Bourne", "jason@bourne.org"),
+                "1005/1:DELETE:" + new Customer(1005, "Jason", "Bourne", "jason@bourne.org")
         );
 
         Pipeline pipeline = Pipeline.create();
@@ -114,14 +112,10 @@ public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTe
     public void orders() {
         // given
         List<String> expectedRecords = Arrays.asList(
-                "10001/0:SYNC:Order {orderNumber=10001, orderDate=" + new Date(1452902400000L) +
-                        ", quantity=1, productId=102}",
-                "10002/0:SYNC:Order {orderNumber=10002, orderDate=" + new Date(1452988800000L) +
-                        ", quantity=2, productId=105}",
-                "10003/0:SYNC:Order {orderNumber=10003, orderDate=" + new Date(1455840000000L) +
-                        ", quantity=2, productId=106}",
-                "10004/0:SYNC:Order {orderNumber=10004, orderDate=" + new Date(1456012800000L) +
-                        ", quantity=1, productId=107}"
+                "10001/0:SYNC:" + new Order(10001, new Date(1452902400000L), 1001, 1, 102),
+                "10002/0:SYNC:" + new Order(10002, new Date(1452988800000L) , 1002, 2, 105),
+                "10003/0:SYNC:" + new Order(10003, new Date(1455840000000L), 1002, 2, 106),
+                "10004/0:SYNC:" + new Order(10004, new Date(1456012800000L), 1003, 1, 107)
         );
 
         Pipeline pipeline = Pipeline.create();
@@ -303,99 +297,6 @@ public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTe
         } else {
             return record.key().toObject(OrderPrimaryKey.class).id;
         }
-    }
-
-    private static class Customer {
-
-        @JsonProperty("id")
-        public int id;
-
-        @JsonProperty("first_name")
-        public String firstName;
-
-        @JsonProperty("last_name")
-        public String lastName;
-
-        @JsonProperty("email")
-        public String email;
-
-        Customer() {
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(email, firstName, id, lastName);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            Customer other = (Customer) obj;
-            return id == other.id
-                    && Objects.equals(firstName, other.firstName)
-                    && Objects.equals(lastName, other.lastName)
-                    && Objects.equals(email, other.email);
-        }
-
-        @Override
-        public String toString() {
-            return "Customer {id=" + id + ", firstName=" + firstName + ", lastName=" + lastName + ", email=" + email + '}';
-        }
-    }
-
-    private static class Order {
-
-        @JsonProperty("id")
-        public int orderNumber;
-
-        @JsonProperty("order_date")
-        public Date orderDate;
-
-        @JsonProperty("quantity")
-        public int quantity;
-
-        @JsonProperty("product_id")
-        public int productId;
-
-        Order() {
-        }
-
-        public void setOrderDate(Date orderDate) {
-            long days = orderDate.getTime();
-            this.orderDate = new Date(TimeUnit.DAYS.toMillis(days));
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(orderNumber, orderDate, quantity, productId);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) {
-                return true;
-            }
-            if (obj == null || getClass() != obj.getClass()) {
-                return false;
-            }
-            Order other = (Order) obj;
-            return orderNumber == other.orderNumber
-                    && Objects.equals(orderDate, other.orderDate)
-                    && Objects.equals(quantity, other.quantity)
-                    && Objects.equals(productId, other.productId);
-        }
-
-        @Override
-        public String toString() {
-            return "Order {orderNumber=" + orderNumber + ", orderDate=" + orderDate + ", quantity=" + quantity +
-                    ", productId=" + productId + '}';
-        }
-
     }
 
     private static class OrderPrimaryKey {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -185,6 +185,21 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for
+     * {@link Sinks#mapWithEntryProcessor(int, String, FunctionEx, FunctionEx)}.
+     */
+    @Nonnull
+    public static <T, K, V, R> ProcessorMetaSupplier updateMapP(
+            int maxParallelAsyncOps,
+            @Nonnull String mapName,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends EntryProcessor<K, V, R>> toEntryProcessorFn
+
+    ) {
+        return HazelcastWriters.updateMapSupplier(maxParallelAsyncOps, mapName, null, toKeyFn, toEntryProcessorFn);
+    }
+
+    /**
+     * Returns a supplier of processors for
      * {@link Sinks#remoteMapWithEntryProcessor(String, ClientConfig, FunctionEx,
      * FunctionEx)}.
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/HazelcastWriters.java
@@ -126,6 +126,22 @@ public final class HazelcastWriters {
     }
 
     @Nonnull
+    public static <T, K, V, R> ProcessorMetaSupplier updateMapSupplier(
+            int maxParallelAsyncOps,
+            @Nonnull String name,
+            @Nullable ClientConfig clientConfig,
+            @Nonnull FunctionEx<? super T, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super T, ? extends EntryProcessor<K, V, R>> toEntryProcessorFn
+    ) {
+        checkSerializable(toKeyFn, "toKeyFn");
+        checkSerializable(toEntryProcessorFn, "toEntryProcessorFn");
+
+        return ProcessorMetaSupplier.of(AbstractHazelcastConnectorSupplier.of(asXmlString(clientConfig),
+                instance -> new UpdateMapWithEntryProcessorP<>(instance, maxParallelAsyncOps, name, toKeyFn,
+                        toEntryProcessorFn)));
+    }
+
+    @Nonnull
     public static ProcessorMetaSupplier writeCacheSupplier(@Nonnull String name, @Nullable ClientConfig clientConfig) {
         return ProcessorMetaSupplier.of(2, new WriteCachePSupplier<>(clientConfig, name));
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Sinks.java
@@ -35,6 +35,7 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.topic.ITopic;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.jms.ConnectionFactory;
 import javax.sql.CommonDataSource;
 import java.nio.charset.Charset;
@@ -95,6 +96,26 @@ public final class Sinks {
             @Nonnull ProcessorMetaSupplier metaSupplier
     ) {
         return new SinkImpl<>(sinkName, metaSupplier);
+    }
+
+    /**
+     * Returns a sink constructed directly from the given Core API processor
+     * meta-supplier.
+     * <p>
+     * The default local parallelism for this source is specified inside the
+     * {@link ProcessorMetaSupplier#preferredLocalParallelism() metaSupplier}.
+     *
+     * @param sinkName user-friendly sink name
+     * @param metaSupplier the processor meta-supplier
+     * @param partitionKeyFn key extractor function for partitioning edges to sink
+     */
+    @Nonnull
+    public static <T> Sink<T> fromProcessor(
+            @Nonnull String sinkName,
+            @Nonnull ProcessorMetaSupplier metaSupplier,
+            @Nullable FunctionEx<? super T, ?> partitionKeyFn
+    ) {
+        return new SinkImpl<>(sinkName, metaSupplier, partitionKeyFn);
     }
 
     /**
@@ -227,7 +248,8 @@ public final class Sinks {
             @Nonnull FunctionEx<? super T, ? extends V> toValueFn
     ) {
         return fromProcessor("remoteMapSink(" + mapName + ')',
-                writeRemoteMapP(mapName, clientConfig, toKeyFn, toValueFn));
+                writeRemoteMapP(mapName, clientConfig, toKeyFn, toValueFn),
+                toKeyFn);
     }
 
     /**
@@ -355,7 +377,8 @@ public final class Sinks {
             @Nonnull BinaryOperatorEx<V> mergeFn
     ) {
         return fromProcessor("remoteMapWithMergingSink(" + mapName + ')',
-                mergeRemoteMapP(mapName, clientConfig, toKeyFn, toValueFn, mergeFn));
+                mergeRemoteMapP(mapName, clientConfig, toKeyFn, toValueFn, mergeFn),
+                toKeyFn);
     }
 
     /**
@@ -508,7 +531,8 @@ public final class Sinks {
             @Nonnull BiFunctionEx<? super V, ? super T, ? extends V> updateFn
     ) {
         return fromProcessor("remoteMapWithUpdatingSink(" + mapName + ')',
-                updateRemoteMapP(mapName, clientConfig, toKeyFn, updateFn));
+                updateRemoteMapP(mapName, clientConfig, toKeyFn, updateFn),
+                toKeyFn);
     }
 
     /**
@@ -551,6 +575,21 @@ public final class Sinks {
     }
 
     /**
+     * Convenience for {@link #mapWithEntryProcessor(int, String, FunctionEx, FunctionEx)}
+     * when the maximum number of async operations is not specified.
+     */
+    @Nonnull
+    public static <E, K, V, R> Sink<E> mapWithEntryProcessor(
+            @Nonnull String mapName,
+            @Nonnull FunctionEx<? super E, ? extends K> toKeyFn,
+            @Nonnull FunctionEx<? super E, ? extends EntryProcessor<K, V, R>> toEntryProcessorFn
+    ) {
+        return fromProcessor("mapWithEntryProcessorSink(" + mapName + ')',
+                updateMapP(mapName, toKeyFn, toEntryProcessorFn),
+                toKeyFn);
+    }
+
+    /**
      * Returns a sink that uses the items it receives to create {@code
      * EntryProcessor}s it submits to a Hazelcast {@code IMap} with the
      * specified name. For each received item it applies {@code toKeyFn} to
@@ -580,6 +619,8 @@ public final class Sinks {
      * <p>
      * The default local parallelism for this sink is 1.
      *
+     * @param maxParallelAsyncOps  maximum number of simultaneous entry
+     *                             processors affecting the map
      * @param mapName  name of the map
      * @param toKeyFn  function that extracts the key from the input item
      * @param toEntryProcessorFn function that returns the {@code EntryProcessor}
@@ -590,12 +631,14 @@ public final class Sinks {
      */
     @Nonnull
     public static <E, K, V, R> Sink<E> mapWithEntryProcessor(
+            int maxParallelAsyncOps,
             @Nonnull String mapName,
             @Nonnull FunctionEx<? super E, ? extends K> toKeyFn,
             @Nonnull FunctionEx<? super E, ? extends EntryProcessor<K, V, R>> toEntryProcessorFn
     ) {
         return fromProcessor("mapWithEntryProcessorSink(" + mapName + ')',
-                updateMapP(mapName, toKeyFn, toEntryProcessorFn));
+                updateMapP(maxParallelAsyncOps, mapName, toKeyFn, toEntryProcessorFn),
+                toKeyFn);
     }
 
     /**
@@ -662,7 +705,8 @@ public final class Sinks {
             @Nonnull FunctionEx<? super E, ? extends EntryProcessor<K, V, R>> toEntryProcessorFn
     ) {
         return fromProcessor("remoteMapWithEntryProcessorSink(" + mapName + ')',
-                updateRemoteMapP(mapName, clientConfig, toKeyFn, toEntryProcessorFn));
+                updateRemoteMapP(mapName, clientConfig, toKeyFn, toEntryProcessorFn),
+                toKeyFn);
     }
 
     /**


### PR DESCRIPTION
Intention: come up with a pipeline, which reads two different tables from a database via CDC and keeps an up-to-date map with their merged values, in this case customers and their orders. 

Particular details to pay attention to:
* I've added a version of `Sinks.mapWithEntryProcessor` where you can specify `maxParallelAsyncOps`; I have to set that to 1 for this scenario, to avoid Sink-to-IMap reordering due to multiple async requests
* I've changed multiple sinks to have partitioned input-edges, where a partitioning function is naturally available
* the test code probably runs on a local member only, a remote cluster will not know how to deserialize objects like `Customer`, `Order` and `OrdersToCustomer`; if/when we turn this into a tutorial or cookbook entry we will need to change it to work with simpler, standard objects

Point is to prove that we can achieve this joining functionality correctly.

Checklist
- [x] Tags Set
- [x] Milestone Set