### PR TITLE
Fix MySql related intermittent network test failures (issue #2534)

### DIFF
--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -132,6 +132,13 @@
             <version>${log4j2.slf4j.binding.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -138,6 +138,12 @@
             <artifactId>system-rules</artifactId>
             <version>1.19.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit-dep</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -101,6 +101,10 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Before
     public void before() {
+        //disable Testcontainer's automatic resource manager
+        //containers are cleaned up explicitly
+        //automatic resource manager is just an extra thing that can break
+        //(have had problems with it not being cleaned up properly itself)
         environmentVariables.set("TESTCONTAINERS_RYUK_DISABLED", "true");
         assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -33,7 +33,10 @@ import com.hazelcast.jet.retry.RetryStrategy;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -75,6 +78,9 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);
 
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
     @Parameter(value = 0)
     public RetryStrategy reconnectBehavior;
 
@@ -91,6 +97,12 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), false, "reconnect"},
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
+    }
+
+    @Before
+    public void before() {
+        environmentVariables.set("TESTCONTAINERS_RYUK_DISABLED", "true");
+        assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }
 
     @Test
@@ -139,31 +151,34 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
             MySQLContainer<?> mysql = initMySql(network, null);
-            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
-            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-            // when job starts
-            JetInstance jet = createJetMembers(2)[0];
-            Job job = jet.newJob(pipeline);
-            assertJobStatusEventually(job, RUNNING);
-
-            // and snapshotting is ongoing (we have no exact way of identifying
-            // the moment, but random sleep will catch it at least some of the time)
-            TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
-
-            // and connection is cut
-            proxy.setConnectionCut(true);
-
-            // and some time passes
-            SECONDS.sleep(2 * MILLISECONDS.toSeconds(RECONNECT_INTERVAL_MS));
-
-            // and connection recovers
-            proxy.setConnectionCut(false);
-
-            // then connector manages to reconnect and finish snapshot
             try {
-                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
+                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
+                // when job starts
+                JetInstance jet = createJetMembers(2)[0];
+                Job job = jet.newJob(pipeline);
+                assertJobStatusEventually(job, RUNNING);
+
+                // and snapshotting is ongoing (we have no exact way of identifying
+                // the moment, but random sleep will catch it at least some of the time)
+                TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
+
+                // and connection is cut
+                proxy.setConnectionCut(true);
+
+                // and some time passes
+                SECONDS.sleep(2 * MILLISECONDS.toSeconds(RECONNECT_INTERVAL_MS));
+
+                // and connection recovers
+                proxy.setConnectionCut(false);
+
+                // then connector manages to reconnect and finish snapshot
+                try {
+                    assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                } finally {
+                    abortJob(job);
+                }
             } finally {
-                abortJob(job);
                 stopContainer(mysql);
             }
         }
@@ -220,33 +235,36 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
             MySQLContainer<?> mysql = initMySql(network, null);
-            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
-            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-            // when connector is up and transitions to binlog reading
-            JetInstance jet = createJetMembers(2)[0];
-            Job job = jet.newJob(pipeline);
-            assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-            SECONDS.sleep(3);
-            insertRecords(mysql, 1005);
-            assertEqualsEventually(() -> jet.getMap("results").size(), 5);
-
-            // and the connection is cut
-            proxy.setConnectionCut(true);
-
-            // and some new events get generated in the DB
-            insertRecords(mysql, 1006, 1007);
-
-            // and some time passes
-            TimeUnit.MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
-
-            // and the connection is re-established
-            proxy.setConnectionCut(false);
-
-            // then the connector catches up
             try {
-                assertEqualsEventually(() -> jet.getMap("results").size(), 7);
+                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
+                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
+                // when connector is up and transitions to binlog reading
+                JetInstance jet = createJetMembers(2)[0];
+                Job job = jet.newJob(pipeline);
+                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                SECONDS.sleep(3);
+                insertRecords(mysql, 1005);
+                assertEqualsEventually(() -> jet.getMap("results").size(), 5);
+
+                // and the connection is cut
+                proxy.setConnectionCut(true);
+
+                // and some new events get generated in the DB
+                insertRecords(mysql, 1006, 1007);
+
+                // and some time passes
+                TimeUnit.MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
+
+                // and the connection is re-established
+                proxy.setConnectionCut(false);
+
+                // then the connector catches up
+                try {
+                    assertEqualsEventually(() -> jet.getMap("results").size(), 7);
+                } finally {
+                    abortJob(job);
+                }
             } finally {
-                abortJob(job);
                 stopContainer(mysql);
             }
         }

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -132,6 +132,13 @@
             <version>${log4j2.slf4j.binding.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -138,6 +138,12 @@
             <artifactId>system-rules</artifactId>
             <version>1.19.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit-dep</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -34,7 +34,10 @@ import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -76,6 +79,9 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
 
     private static final long RECONNECT_INTERVAL_MS = SECONDS.toMillis(1);
 
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
     @Parameter(value = 0)
     public RetryStrategy reconnectBehavior;
 
@@ -92,6 +98,12 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), false, "reconnect"},
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
+    }
+
+    @Before
+    public void before() {
+        environmentVariables.set("TESTCONTAINERS_RYUK_DISABLED", "true");
+        assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }
 
     @Test
