### PR TITLE
Fix serial tests in profile all

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,6 +539,9 @@
                                 <goals>
                                     <goal>test</goal>
                                 </goals>
+                                <configuration>
+                                    <skip combine.self="override">true</skip>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>regular-tests</id>
@@ -550,6 +553,7 @@
                                         ${argLine}
                                         -Dhazelcast.test.defaultTestTimeoutInSeconds=600
                                     </argLine>
+                                    <forkCount combine.self="override">1</forkCount>
                                     <excludedGroups combine.self="override" />
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Serial tests are executed in both `serial-tests` and `regular-tests` parts of `all` profile. Solution is to have only one execution in `all` profile (in the same way as it is for `nightly` profile).

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated