### PR TITLE
Add ElasticClients#client(java.lang.String) convenience method 

### DIFF
--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -63,10 +63,11 @@ public final class ElasticClients {
      * http://elastic-host:9200}</pre>
      *
      * @see HttpHost#create(String)
+     * @since 4.3
      */
     @Nonnull
-    public static RestClientBuilder client(@Nonnull String s) {
-        return RestClient.builder(HttpHost.create(s));
+    public static RestClientBuilder client(@Nonnull String location) {
+        return RestClient.builder(HttpHost.create(location));
     }
 
     /**

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -54,6 +54,22 @@ public final class ElasticClients {
     }
 
     /**
+     * Convenience method to create {@link RestClientBuilder} with given string, it must contain host, and optionally
+     * the scheme and a port.
+     *
+     * Valid examples:
+     * <pre>{@code elastic-host
+     * elastic-host:9200
+     * http://elastic-host:9200}</pre>
+     *
+     * @see HttpHost#create(String)
+     */
+    @Nonnull
+    public static RestClientBuilder client(@Nonnull String s) {
+        return RestClient.builder(HttpHost.create(s));
+    }
+
+    /**
      * Convenience method to create {@link RestClientBuilder} with given
      * hostname and port
      */

--- a/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSources.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/main/java/com/hazelcast/jet/elastic/ElasticSources.java
@@ -52,7 +52,8 @@ public final class ElasticSources {
      */
     @Nonnull
     public static BatchSource<String> elastic() {
-        return elastic(ElasticClients::client);
+        SupplierEx<RestClientBuilder> client = ElasticClients::client;
+        return elastic(client);
     }
 
     /**

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import com.google.common.collect.ImmutableMap;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import org.elasticsearch.search.SearchHit;
+import org.junit.After;
+import org.junit.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElasticClientsTest extends BaseElasticTest {
+
+    private final JetTestInstanceFactory factory = new JetTestInstanceFactory();
+
+    @After
+    public void afterClass() throws Exception {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected JetInstance createJetInstance() {
+        return factory.newMember(new JetConfig());
+    }
+
+    @Test
+    public void given_clientAsString_whenReadFromElasticSource_thenFinishSuccessfully() {
+        ElasticsearchContainer container = ElasticSupport.elastic.get();
+        String httpHostAddress = container.getHttpHostAddress();
+
+        indexDocument("my-index", ImmutableMap.of("name", "Frantisek"));
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(ElasticSources.elastic(
+                () -> ElasticClients.client(httpHostAddress),
+                SearchHit::getSourceAsString)
+        ).writeTo(Sinks.list(results));
+
+        submitJob(p);
+
+        assertThat(results).hasSize(1);
+    }
+
+}

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -63,10 +63,11 @@ public final class ElasticClients {
      * http://elastic-host:9200}</pre>
      *
      * @see HttpHost#create(String)
+     * @since 4.3
      */
     @Nonnull
-    public static RestClientBuilder client(@Nonnull String s) {
-        return RestClient.builder(HttpHost.create(s));
+    public static RestClientBuilder client(@Nonnull String location) {
+        return RestClient.builder(HttpHost.create(location));
     }
 
     /**

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -54,6 +54,22 @@ public final class ElasticClients {
     }
 
     /**
+     * Convenience method to create {@link RestClientBuilder} with given string, it must contain host, and optionally
+     * the scheme and a port.
+     *
+     * Valid examples:
+     * <pre>{@code elastic-host
+     * elastic-host:9200
+     * http://elastic-host:9200}</pre>
+     *
+     * @see HttpHost#create(String)
+     */
+    @Nonnull
+    public static RestClientBuilder client(@Nonnull String s) {
+        return RestClient.builder(HttpHost.create(s));
+    }
+
+    /**
      * Convenience method to create {@link RestClientBuilder} with given
      * hostname and port
      */

--- a/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticSources.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/main/java/com/hazelcast/jet/elastic/ElasticSources.java
@@ -52,7 +52,8 @@ public final class ElasticSources {
      */
     @Nonnull
     public static BatchSource<String> elastic() {
-        return elastic(ElasticClients::client);
+        SupplierEx<RestClientBuilder> client = ElasticClients::client;
+        return elastic(client);
     }
 
     /**

--- a/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
+++ b/extensions/elasticsearch/elasticsearch-6/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import com.google.common.collect.ImmutableMap;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import org.elasticsearch.search.SearchHit;
+import org.junit.After;
+import org.junit.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElasticClientsTest extends BaseElasticTest {
+
+    private final JetTestInstanceFactory factory = new JetTestInstanceFactory();
+
+    @After
+    public void afterClass() throws Exception {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected JetInstance createJetInstance() {
+        return factory.newMember(new JetConfig());
+    }
+
+    @Test
+    public void given_clientAsString_whenReadFromElasticSource_thenFinishSuccessfully() {
+        ElasticsearchContainer container = ElasticSupport.elastic.get();
+        String httpHostAddress = container.getHttpHostAddress();
+
+        indexDocument("my-index", ImmutableMap.of("name", "Frantisek"));
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(ElasticSources.elastic(
+                () -> ElasticClients.client(httpHostAddress),
+                SearchHit::getSourceAsString)
+        ).writeTo(Sinks.list(results));
+
+        submitJob(p);
+
+        assertThat(results).hasSize(1);
+    }
+
+}

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -63,10 +63,11 @@ public final class ElasticClients {
      * http://elastic-host:9200}</pre>
      *
      * @see HttpHost#create(String)
+     * @since 4.3
      */
     @Nonnull
-    public static RestClientBuilder client(@Nonnull String s) {
-        return RestClient.builder(HttpHost.create(s));
+    public static RestClientBuilder client(@Nonnull String location) {
+        return RestClient.builder(HttpHost.create(location));
     }
 
     /**

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticClients.java
@@ -54,6 +54,22 @@ public final class ElasticClients {
     }
 
     /**
+     * Convenience method to create {@link RestClientBuilder} with given string, it must contain host, and optionally
+     * the scheme and a port.
+     *
+     * Valid examples:
+     * <pre>{@code elastic-host
+     * elastic-host:9200
+     * http://elastic-host:9200}</pre>
+     *
+     * @see HttpHost#create(String)
+     */
+    @Nonnull
+    public static RestClientBuilder client(@Nonnull String s) {
+        return RestClient.builder(HttpHost.create(s));
+    }
+
+    /**
      * Convenience method to create {@link RestClientBuilder} with given
      * hostname and port
      */

--- a/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSources.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/main/java/com/hazelcast/jet/elastic/ElasticSources.java
@@ -52,7 +52,8 @@ public final class ElasticSources {
      */
     @Nonnull
     public static BatchSource<String> elastic() {
-        return elastic(ElasticClients::client);
+        SupplierEx<RestClientBuilder> client = ElasticClients::client;
+        return elastic(client);
     }
 
     /**

--- a/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
+++ b/extensions/elasticsearch/elasticsearch-7/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Hazelcast Inc.
+ *
+ * Licensed under the Hazelcast Community License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://hazelcast.com/hazelcast-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.elastic;
+
+import com.google.common.collect.ImmutableMap;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.JetTestInstanceFactory;
+import com.hazelcast.jet.config.JetConfig;
+import com.hazelcast.jet.pipeline.Pipeline;
+import com.hazelcast.jet.pipeline.Sinks;
+import org.elasticsearch.search.SearchHit;
+import org.junit.After;
+import org.junit.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElasticClientsTest extends BaseElasticTest {
+
+    private final JetTestInstanceFactory factory = new JetTestInstanceFactory();
+
+    @After
+    public void afterClass() throws Exception {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected JetInstance createJetInstance() {
+        return factory.newMember(new JetConfig());
+    }
+
+    @Test
+    public void given_clientAsString_whenReadFromElasticSource_thenFinishSuccessfully() {
+        ElasticsearchContainer container = ElasticSupport.elastic.get();
+        String httpHostAddress = container.getHttpHostAddress();
+
+        indexDocument("my-index", ImmutableMap.of("name", "Frantisek"));
+
+        Pipeline p = Pipeline.create();
+        p.readFrom(ElasticSources.elastic(
+                () -> ElasticClients.client(httpHostAddress),
+                SearchHit::getSourceAsString)
+        ).writeTo(Sinks.list(results));
+
+        submitJob(p);
+
+        assertThat(results).hasSize(1);
+    }
+}


### PR DESCRIPTION
Takes host and optional scheme and port. Came up during the CDC/Elastic example. This is what most users most likely want to use.