### PR TITLE
Decrease the itemsPerSecond from 1_000 to 250 in test_longStream.

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/test/TestSourcesTest.java
@@ -51,7 +51,7 @@ public class TestSourcesTest extends PipelineTestSupport {
 
     @Test
     public void test_longStream() throws Throwable {
-        int itemsPerSecond = 1_000;
+        int itemsPerSecond = 250;
         int timeoutSeconds = 10;
         int numWindowResultsToWaitFor = 3;
 


### PR DESCRIPTION
When Jenkins slowed down, tests are failed with this many items. I reduced its number.

Checklist
- [x] Tags Set
- [x] Milestone Set

Links to issues fixed (if any):

Fixes #2477 
