### PR TITLE
[005] Make Debezium sequences public

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
@@ -21,14 +21,14 @@ import com.hazelcast.jet.annotation.EvolvingApi;
 import javax.annotation.Nonnull;
 
 /**
- * Information pertaining to a single data change event (insertion, delete or
+ * Information pertaining to a single data change event (insert, delete or
  * update), affecting a single database record.
  * <p>
  * Each event has a <em>key</em>, identifying the affected record, and a
  * <em>value</em>, describing the change to that record.
  * <p>
  * Most events have an <em>operation</em> which specifies the type of change
- * (insertion, delete or update). Events without an operation have specialized
+ * (insert, delete or update). Events without an operation have specialized
  * usage, for example heartbeats, and aren't supposed to affect the data model.
  * You can observe and act upon them in a Jet CDC sink, but we discourage such
  * usage.
@@ -42,7 +42,7 @@ import javax.annotation.Nonnull;
  * operation instead of {@code INSERT}, however some databases emit {@code INSERT}
  * events in both cases (a notable example is MySQL).
  * <p>
- * All events have a source specific <em>sequence</em> which can be used to
+ * All events have a source-specific <em>sequence</em> which can be used to
  * ensure their ordering. The sequence consists of two parts: a monotonically
  * increasing <em>numeric value</em> and a <em>source descriptor</em>, which
  * provides the scope of validity of the numeric value. This is needed because
@@ -72,7 +72,7 @@ public interface ChangeRecord {
 
     /**
      * Specifies the numeric value part of the record's source sequence. As long
-     * as the source sequence doesn't change the values will be monotonically
+     * as the source sequence doesn't change, the values will be monotonically
      * increasing and can be used to impose ordering over the stream of records.
      *
      * @since 4.3

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
@@ -21,27 +21,34 @@ import com.hazelcast.jet.annotation.EvolvingApi;
 import javax.annotation.Nonnull;
 
 /**
- * Information pertaining to a single data change event (insertion,
- * delete or update), affecting a single database record.
+ * Information pertaining to a single data change event (insertion, delete or
+ * update), affecting a single database record.
  * <p>
  * Each event has a <em>key</em>, identifying the affected record, and a
  * <em>value</em>, describing the change to that record.
  * <p>
- * Most events have an <em>operation</em> which specifies the type of
- * change (insertion, delete or update). Events without an operation
- * have specialized usage, for example heartbeats, and aren't supposed
- * to affect the data model. You can observe and act upon them in a Jet
- * CDC sink, but we discourage such usage.
+ * Most events have an <em>operation</em> which specifies the type of change
+ * (insertion, delete or update). Events without an operation have specialized
+ * usage, for example heartbeats, and aren't supposed to affect the data model.
+ * You can observe and act upon them in a Jet CDC sink, but we discourage such
+ * usage.
  * <p>
- * All events have a <em>timestamp</em> specifying the moment when the
- * change event occurred in the database. Normally this is the timestamp
- * recorded in the database's change log, but since it has a finite size,
- * the change stream begins with virtual events that reproduce the state of
- * the table at the start of the change log. These events have an
- * artificial timestamp. In principle, it should be easy to identify them
- * because they have a separate {@code SYNC} operation instead of {@code
- * INSERT}, however some databases emit {@code INSERT} events in both
- * cases (a notable example is MySQL).
+ * All events have a <em>timestamp</em> specifying the moment when the change
+ * event occurred in the database. Normally this is the timestamp recorded in
+ * the database's change log, but since it has a finite size, the change stream
+ * begins with virtual events that reproduce the state of the table at the start
+ * of the change log. These events have an artificial timestamp. In principle,
+ * it should be easy to identify them because they have a separate {@code SYNC}
+ * operation instead of {@code INSERT}, however some databases emit {@code INSERT}
+ * events in both cases (a notable example is MySQL).
+ * <p>
+ * All events have a source specific <em>sequence</em> which can be used to
+ * ensure their ordering. The sequence consists of two parts: a monotonically
+ * increasing <em>numeric value</em> and a <em>source descriptor</em>, which
+ * provides the scope of validity of the numeric value. This is needed because
+ * many CDC sources don't provide a globally valid sequence. For example, the
+ * sequence may be the offset in a write-ahead log. Then it makes sense to
+ * compare them only if they come from the same log file.
  *
  * @since 4.2
  */
