### PR TITLE
Increase timeout in JobRestartWithSnapshotTest.when_nodeDown_then_jobRestartsFromSnapshot

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -267,7 +267,7 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
             JobExecutionRecord record = jr.getJobExecutionRecord(jobId);
             assertNotNull("jobExecutionRecord is null", record);
             snapshotId[0] = record.snapshotId();
-            assertTrue("No more snapshots produced after restart in " + timeoutSeconds + " seconds",
+            assertTrue("No more snapshots produced in " + timeoutSeconds + " seconds",
                     snapshotId[0] > originalSnapshotId);
             assertTrue("stats are 0", allowEmptySnapshot || record.snapshotStats().numBytes() > 0);
         }, timeoutSeconds);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -199,7 +199,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         Job job = instance1.newJob(dag, config);
 
         JobRepository jobRepository = new JobRepository(instance1);
-        int timeout = (int) (MILLISECONDS.toSeconds(config.getSnapshotIntervalMillis() * 3) + 2);
+        int timeout = (int) (MILLISECONDS.toSeconds(config.getSnapshotIntervalMillis() * 7) + 2);
 
         waitForFirstSnapshot(jobRepository, job.getId(), timeout, false);
         waitForNextSnapshot(jobRepository, job.getId(), timeout, false);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobRestartWithSnapshotTest.java
@@ -199,7 +199,7 @@ public class JobRestartWithSnapshotTest extends JetTestSupport {
         Job job = instance1.newJob(dag, config);
 
         JobRepository jobRepository = new JobRepository(instance1);
-        int timeout = (int) (MILLISECONDS.toSeconds(config.getSnapshotIntervalMillis() * 7) + 2);
+        int timeout = (int) (MILLISECONDS.toSeconds(config.getSnapshotIntervalMillis() * 3) + 8);
 
         waitForFirstSnapshot(jobRepository, job.getId(), timeout, false);
         waitForNextSnapshot(jobRepository, job.getId(), timeout, false);


### PR DESCRIPTION
The test waits for a snapshot. The snapshot was proceeding correctly but slowly, causing the test to fail.

Checklist
- [x] Tags Set
- [x] Milestone Set

Fixes #2450 
