### PR TITLE
Convert JetCommandLineTest to serial

### DIFF
--- a/hazelcast-jet-all/src/test/java/com/hazelcast/jet/server/JetCommandLineTest.java
+++ b/hazelcast-jet-all/src/test/java/com/hazelcast/jet/server/JetCommandLineTest.java
@@ -30,7 +30,7 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.Sources;
 import com.hazelcast.map.IMap;
-import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -61,7 +61,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(HazelcastParallelClassRunner.class)
+@RunWith(HazelcastSerialClassRunner.class)
 public class JetCommandLineTest extends JetTestSupport {
 
     private static final String SOURCE_NAME = "source";


### PR DESCRIPTION
The test `test_targets_after_command_and_configuration_from_default_config_together` creates a client config which is picked up by other tests if run parallel. There are also other test failures in this class which can be avoided if the tests run serial.

Checklist
- [X] Tags Set
- [X] Milestone Set
- [NA] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #2470

List of breaking changes:

* ..
