### PR TITLE
Use host:port for client to connect to remote cluster

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP_ConsistencyTest.java
@@ -142,25 +142,25 @@ public class ReadMapOrCacheP_ConsistencyTest extends JetTestSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(mapSource(clientConfig))
-                .map(o -> {
-                    proceedLatch.await();
-                    // apply some gentle backpressure
-                    if (processedCount.incrementAndGet() % 128 == 0) {
-                        Thread.sleep(10);
-                    }
-                    return o.getKey();
-                })
-                .setLocalParallelism(1)
-                .writeTo(AssertionSinks.assertCollected(list -> {
-                    // check no duplicates
-                    Set<Integer> collected = new HashSet<>(list);
-                    assertEquals("there were duplicates", list.size(), collected.size());
+         .map(o -> {
+             proceedLatch.await();
+             // apply some gentle backpressure
+             if (processedCount.incrementAndGet() % 128 == 0) {
+                 Thread.sleep(10);
+             }
+             return o.getKey();
+         })
+         .setLocalParallelism(1)
+         .writeTo(AssertionSinks.assertCollected(list -> {
+             // check no duplicates
+             Set<Integer> collected = new HashSet<>(list);
+             assertEquals("there were duplicates", list.size(), collected.size());
 
-                    // we should still have the items we didn't remove
-                    for (int i = 0; i < remainingItemCount; i++) {
-                        assertTrue("key " + i + " was missing", collected.contains(i));
-                    }
-                }));
+             // we should still have the items we didn't remove
+             for (int i = 0; i < remainingItemCount; i++) {
+                 assertTrue("key " + i + " was missing", collected.contains(i));
+             }
+         }));
 
         Job job = jet.newJob(p);
 
@@ -182,25 +182,25 @@ public class ReadMapOrCacheP_ConsistencyTest extends JetTestSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(mapSource(clientConfig))
-                .map(o -> {
-                    proceedLatch.await();
-                    // apply some gentle backpressure
-                    if (processedCount.incrementAndGet() % 128 == 0) {
-                        Thread.sleep(10);
-                    }
-                    return o.getKey();
-                })
-                .setLocalParallelism(1)
-                .writeTo(AssertionSinks.assertCollected(list -> {
-                    // check no duplicates
-                    Set<Integer> collected = new HashSet<>(list);
-                    assertEquals("there were duplicates", list.size(), collected.size());
+         .map(o -> {
+             proceedLatch.await();
+             // apply some gentle backpressure
+             if (processedCount.incrementAndGet() % 128 == 0) {
+                 Thread.sleep(10);
+             }
+             return o.getKey();
+         })
+         .setLocalParallelism(1)
+         .writeTo(AssertionSinks.assertCollected(list -> {
+             // check no duplicates
+             Set<Integer> collected = new HashSet<>(list);
+             assertEquals("there were duplicates", list.size(), collected.size());
 
-                    // check all initial items before iteration started
-                    for (int i = 0; i < initialItemCount; i++) {
-                        assertTrue("key " + i + " was missing", collected.contains(i));
-                    }
-                }));
+             // check all initial items before iteration started
+             for (int i = 0; i < initialItemCount; i++) {
+                 assertTrue("key " + i + " was missing", collected.contains(i));
+             }
+         }));
 
         Job job = jet.newJob(p);
 
@@ -226,20 +226,20 @@ public class ReadMapOrCacheP_ConsistencyTest extends JetTestSupport {
         int initialProcessingLimit = 1024;
         Pipeline p = Pipeline.create();
         p.readFrom(mapSource(clientConfig))
-                .map(o -> {
-                    // process first 1024 items, then wait for migration
-                    int count = processedCount.incrementAndGet();
-                    if (count == initialProcessingLimit) {
-                        // signal to start new node
-                        startLatch.countDown();
-                    } else if (count > initialProcessingLimit) {
-                        // wait for migration to complete
-                        proceedLatch.await();
-                    }
-                    return o.getKey();
-                })
-                .setLocalParallelism(1)
-                .writeTo(AssertionSinks.assertAnyOrder(IntStream.range(0, NUM_ITEMS).boxed().collect(toList())));
+         .map(o -> {
+             // process first 1024 items, then wait for migration
+             int count = processedCount.incrementAndGet();
+             if (count == initialProcessingLimit) {
+                 // signal to start new node
+                 startLatch.countDown();
+             } else if (count > initialProcessingLimit) {
+                 // wait for migration to complete
+                 proceedLatch.await();
+             }
+             return o.getKey();
+         })
+         .setLocalParallelism(1)
+         .writeTo(AssertionSinks.assertAnyOrder(IntStream.range(0, NUM_ITEMS).boxed().collect(toList())));
 
         Job job = jet.newJob(p, new JobConfig().setAutoScaling(false));
 


### PR DESCRIPTION
Currently we create a `ClientConfig` to connect to the remote cluster but does not set the port. 
We expect it to have the default port. 
But sometimes the created remote cluster has higher port number such as 5705, in which case client cannot connect to the cluster. 

With the fix we configure the client with the host:port value of the created hazelcast instance.

Checklist
- [X] Tags Set
- [X] Milestone Set
- [NA] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #2437 

List of breaking changes:

* ..
