### PR TITLE
Add windows-jenkins profile

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.impl.JetEvent;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import com.hazelcast.map.IMap;
 
 import javax.annotation.Nonnull;
@@ -30,10 +31,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.junit.experimental.categories.Category;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@Category({IgnoreOnJenkinsWindows.class})
 public class AbstractCdcIntegrationTest extends JetTestSupport {
 
     @Nonnull

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.jet.core.Processor;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.impl.JetEvent;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.map.IMap;
 
 import javax.annotation.Nonnull;
@@ -36,7 +36,7 @@ import org.junit.experimental.categories.Category;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Category({IgnoreOnJenkinsWindows.class})
+@Category({IgnoreInJenkinsOnWindows.class})
 public class AbstractCdcIntegrationTest extends JetTestSupport {
 
     @Nonnull

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.jet.cdc.mysql;
 
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import org.junit.Rule;
 import org.testcontainers.containers.MySQLContainer;
 
@@ -29,7 +29,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
-@Category({IgnoreOnJenkinsWindows.class})
+@Category({IgnoreInJenkinsOnWindows.class})
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Rule

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.cdc.mysql;
 
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import org.junit.Rule;
 import org.testcontainers.containers.MySQLContainer;
 
@@ -24,9 +25,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import org.junit.experimental.categories.Category;
 
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
+@Category({IgnoreOnJenkinsWindows.class})
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Rule

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.jet.cdc.postgres;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import org.junit.Rule;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -33,7 +33,7 @@ import org.junit.experimental.categories.Category;
 
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
-@Category({IgnoreOnJenkinsWindows.class})
+@Category({IgnoreInJenkinsOnWindows.class})
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Rule

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.cdc.postgres;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import org.junit.Rule;
 import org.testcontainers.containers.PostgreSQLContainer;
 
@@ -28,9 +29,11 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import org.junit.experimental.categories.Category;
 
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
+@Category({IgnoreOnJenkinsWindows.class})
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Rule

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -67,7 +68,7 @@ import static org.assertj.core.util.Lists.newArrayList;
  * Subclasses are free to cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, IgnoreOnJenkinsWindows.class})
 public abstract class BaseElasticTest {
 
     protected static final int BATCH_SIZE = 42;

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -68,7 +68,7 @@ import static org.assertj.core.util.Lists.newArrayList;
  * Subclasses are free to cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, IgnoreOnJenkinsWindows.class})
