### PR TITLE
Fix job hanging due to lost DONE_ITEM

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobRepository.java
@@ -401,8 +401,8 @@ public class JobRepository {
      */
     void deleteJob(long jobId) {
         // delete the job record and related records
-        jobExecutionRecords.remove(jobId);
-        jobRecords.remove(jobId);
+        jobExecutionRecords.delete(jobId);
+        jobRecords.delete(jobId);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/Networking.java
@@ -138,8 +138,9 @@ public class Networking {
             output.writeInt(executionContexts.size());
             for (Entry<Long, ExecutionContext> entry : executionContexts.entrySet()) {
                 output.writeLong(entry.getKey()); // executionId
-                output.writeInt(entry.getValue().receiverMap().values().stream().mapToInt(Map::size).sum());
-                for (Entry<Integer, Map<Integer, Map<Address, ReceiverTasklet>>> e : entry.getValue().receiverMap().entrySet()) {
+                Map<Integer, Map<Integer, Map<Address, ReceiverTasklet>>> receiverMap = entry.getValue().receiverMap();
+                output.writeInt(receiverMap.values().stream().mapToInt(Map::size).sum());
+                for (Entry<Integer, Map<Integer, Map<Address, ReceiverTasklet>>> e : receiverMap.entrySet()) {
                     for (Entry<Integer, Map<Address, ReceiverTasklet>> mapEntry : e.getValue().entrySet()) {
                         output.writeInt(e.getKey());
                         output.writeInt(mapEntry.getKey());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.metrics.MetricsCollectionContext;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeUnit;
 import com.hazelcast.internal.nio.BufferObjectDataInput;
+import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.concurrent.MPSCQueue;
 import com.hazelcast.internal.util.counters.Counter;
@@ -38,6 +39,7 @@ import com.hazelcast.logging.LoggingService;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.Objects;
 import java.util.Queue;
 
 import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
@@ -52,13 +54,14 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class ReceiverTasklet implements Tasklet {
 
     /**
-     * The {@code ackedSeq} atomic array holds, per sending member, the sequence
-     * number acknowledged to the sender as having been received and processed.
-     * The sequence increments in terms of the estimated heap occupancy of each
-     * received item, in bytes. However, to save on network traffic, the number
-     * reported to the sender is coarser-grained: it counts in units of {@code
-     * 1 << COMPRESSED_SEQ_UNIT_LOG2}. For example, with a value of 20 the unit
-     * would be one megabyte. The coarse-grained seq is called "compressed seq".
+     * The {@code ackedSeq} field holds the sequence number acknowledged to the
+     * sender as having been received and processed. The sequence increments in
+     * terms of the estimated heap occupancy of each received item, in bytes.
+     * However, to save on network traffic, the number reported to the sender
+     * is coarser-grained: it counts in units of {@code 1 <<
+     * COMPRESSED_SEQ_UNIT_LOG2}. For example, with a value of 20 the unit
+     * would be one megabyte. The coarse-grained seq is called "compressed
+     * seq".
      */
     static final int COMPRESSED_SEQ_UNIT_LOG2 = 16;
     /**
@@ -88,6 +91,7 @@ public class ReceiverTasklet implements Tasklet {
     private final String sourceAddressString;
     private final String ordinalString;
     private final String destinationVertexName;
+    private final Connection memberConnection;
 
     private final Queue<BufferObjectDataInput> incoming = new MPSCQueue<>(null);
     private final ProgressTracker tracker = new ProgressTracker();
@@ -109,6 +113,7 @@ public class ReceiverTasklet implements Tasklet {
     // read by a task scheduler thread, written by a tasklet execution thread
     private volatile long ackedSeq;
     private volatile int numWaitingInInbox;
+    private volatile boolean connectionChanged;
 
     // read and written by updateAndGetSendSeqLimitCompressed(), which is invoked sequentially by a task scheduler
     private int receiveWindowCompressed;
@@ -120,7 +125,8 @@ public class ReceiverTasklet implements Tasklet {
     public ReceiverTasklet(
             OutboundCollector collector, InternalSerializationService serializationService,
             int rwinMultiplier, int flowControlPeriodMs, LoggingService loggingService,
-            Address sourceAddress, int ordinal, String destinationVertexName
+            Address sourceAddress, int ordinal, String destinationVertexName,
+            Connection memberConnection
     ) {
         this.collector = collector;
         this.serializationService = serializationService;
@@ -129,6 +135,7 @@ public class ReceiverTasklet implements Tasklet {
         this.sourceAddressString = sourceAddress.toString();
         this.ordinalString = "" + ordinal;
         this.destinationVertexName = destinationVertexName;
+        this.memberConnection = memberConnection;
         String loggerName = String.format("%s.receiverFor:%s#%d", getClass().getName(), destinationVertexName, ordinal);
         this.logger = loggingService.getLogger(loggerName);
         this.receiveWindowCompressed = INITIAL_RECEIVE_WINDOW_COMPRESSED;
@@ -140,9 +147,13 @@ public class ReceiverTasklet implements Tasklet {
         if (receptionDone) {
             return collector.offerBroadcast(DONE_ITEM);
         }
+        if (connectionChanged) {
+            throw new RuntimeException("The member was reconnected: " + sourceAddressString);
+        }
         tracker.reset();
         tracker.notDone();
         tryFillInbox();
+        int ackItemLocal = 0;
         for (ObjWithPtionIdAndSize o; (o = inbox.peek()) != null; ) {
             final Object item = o.getItem();
             if (item == DONE_ITEM) {
@@ -160,8 +171,9 @@ public class ReceiverTasklet implements Tasklet {
             }
             tracker.madeProgress();
             inbox.remove();
-            ackItem(o.estimatedMemoryFootprint);
+            ackItemLocal += o.estimatedMemoryFootprint;
         }
+        ackItem(ackItemLocal);
         numWaitingInInbox = inbox.size();
         return tracker.toProgressState();
     }
@@ -172,11 +184,11 @@ public class ReceiverTasklet implements Tasklet {
     }
 
     /**
-     * Calls {@link #updateAndGetSendSeqLimitCompressed(long)} with {@code
+     * Calls {@link #updateAndGetSendSeqLimitCompressed(long, Connection)} with {@code
      * System.nanoTime()} and the current acked seq for the given sender ID.
      */
-    public int updateAndGetSendSeqLimitCompressed() {
-        return updateAndGetSendSeqLimitCompressed(System.nanoTime());
+    public int updateAndGetSendSeqLimitCompressed(Connection expectedConnection) {
+        return updateAndGetSendSeqLimitCompressed(System.nanoTime(), expectedConnection);
     }
 
     /**
@@ -208,9 +220,14 @@ public class ReceiverTasklet implements Tasklet {
      *
      * @param timestampNow value of the timestamp at the time the method is called. The timestamp
      *                     must be obtained from {@code System.nanoTime()}.
+     * @param expectedConnection The connection to which the result will be sent. We use it
+     *                           to check that it's the same connection the tasklet was crated with.
      */
     // Invoked sequentially by a task scheduler
-    int updateAndGetSendSeqLimitCompressed(long timestampNow) {
+    int updateAndGetSendSeqLimitCompressed(long timestampNow, Connection expectedConnection) {
+        if (!Objects.equals(expectedConnection, memberConnection)) {
+            connectionChanged = true;
+        }
         final boolean hadPrevStats = prevTimestamp != 0 || prevAckedSeqCompressed != 0;
 
         final long ackTimeDelta = timestampNow - prevTimestamp;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ReceiverTasklet.java
@@ -70,9 +70,6 @@ public class ReceiverTasklet implements Tasklet {
      * correspondence between a compressed seq unit and bytes is defined by the
      * constant {@link #COMPRESSED_SEQ_UNIT_LOG2}.
      * <p>
-     * The receiver tasklet keeps an array of receive window sizes, one for each
-     * sender.
-     * <p>
      * This constant specifies the initial size of the receive window. The
      * window is constantly adapted according to the actual data flow through
      * the receiver tasklet.
@@ -80,8 +77,8 @@ public class ReceiverTasklet implements Tasklet {
     static final int INITIAL_RECEIVE_WINDOW_COMPRESSED = 800;
 
     /**
-     * Receive Window converges towards the amount of data processed per flow-control
-     * period multiplied by this number.
+     * The Receive Window converges towards the amount of data processed per
+     * flow-control period multiplied by this number.
      */
     private final int rwinMultiplier;
     private final double flowControlPeriodNs;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SenderTasklet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/SenderTasklet.java
@@ -47,7 +47,6 @@ import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.execution.ReceiverTasklet.compressSeq;
 import static com.hazelcast.jet.impl.execution.ReceiverTasklet.estimatedMemoryFootprint;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.rethrow;
-import static com.hazelcast.jet.impl.util.ImdgUtil.getMemberConnection;
 import static com.hazelcast.jet.impl.util.Util.uncheckRun;
 
 public class SenderTasklet implements Tasklet {
@@ -85,6 +84,7 @@ public class SenderTasklet implements Tasklet {
             InboundEdgeStream inboundEdgeStream,
             NodeEngine nodeEngine,
             Address destinationAddress,
+            Connection connection,
             int destinationVertexId, int packetSizeLimit, long executionId,
             String sourceVertexName, int sourceOrdinal,
             InternalSerializationService serializationService
@@ -95,7 +95,7 @@ public class SenderTasklet implements Tasklet {
         this.sourceOrdinalString = "" + sourceOrdinal;
         this.packetSizeLimit = packetSizeLimit;
         // we use Connection directly because we rely on packets not being transparently skipped or reordered
-        this.connection = getMemberConnection(nodeEngine, destinationAddress);
+        this.connection = connection;
         this.outputBuffer = serializationService.createObjectDataOutput(BUFFER_SIZE);
         uncheckRun(() -> outputBuffer.write(createStreamPacketHeader(nodeEngine,
                 executionId, destinationVertexId, inboundEdgeStream.ordinal())));

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
@@ -19,9 +19,11 @@ package com.hazelcast.jet;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.cluster.Address;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.config.JetClientConfig;
+import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.TestProcessors;
 import com.hazelcast.jet.test.SerialTest;
@@ -59,16 +61,22 @@ public class MulticastDiscoveryTest extends JetTestSupport {
 
     @Test
     public void when_twoJetInstancesCreated_then_clusterOfTwoShouldBeFormed() {
-        JetInstance instance = Jet.newJetInstance();
-        Jet.newJetInstance();
+        JetConfig config = new JetConfig();
+        config.getHazelcastConfig().setClusterName(randomName());
+
+        JetInstance instance = Jet.newJetInstance(config);
+        Jet.newJetInstance(config);
 
         assertEquals(2, instance.getCluster().getMembers().size());
     }
 
     @Test
     public void when_twoJetAndTwoHzInstancesCreated_then_twoClustersOfTwoShouldBeFormed() {
-        JetInstance jetInstance = Jet.newJetInstance();
-        Jet.newJetInstance();
+        JetConfig config = new JetConfig();
+        config.getHazelcastConfig().setClusterName(randomName());
+
+        JetInstance jetInstance = Jet.newJetInstance(config);
+        Jet.newJetInstance(config);
 
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
         Hazelcast.newHazelcastInstance();
@@ -79,8 +87,11 @@ public class MulticastDiscoveryTest extends JetTestSupport {
 
     @Test
     public void when_jetClientCreated_then_connectsToJetCluster() {
-        JetInstance jetInstance1 = Jet.newJetInstance();
-        JetInstance jetInstance2 = Jet.newJetInstance();
+        JetConfig config = new JetConfig();
+        config.getHazelcastConfig().setClusterName(randomName());
+
+        JetInstance jetInstance1 = Jet.newJetInstance(config);
+        JetInstance jetInstance2 = Jet.newJetInstance(config);
 
         // Configure client with the address of the created instance
         // Sometimes the instances are created with a different port number
@@ -92,7 +103,10 @@ public class MulticastDiscoveryTest extends JetTestSupport {
 
     @Test
     public void when_jetClientCreated_then_doesNotConnectToHazelcastCluster() {
-        Hazelcast.newHazelcastInstance();
+        Config config = new Config();
+        config.setClusterName(randomName());
+
+        Hazelcast.newHazelcastInstance(config);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(UNABLE_TO_CONNECT_MESSAGE);
@@ -101,7 +115,10 @@ public class MulticastDiscoveryTest extends JetTestSupport {
 
     @Test
     public void when_hazelcastClientCreated_then_doesNotConnectToJetCluster() {
-        Jet.newJetInstance();
+        JetConfig config = new JetConfig();
+        config.getHazelcastConfig().setClusterName(randomName());
+
+        Jet.newJetInstance(config);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(UNABLE_TO_CONNECT_MESSAGE);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.core.TestProcessors.MockP;
+import com.hazelcast.jet.impl.util.ImdgUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.jet.core.Edge.between;
+import static com.hazelcast.jet.core.JobStatus.RUNNING;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@RunWith(HazelcastSerialClassRunner.class)
+public class MemberReconnectionTest extends JetTestSupport {
+
+    @Test
+    public void when_connectionDropped_then_detectedInReceiverTaskletAndFails() {
+        // we use real-network instances, closing the mock connection doesn't cause them to reconnect
+        JetInstance inst1 = Jet.newJetInstance();
+        JetInstance inst2 = Jet.newJetInstance();
+
+        try {
+            DAG dag = new DAG();
+            Vertex v1 = dag.newVertex("v1", () -> new MockP().streaming());
+            Vertex v2 = dag.newVertex("v2", () -> new MockP());
+            dag.edge(between(v1, v2).distributed());
+
+            Job job = inst1.newJob(dag);
+            assertJobStatusEventually(job, RUNNING);
+
+            // Close the connection. Nothing is sent through the SenderTasklet, therefore we won't detect
+            // it there. We rely on detecting it in ReceiverTasklet, we assert that it was detected there.
+            ImdgUtil.getMemberConnection(getNodeEngineImpl(inst1), getNodeEngineImpl(inst2).getThisAddress())
+                    .close("mock close", new Exception("mock close"));
+
+            logger.info("joining...");
+            assertThatThrownBy(() -> job.join())
+                    .hasMessageContaining("The member was reconnected")
+                    .hasMessageContaining("Exception in ReceiverTasklet");
+        } finally {
+            Jet.shutdownAll();
+        }
+    }
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/MemberReconnectionTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.core;
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
+import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.core.TestProcessors.MockP;
 import com.hazelcast.jet.impl.util.ImdgUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -35,8 +36,11 @@ public class MemberReconnectionTest extends JetTestSupport {
     @Test
     public void when_connectionDropped_then_detectedInReceiverTaskletAndFails() {
         // we use real-network instances, closing the mock connection doesn't cause them to reconnect
-        JetInstance inst1 = Jet.newJetInstance();
-        JetInstance inst2 = Jet.newJetInstance();
+        JetConfig config = new JetConfig();
+        config.getHazelcastConfig().setClusterName(randomName());
+
+        JetInstance inst1 = Jet.newJetInstance(config);
+        JetInstance inst2 = Jet.newJetInstance(config);
 
         try {
             DAG dag = new DAG();

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletSendLimitTest.java
@@ -50,14 +50,14 @@ public class ReceiverTaskletSendLimitTest {
         tasklet = new ReceiverTasklet(null,
                 new DefaultSerializationServiceBuilder().build(),
                 RWIN_MULTIPLIER, FLOW_CONTROL_PERIOD_MS,
-                new LoggingServiceImpl(null, null, BuildInfoProvider.getBuildInfo(), false), new Address(), 0, "");
+                new LoggingServiceImpl(null, null, BuildInfoProvider.getBuildInfo(), false), new Address(), 0, "", null);
     }
 
     @Test
     public void when_noData_then_rwinRemainsUnchanged() {
         double expectedSeq = INITIAL_RECEIVE_WINDOW_COMPRESSED;
         for (int i = 0; i < 10; i++) {
-            assertEquals((long) expectedSeq, tasklet.updateAndGetSendSeqLimitCompressed(START + i * ACK_PERIOD));
+            assertEquals((long) expectedSeq, tasklet.updateAndGetSendSeqLimitCompressed(START + i * ACK_PERIOD, null));
             expectedSeq = ceil(expectedSeq);
         }
     }
@@ -73,7 +73,7 @@ public class ReceiverTaskletSendLimitTest {
         // When
         for (int i = 0; i < iterCount; i++) {
             tasklet.ackItem(ackedSeqsPerIter);
-            seqLimitCompressed = tasklet.updateAndGetSendSeqLimitCompressed(START + i * ACK_PERIOD);
+            seqLimitCompressed = tasklet.updateAndGetSendSeqLimitCompressed(START + i * ACK_PERIOD, null);
         }
 
         // Then
@@ -94,14 +94,14 @@ public class ReceiverTaskletSendLimitTest {
 
         for (int i = 0; i < warmupIters; i++, iter++) {
             tasklet.ackItem(ackedSeqsPerIter);
-            tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD);
+            tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD, null);
         }
 
         // When
         tasklet.setNumWaitingInInbox(1);
         long seqLimit = 0;
         for (int i = 0; i < hiccupIters; i++, iter++) {
-            seqLimit = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD);
+            seqLimit = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD, null);
         }
 
         // Then
@@ -124,10 +124,10 @@ public class ReceiverTaskletSendLimitTest {
 
         for (int i = 0; i < warmupIters; i++, iter++) {
             ackedBeforeHiccup = tasklet.ackItem(ackedSeqsPerIter);
-            seqLimitBeforeHiccup = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD);
+            seqLimitBeforeHiccup = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD, null);
         }
         for (int i = 0; i < hiccupIters; i++, iter++) {
-            tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD);
+            tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD, null);
         }
 
         // When
@@ -135,7 +135,7 @@ public class ReceiverTaskletSendLimitTest {
         // After a hiccup all the enqueued items are processed within one ack period:
         final long recoverySize = (seqLimitBeforeHiccup << COMPRESSED_SEQ_UNIT_LOG2) - ackedBeforeHiccup;
         final long ackedAfterRecover = tasklet.ackItem(recoverySize);
-        final int seqLimitAfterRecover = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD);
+        final int seqLimitAfterRecover = tasklet.updateAndGetSendSeqLimitCompressed(START + iter * ACK_PERIOD, null);
 
         // Then
         final long ackedSeqCompressed = ackedAfterRecover >> COMPRESSED_SEQ_UNIT_LOG2;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ReceiverTaskletTest.java
@@ -43,7 +43,7 @@ public class ReceiverTaskletTest {
     public void before() {
         collector = new MockOutboundCollector(2);
         serService = new DefaultSerializationServiceBuilder().build();
-        t = new ReceiverTasklet(collector, serService, 3, 100, mock(LoggingService.class), new Address(), 0, "");
+        t = new ReceiverTasklet(collector, serService, 3, 100, mock(LoggingService.class), new Address(), 0, "", null);
     }
 
     @Test


### PR DESCRIPTION
The failure scenario was this:

- SenderTasklet reaches EOS in tryFillInbox(), writes DONE_ITEM

- We try to send the last packet in the call method, Connection.write()
returns true

- The connection is broken and the packet is never sent. The connection
is transparently reestablished, but the packet isn't sent again.

- Jet doesn't use this connection anymore in SenderTasklet as EOS has
been reached, so the failure goes unnoticed

- Remote member never receives the packet, the ReceiverTasklet will keep
waiting for the DONE_ITEM

The solution is that when the ReceiverTasklet creates data for the flow
control packet, it compares that the Connection object it was crated
with is the same.

We send the flow control packet regularly so any transparent
reconnection will cause the job to fail. Currently it would fail only if
some SenderTasklet tried to send something.

Fixes #2158