### PR TITLE
Increase timeout for OperationLossTest

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -31,9 +31,11 @@ import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.spi.properties.ClusterProperty;
 import com.hazelcast.test.PacketFiltersUtil;
+import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.util.concurrent.CancellationException;
 
@@ -52,6 +54,7 @@ import static org.junit.Assert.assertNotNull;
 
 // TODO this test does not test when responses are lost. There is currently no test
 //   harness to simulate that.
+@Category(NightlyTest.class)
 public class OperationLossTest extends SimpleTestInClusterSupport {
 
     @BeforeClass

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/OperationLossTest.java
@@ -57,7 +57,7 @@ public class OperationLossTest extends SimpleTestInClusterSupport {
     @BeforeClass
     public static void beforeClass() {
         JetConfig config = new JetConfig();
-        config.getHazelcastConfig().setProperty(ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "1000");
+        config.getHazelcastConfig().setProperty(ClusterProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "2000");
 
         initialize(2, config);
     }


### PR DESCRIPTION
Fixes #2498

The change unfortunately makes the test run more slowly, from 25s to 37s locally. Can't make the test parallel because it uses `TestProcessors` which use static variables (also the logs would mess up).