### PR TITLE
Fix client.close() verification in Elastic sink test

### DIFF
--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticSinkBuilderTest.java
@@ -29,7 +29,10 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -39,14 +42,16 @@ public class ElasticSinkBuilderTest extends PipelineTestSupport {
 
     @Test
     public void when_writeToFailingSink_then_shouldCloseClient() throws IOException {
+        ClientHolder.elasticClients.clear();
 
         Sink<String> elasticSink = new ElasticSinkBuilder<>()
                 .clientFn(() -> {
                     RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
                     when(builder.build()).thenAnswer(invocation -> {
                         Object result = invocation.callRealMethod();
-                        ClientHolder.elasticClient = (RestClient) spy(result);
-                        return ClientHolder.elasticClient;
+                        RestClient client = (RestClient) spy(result);
+                        ClientHolder.elasticClients.add(client);
+                        return client;
                     });
                     return builder;
                 })
@@ -63,10 +68,12 @@ public class ElasticSinkBuilderTest extends PipelineTestSupport {
             // ignore - elastic is not running
         }
 
-        verify(ClientHolder.elasticClient).close();
+        for (RestClient client : ClientHolder.elasticClients) {
+            verify(client).close();
+        }
     }
 
     static class ClientHolder implements Serializable {
-        static RestClient elasticClient;
+        static Set<RestClient> elasticClients = Collections.synchronizedSet(new HashSet<>());
     }
 }

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -63,7 +63,9 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
 
         Sink<String> elasticSink = new ElasticSinkBuilder<>()
                 .clientFn(() -> {
-                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
+                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create(
+                            ElasticSupport.elastic.get().getHttpHostAddress()
+                    )));
                     when(builder.build()).thenAnswer(invocation -> {
                         Object result = invocation.callRealMethod();
                         RestClient client = (RestClient) spy(result);

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -19,7 +19,25 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.elastic.ElasticSinkBuilderTest.ClientHolder;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sink;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test running single Jet member locally and Elastic in docker
@@ -37,6 +55,36 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
     protected JetInstance createJetInstance() {
         // This starts very quickly, no need to cache the instance
         return factory.newMember(new JetConfig());
+    }
+
+    @Test
+    public void when_writeToSink_then_shouldCloseClient() throws IOException {
+        ClientHolder.elasticClients.clear();
+
+        Sink<String> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(() -> {
+                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
+                    when(builder.build()).thenAnswer(invocation -> {
+                        Object result = invocation.callRealMethod();
+                        RestClient client = (RestClient) spy(result);
+                        ClientHolder.elasticClients.add(client);
+                        return client;
+                    });
+                    return builder;
+                })
+                .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
+                .mapToRequestFn((String item) -> new IndexRequest("my-index", "document").source(Collections.emptyMap()))
+                .build();
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(TestSources.items("a", "b", "c"))
+         .writeTo(elasticSink);
+
+        jet.newJob(p).join();
+
+        for (RestClient client : ClientHolder.elasticClients) {
+            verify(client).close();
+        }
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -63,7 +63,9 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
 
         Sink<String> elasticSink = new ElasticSinkBuilder<>()
                 .clientFn(() -> {
-                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
+                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create(
+                            ElasticSupport.elastic.get().getHttpHostAddress()
+                    )));
                     when(builder.build()).thenAnswer(invocation -> {
                         Object result = invocation.callRealMethod();
                         RestClient client = (RestClient) spy(result);

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -19,7 +19,25 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.elastic.ElasticSinkBuilderTest.ClientHolder;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sink;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test running single Jet member locally and Elastic in docker
@@ -37,6 +55,36 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
     protected JetInstance createJetInstance() {
         // This starts very quickly, no need to cache the instance
         return factory.newMember(new JetConfig());
+    }
+
+    @Test
+    public void when_writeToSink_then_shouldCloseClient() throws IOException {
+        ClientHolder.elasticClients.clear();
+
+        Sink<String> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(() -> {
+                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
+                    when(builder.build()).thenAnswer(invocation -> {
+                        Object result = invocation.callRealMethod();
+                        RestClient client = (RestClient) spy(result);
+                        ClientHolder.elasticClients.add(client);
+                        return client;
+                    });
+                    return builder;
+                })
+                .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
+                .mapToRequestFn((String item) -> new IndexRequest("my-index", "document").source(Collections.emptyMap()))
+                .build();
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(TestSources.items("a", "b", "c"))
+         .writeTo(elasticSink);
+
+        jet.newJob(p).join();
+
+        for (RestClient client : ClientHolder.elasticClients) {
+            verify(client).close();
+        }
     }
 
 }

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -63,7 +63,9 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
 
         Sink<String> elasticSink = new ElasticSinkBuilder<>()
                 .clientFn(() -> {
-                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
+                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create(
+                            ElasticSupport.elastic.get().getHttpHostAddress()
+                    )));
                     when(builder.build()).thenAnswer(invocation -> {
                         Object result = invocation.callRealMethod();
                         RestClient client = (RestClient) spy(result);

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/LocalElasticSinkTest.java
@@ -19,7 +19,25 @@ package com.hazelcast.jet.elastic;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.elastic.ElasticSinkBuilderTest.ClientHolder;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sink;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
 import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test running single Jet member locally and Elastic in docker
@@ -37,6 +55,36 @@ public class LocalElasticSinkTest extends CommonElasticSinksTest {
     protected JetInstance createJetInstance() {
         // This starts very quickly, no need to cache the instance
         return factory.newMember(new JetConfig());
+    }
+
+    @Test
+    public void when_writeToSink_then_shouldCloseClient() throws IOException {
+        ClientHolder.elasticClients.clear();
+
+        Sink<String> elasticSink = new ElasticSinkBuilder<>()
+                .clientFn(() -> {
+                    RestClientBuilder builder = spy(RestClient.builder(HttpHost.create("localhost:9200")));
+                    when(builder.build()).thenAnswer(invocation -> {
+                        Object result = invocation.callRealMethod();
+                        RestClient client = (RestClient) spy(result);
+                        ClientHolder.elasticClients.add(client);
+                        return client;
+                    });
+                    return builder;
+                })
+                .bulkRequestFn(() -> new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE))
+                .mapToRequestFn((String item) -> new IndexRequest("my-index").source(Collections.emptyMap()))
+                .build();
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(TestSources.items("a", "b", "c"))
+         .writeTo(elasticSink);
+
+        jet.newJob(p).join();
+
+        for (RestClient client : ClientHolder.elasticClients) {
+            verify(client).close();
+        }
     }
 
 }


### PR DESCRIPTION
The default parallelism for the Sink is 2, so 2 clients are created.
The ClientHolder in the test stored only one of the 2 clients created.
Sometimes the same client instance is returned for both threads,
causing the issue #2427.

This commit changes so all clients are stored in the holder and verified.

Also adds a test for closing the client in a non-failing Sink.

Fixes #2427

Checklist
- [x] Tags Set
- [x] Milestone Set
