### PR TITLE
[005] Make Postgres dataloss on snapshot-stream sync less severe

### DIFF
--- a/extensions/cdc-mysql/src/main/java/com/hazelcast/jet/cdc/mysql/MySqlCdcSources.java
+++ b/extensions/cdc-mysql/src/main/java/com/hazelcast/jet/cdc/mysql/MySqlCdcSources.java
@@ -45,12 +45,12 @@ public final class MySqlCdcSources {
      * Creates a CDC source that streams change data from a MySQL database to
      * Hazelcast Jet.
      * <p>
-     * If Jet can't reach the database when it attempts to start the source or
-     * if it looses the connection to the database from an already running
-     * source, it throws an exception and terminate the execution of the job.
-     * This behaviour is not ideal, would be much better to try to reconnect,
-     * at least for a certain amount of time. Future versions will address the
-     * problem.
+     * <b>KNOWN ISSUE:</b> If Jet can't reach the database when it attempts to
+     * start the source or if it looses the connection to the database from an
+     * already running source, it throws an exception and terminate the
+     * execution of the job. This behaviour is not ideal, would be much better
+     * to try to reconnect, at least for a certain amount of time. Future
+     * versions will address the problem.
      *
      * @param name name of this source, needs to be unique, will be passed to
      *             the underlying Kafka Connect source

--- a/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
+++ b/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
@@ -53,13 +53,14 @@ public final class PostgresCdcSources {
      * to try to reconnect, at least for a certain amount of time. Future
      * versions will address the problem.
      * <p>
-     * <b>KNOWN ISSUE 2:</b> The Debezium PostgreSQL Connector this source is
-     * based on has data loss issues when synchronizing snapshots with event
-     * streams based on the Postgres WAL (Write-Ahead Log). For details see
-     * <a href="https://issues.redhat.com/browse/DBZ-2288">DBZ-2288</a>.
+     * <b>KNOWN ISSUE 2:</b> This source is based on the Debezium PostgreSQL
+     * Connector, which has some data loss issues when synchronizing snapshots
+     * with the stream of events coming from the Postgres WAL (Write-Ahead Log).
+     * For details see <a href="https://issues.redhat.com/browse/DBZ-2288">DBZ-2288</a>.
      * Currently the first streaming event that should come in right after the
-     * snapshot ends is lost. The issue is actively being looked into and we
-     * will release a fix immediately as it's available.
+     * snapshot ends is lost. Sometimes even more events can be lost. The issue
+     * is actively being looked into and we will release a fix immediately as
+     * it's available.
      *
      * @param name name of this source, needs to be unique, will be passed to
      *             the underlying Kafka Connect source

--- a/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
+++ b/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
@@ -91,6 +91,7 @@ public final class PostgresCdcSources {
             config.setProperty(CdcSource.SEQUENCE_EXTRACTOR_CLASS_PROPERTY, PostgresSequenceExtractor.class.getName());
             config.setProperty(ChangeRecordCdcSource.DB_SPECIFIC_EXTRA_FIELDS_PROPERTY, "schema");
             config.setProperty("database.server.name", UuidUtil.newUnsecureUuidString());
+            config.setProperty("snapshot.mode", "exported");
         }
 
         /**

--- a/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
+++ b/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
@@ -46,12 +46,20 @@ public final class PostgresCdcSources {
      * Creates a CDC source that streams change data from a PostgreSQL database
      * to Hazelcast Jet.
      * <p>
-     * If Jet can't reach the database when it attempts to start the source or
-     * if it looses the connection to the database from an already running
-     * source, it throws an exception and terminate the execution of the job.
-     * This behaviour is not ideal, would be much better to try to reconnect,
-     * at least for a certain amount of time. Future versions will address the
-     * problem.
+     * <b>KNOWN ISSUE 1:</b> If Jet can't reach the database when it attempts to
+     * start the source or if it looses the connection to the database from an
+     * already running source, it throws an exception and terminate the
+     * execution of the job. This behaviour is not ideal, would be much better
+     * to try to reconnect, at least for a certain amount of time. Future
+     * versions will address the problem.
+     * <p>
+     * <b>KNOWN ISSUE 2:</b> The Debezium PostgreSQL Connector this source is
+     * based on has data loss issues when synchronizing snapshots with event
+     * streams based on the Postgres WAL (Write-Ahead Log). For details see
+     * <a href="https://issues.redhat.com/browse/DBZ-2288">DBZ-2288</a>.
+     * Currently the first streaming event that should come in right after the
+     * snapshot ends is lost. The issue is actively being looked into and we
+     * will release a fix immediately as it's available.
      *
      * @param name name of this source, needs to be unique, will be passed to
      *             the underlying Kafka Connect source

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.jet.core.JobStatus;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
+import com.hazelcast.map.IMap;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,6 +41,7 @@ import javax.annotation.Nonnull;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -48,6 +50,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.jet.Util.entry;
+import static org.junit.Assert.assertEquals;
 
 public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTest {
 
@@ -286,6 +289,81 @@ public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTe
                         "1004:Customer {id=1004, firstName=Anne Marie, lastName=Kretchmar, email=annek@noanswer.org}"
                 )
         );
+    }
+
+    @Test
+    @Category(NightlyTest.class)
+    public void dataLoss() throws Exception {
+        int offset = 1005;
+        int length = 10_000;
+
+        // given
+        List<String> expectedRecords = new ArrayList<>(Arrays.asList(
+                "1001/0:(SYNC|INSERT):Customer \\{id=1001, firstName=Sally, lastName=Thomas, "
+                        + "email=sally.thomas@acme.com\\}",
+                "1002/0:(SYNC|INSERT):Customer \\{id=1002, firstName=George, lastName=Bailey, "
+                        + "email=gbailey@foobar.com\\}",
+                "1003/0:(SYNC|INSERT):Customer \\{id=1003, firstName=Edward, lastName=Walker, "
+                        + "email=ed@walker.com\\}",
+                "1004/0:(SYNC|INSERT):Customer \\{id=1004, firstName=Anne, lastName=Kretchmar, "
+                        + "email=annek@noanswer.org\\}"
+        ));
+        for (int i = offset; i < offset + length; i++) {
+            expectedRecords.add(i + "/0:(SYNC|INSERT):Customer \\{id=" + i + ", firstName=first" + i + ", lastName=last"
+                    + i + ", email=" + i + "@google.com\\}");
+        }
+        expectedRecords.sort(String::compareTo);
+
+        Pipeline pipeline = Pipeline.create();
+        pipeline.readFrom(source("customers"))
+                .withNativeTimestamps(0)
+                .<ChangeRecord>customTransform("filter_timestamps", filterTimestampsProcessorSupplier())
+                .groupingKey(record -> (Integer) record.key().toMap().get("id"))
+                .mapStateful(
+                        LongAccumulator::new,
+                        (accumulator, customerId, record) -> {
+                            long count = accumulator.get();
+                            accumulator.add(1);
+                            Operation operation = record.operation();
+                            RecordPart value = record.value();
+                            Customer customer = value.toObject(Customer.class);
+                            return entry(customerId + "/" + count, operation + ":" + customer);
+                        })
+                .setLocalParallelism(1)
+                .writeTo(Sinks.map("results"));
+
+        // when
+        JetInstance jet = createJetMembers(1)[0];
+        Job job = jet.newJob(pipeline);
+
+        //then
+        assertJobStatusEventually(job, JobStatus.RUNNING);
+
+        //when
+        try (Connection connection = DriverManager.getConnection(postgres.getJdbcUrl(), postgres.getUsername(),
+                postgres.getPassword())) {
+            connection.setSchema("inventory");
+            Statement statement = connection.createStatement();
+            for (int i = offset; i < offset + length; i++) {
+                statement.addBatch("INSERT INTO customers VALUES (" + i + ", 'first" + i + "', 'last" + i + "', '"
+                        + i + "@google.com')");
+            }
+            statement.executeBatch();
+        }
+
+        //then
+        try {
+            assertTrueEventually(() -> {
+                IMap<Object, Object> map = jet.getMap("results");
+                int size = map.size();
+                System.err.println("No. of records: " + size);
+                assertEquals(expectedRecords.size(), size);
+
+                assertMatch(expectedRecords, mapResultsToSortedList(map));
+            });
+        } finally {
+            job.cancel();
+        }
     }
 
     @Nonnull

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcIntegrationTest.java
@@ -34,6 +34,7 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.map.IMap;
 import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -293,9 +294,10 @@ public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTe
 
     @Test
     @Category(NightlyTest.class)
+    @Ignore //todo: until https://issues.redhat.com/browse/DBZ-2288 fixed
     public void dataLoss() throws Exception {
         int offset = 1005;
-        int length = 10_000;
+        int length = 9995;
 
         // given
         List<String> expectedRecords = new ArrayList<>(Arrays.asList(
@@ -356,7 +358,7 @@ public class PostgresCdcIntegrationTest extends AbstractPostgresCdcIntegrationTe
             assertTrueEventually(() -> {
                 IMap<Object, Object> map = jet.getMap("results");
                 int size = map.size();
-                System.err.println("No. of records: " + size);
+                System.out.println("No. of records: " + size);
                 assertEquals(expectedRecords.size(), size);
 
                 assertMatch(expectedRecords, mapResultsToSortedList(map));


### PR DESCRIPTION
Set snapshot mode to `exported` where data loss is one message only.

Checklist
- [x] Tags Set
- [x] Milestone Set
