### PR TITLE
Fix handling of late snapshot responses

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJobProxy.java
@@ -71,9 +71,7 @@ public abstract class AbstractJobProxy<T> implements Job {
     }
 
     AbstractJobProxy(T container, long jobId, DAG dag, JobConfig config) {
-        this.jobId = jobId;
-        this.container = container;
-        this.logger = loggingService().getLogger(Job.class);
+        this(container, jobId);
 
         try {
             doSubmitJob(dag, config);


### PR DESCRIPTION
Fixes #2487

Scenario:

- The current successful snapshot is 10.

- The master started snapshot 11 phase 1. The (only) member executed it,
but before the master handled the phase1 response, the job was
forcefully restarted.

- The master restarted the job. Handling of the phase1 response was
blocked due to synchronization in MasterContext.

- The master started the job and was about to restore state from
snapshot 10.

- The response for snapshot 11 phase 1 was handled by the master. It was
a success response so the master stored it and cleared the snapshot map
for snapshot 10.

- "snapshot doesn't exist or is damaged" error was thrown because the
restoration from snapshot 10 still didn't begin.

This issue went unnoticed for a long time because there was partial
handling for it: even though we submitted phase2 for snapshot 10, the
members ignored it because it was for a different execution. However, in
the process, we cleared the snapshot map for the previous snapshot,
which would be unnoticed only if we actually tried to restore from it.
Happens only with a forceful restart, but this API isn't available to
the user, it only happens if some member is forcefully terminated, in
which case the late response is likely to not contain a success.

We don't add a test for this situation because we don't have a harness
to control when a snapshot response is sent.
