### PR TITLE
Fix error handling in tryStartJob()

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -986,6 +986,8 @@ public class JobCoordinationService {
             try {
                 return CompletableFuture.completedFuture(action.call());
             } catch (Throwable e) {
+                // most callers ignore the failure on the returned future, let's log it at least
+                logger.warning(null, e);
                 return com.hazelcast.jet.impl.util.Util.exceptionallyCompletedFuture(e);
             }
         }
@@ -996,7 +998,7 @@ public class JobCoordinationService {
             try {
                 return action.call();
             } catch (Throwable e) {
-                // the executor ignores exceptions, let's log it at least
+                // most callers ignore the failure on the returned future, let's log it at least
                 logger.warning(null, e);
                 throw e;
             } finally {


### PR DESCRIPTION
Every exception during tryStartJob should finalize the job with the error. The
previous alternative just ignored it and left the job in an inconsistent state.
What triggered this error was a non-serializable ProcessorSupplier that
implemented DataSerializable: it wasn't caught in `checkSerializable`, but
later when calling `toData(plan)`.

