### PR TITLE
Use the configured cluster name of the instance for client

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
@@ -133,6 +133,7 @@ public class MulticastDiscoveryTest extends JetTestSupport {
         JetClientConfig jetClientConfig = new JetClientConfig();
         ClientNetworkConfig networkConfig = jetClientConfig.getNetworkConfig();
         for (JetInstance jet : jetInstances) {
+            jetClientConfig.setClusterName(jet.getConfig().getHazelcastConfig().getClusterName());
             Address address = getAddress(jet);
             networkConfig.addAddress(address.getHost() + ":" + address.getPort());
         }


### PR DESCRIPTION
With this [commit](https://github.com/hazelcast/hazelcast-jet/commit/424e109af3709ad860d65230ef7f92ef7c73964a), we've introduced random cluster name to isolate tests.
Looks like we've missed setting the cluster name to client 

Checklist
- [X] Tags Set
- [X] Milestone Set
- [NA] Any breaking changes are documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

Links to issues fixed (if any):

Fixes #1407

List of breaking changes:

* ..
