### PR TITLE
Fix WriteKafkaPTest.test_resumeTransaction failure

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/WriteKafkaPTest.java
@@ -264,10 +264,14 @@ public class WriteKafkaPTest extends SimpleTestInClusterSupport {
         producer.commitTransaction();
 
         // verify items are visible
-        polledRecords = consumer.poll(Duration.ofSeconds(2));
         StringBuilder actualContents = new StringBuilder();
-        for (ConsumerRecord<String, String> record : polledRecords) {
-            actualContents.append(record.value()).append('\n');
+        for (int receivedCount = 0; receivedCount < 2; ) {
+            polledRecords = consumer.poll(Duration.ofSeconds(2));
+            for (ConsumerRecord<String, String> record : polledRecords) {
+                actualContents.append(record.value()).append('\n');
+                receivedCount++;
+            }
+            logger.info("Received " + receivedCount + " records so far");
         }
         assertEquals("0\n1\n", actualContents.toString());
 


### PR DESCRIPTION
We waited for 2 seconds for the kafka to deliver the results, probably
it wasn't long enough. Also it could happen that we receive 1 record and
don't poll for the next, even though it wasn't the case this time.

An attempt to fix #2398
