### PR TITLE
Close YamlJetConfigBuilder input on build()

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetConfigBuilder.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/config/YamlJetConfigBuilder.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.impl.config;
 import com.hazelcast.config.AbstractYamlConfigBuilder;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.internal.config.yaml.YamlDomChecker;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
@@ -80,6 +81,8 @@ public class YamlJetConfigBuilder extends AbstractYamlConfigBuilder {
             yamlRootNode = ((YamlMapping) YamlLoader.load(in));
         } catch (Exception ex) {
             throw new InvalidConfigurationException("Invalid YAML configuration", ex);
+        } finally {
+            IOUtil.closeResource(in);
         }
 
         YamlNode jetRoot = yamlRootNode.childAsMapping(JetConfigSections.HAZELCAST_JET.name);
@@ -96,7 +99,6 @@ public class YamlJetConfigBuilder extends AbstractYamlConfigBuilder {
         new YamlJetDomConfigProcessor(true, config).buildConfig(w3cRootNode);
     }
 
-
     public YamlJetConfigBuilder setProperties(@Nullable Properties properties) {
         if (properties == null) {
             properties = System.getProperties();
@@ -104,5 +106,4 @@ public class YamlJetConfigBuilder extends AbstractYamlConfigBuilder {
         setPropertiesInternal(properties);
         return this;
     }
-
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigResolutionTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/config/YamlJetConfigResolutionTest.java
@@ -42,11 +42,11 @@ public class YamlJetConfigResolutionTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private JetDeclarativeConfigFileHelper helper = new JetDeclarativeConfigFileHelper();
+    private final JetDeclarativeConfigFileHelper helper = new JetDeclarativeConfigFileHelper();
 
     @Before
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         System.clearProperty(SYSPROP_JET_CONFIG);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/JetDeclarativeConfigFileHelper.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/test/JetDeclarativeConfigFileHelper.java
@@ -24,33 +24,28 @@ import java.net.URL;
 public class JetDeclarativeConfigFileHelper extends DeclarativeConfigFileHelper {
 
     public URL givenYamlJetConfigFileOnClasspath(String filename, String property, String value) throws Exception {
-        String yaml = this.yamlJetConfigWithProperty(property, value);
-        return this.givenConfigFileOnClasspath(filename, yaml);
+        String yaml = yamlJetConfigWithProperty(property, value);
+        return givenConfigFileOnClasspath(filename, yaml);
     }
 
     public URL givenYmlJetConfigFileOnClasspath(String filename, String property, String value) throws Exception {
-        String yaml = this.yamlJetConfigWithProperty(property, value);
-        return this.givenConfigFileOnClasspath(filename, yaml);
+        String yaml = yamlJetConfigWithProperty(property, value);
+        return givenConfigFileOnClasspath(filename, yaml);
     }
 
     public File givenYamlJetConfigFileOnWorkdir(String filename, String property, String value) throws Exception {
-        String yaml = this.yamlJetConfigWithProperty(property, value);
-        return this.givenConfigFileInWorkDir(filename, yaml);
+        String yaml = yamlJetConfigWithProperty(property, value);
+        return givenConfigFileInWorkDir(filename, yaml);
     }
 
     public File givenYmlJetConfigFileOnWorkdir(String filename, String property, String value) throws Exception {
-        String yaml = this.yamlJetConfigWithProperty(property, value);
-        return this.givenConfigFileInWorkDir(filename, yaml);
-    }
-
-    public URL givenXmlJetConfigFileOnClasspath(String filename, String property, String value) throws Exception {
-        String xml = this.xmlJetConfigWithProperty(property, value);
-        return this.givenConfigFileOnClasspath(filename, xml);
+        String yaml = yamlJetConfigWithProperty(property, value);
+        return givenConfigFileInWorkDir(filename, yaml);
     }
 
     public File givenXmlJetConfigFileOnWorkdir(String filename, String property, String value) throws Exception {
-        String xml = this.xmlJetConfigWithProperty(property, value);
-        return this.givenConfigFileInWorkDir(filename, xml);
+        String xml = xmlJetConfigWithProperty(property, value);
+        return givenConfigFileInWorkDir(filename, xml);
     }
 
     private String yamlJetConfigWithProperty(String property, String value) {
@@ -64,6 +59,4 @@ public class JetDeclarativeConfigFileHelper extends DeclarativeConfigFileHelper 
                 "<property name=\"" + property + "\">" + value + "</property>\n</properties>\n" +
                 "</hazelcast-jet>";
     }
-
-
 }


### PR DESCRIPTION
Added closing `YamlJetConfigBuilder` input on `build()` so the resources are correctly released.

Fixes #2395 