@@ -62,6 +69,21 @@ public interface ChangeRecord {
      *                          is unparsable
      */
     long timestamp() throws ParsingException;
+
+    /**
+     * Specifies the numeric value part of the record's source sequence. As long
+     * as the source sequence doesn't change the values will be monotonically
+     * increasing and can be used to impose ordering over the stream of records.
+     */
+    long sequenceValue();
+
+    /**
+     * Specifies the source descriptor of the record's sequence. Any changes
+     * observed in its value should be interpreted as a reset in the sequence's
+     * numeric values. No ordering can be deduced for two records with different
+     * sequence sources.
+     */
+    long sequenceSource();
 
     /**
      * Returns the type of change this record describes (insert, delete or

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/ChangeRecord.java
@@ -74,6 +74,8 @@ public interface ChangeRecord {
      * Specifies the numeric value part of the record's source sequence. As long
      * as the source sequence doesn't change the values will be monotonically
      * increasing and can be used to impose ordering over the stream of records.
+     *
+     * @since 4.3
      */
     long sequenceValue();
 
@@ -82,6 +84,8 @@ public interface ChangeRecord {
      * observed in its value should be interpreted as a reset in the sequence's
      * numeric values. No ordering can be deduced for two records with different
      * sequence sources.
+     *
+     * @since 4.3
      */
     long sequenceSource();
 

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSerializerHooks.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSerializerHooks.java
@@ -50,8 +50,8 @@ public class CdcSerializerHooks {
 
                 @Override
                 public void write(ObjectDataOutput out, ChangeRecordImpl record) throws IOException {
-                    out.writeLong(record.getSequenceSource());
-                    out.writeLong(record.getSequenceValue());
+                    out.writeLong(record.sequenceSource());
+                    out.writeLong(record.sequenceValue());
                     out.writeUTF(record.getKeyJson());
                     out.writeUTF(record.getValueJson());
                 }

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/ChangeRecordImpl.java
@@ -138,11 +138,13 @@ public class ChangeRecordImpl implements ChangeRecord {
         return json;
     }
 
-    public long getSequenceSource() {
+    @Override
+    public long sequenceSource() {
         return sequenceSource;
     }
 
-    public long getSequenceValue() {
+    @Override
+    public long sequenceValue() {
         return sequenceValue;
     }
 

--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/WriteCdcP.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/WriteCdcP.java
@@ -122,9 +122,8 @@ public class WriteCdcP<K, V> extends AbstractUpdateMapP<ChangeRecord, K, V> {
     }
 
     private boolean shouldBeDropped(K key, ChangeRecord item) {
-        ChangeRecordImpl recordImpl = (ChangeRecordImpl) item;
-        long sequenceSource = recordImpl.getSequenceSource();
-        long sequenceValue = recordImpl.getSequenceValue();
+        long sequenceSource = item.sequenceSource();
+        long sequenceValue = item.sequenceValue();
 
         return !updateSequence(key, sequenceSource, sequenceValue);
     }

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/MultiTableCacheIntegrationTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.jet.cdc.ChangeRecord;
 import com.hazelcast.jet.cdc.Operation;
 import com.hazelcast.jet.cdc.ParsingException;
 import com.hazelcast.jet.cdc.RecordPart;
-import com.hazelcast.jet.cdc.impl.ChangeRecordImpl;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
@@ -140,9 +139,8 @@ public class MultiTableCacheIntegrationTest extends AbstractPostgresCdcIntegrati
                         TimeUnit.SECONDS.toMillis(10),
                         () -> new Sequence(0, 0),
                         (lastSequence, key, record) -> {
-                            ChangeRecordImpl recordImpl = (ChangeRecordImpl) record;
-                            long source = recordImpl.getSequenceSource();
-                            long sequence = recordImpl.getSequenceValue();
+                            long source = record.sequenceSource();
+                            long sequence = record.sequenceValue();
                             if (lastSequence.update(source, sequence)) {
                                 return record;
                             }

--- a/site/docs/tutorials/cdc-join.md
+++ b/site/docs/tutorials/cdc-join.md
@@ -420,9 +420,10 @@ public class OrdersOfCustomer implements Serializable {
 
 There is also another element in the pipeline, an extra processing stage
 which handles and fixes event reordering that might happen due to
-parallel processing. It's based on non-public classes because future
-versions of Jet (4.3 most likely) will contain generic solutions for
-the reordering problem and then this code will no longer be necessary:
+parallel processing. It's based on sequence numbers specific to CDC
+sources so can be used only for these kinds of pipelines. Hopefully
+future versions of Jet will contain generic solutions for the reoreding
+problem.
 
 ```java
 package org.example;

--- a/site/docs/tutorials/cdc-join.md
+++ b/site/docs/tutorials/cdc-join.md
@@ -421,9 +421,9 @@ public class OrdersOfCustomer implements Serializable {
 There is also another element in the pipeline, an extra processing stage
 which handles and fixes event reordering that might happen due to
 parallel processing. It's based on sequence numbers specific to CDC
-sources so can be used only for these kinds of pipelines. Hopefully
-future versions of Jet will contain generic solutions for the reoreding
-problem.
+sources and so can be used only for these kinds of pipelines. Hopefully
+a future version of Jet will introduce a generic solution for the
+reoreding problem.
 
 ```java
 package org.example;


### PR DESCRIPTION
We are using sequence numbers from Debezium to fix reordering of CDC events anyways, so why not make them part of the API.

Checklist
- [x] Tags Set
- [x] Milestone Set
