### PR TITLE
Fix S3SinkTest Issue

### DIFF
--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -97,11 +97,23 @@
             <artifactId>s3mock</artifactId>
             <version>2.1.15</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>1.11.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j2.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3MockTest.java
@@ -117,7 +117,7 @@ public class S3MockTest extends S3TestBase {
 
         try (S3Client client = clientSupplier().get()) {
             List<String> lines = client
-                    .listObjects(req -> req.bucket(SINK_BUCKET))
+                    .listObjectsV2(req -> req.bucket(SINK_BUCKET))
                     .contents()
                     .stream()
                     .peek(o -> System.out.println("Found object: " + o))

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
@@ -31,6 +31,8 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 @Category(NightlyTest.class)
 public class S3SinkTest extends S3TestBase {
 
@@ -50,6 +52,13 @@ public class S3SinkTest extends S3TestBase {
 
         if (!identifiers.isEmpty()) {
             client.deleteObjects(b -> b.bucket(bucketName).delete(d -> d.objects(identifiers)));
+        }
+
+        int sleepMillis = 250;
+        long deadline = System.currentTimeMillis() + SECONDS.toMillis(3);
+        while (client.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName).build()).keyCount() != 0
+                && System.currentTimeMillis() < deadline) {
+            sleepMillis(sleepMillis);
         }
     }
 

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
@@ -25,6 +25,7 @@ import org.junit.experimental.categories.Category;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
@@ -43,8 +44,7 @@ public class S3SinkTest extends S3TestBase {
     @After
     public void deleteObjects() {
         S3Client client = clientSupplier().get();
-        List<ObjectIdentifier> identifiers = client
-                .listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName).build())
+        List<ObjectIdentifier> identifiers = listObjects(client)
                 .contents()
                 .stream()
                 .map(S3Object::key)
@@ -58,8 +58,7 @@ public class S3SinkTest extends S3TestBase {
         int sleepMillis = (int) (SECONDS.toMillis(WAIT_AFTER_CLEANUP_IN_SECS) / 10);
         long deadline = System.currentTimeMillis() + SECONDS.toMillis(WAIT_AFTER_CLEANUP_IN_SECS);
         int keyCount;
-        while ((keyCount = client.listObjectsV2(ListObjectsV2Request
-                .builder().bucket(bucketName).build()).keyCount()) != 0 && System.currentTimeMillis() < deadline) {
+        while ((keyCount = listObjects(client).keyCount()) != 0 && System.currentTimeMillis() < deadline) {
 
             logger.info("After sending the object cleanup request to S3, the bucket, " + bucketName
                     + ", still has " + keyCount + " keys.");
@@ -72,6 +71,11 @@ public class S3SinkTest extends S3TestBase {
                     "At our last check, keyCount was " + keyCount +
                     "\n We finished waiting because of the timeout.");
         }
+    }
+
+    private ListObjectsV2Response listObjects(S3Client client) {
+        return client.listObjectsV2(ListObjectsV2Request
+                .builder().bucket(bucketName).build());
     }
 
     @Test

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3SinkTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
@@ -41,7 +41,7 @@ public class S3SinkTest extends S3TestBase {
     public void deleteObjects() {
         S3Client client = clientSupplier().get();
         List<ObjectIdentifier> identifiers = client
-                .listObjects(ListObjectsRequest.builder().bucket(bucketName).build())
+                .listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName).build())
                 .contents()
                 .stream()
                 .map(S3Object::key)

--- a/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3TestBase.java
+++ b/extensions/s3/src/test/java/com/hazelcast/jet/s3/S3TestBase.java
@@ -173,7 +173,8 @@ abstract class S3TestBase extends JetTestSupport {
 
     Stream<String> s3ObjectToLines(S3Object o, S3Client client, String bucketName) {
         try {
-            ResponseInputStream<GetObjectResponse> is = client.getObject(req -> req.bucket(bucketName).key(o.key()), toInputStream());
+            ResponseInputStream<GetObjectResponse> is = client
+                    .getObject(req -> req.bucket(bucketName).key(o.key()), toInputStream());
             return inputStreamToLines(is);
         } catch (S3Exception e) {
             logger.warning("S3 side is having eventual consistency issue that it could not" +

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JetTestSupport.java
@@ -35,6 +35,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.IMap;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
 import org.junit.ClassRule;
@@ -52,9 +53,11 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.internal.util.ExceptionUtil.rethrow;
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -198,6 +201,54 @@ public abstract class JetTestSupport extends HazelcastTestSupport {
     public static void assertClusterSizeEventually(int size, JetInstance jetInstance) {
         HazelcastTestSupport.assertClusterSizeEventually(size, jetInstance.getHazelcastInstance());
     }
+
+    public static void assertTrueEventuallyAndSuppressExceptions(String message, AssertTask task, long timeoutSeconds) {
+        AssertionError error = null;
+        Exception suppressed = null;
+        // we are going to check five times a second
+        int sleepMillis = 200;
+        long iterations = timeoutSeconds * 5;
+        long deadline = System.currentTimeMillis() + SECONDS.toMillis(timeoutSeconds);
+        for (int i = 0; i < iterations && System.currentTimeMillis() < deadline; i++) {
+            try {
+                try {
+                    task.run();
+                } catch (Exception e) {
+                    throw rethrow(e);
+                }
+                return;
+            } catch (AssertionError e) {
+                error = e;
+            } catch (Exception e) {
+                if (suppressed != null) {
+                    e.addSuppressed(suppressed);
+                }
+                suppressed = e;
+            }
+            sleepMillis(sleepMillis);
+        }
+        if (error != null) {
+            if (suppressed != null) {
+                error.addSuppressed(suppressed);
+            }
+            throw error;
+        }
+        fail("assertTrueEventuallyAndSuppressExceptions() failed without AssertionError! " + message);
+    }
+
+    public static void assertTrueEventuallyAndSuppressExceptions(AssertTask task, long timeoutSeconds) {
+        assertTrueEventuallyAndSuppressExceptions(null, task, timeoutSeconds);
+    }
+
+
+    public static void assertTrueEventuallyAndSuppressExceptions(String message, AssertTask task) {
+        assertTrueEventuallyAndSuppressExceptions(message, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+    }
+
+    public static void assertTrueEventuallyAndSuppressExceptions(AssertTask task) {
+        assertTrueEventuallyAndSuppressExceptions(null, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+    }
+
 
     public static JetService getJetService(JetInstance jetInstance) {
         return getNodeEngineImpl(jetInstance).getService(JetService.SERVICE_NAME);


### PR DESCRIPTION
The issue here is that the test code gets the list of keys by asking the s3 server, but when it asks for the value of one of these keys in the next step, the s3 server could not find this key. We can say that seeing a key, then not seeing the same key is an eventual consistency issue in the S3 side (Note: Frantisek showed me this point and said that he also encountered this type of issue during s3 benchmarks. He can help discussions on this topic). Although they say s3 provides eventual consistency, it may not. I added a conditional wait after these key deletions because maybe the key deletions are running slowly.
I am aware that with eventual consistency guarantee, write operations may be reflected after cleanup. But we call cleanup before and after tests. In such a case, the test including these writes will fail before since these writes will not be visible in this test.

- Add a new method that suppresses exceptions in AssertTrueEventually. Use this AssertTrueEventuallyAndSuppressExceptions method in S3SinkTests. (This is somewhat controversial. Is it okay to suppress the exceptions here?)
- Use the latest versions of S3 APIs which are recommended.
- Also, add conditional wait after test cleanup which is called before and after tests.
- Change the logging level to INFO.

Checklist
- [x] Tags Set
- [x] Milestone Set

Links to issues fixed (if any):

Fixes #2317
