### PR TITLE
Change Evergreen Cache tutorial to proper CDC sink

### DIFF
--- a/site/website/blog/2020-07-16-designing-evergreen-cache-cdc.md
+++ b/site/website/blog/2020-07-16-designing-evergreen-cache-cdc.md
@@ -206,7 +206,7 @@ data, depending on the underlying disk technology.
 [Hazelcast Jet](https://jet-start.sh/) is a distributed stream
 processing framework built on Hazelcast and combines a cache with
 fault-tolerant data processing. It has sources and sinks to integrate
-with various file-, messaging- and database systems (such as Amazon S3,
+with various file, messaging and database systems (such as Amazon S3,
 Kafka, message brokers and relational databases).
 
 Jet also provides a Debezium module where it can process change events
@@ -285,9 +285,11 @@ pipeline.readFrom(source)                                       //1
 4. Client configuration so it can connect to the right host, cluster
 and instance
 
-5. Provide mapping from `ChangeRecord` to cache key
+5. Provide a mapping function to extract the cache key from the
+`ChangeRecord`
 
-6. Provide mapping from `ChangeRecord` to cache value (`Person` POJO)
+6. Provide a mapping function to extract the cache value (`Person` POJO)
+from the `ChangeRecord`
 
 ```java
 public class CustomClientConfig extends ClientConfig {

--- a/site/website/blog/2020-07-16-designing-evergreen-cache-cdc.md
+++ b/site/website/blog/2020-07-16-designing-evergreen-cache-cdc.md
@@ -205,14 +205,16 @@ data, depending on the underlying disk technology.
 
 [Hazelcast Jet](https://jet-start.sh/) is a distributed stream
 processing framework built on Hazelcast and combines a cache with
-fault-tolerant data processing. It has sources and sinks to integrate
+fault-tolerant data processing.
+It has sources and sinks to integrate
 with various file, messaging and database systems (such as Amazon S3,
 Kafka, message brokers and relational databases).
 
 Jet also provides a Debezium module where it can process change events
 directly from the database and write them to its distributed key-value
-store. This avoids having to write the intermediate messages to Kafka
-and then read again to be written to a separate cache.
+store.
+This avoids having to write the intermediate messages to Kafka and then
+read again to be written to a separate cache.
 
 ## Putting it all together
 
@@ -278,7 +280,7 @@ pipeline.readFrom(source)                                       //1
 
 1. Get a stream of Jet `ChangeRecord` items
 
-2. Create the sink to write to, a remote map
+2. Create the sink to write to a remote map
 
 3. Name of the remote map
 

--- a/site/website/blog/2020-07-16-designing-evergreen-cache-cdc.md
+++ b/site/website/blog/2020-07-16-designing-evergreen-cache-cdc.md
@@ -206,9 +206,9 @@ data, depending on the underlying disk technology.
 [Hazelcast Jet](https://jet-start.sh/) is a distributed stream
 processing framework built on Hazelcast and combines a cache with
 fault-tolerant data processing.
-It has sources and sinks to integrate
-with various file, messaging and database systems (such as Amazon S3,
-Kafka, message brokers and relational databases).
+It has sources and sinks to integrate with various file, messaging and
+database systems (such as Amazon S3, Kafka, message brokers and
+relational databases).
 
 Jet also provides a Debezium module where it can process change events
 directly from the database and write them to its distributed key-value


### PR DESCRIPTION
There are other changes backing these on the [Evergreen Cache repo's `fix-sink` branch](https://github.com/hazelcast-demos/evergreen-cache/tree/fix-sink), but I will keep those away from the `master` branch until merging this in, so the Blog and backing codebase remain in sync.