### PR TITLE
Disable access to external entities in XML parsing

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfigXmlGenerator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfigXmlGenerator.java
@@ -29,6 +29,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.StringReader;
 import java.io.StringWriter;
+import javax.xml.XMLConstants;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 
@@ -88,6 +89,8 @@ public final class JetConfigXmlGenerator {
             Source xmlInput = new StreamSource(new StringReader(input));
             xmlOutput = new StreamResult(new StringWriter());
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             /*
              * Older versions of Xalan still use this method of setting indent values.
              * Attempt to make this work but don't completely fail if it's a problem.


### PR DESCRIPTION
Found by analysis in Sonar - https://sonarcloud.io/organizations/devopshazelcast-github/rules?open=java%3AS2755&rule_key=java%3AS2755

Checklist
- [x] Tags Set
- [x] Milestone Set
- [N/A] Any breaking changes are documented
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] For code samples, code sample main readme is updated
