### PR TITLE
[005] Upgrade Jackson jr version to get rid of null value bug

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/RecordPart.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/RecordPart.java
@@ -41,13 +41,7 @@ public interface RecordPart {
      * href="https://github.com/FasterXML/jackson-jr/tree/master/jr-annotation-support">
      * annotation support</a>, so the supplied class can be annotated accordingly.
      * <p>
-     * Note: there is a bug in jackson-jr's object mapping, where it doesn't
-     * handle fields of type {@code Date} properly, if they are nullable.
-     * The null values trigger exceptions and failure in the object mapping code.
-     * <p>
-     * This can be overcome via following trick, which in fact could come
-     * in handy in many other situations.
-     * <p>
+     * Note: there is a neat trick for converting types during object mapping.
      * Let's say we have a {@code birth_date} column in a table of type
      * {@code DATE} and we want to map it to a field named {@code birthDate}
      * in our row object, of type {@code LocalDate}. We would write

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/JsonUtilTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/util/JsonUtilTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -201,6 +202,16 @@ public class JsonUtilTest extends JetTestSupport {
         assertIteratorObject(iterator, 20);
     }
 
+    @Test
+    public void when_mappingToObject_then_nullFieldsHandledProperly() throws IOException {
+        long currentTimeMillis = System.currentTimeMillis();
+        Birthdate birthdate1 = JsonUtil.beanFrom("{ \"date\" : " + currentTimeMillis + "  }", Birthdate.class);
+        assertEquals(new Date(currentTimeMillis), birthdate1.date);
+
+        Birthdate birthdate2 = JsonUtil.beanFrom("{ \"date\" : null }", Birthdate.class);
+        assertNull(birthdate2.date);
+    }
+
     private void assertIteratorObject(Iterator<TestJsonObject> iterator, int expectedCount) {
         int count = 0;
         while (iterator.hasNext()) {
@@ -300,7 +311,6 @@ public class JsonUtilTest extends JetTestSupport {
         }
     }
 
-
     public static class InnerTestJsonObject {
 
         public String val;
@@ -364,6 +374,10 @@ public class JsonUtilTest extends JetTestSupport {
             return Objects.hash(username, userage);
         }
 
+    }
+
+    public static class Birthdate {
+        public Date date;
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <protobuf.version>3.12.2</protobuf.version>
         <picocli.version>3.9.0</picocli.version>
         <classgraph.version>4.8.66</classgraph.version>
-        <jackson.jr.version>2.11.0</jackson.jr.version>
+        <jackson.jr.version>2.11.2</jackson.jr.version>
         <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
 
         <!-- test dependencies -->


### PR DESCRIPTION
When doing object mapping from JSON for CDC we've noticed that there is a problem with null values not being handled properly by Jackson jr (used by our JSON convenience code). This is the issue that has been submitted to them: https://github.com/FasterXML/jackson-jr/issues/73. They have fixed the problem and now we need to upgrade to the fixed version. That's what this PR does.

Checklist
- [x] Tags Set
- [x] Milestone Set