### PR TITLE
Fix AbstractJobProxy issues

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobProxy.java
@@ -154,7 +154,7 @@ public class JobProxy extends AbstractJobProxy<NodeEngineImpl> {
         }
     }
 
-    @Override
+    @Nonnull @Override
     protected UUID masterUuid() {
         Collection<Member> members = container().getClusterService().getMembers();
         if (members.isEmpty()) {
@@ -171,6 +171,11 @@ public class JobProxy extends AbstractJobProxy<NodeEngineImpl> {
     @Override
     protected LoggingService loggingService() {
         return container().getLoggingService();
+    }
+
+    @Override
+    protected boolean isRunning() {
+        return container().isRunning();
     }
 
     private <T> CompletableFuture<T> invokeOp(Operation op) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -68,12 +68,15 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
     @ClassRule
     public static Timeout globalTimeout = Timeout.seconds(15 * 60);
 
+    private static final ILogger SUPPORT_LOGGER = Logger.getLogger(JetTestSupport.class);
+
     protected ILogger logger = Logger.getLogger(getClass());
     private JetTestInstanceFactory instanceFactory;
 
     @After
     public void shutdownFactory() throws Exception {
         if (instanceFactory != null) {
+            SUPPORT_LOGGER.info("Terminating instanceFactory in JetTestSupport.@After");
             spawn(() -> instanceFactory.terminateAll())
                     .get(1, TimeUnit.MINUTES);
         }
@@ -236,7 +239,7 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
             try {
                 r.runEx();
             } catch (Throwable e) {
-                logger.warning("Spawned Runnable failed", e);
+                SUPPORT_LOGGER.warning("Spawned Runnable failed", e);
             }
         });
     }
@@ -255,7 +258,7 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
             assertTrue("stats are 0", allowEmptySnapshot || record.snapshotStats().numBytes() > 0);
             snapshotId[0] = record.snapshotId();
         }, timeoutSeconds);
-        logger.info("First snapshot found (id=" + snapshotId[0] + ")");
+        SUPPORT_LOGGER.info("First snapshot found (id=" + snapshotId[0] + ")");
     }
 
     public void waitForNextSnapshot(JobRepository jr, long jobId, int timeoutSeconds, boolean allowEmptySnapshot) {
@@ -271,7 +274,7 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
                     snapshotId[0] > originalSnapshotId);
             assertTrue("stats are 0", allowEmptySnapshot || record.snapshotStats().numBytes() > 0);
         }, timeoutSeconds);
-        logger.info("Next snapshot found after " + NANOSECONDS.toMillis(System.nanoTime() - start) + " ms (id="
+        SUPPORT_LOGGER.info("Next snapshot found after " + NANOSECONDS.toMillis(System.nanoTime() - start) + " ms (id="
                 + snapshotId[0] + ", previous id=" + originalSnapshotId + ")");
     }
 
@@ -306,7 +309,7 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
                     return;
                 }
             } catch (Exception e) {
-                logger.warning("Failure to read job status: " + e, e);
+                SUPPORT_LOGGER.warning("Failure to read job status: " + e, e);
             }
 
             Exception cancellationFailure;
@@ -324,8 +327,8 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
             }
 
             sleepMillis(500);
-            logger.warning("Failed to cancel the job and it is " + status + ", retrying. Failure: " + cancellationFailure,
-                    cancellationFailure);
+            SUPPORT_LOGGER.warning("Failed to cancel the job and it is " + status + ", retrying. Failure: "
+                            + cancellationFailure, cancellationFailure);
         }
         // if we got here, 10 attempts to cancel the job have failed. Cluster is in bad shape probably, shut it down
         try {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/TopologyChangeTest.java
@@ -96,7 +96,7 @@ public class TopologyChangeTest extends JetTestSupport {
     private JetInstance[] instances;
     private JetConfig config;
 
-    @Parameterized.Parameters(name = "liteMemberFlags({index}")
+    @Parameterized.Parameters(name = "liteMemberFlags({index})")
     public static Collection<boolean[]> parameters() {
         return Arrays.asList(new boolean[][]{
                 {false, false, false},


### PR DESCRIPTION
- fix when `Job` instance is from non-coordinator and the coordinator
leaves, the job completes. The issue was that in a specific case,
`HazelcastInstanceNotActiveException` was thrown on the
`JoinJobOperation` target member (the master) and the non-coordinator
didn't retry the operation. The fix is to retry the operation in case of
`HazelcastInstanceNotActiveException`, but only if the local member is
running and the exception likely originates on the remote member. Fixes
#2461 

- `AbstractJobProxy.resubmitJob()` and `rejoinJob()` checked
`AbstractJobProxy.memberUuid()` for a `null` result, but it never
actually returned null but threw instead. The fix is to specify a single
exception to throw (the `IllegalStateException`) and fix the code to
check for the exception.

- Unify the code of `SubmitJobCallback` and `JoinJobCallback` into a
base class.


* Log when test support classes clean up

From the test logs I often wasn't sure whether the instance termination
or job cancellation was due to the cleanup in `@After` classes or for
other reason.
