### PR TITLE
Fix race in Job.getStatus()

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -616,10 +616,6 @@ public class MasterJobContext {
                 }
                 completeVertices(failure);
 
-                // reset state for the next execution
-                boolean wasCancelled = isCancelled();
-                requestedTerminationMode = null;
-                executionFailureCallback = null;
                 ActionAfterTerminate terminationModeAction = failure instanceof JobTerminateRequestedException
                         ? ((JobTerminateRequestedException) failure).mode().actionAfterTerminate() : null;
                 mc.snapshotContext().onExecutionTerminated();
@@ -628,20 +624,20 @@ public class MasterJobContext {
                 if (terminationModeAction == RESTART) {
                     mc.setJobStatus(NOT_RUNNING);
                     nonSynchronizedAction = () -> mc.coordinationService().restartJob(mc.jobId());
-                } else if (!wasCancelled && isRestartableException(failure) && mc.jobConfig().isAutoScaling()) {
+                } else if (!isCancelled() && isRestartableException(failure) && mc.jobConfig().isAutoScaling()) {
                     // if restart is due to a failure, schedule a restart after a delay
                     scheduleRestart();
                     nonSynchronizedAction = NO_OP;
                 } else if (terminationModeAction == SUSPEND
                         || isRestartableException(failure)
-                        && !wasCancelled
+                        && !isCancelled()
                         && !mc.jobConfig().isAutoScaling()
                         && mc.jobConfig().getProcessingGuarantee() != NONE
                 ) {
                     mc.setJobStatus(SUSPENDED);
                     mc.jobExecutionRecord().setSuspended("Requested by user");
                     nonSynchronizedAction = () -> mc.writeJobExecutionRecord(false);
-                } else if (failure != null && !wasCancelled && mc.jobConfig().isSuspendOnFailure()) {
+                } else if (failure != null && !isCancelled() && mc.jobConfig().isSuspendOnFailure()) {
                     mc.setJobStatus(SUSPENDED);
                     mc.jobExecutionRecord().setSuspended("Execution failure:\n" +
                             ExceptionUtil.stackTraceToString(failure));
@@ -652,19 +648,22 @@ public class MasterJobContext {
                         logger.fine("Cancelling job " + mc.jobIdString() + " locally: member (local or remote) reset. " +
                                 "We don't delete job metadata: job will restart on majority cluster");
                         setFinalResult(new CancellationException());
-                        return;
+                    } else {
+                        mc.coordinationService()
+                          .completeJob(mc, failure)
+                          .whenComplete(withTryCatch(logger, (r, f) -> {
+                              if (f != null) {
+                                  logger.warning("Completion of " + mc.jobIdString() + " failed", f);
+                              } else {
+                                  setFinalResult(failure);
+                              }
+                          }));
                     }
-                    mc.coordinationService()
-                      .completeJob(mc, failure)
-                      .whenComplete(withTryCatch(logger, (r, f) -> {
-                          if (f != null) {
-                              logger.warning("Completion of " + mc.jobIdString() + " failed", f);
-                          } else {
-                              setFinalResult(failure);
-                          }
-                      }));
                     nonSynchronizedAction = NO_OP;
                 }
+                // reset the state for the next execution
+                requestedTerminationMode = null;
+                executionFailureCallback = null;
             } finally {
                 mc.unlock();
             }


### PR DESCRIPTION
The job status was reported as `RUNNING` briefly while the `finalizeJob`
method was running. The `COMPLETING` state is actually never set to
`MasterContext.jobStatus`. It is only calculated in
`JobCoordinationService.getJobStatus()` if the status is `RUNNING`, but
the execution has been terminated. However, we've assigned `null` to
`requestedTerminationMode` before setting `jobStatus` to something else
than `RUNNING`.

The fix is to set the `jobStatus` before clearing the
`requestedTerminationMode`.
