### PR TITLE
Avoid shading already shaded jar

### DIFF
--- a/hazelcast-jet-all/pom.xml
+++ b/hazelcast-jet-all/pom.xml
@@ -41,6 +41,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <forceCreation>true</forceCreation>
                     <archive>
                         <index>true</index>
                         <compress>true</compress>


### PR DESCRIPTION
Maven jar plugin recreates the original jar only
if the jar is missing or there are changes in the inputs.
The shaded jar contains all inputs up to date so it is not
changed and is used as input for shade plugin if you run
the build 2nd time. Causing the build to fail due to overlapping
resources.

The forceCreation parameter forces the creation of the jar every time,
only for the hazelcast-jet-all module.

See https://maven.apache.org/plugins/maven-jar-plugin/jar-mojo.html#forceCreation
