### PR TITLE
Fix the issue that some jobs cannot be sent to cluster.

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetBootstrap.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JetBootstrap.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.impl.util.ConcurrentMemoizingSupplier;
 import com.hazelcast.jet.impl.util.JetConsoleLogHandler;
+import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
@@ -253,8 +254,18 @@ public final class JetBootstrap {
         }
 
         @Nonnull @Override
+        public Job newJob(@Nonnull Pipeline pipeline, @Nonnull JobConfig config) {
+            return instance.newJob(pipeline, updateJobConfig(config));
+        }
+
+        @Nonnull @Override
         public Job newJob(@Nonnull DAG dag, @Nonnull JobConfig config) {
             return instance.newJob(dag, updateJobConfig(config));
+        }
+
+        @Nonnull @Override
+        public Job newJobIfAbsent(@Nonnull Pipeline pipeline, @Nonnull JobConfig config) {
+            return instance.newJobIfAbsent(pipeline, updateJobConfig(config));
         }
 
         @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalFlatMapStatefulTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalFlatMapStatefulTransform.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.pipeline.transform;
 
+import com.hazelcast.function.SupplierEx;
 import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.Traverser;
 import com.hazelcast.jet.function.TriFunction;
@@ -24,20 +25,19 @@ import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.util.ConstantFunctionEx;
 
 import javax.annotation.Nonnull;
-import java.util.function.Supplier;
 
 import static com.hazelcast.jet.core.processor.Processors.flatMapStatefulP;
 
 public class GlobalFlatMapStatefulTransform<T, S, R> extends AbstractTransform {
 
     private final ToLongFunctionEx<? super T> timestampFn;
-    private final Supplier<? extends S> createFn;
+    private final SupplierEx<? extends S> createFn;
     private final TriFunction<? super S, Object, ? super T, ? extends Traverser<R>> statefulFlatMapFn;
 
     public GlobalFlatMapStatefulTransform(
             @Nonnull Transform upstream,
             @Nonnull ToLongFunctionEx<? super T> timestampFn,
-            @Nonnull Supplier<? extends S> createFn,
+            @Nonnull SupplierEx<? extends S> createFn,
             @Nonnull TriFunction<? super S, Object, ? super T, ? extends Traverser<R>> statefulFlatMapFn
     ) {
         super("flatmap-stateful-global", upstream);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalMapStatefulTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/GlobalMapStatefulTransform.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.pipeline.transform;
 
+import com.hazelcast.function.SupplierEx;
 import com.hazelcast.function.ToLongFunctionEx;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.impl.pipeline.Planner;
@@ -23,20 +24,19 @@ import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import com.hazelcast.jet.impl.util.ConstantFunctionEx;
 
 import javax.annotation.Nonnull;
-import java.util.function.Supplier;
 
 import static com.hazelcast.jet.core.processor.Processors.mapStatefulP;
 
 public class GlobalMapStatefulTransform<T, S, R> extends AbstractTransform {
 
     private final ToLongFunctionEx<? super T> timestampFn;
-    private final Supplier<? extends S> createFn;
+    private final SupplierEx<? extends S> createFn;
     private final TriFunction<? super S, Object, ? super T, ? extends R> statefulMapFn;
 
     public GlobalMapStatefulTransform(
             @Nonnull Transform upstream,
             @Nonnull ToLongFunctionEx<? super T> timestampFn,
-            @Nonnull Supplier<? extends S> createFn,
+            @Nonnull SupplierEx<? extends S> createFn,
             @Nonnull TriFunction<? super S, Object, ? super T, ? extends R> statefulMapFn
     ) {
         super("map-stateful-global", upstream);


### PR DESCRIPTION
- Add missing newJob(Pipeline, JobConfig) and newJobIfAbsent(Pipeline, JobConfig) methods to JetBootstrap. Because of these missing methods, we do not add the class definitions in the jar to JobConfig and that was causing us to get ClassCastException.

- Extra: Converted two forgotten non-serializable functions to serializable.

Checklist
- [x] Tags Set
- [x] Milestone Set

Links to issues fixed (if any): 

Fixes #2510 

