### PR TITLE
[005] Create replication slot before Postgres is used for CDC

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSource.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSource.java
@@ -106,6 +106,7 @@ public abstract class CdcSource<T> {
     }
 
     private boolean addToBuffer(SourceRecord sourceRecord, SourceBuilder.TimestampedSourceBuffer<T> buf) {
+        System.err.println("sourceRecord.sourceOffset() = " + sourceRecord.sourceOffset()); //todo: remove
         T t = mapToOutput(sourceRecord);
         if (t != null) {
             long timestamp = extractTimestamp(sourceRecord);

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -49,7 +49,9 @@ public class ChangeRecordImpl implements ChangeRecord {
     ) {
         this.sequenceSource = sequenceSource;
         this.sequenceValue = sequenceValue;
+        System.err.println("\tsequenceValue = " + sequenceValue); //todo: remove
         this.keyJson = Objects.requireNonNull(keyJson, "keyJson");
+        System.err.println("\tkeyJson = " + keyJson); //todo: remove
         this.valueJson = Objects.requireNonNull(valueJson, "valueJson");
     }
 


### PR DESCRIPTION
Modify tests to create needed replication slots before starting the connector and describe the need for this in the operations guide.

Checklist
- [ ] Tags Set
- [ ] Milestone Set