### PR TITLE
Add nightly tests to test-coverage profile

### DIFF
--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/LocalClusterElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/LocalClusterElasticSourcesTest.java
@@ -20,13 +20,16 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.impl.util.Util;
+import com.hazelcast.jet.test.IgnoredForCoverage;
 import org.junit.AfterClass;
 
 import java.util.function.Supplier;
+import org.junit.experimental.categories.Category;
 
 /**
  * Test running 3 local Jet members in a cluster and Elastic in docker
  */
+@Category({IgnoredForCoverage.class})
 public class LocalClusterElasticSourcesTest extends CommonElasticSourcesTest {
 
     private static JetInstance[] instances;

--- a/pom.xml
+++ b/pom.xml
@@ -631,9 +631,12 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <argLine>@{argLine}</argLine>
+                                    <argLine>
+                                        @{argLine}
+                                        -Dhazelcast.test.defaultTestTimeoutInSeconds=600
+                                    </argLine>
                                     <excludedGroups combine.self="override">
-                                        com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest,com.hazelcast.jet.test.IgnoredForCoverage
+                                        com.hazelcast.jet.test.IgnoredForCoverage
                                     </excludedGroups>
                                 </configuration>
                             </execution>
@@ -643,9 +646,13 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
-                                    <argLine>@{argLine}</argLine>
-                                    <excludedGroups>
-                                        com.hazelcast.jet.test.SerialTest,com.hazelcast.test.annotation.SlowTest,com.hazelcast.test.annotation.NightlyTest,com.hazelcast.jet.test.IgnoredForCoverage
+                                    <argLine>
+                                        @{argLine}
+                                        -Dhazelcast.test.defaultTestTimeoutInSeconds=600
+                                    </argLine>
+                                    <forkCount combine.self="override">1</forkCount>
+                                    <excludedGroups combine.self="override">
+                                        com.hazelcast.jet.test.SerialTest,com.hazelcast.jet.test.IgnoredForCoverage
                                     </excludedGroups>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
`test-coverage` profile did not run nightly test.

`LocalClusterElasticSourcesTest` in `elasticsearch-5` module is ignored for test coverage since it gets stuck in this configuration for some reason. We can investigate it deeper later.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