@@ -139,32 +151,35 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
             PostgreSQLContainer<?> postgres = initPostgres(network, null);
-            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
-            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-            // when job starts
-            JetInstance jet = createJetMembers(2)[0];
-            Job job = jet.newJob(pipeline);
-            assertJobStatusEventually(job, RUNNING);
-
-            // and snapshotting is ongoing (we have no exact way of identifying
-            // the moment, but random sleep will catch it at least some of the time)
-            MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
-
-            // and connection is cut
-            proxy.setConnectionCut(true);
-
-            // and some time passes
-            MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
-            //it takes the bloody thing 150 seconds to notice the connection being down, so it won't notice this...
-
-            // and connection recovers
-            proxy.setConnectionCut(false);
-
-            // then connector manages to reconnect and finish snapshot
             try {
-                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
+                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
+                // when job starts
+                JetInstance jet = createJetMembers(2)[0];
+                Job job = jet.newJob(pipeline);
+                assertJobStatusEventually(job, RUNNING);
+
+                // and snapshotting is ongoing (we have no exact way of identifying
+                // the moment, but random sleep will catch it at least some of the time)
+                MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
+
+                // and connection is cut
+                proxy.setConnectionCut(true);
+
+                // and some time passes
+                MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
+                //it takes the bloody thing 150 seconds to notice the connection being down, so it won't notice this...
+
+                // and connection recovers
+                proxy.setConnectionCut(false);
+
+                // then connector manages to reconnect and finish snapshot
+                try {
+                    assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                } finally {
+                    abortJob(job);
+                }
             } finally {
-                abortJob(job);
                 stopContainer(postgres);
             }
         }
@@ -222,35 +237,38 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
             PostgreSQLContainer<?> postgres = initPostgres(network, null);
-            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
-            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-            // when connector is up and transitions to binlog reading
-            JetInstance jet = createJetMembers(2)[0];
-            Job job = jet.newJob(pipeline);
-            assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-            SECONDS.sleep(3);
-            insertRecords(postgres, 1005);
-            assertEqualsEventually(() -> jet.getMap("results").size(), 5);
-
-            // and the connection is cut
-            proxy.setConnectionCut(true);
-
-            // and some new events get generated in the DB
-            insertRecords(postgres, 1006, 1007);
-
-            // and some time passes
-            MILLISECONDS.sleep(5 * RECONNECT_INTERVAL_MS);
-
-            // and the connection is re-established
-            proxy.setConnectionCut(false);
-
-            // then
             try {
-                // then job keeps running, connector starts freshly, including snapshotting
-                assertEqualsEventually(() -> jet.getMap("results").size(), 7);
-                assertEquals(RUNNING, job.getStatus());
+                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
+                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
+                // when connector is up and transitions to binlog reading
+                JetInstance jet = createJetMembers(2)[0];
+                Job job = jet.newJob(pipeline);
+                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                SECONDS.sleep(3);
+                insertRecords(postgres, 1005);
+                assertEqualsEventually(() -> jet.getMap("results").size(), 5);
+
+                // and the connection is cut
+                proxy.setConnectionCut(true);
+
+                // and some new events get generated in the DB
+                insertRecords(postgres, 1006, 1007);
+
+                // and some time passes
+                MILLISECONDS.sleep(5 * RECONNECT_INTERVAL_MS);
+
+                // and the connection is re-established
+                proxy.setConnectionCut(false);
+
+                // then
+                try {
+                    // then job keeps running, connector starts freshly, including snapshotting
+                    assertEqualsEventually(() -> jet.getMap("results").size(), 7);
+                    assertEquals(RUNNING, job.getStatus());
+                } finally {
+                    abortJob(job);
+                }
             } finally {
-                abortJob(job);
                 stopContainer(postgres);
             }
         }

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -102,6 +102,10 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
 
     @Before
     public void before() {
+        //disable Testcontainer's automatic resource manager
+        //containers are cleaned up explicitly
+        //automatic resource manager is just an extra thing that can break
+        //(have had problems with it not being cleaned up properly itself)
         environmentVariables.set("TESTCONTAINERS_RYUK_DISABLED", "true");
         assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }


### PR DESCRIPTION
Issue is caused by some kind of cleanup problem, affecting the Ryuk resource reapers. This resource manager is not mandatory, tests already do manual container management, so will disable it. Hopefully the reduced complexity will get rid of the clean-up issues experienced.

Fixes #2534