### PR TITLE
Limit all ES 5 tests to `my-index`

### DIFF
--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/CommonElasticSourcesTest.java
@@ -101,6 +101,7 @@ public abstract class CommonElasticSourcesTest extends BaseElasticTest {
 
         BatchSource<String> source = ElasticSources.elastic(
                 elasticClientSupplier(),
+                () -> new SearchRequest("my-index"),
                 hit -> (String) hit.getSourceAsMap().get("name")
         );
 

--- a/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
+++ b/extensions/elasticsearch/elasticsearch-5/src/test/java/com/hazelcast/jet/elastic/ElasticClientsTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.JetTestInstanceFactory;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
+import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.search.SearchHit;
 import org.junit.After;
 import org.junit.Test;
@@ -53,6 +54,7 @@ public class ElasticClientsTest extends BaseElasticTest {
         Pipeline p = Pipeline.create();
         p.readFrom(ElasticSources.elastic(
                 () -> ElasticClients.client(httpHostAddress),
+                () -> new SearchRequest("my-index"),
                 SearchHit::getSourceAsString)
         ).writeTo(Sinks.list(results));
 


### PR DESCRIPTION
Some tests used empty SearchRequests, which searches in whole ES instance.
ES 5.6.x creates an index with monitoring events after it runs for around half a minute.
These documents then appeared in search results causing the test to fail.
Limiting the search request to `my-index` fetches only the required results.

Fixes #2486.
