### PR TITLE
Skip processing in-flight observable results when observer is cancelled

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/observer/ObservableImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/observer/ObservableImpl.java
@@ -216,6 +216,9 @@ public class ObservableImpl<T> implements Observable<T> {
 
                 for (int i = 0; i < result.size(); i++) {
                     try {
+                        if (cancelled) {
+                            return;
+                        }
                         onNewMessage(result.get(i));
                     } catch (Throwable t) {
                         logger.warning("Terminating message listener '" + id + "'. " +

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableResultsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/ObservableResultsTest.java
@@ -392,7 +392,7 @@ public class ObservableResultsTest extends TestInClusterSupport {
         testObservable.removeObserver(registrationId);
         //then
         int resultsSoFar = testObserver.getNoOfValues();
-        assertTrueAllTheTime(() -> assertEquals(resultsSoFar, testObserver.getNoOfValues()), 2);
+        assertTrueAllTheTime(() -> assertTrue(testObserver.getNoOfValues() <= resultsSoFar + 1), 2);
 
         job.cancel();
     }
@@ -419,7 +419,7 @@ public class ObservableResultsTest extends TestInClusterSupport {
         destroyedObservable.destroy();
         //then
         int resultsSoFar = otherTestObserver.getNoOfValues();
-        assertTrueAllTheTime(() -> assertEquals(resultsSoFar, otherTestObserver.getNoOfValues()), 2);
+        assertTrueAllTheTime(() -> assertTrue(otherTestObserver.getNoOfValues() <= resultsSoFar + 1), 2);
         job.cancel();
         assertError(otherTestObserver, null);
         assertCompletions(otherTestObserver, 0);


### PR DESCRIPTION
Cancelling an observable's listener was just setting a flag and not actually stopping any ongoing processing of previously received results. This fix improves the situation and also makes the test a bit more tolerant. 

Checklist
- [x] Tags Set
- [x] Milestone Set

Fixes #2415