### PR TITLE
Fix client config overriding by --targets option

### DIFF
--- a/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
+++ b/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
@@ -477,13 +477,15 @@ public class JetCommandLine implements Runnable {
             config.setClusterName(clusterName);
             return config;
         }
+
+        ClientConfig config = ConfigProvider.locateAndGetClientConfig();
         if (targetsMixin.getTargets() != null) {
-            ClientConfig config = new ClientConfig();
             config.getNetworkConfig().setAddresses(targetsMixin.getAddresses());
             config.setClusterName(targetsMixin.getClusterName());
             return config;
         }
-        return ConfigProvider.locateAndGetClientConfig();
+
+        return config;
     }
 
     private boolean isYaml() {

--- a/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
+++ b/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
@@ -98,8 +98,7 @@ public class JetCommandLine implements Runnable {
 
     @Option(names = {"-f", "--config"},
             description = "Optional path to a client config XML/YAML file." +
-                    " The default is to use config/hazelcast-client.yaml." +
-                    " If you set this option, Jet will ignore the --targets option.",
+                    " The default is to use config/hazelcast-client.yaml.",
             order = 0
     )
     private File config;
@@ -465,35 +464,37 @@ public class JetCommandLine implements Runnable {
     }
 
     private ClientConfig getClientConfig() throws IOException {
+        ClientConfig config;
         if (isYaml()) {
-            return new YamlClientConfigBuilder(config).build();
-        }
-        if (isConfigNotNull()) {
-            return new XmlClientConfigBuilder(config).build();
-        }
-        if (addresses != null) {
-            ClientConfig config = new ClientConfig();
-            config.getNetworkConfig().addAddress(addresses.toArray(new String[0]));
-            config.setClusterName(clusterName);
-            return config;
+            config = new YamlClientConfigBuilder(this.config).build();
+        } else if (isConfigFileNotNull()) {
+            config = new XmlClientConfigBuilder(this.config).build();
+        } else if (addresses != null) {
+            // Whole default configuration is ignored if addresses is provided.
+            // This doesn't make much sense, but but addresses is deprecated, so will leave as is until it can be
+            // removed in next major version
+            ClientConfig c = new ClientConfig();
+            c.getNetworkConfig().addAddress(addresses.toArray(new String[0]));
+            c.setClusterName(clusterName);
+            return c;
+        } else {
+            config = ConfigProvider.locateAndGetClientConfig();
         }
 
-        ClientConfig config = ConfigProvider.locateAndGetClientConfig();
         if (targetsMixin.getTargets() != null) {
             config.getNetworkConfig().setAddresses(targetsMixin.getAddresses());
             config.setClusterName(targetsMixin.getClusterName());
-            return config;
         }
 
         return config;
     }
 
     private boolean isYaml() {
-        return isConfigNotNull() &&
+        return isConfigFileNotNull() &&
                 (config.getPath().endsWith(".yaml") || config.getPath().endsWith(".yml"));
     }
 
-    private boolean isConfigNotNull() {
+    private boolean isConfigFileNotNull() {
         return config != null;
     }
 

--- a/hazelcast-jet-all/src/test/resources/com/hazelcast/jet/server/hazelcast-client-template.yaml
+++ b/hazelcast-jet-all/src/test/resources/com/hazelcast/jet/server/hazelcast-client-template.yaml
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 hazelcast-client:
-  cluster-name: ${group}
+  cluster-name: jet-test
 
   network:
     cluster-members:
-      - ${member}
+      - jet-test-member:5701
 
   client-labels:
     - yaml-label

--- a/hazelcast-jet-all/src/test/resources/com/hazelcast/jet/server/hazelcast-client-test.xml
+++ b/hazelcast-jet-all/src/test/resources/com/hazelcast/jet/server/hazelcast-client-test.xml
@@ -24,4 +24,7 @@
             <address>${member}</address>
         </cluster-members>
     </network>
+    <client-labels>
+        <label>xml-label</label>
+    </client-labels>
 </hazelcast-client>


### PR DESCRIPTION
Make --targets update only the relevant options (cluster name and address) of `hazelcast-client.yaml`.

Checklist
- [ ] Tags Set
- [ ] Milestone Set

Fixes #2373