+@Category({NightlyTest.class, IgnoreInJenkinsOnWindows.class})
 public abstract class BaseElasticTest {
 
     protected static final int BATCH_SIZE = 42;

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -65,7 +66,7 @@ import static org.elasticsearch.client.RequestOptions.DEFAULT;
  * Subclasses are free to cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, IgnoreOnJenkinsWindows.class})
 public abstract class BaseElasticTest {
 
     protected static final int BATCH_SIZE = 42;

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -66,7 +66,7 @@ import static org.elasticsearch.client.RequestOptions.DEFAULT;
  * Subclasses are free to cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({NightlyTest.class, IgnoreOnJenkinsWindows.class})
+@Category({NightlyTest.class, IgnoreInJenkinsOnWindows.class})
 public abstract class BaseElasticTest {
 
     protected static final int BATCH_SIZE = 42;

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -22,7 +22,7 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -67,7 +67,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
  * Subclasses are free to cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({SerialTest.class, IgnoreOnJenkinsWindows.class})
+@Category({SerialTest.class, IgnoreInJenkinsOnWindows.class})
 public abstract class BaseElasticTest {
 
     protected static final int BATCH_SIZE = 42;

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/BaseElasticTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -66,7 +67,7 @@ import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
  * Subclasses are free to cache
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(SerialTest.class)
+@Category({SerialTest.class, IgnoreOnJenkinsWindows.class})
 public abstract class BaseElasticTest {
 
     protected static final int BATCH_SIZE = 42;

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
@@ -17,11 +17,11 @@
 package com.hazelcast.jet.hadoop.impl;
 
 import com.hazelcast.jet.SimpleTestInClusterSupport;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 
-@Category({IgnoreOnJenkinsWindows.class})
+@Category({IgnoreInJenkinsOnWindows.class})
 public abstract class HadoopTestSupport extends SimpleTestInClusterSupport {
 
     @Before

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/HadoopTestSupport.java
@@ -17,8 +17,11 @@
 package com.hazelcast.jet.hadoop.impl;
 
 import com.hazelcast.jet.SimpleTestInClusterSupport;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 
+@Category({IgnoreOnJenkinsWindows.class})
 public abstract class HadoopTestSupport extends SimpleTestInClusterSupport {
 
     @Before

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.s3.S3Sinks.S3SinkContext;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertEquals;
 import static software.amazon.awssdk.core.sync.ResponseTransformer.toInputStream;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({IgnoreOnJenkinsWindows.class})
+@Category({IgnoreInJenkinsOnWindows.class})
 public class S3MockTest extends S3TestBase {
 
     @ClassRule

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.jet.s3.S3Sinks.S3SinkContext;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -37,6 +38,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.experimental.categories.Category;
 
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -45,6 +47,7 @@ import static org.junit.Assert.assertEquals;
 import static software.amazon.awssdk.core.sync.ResponseTransformer.toInputStream;
 
 @RunWith(HazelcastSerialClassRunner.class)
+@Category({IgnoreOnJenkinsWindows.class})
 public class S3MockTest extends S3TestBase {
 
     @ClassRule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
@@ -17,7 +17,7 @@
 package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.function.SupplierEx;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 import org.junit.ClassRule;
@@ -26,7 +26,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 
 import javax.jms.ConnectionFactory;
 
-@Category({NightlyTest.class, IgnoreOnJenkinsWindows.class})
+@Category({NightlyTest.class, IgnoreInJenkinsOnWindows.class})
 public class JmsSourceIntegrationTest_RabbitMQ extends JmsSourceIntegrationTestBase {
 
     @ClassRule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/JmsSourceIntegrationTest_RabbitMQ.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.connector;
 
 import com.hazelcast.function.SupplierEx;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 import org.junit.ClassRule;
@@ -25,7 +26,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 
 import javax.jms.ConnectionFactory;
 
-@Category(NightlyTest.class)
+@Category({NightlyTest.class, IgnoreOnJenkinsWindows.class})
 public class JmsSourceIntegrationTest_RabbitMQ extends JmsSourceIntegrationTestBase {
 
     @ClassRule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -46,12 +47,14 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
+import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.jet.Util.entry;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+@Category({IgnoreOnJenkinsWindows.class})
 public class WriteJdbcPTest extends SimpleTestInClusterSupport {
 
     @ClassRule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/WriteJdbcPTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sink;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
-import com.hazelcast.jet.test.IgnoreOnJenkinsWindows;
+import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-@Category({IgnoreOnJenkinsWindows.class})
+@Category({IgnoreInJenkinsOnWindows.class})
 public class WriteJdbcPTest extends SimpleTestInClusterSupport {
 
     @ClassRule

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/IgnoreInJenkinsOnWindows.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/IgnoreInJenkinsOnWindows.java
@@ -21,5 +21,5 @@ package com.hazelcast.jet.test;
  * <p>
  * This is typically used for tests which use docker.
  */
-public interface IgnoreOnJenkinsWindows {
+public interface IgnoreInJenkinsOnWindows {
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/IgnoreOnJenkinsWindows.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/IgnoreOnJenkinsWindows.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.test;
+
+/**
+ * Category marker for the tests which should not be executed in windows profile on Jenkins.
+ * <p>
+ * This is typically used for tests which use docker.
+ */
+public interface IgnoreOnJenkinsWindows {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -617,7 +617,7 @@
                                 </goals>
                                 <configuration>
                                     <excludedGroups combine.self="override">
-                                        com.hazelcast.jet.test.IgnoreOnJenkinsWindows
+                                        com.hazelcast.jet.test.IgnoreInJenkinsOnWindows
                                     </excludedGroups>
                                 </configuration>
                             </execution>
@@ -628,7 +628,7 @@
                                 </goals>
                                 <configuration>
                                     <excludedGroups combine.self="override">
-                                        com.hazelcast.jet.test.IgnoreOnJenkinsWindows
+                                        com.hazelcast.jet.test.IgnoreInJenkinsOnWindows
                                     </excludedGroups>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -603,6 +603,41 @@
             </build>
         </profile>
         <profile>
+            <id>windows-jenkins</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>serial-tests</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludedGroups combine.self="override">
+                                        com.hazelcast.jet.test.IgnoreOnJenkinsWindows
+                                    </excludedGroups>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>regular-tests</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludedGroups combine.self="override">
+                                        com.hazelcast.jet.test.IgnoreOnJenkinsWindows
+                                    </excludedGroups>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>test-coverage</id>
             <build>
                 <plugins>


### PR DESCRIPTION
Introduce `windows-jenkins` which can be used for running test on our AWS windows machine from jenkins. Some notes:
- It runs all tests (common and nightly). 
- There is `IgnoreOnJenkinsWindows` category for tests which uses docker since our machine is not able to run them.
- There are some failures in `YamlJetConfigResolutionTest`. We should investigate them after merge once this profile will be available for jenkins job.

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated

