### PR TITLE
Improve & fix merge-sorting in CIES

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -382,7 +382,7 @@ public class Edge implements IdentifiedDataSerializable {
      *
      * @since 4.3
      */
-    public Edge monotonicOrder(@Nonnull ComparatorEx<?> comparator) {
+    public Edge ordered(@Nonnull ComparatorEx<?> comparator) {
         this.comparator = comparator;
         return this;
     }
@@ -398,12 +398,12 @@ public class Edge implements IdentifiedDataSerializable {
 
     /**
      * Returns the comparator defined on this edge using {@link
-     * #monotonicOrder(ComparatorEx)}.
+     * #ordered(ComparatorEx)}.
      *
      * @since 4.3
      **/
     @Nullable
-    public ComparatorEx<?> getMonotonicOrderComparator() {
+    public ComparatorEx<?> getOrderComparator() {
         return comparator;
     }
 
@@ -604,7 +604,7 @@ public class Edge implements IdentifiedDataSerializable {
         out.writeUTF(getDestName());
         out.writeInt(getDestOrdinal());
         out.writeInt(getPriority());
-        out.writeObject(getMonotonicOrderComparator());
+        out.writeObject(getOrderComparator());
         out.writeObject(getDistributedTo());
         out.writeObject(getRoutingPolicy());
         CustomClassLoadedObject.write(out, getPartitioner());

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -364,17 +364,12 @@ public class Edge implements IdentifiedDataSerializable {
     }
 
     /**
-     * Specifies that the items received by each destination processor will be
-     * composed by merge-sorting the sorted streams of input items. For this
-     * behavior to be applicable, every upstream processor must ensure it emits
-     * the data according to the given ordering.
-     * <p>
-     * The use case for this edge type is merging of sorted streams. The
-     * processors of the source vertex sort their partial data and the
-     * processor in the destination vertex merges the sorted streams while
-     * consuming the data from many concurrent inputs.
-     * <p>
-     * The job will fail if item disorder is detected in the output of some processor
+     * Specifies that the data traveling on this edge is ordered according to
+     * the provided comparator. The edge maintains this property when merging
+     * the data coming from different upstream processors, so that the
+     * receiving processor observes them in the proper order. Every upstream
+     * processor must emit the data in the same order because the edge doesn't
+     * sort, it only prevents reordering while receiving.
      * <p>
      * The implementation currently doesn't handle watermarks or barriers: if
      * the source processors emit watermarks or you add a processing guarantee,

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -981,7 +981,7 @@ public final class Processors {
      * a {@link PriorityQueue} and emits it in the {@code complete} phase.
      * <p>
      * The output edge of this vertex should be {@link Edge#distributed
-     * distributed} {@link Edge#monotonicOrder monotonicOrder} {@link
+     * distributed} {@link Edge#ordered monotonicOrder} {@link
      * Edge#allToOne allToOne} so it preserves the ordering when merging
      * the data from all upstream processors.
      *

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream.java
@@ -22,15 +22,18 @@ import com.hazelcast.internal.util.concurrent.Pipe;
 import com.hazelcast.internal.util.concurrent.QueuedPipe;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.Watermark;
-import com.hazelcast.jet.impl.util.ObjectWithPartitionId;
 import com.hazelcast.jet.impl.util.ProgressState;
 import com.hazelcast.jet.impl.util.ProgressTracker;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 
@@ -45,24 +48,13 @@ import static com.hazelcast.jet.impl.util.Util.toLocalTime;
  * The conveyor has as many 1-to-1 concurrent queues as there are upstream tasklets
  * contributing to it.
  */
-public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
+public abstract class ConcurrentInboundEdgeStream implements InboundEdgeStream {
 
+    private final ConcurrentConveyor<Object> conveyor;
     private final int ordinal;
     private final int priority;
-    private final ConcurrentConveyor<Object> conveyor;
     private final ProgressTracker tracker = new ProgressTracker();
-    private final ItemDetector itemDetector = new ItemDetector();
-    private Comparator<Object> comparator;
-    private final WatermarkCoalescer watermarkCoalescer;
-    private final BitSet receivedBarriers; // indicates if current snapshot is received on the queue
     private final ILogger logger;
-
-    // Tells whether we are operating in exactly-once or at-least-once mode.
-    // In other words, whether a barrier from all queues must be present before
-    // draining more items from a queue where a barrier has been reached.
-    // Once a terminal snapshot barrier is reached, this is always true.
-    private boolean waitForAllBarriers;
-    private SnapshotBarrier currentBarrier;  // next snapshot barrier to emit
 
     /**
      * @param waitForAllBarriers If {@code true}, a queue that had a barrier won't
@@ -70,28 +62,277 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
      *          queues. This will enforce exactly-once vs. at-least-once, if it
      *          is {@code false}.
      */
-    public ConcurrentInboundEdgeStream(
-            @Nonnull ConcurrentConveyor<Object> conveyor, int ordinal, int priority, boolean waitForAllBarriers,
-            @Nonnull String debugName
+    public static ConcurrentInboundEdgeStream create(
+            @Nonnull ConcurrentConveyor<Object> conveyor,
+            int ordinal,
+            int priority,
+            boolean waitForAllBarriers,
+            @Nonnull String debugName,
+            @Nullable ComparatorEx<?> comparator
     ) {
+        if (comparator == null) {
+            return new RoundRobinDrain(conveyor, ordinal, priority, debugName, waitForAllBarriers);
+        } else {
+            return new MergeSortDrain(conveyor, ordinal, priority, debugName, comparator);
+        }
+    }
+
+    /**
+     * An implementation that drains the full contents of each queue once into
+     * the dest, while handling watermarks & barriers.
+     */
+    private static final class RoundRobinDrain extends ConcurrentInboundEdgeStream {
+        private final ItemDetector itemDetector = new ItemDetector();
+        private final WatermarkCoalescer watermarkCoalescer;
+        private final BitSet receivedBarriers; // indicates if current snapshot is received on the queue
+        // Tells whether we are operating in exactly-once or at-least-once mode.
+        // In other words, whether a barrier from all queues must be present before
+        // draining more items from a queue where a barrier has been reached.
+        // Once a terminal snapshot barrier is reached, this is always true.
+        private boolean waitForAllBarriers;
+        private SnapshotBarrier currentBarrier;  // next snapshot barrier to emit
+
+        public RoundRobinDrain(
+                @Nonnull ConcurrentConveyor<Object> conveyor,
+                int ordinal,
+                int priority,
+                @Nonnull String debugName,
+                boolean waitForAllBarriers
+        ) {
+            super(conveyor, ordinal, priority, debugName);
+
+            this.waitForAllBarriers = waitForAllBarriers;
+            watermarkCoalescer = WatermarkCoalescer.create(conveyor.queueCount());
+            receivedBarriers = new BitSet(conveyor.queueCount());
+        }
+
+        @Nonnull @Override
+        public ProgressState drainTo(@Nonnull Predicate<Object> dest) {
+            super.tracker.reset();
+            for (int queueIndex = 0; queueIndex < super.conveyor.queueCount(); queueIndex++) {
+                final QueuedPipe<Object> q = super.conveyor.queue(queueIndex);
+                if (q == null) {
+                    continue;
+                }
+
+                // skip queues where a snapshot barrier has already been received
+                if (waitForAllBarriers && receivedBarriers.get(queueIndex)) {
+                    continue;
+                }
+
+                ProgressState result = drainQueue(q, dest);
+                super.tracker.mergeWith(result);
+
+                if (itemDetector.item == DONE_ITEM) {
+                    super.conveyor.removeQueue(queueIndex);
+                    receivedBarriers.clear(queueIndex);
+                    long wmTimestamp = watermarkCoalescer.queueDone(queueIndex);
+                    if (maybeEmitWm(wmTimestamp, dest)) {
+                        if (super.logger.isFinestEnabled()) {
+                            super.logger.finest("Queue " + queueIndex + " is done, forwarding " + new Watermark(wmTimestamp));
+                        }
+                        return super.conveyor.liveQueueCount() == 0 ? DONE : MADE_PROGRESS;
+                    }
+                } else if (itemDetector.item instanceof Watermark) {
+                    long wmTimestamp = ((Watermark) itemDetector.item).timestamp();
+                    boolean forwarded = maybeEmitWm(watermarkCoalescer.observeWm(queueIndex, wmTimestamp), dest);
+                    if (super.logger.isFinestEnabled()) {
+                        super.logger.finest("Received " + itemDetector.item + " from queue " + queueIndex
+                                + (forwarded ? ", forwarded=" : ", not forwarded")
+                                + ", coalescedWm=" + toLocalTime(watermarkCoalescer.coalescedWm())
+                                + ", topObservedWm=" + toLocalTime(topObservedWm()));
+                    }
+                    if (forwarded) {
+                        return MADE_PROGRESS;
+                    }
+                } else if (itemDetector.item instanceof SnapshotBarrier) {
+                    observeBarrier(queueIndex, (SnapshotBarrier) itemDetector.item);
+                } else if (result.isMadeProgress()) {
+                    watermarkCoalescer.observeEvent(queueIndex);
+                }
+
+                int liveQueueCount = super.conveyor.liveQueueCount();
+                if (liveQueueCount == 0) {
+                    return super.tracker.toProgressState();
+                }
+                // if we have received the current snapshot from all active queues, forward it
+                if (itemDetector.item != null && receivedBarriers.cardinality() == liveQueueCount) {
+                    assert currentBarrier != null : "currentBarrier == null";
+                    boolean res = dest.test(currentBarrier);
+                    assert res : "test result expected to be true";
+                    currentBarrier = null;
+                    receivedBarriers.clear();
+                    return MADE_PROGRESS;
+                }
+            }
+
+            // try to emit WM based on history
+            if (maybeEmitWm(watermarkCoalescer.checkWmHistory(), dest)) {
+                return MADE_PROGRESS;
+            }
+
+            if (super.conveyor.liveQueueCount() > 0) {
+                super.tracker.notDone();
+            }
+            return super.tracker.toProgressState();
+        }
+
+        /**
+         * Drains the supplied queue into a {@code dest} collection, up to the next
+         * {@link Watermark} or {@link SnapshotBarrier}. Also updates the {@code tracker} with new status.
+         */
+        private ProgressState drainQueue(Pipe<Object> queue, Predicate<Object> dest) {
+            itemDetector.reset(dest);
+
+            int drainedCount = queue.drain(itemDetector);
+
+            itemDetector.dest = null;
+            return ProgressState.valueOf(drainedCount > 0, itemDetector.item == DONE_ITEM);
+        }
+
+        private void observeBarrier(int queueIndex, SnapshotBarrier barrier) {
+            if (currentBarrier == null) {
+                currentBarrier = barrier;
+            } else {
+                assert currentBarrier.equals(barrier) : currentBarrier + " != " + barrier;
+            }
+            if (barrier.isTerminal()) {
+                // Switch to exactly-once mode. The reason is that there will be DONE_ITEM just after the
+                // terminal barrier and if we process it before receiving the other barriers, it could cause
+                // the watermark to advance. The exactly-once mode disallows processing of any items after
+                // the barrier before the barrier is processed.
+                waitForAllBarriers = true;
+            }
+            receivedBarriers.set(queueIndex);
+        }
+
+        private boolean maybeEmitWm(long timestamp, Predicate<Object> dest) {
+            if (timestamp != NO_NEW_WM) {
+                boolean res = dest.test(new Watermark(timestamp));
+                assert res : "test result expected to be true";
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public long topObservedWm() {
+            return watermarkCoalescer.topObservedWm();
+        }
+
+        @Override
+        public long coalescedWm() {
+            return watermarkCoalescer.coalescedWm();
+        }
+    }
+
+    /**
+     * An implementation that assumes that the inputs are ordered and merges
+     * the inputs into one output stream, preserving the order. Currently
+     * doesn't handle watermarks or barriers.
+     */
+    private static final class MergeSortDrain extends ConcurrentInboundEdgeStream {
+        private final Comparator<Object> comparator;
+
+        private List<ArrayDeque<Object>> drainedItems;
+        private Object lastItem;
+        private int lastMinIndex;
+        private final List<QueuedPipe<Object>> queues;
+
+        @SuppressWarnings("unchecked")
+        public MergeSortDrain(
+                @Nonnull ConcurrentConveyor<Object> conveyor,
+                int ordinal,
+                int priority,
+                @Nonnull String debugName,
+                @Nullable ComparatorEx<?> comparator
+        ) {
+            super(conveyor, ordinal, priority, debugName);
+
+            this.comparator = (Comparator<Object>) comparator;
+            drainedItems = new ArrayList<>(super.conveyor.queueCount());
+            queues = new ArrayList<>(super.conveyor.queueCount());
+            for (int i = 0; i < super.conveyor.queueCount(); i++) {
+                QueuedPipe<Object> q = super.conveyor.queue(i);
+                drainedItems.add(new ArrayDeque<>(q.capacity()));
+                queues.add(q);
+            }
+        }
+
+        @Nonnull @Override
+        public ProgressState drainTo(@Nonnull Predicate<Object> dest) {
+            super.tracker.reset();
+            super.tracker.notDone();
+
+            // drain queues that are fully consumed
+            for (int i = 0; i < queues.size(); i++) {
+                if (drainedItems.get(i).isEmpty()) {
+                    queues.get(i).drainTo(drainedItems.get(i), Integer.MAX_VALUE);
+                }
+            }
+
+            outer:
+            for (;;) {
+                // find the current minimum item at the tail of queues
+                Object minItem = null;
+                for (int i = 0; i < drainedItems.size(); i++) {
+                    Object item = drainedItems.get(i).peek();
+                    if (item == null) {
+                        // this queue doesn't have data and isn't done, we can't proceed
+                        return super.tracker.toProgressState();
+                    }
+                    super.tracker.madeProgress();
+                    if (item == DONE_ITEM) {
+                        // queue is done, try again with it removed
+                        queues.remove(i);
+                        drainedItems.remove(i);
+                        if (queues.isEmpty()) {
+                            super.tracker.done();
+                            return super.tracker.toProgressState();
+                        }
+                        continue outer;
+                    }
+                    if (item instanceof Watermark || item instanceof SnapshotBarrier) {
+                        throw new JetException("Unexpected item observed: " + item);
+                    }
+                    if (minItem == null || comparator.compare(minItem, item) > 0) {
+                        minItem = item;
+                        lastMinIndex = i;
+                    }
+                }
+                // return the item
+                drainedItems.get(lastMinIndex).remove();
+                assert lastItem == null || comparator.compare(lastItem, minItem) <= 0 : "Disorder on a monotonicOrder edge";
+                lastItem = minItem;
+                boolean consumeResult = dest.test(lastItem);
+                assert consumeResult : "consumeResult is false";
+            }
+        }
+
+        @Override
+        public long topObservedWm() {
+            return Long.MIN_VALUE;
+        }
+
+        @Override
+        public long coalescedWm() {
+            return Long.MIN_VALUE;
+        }
+
+        @Override
+        public boolean isDone() {
+            return queues.isEmpty();
+        }
+    }
+
+    private ConcurrentInboundEdgeStream(
+            @Nonnull ConcurrentConveyor<Object> conveyor, int ordinal, int priority, @Nonnull String debugName) {
         this.conveyor = conveyor;
         this.ordinal = ordinal;
         this.priority = priority;
-        this.waitForAllBarriers = waitForAllBarriers;
 
-        watermarkCoalescer = WatermarkCoalescer.create(conveyor.queueCount());
-        receivedBarriers = new BitSet(conveyor.queueCount());
         logger = Logger.getLogger(ConcurrentInboundEdgeStream.class.getName() + "." + debugName);
         logger.finest("Coalescing " + conveyor.queueCount() + " input queues");
-    }
-
-    @SuppressWarnings("unchecked")
-    public ConcurrentInboundEdgeStream(
-            @Nonnull ConcurrentConveyor<Object> conveyor, int ordinal, int priority, boolean waitForAllBarriers,
-            @Nonnull String debugName, @Nonnull ComparatorEx<?> comparator
-    ) {
-        this(conveyor, ordinal, priority, waitForAllBarriers, debugName);
-        this.comparator = (Comparator<Object>) comparator;
     }
 
     @Override
@@ -104,177 +345,9 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
         return priority;
     }
 
-    @Nonnull @Override
-    public ProgressState drainTo(@Nonnull Predicate<Object> dest) {
-        if (comparator != null) {
-            return drainToWithComparator(dest);
-        }
-        tracker.reset();
-        for (int queueIndex = 0; queueIndex < conveyor.queueCount(); queueIndex++) {
-            final QueuedPipe<Object> q = conveyor.queue(queueIndex);
-            if (q == null) {
-                continue;
-            }
-
-            // skip queues where a snapshot barrier has already been received
-            if (waitForAllBarriers && receivedBarriers.get(queueIndex)) {
-                continue;
-            }
-
-            ProgressState result = drainQueue(q, dest);
-            tracker.mergeWith(result);
-
-            if (itemDetector.item == DONE_ITEM) {
-                conveyor.removeQueue(queueIndex);
-                receivedBarriers.clear(queueIndex);
-                long wmTimestamp = watermarkCoalescer.queueDone(queueIndex);
-                if (maybeEmitWm(wmTimestamp, dest)) {
-                    if (logger.isFinestEnabled()) {
-                        logger.finest("Queue " + queueIndex + " is done, forwarding " + new Watermark(wmTimestamp));
-                    }
-                    return conveyor.liveQueueCount() == 0 ? DONE : MADE_PROGRESS;
-                }
-            } else if (itemDetector.item instanceof Watermark) {
-                long wmTimestamp = ((Watermark) itemDetector.item).timestamp();
-                boolean forwarded = maybeEmitWm(watermarkCoalescer.observeWm(queueIndex, wmTimestamp), dest);
-                if (logger.isFinestEnabled()) {
-                    logger.finest("Received " + itemDetector.item + " from queue " + queueIndex
-                            + (forwarded ? ", forwarded=" : ", not forwarded")
-                            + ", coalescedWm=" + toLocalTime(watermarkCoalescer.coalescedWm())
-                            + ", topObservedWm=" + toLocalTime(topObservedWm()));
-                }
-                if (forwarded) {
-                    return MADE_PROGRESS;
-                }
-            } else if (itemDetector.item instanceof SnapshotBarrier) {
-                observeBarrier(queueIndex, (SnapshotBarrier) itemDetector.item);
-            } else if (result.isMadeProgress()) {
-                watermarkCoalescer.observeEvent(queueIndex);
-            }
-
-            int liveQueueCount = conveyor.liveQueueCount();
-            if (liveQueueCount == 0) {
-                return tracker.toProgressState();
-            }
-            // if we have received the current snapshot from all active queues, forward it
-            if (itemDetector.item != null && receivedBarriers.cardinality() == liveQueueCount) {
-                assert currentBarrier != null : "currentBarrier == null";
-                boolean res = dest.test(currentBarrier);
-                assert res : "test result expected to be true";
-                currentBarrier = null;
-                receivedBarriers.clear();
-                return MADE_PROGRESS;
-            }
-        }
-
-        // try to emit WM based on history
-        if (maybeEmitWm(watermarkCoalescer.checkWmHistory(), dest)) {
-            return MADE_PROGRESS;
-        }
-
-        if (conveyor.liveQueueCount() > 0) {
-            tracker.notDone();
-        }
-        return tracker.toProgressState();
-    }
-
-    private ProgressState drainToWithComparator(Predicate<Object> dest) {
-        tracker.reset();
-        tracker.notDone();
-        int batchSize = -1;
-        Object lastItem = null;
-        do {
-            int minIndex = 0;
-            Object minItem = null;
-            for (int queueIndex = 0; queueIndex < conveyor.queueCount(); queueIndex++) {
-                final QueuedPipe<Object> q = conveyor.queue(queueIndex);
-                if (q == null) {
-                    continue;
-                }
-                Object headItem = unwrap(q.peek());
-                if (headItem == null) {
-                    return tracker.toProgressState();
-                }
-                if (headItem == DONE_ITEM) {
-                    conveyor.removeQueue(queueIndex);
-                    continue;
-                }
-                if (minItem == null || comparator.compare(minItem, headItem) > 0) {
-                    minIndex = queueIndex;
-                    minItem = headItem;
-                }
-            }
-            if (conveyor.liveQueueCount() == 0) {
-                tracker.done();
-                return tracker.toProgressState();
-            }
-            if (batchSize == -1) {
-                batchSize = conveyor.queue(minIndex).size();
-            }
-            if (lastItem != null && comparator.compare(lastItem, minItem) > 0) {
-                throw new JetException(String.format(
-                    "Disorder on a monotonicOrder edge: received %s and then %s from the same queue",
-                        lastItem, minItem
-                ));
-            }
-            lastItem = minItem;
-            Object polledItem = unwrap(conveyor.queue(minIndex).poll());
-            tracker.madeProgress();
-            assert polledItem == minItem : "polledItem != minItem";
-            boolean consumeResult = dest.test(minItem);
-            assert consumeResult : "consumeResult is false";
-        } while (--batchSize > 0);
-        return tracker.toProgressState();
-    }
-
-    private Object unwrap(Object item) {
-        return item instanceof ObjectWithPartitionId
-                ? ((ObjectWithPartitionId) item).getItem()
-                : item;
-    }
-
-    private boolean maybeEmitWm(long timestamp, Predicate<Object> dest) {
-        if (timestamp != NO_NEW_WM) {
-            boolean res = dest.test(new Watermark(timestamp));
-            assert res : "test result expected to be true";
-            return true;
-        }
-        return false;
-    }
-
     @Override
     public boolean isDone() {
         return conveyor.liveQueueCount() == 0;
-    }
-
-    /**
-     * Drains the supplied queue into a {@code dest} collection, up to the next
-     * {@link Watermark} or {@link SnapshotBarrier}. Also updates the {@code tracker} with new status.
-     *
-     */
-    private ProgressState drainQueue(Pipe<Object> queue, Predicate<Object> dest) {
-        itemDetector.reset(dest);
-
-        int drainedCount = queue.drain(itemDetector);
-
-        itemDetector.dest = null;
-        return ProgressState.valueOf(drainedCount > 0, itemDetector.item == DONE_ITEM);
-    }
-
-    private void observeBarrier(int queueIndex, SnapshotBarrier barrier) {
-        if (currentBarrier == null) {
-            currentBarrier = barrier;
-        } else {
-            assert currentBarrier.equals(barrier) : currentBarrier + " != " + barrier;
-        }
-        if (barrier.isTerminal()) {
-            // Switch to exactly-once mode. The reason is that there will be DONE_ITEM just after the
-            // terminal barrier and if we process it before receiving the other barriers, it could cause
-            // the watermark to advance. The exactly-once mode disallows processing of any items after
-            // the barrier before the barrier is processed.
-            waitForAllBarriers = true;
-        }
-        receivedBarriers.set(queueIndex);
     }
 
     /**
@@ -321,15 +394,5 @@ public class ConcurrentInboundEdgeStream implements InboundEdgeStream {
             }
         }
         return sum;
-    }
-
-    @Override
-    public long topObservedWm() {
-        return watermarkCoalescer.topObservedWm();
-    }
-
-    @Override
-    public long coalescedWm() {
-        return watermarkCoalescer.coalescedWm();
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
@@ -118,7 +118,7 @@ public class EdgeDef implements IdentifiedDataSerializable {
         return config;
     }
 
-    ComparatorEx<?> getMonotonicOrderComparator() {
+    ComparatorEx<?> getOrderComparator() {
         return comparator;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
@@ -59,7 +59,7 @@ public class EdgeDef implements IdentifiedDataSerializable {
         this.routingPolicy = edge.getRoutingPolicy();
         this.partitioner = edge.getPartitioner();
         this.config = config;
-        this.comparator = edge.getComparator();
+        this.comparator = edge.getMonotonicOrderComparator();
     }
 
     void initTransientFields(Map<Integer, VertexDef> vMap, VertexDef nearVertex, boolean isOutbound) {
@@ -118,7 +118,7 @@ public class EdgeDef implements IdentifiedDataSerializable {
         return config;
     }
 
-    ComparatorEx<?> getComparator() {
+    ComparatorEx<?> getMonotonicOrderComparator() {
         return comparator;
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
@@ -59,7 +59,7 @@ public class EdgeDef implements IdentifiedDataSerializable {
         this.routingPolicy = edge.getRoutingPolicy();
         this.partitioner = edge.getPartitioner();
         this.config = config;
-        this.comparator = edge.getMonotonicOrderComparator();
+        this.comparator = edge.getOrderComparator();
     }
 
     void initTransientFields(Map<Integer, VertexDef> vMap, VertexDef nearVertex, boolean isOutbound) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -609,7 +609,8 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             // each tasklet has one input conveyor per edge
             final ConcurrentConveyor<Object> conveyor = localConveyorMap.get(inEdge.edgeId())[localProcessorIdx];
             inboundStreams.add(newEdgeStream(inEdge, conveyor,
-                    "inputTo:" + inEdge.destVertex().name() + '#' + globalProcessorIdx, inEdge.getMonotonicOrderComparator()));
+                    "inputTo:" + inEdge.destVertex().name() + '#' + globalProcessorIdx,
+                    inEdge.getMonotonicOrderComparator()));
         }
         return inboundStreams;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.cluster.Address;
+import com.hazelcast.function.ComparatorEx;
 import com.hazelcast.internal.nio.Connection;
 import com.hazelcast.internal.partition.IPartitionService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -48,6 +49,7 @@ import com.hazelcast.jet.impl.execution.Tasklet;
 import com.hazelcast.jet.impl.execution.init.Contexts.ProcCtx;
 import com.hazelcast.jet.impl.execution.init.Contexts.ProcSupplierCtx;
 import com.hazelcast.jet.impl.util.AsyncSnapshotWriterImpl;
+import com.hazelcast.jet.impl.util.ObjectWithPartitionId;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -171,8 +173,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             Arrays.setAll(snapshotQueues, i -> new OneToOneConcurrentArrayQueue<>(SNAPSHOT_QUEUE_SIZE));
             ConcurrentConveyor<Object> ssConveyor = ConcurrentConveyor.concurrentConveyor(null, snapshotQueues);
             StoreSnapshotTasklet ssTasklet = new StoreSnapshotTasklet(snapshotContext,
-                    new ConcurrentInboundEdgeStream(ssConveyor, 0, 0, true,
-                            "ssFrom:" + vertex.name()),
+                    ConcurrentInboundEdgeStream.create(ssConveyor, 0, 0, true, "ssFrom:" + vertex.name(), null),
                     new AsyncSnapshotWriterImpl(nodeEngine, snapshotContext, vertex.name(), memberIndex, memberCount,
                             jobSerializationService),
                     nodeEngine.getLogger(StoreSnapshotTasklet.class.getName() + "."
@@ -405,9 +406,14 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             for (Address destAddr : remoteMembers.get()) {
                 final ConcurrentConveyor<Object> conveyor = createConveyorArray(
                         1, edge.sourceVertex().localParallelism(), edge.getConfig().getQueueSize())[0];
+                @SuppressWarnings("unchecked")
+                ComparatorEx<Object> origComparator = (ComparatorEx<Object>) edge.getMonotonicOrderComparator();
+                ComparatorEx<ObjectWithPartitionId> adaptedComparator = origComparator == null ? null
+                        : (l, r) -> origComparator.compare(l.getItem(), r.getItem());
+
                 final ConcurrentInboundEdgeStream inboundEdgeStream = newEdgeStream(edge, conveyor,
                         "sender-toVertex:" + edge.destVertex().name() + "-toMember:"
-                                + destAddr.toString().replace('.', '-'));
+                                + destAddr.toString().replace('.', '-'), adaptedComparator);
                 final int destVertexId = edge.destVertex().vertexId();
                 final SenderTasklet t = new SenderTasklet(inboundEdgeStream, nodeEngine, destAddr,
                         memberConnections.get(destAddr),
@@ -603,17 +609,17 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             // each tasklet has one input conveyor per edge
             final ConcurrentConveyor<Object> conveyor = localConveyorMap.get(inEdge.edgeId())[localProcessorIdx];
             inboundStreams.add(newEdgeStream(inEdge, conveyor,
-                    "inputTo:" + inEdge.destVertex().name() + '#' + globalProcessorIdx));
+                    "inputTo:" + inEdge.destVertex().name() + '#' + globalProcessorIdx, inEdge.getMonotonicOrderComparator()));
         }
         return inboundStreams;
     }
 
     private ConcurrentInboundEdgeStream newEdgeStream(
-            EdgeDef inEdge, ConcurrentConveyor<Object> conveyor, String debugName
+            EdgeDef inEdge, ConcurrentConveyor<Object> conveyor, String debugName, ComparatorEx<?> comparator
     ) {
-        return new ConcurrentInboundEdgeStream(conveyor, inEdge.destOrdinal(), inEdge.priority(),
+        return ConcurrentInboundEdgeStream.create(conveyor, inEdge.destOrdinal(), inEdge.priority(),
                 jobConfig.getProcessingGuarantee() == ProcessingGuarantee.EXACTLY_ONCE,
-                debugName, inEdge.getComparator());
+                debugName, comparator);
     }
 
     public List<Processor> getProcessors() {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -407,7 +407,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                 final ConcurrentConveyor<Object> conveyor = createConveyorArray(
                         1, edge.sourceVertex().localParallelism(), edge.getConfig().getQueueSize())[0];
                 @SuppressWarnings("unchecked")
-                ComparatorEx<Object> origComparator = (ComparatorEx<Object>) edge.getMonotonicOrderComparator();
+                ComparatorEx<Object> origComparator = (ComparatorEx<Object>) edge.getOrderComparator();
                 ComparatorEx<ObjectWithPartitionId> adaptedComparator = origComparator == null ? null
                         : (l, r) -> origComparator.compare(l.getItem(), r.getItem());
 
@@ -609,8 +609,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             // each tasklet has one input conveyor per edge
             final ConcurrentConveyor<Object> conveyor = localConveyorMap.get(inEdge.edgeId())[localProcessorIdx];
             inboundStreams.add(newEdgeStream(inEdge, conveyor,
-                    "inputTo:" + inEdge.destVertex().name() + '#' + globalProcessorIdx,
-                    inEdge.getMonotonicOrderComparator()));
+                    "inputTo:" + inEdge.destVertex().name() + '#' + globalProcessorIdx, inEdge.getOrderComparator()));
         }
         return inboundStreams;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
@@ -55,6 +55,6 @@ public class SortTransform<T> extends AbstractTransform {
         p.addEdges(this, v1);
         p.dag.edge(between(v1, pv2.v).distributed()
                                      .allToOne(name())
-                                     .monotonicOrder(comparator));
+                                     .ordered(comparator));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
@@ -50,8 +50,8 @@ public class SortTransform<T> extends AbstractTransform {
     @Override
     public void addToDag(Planner p) {
         Vertex v1 = p.dag.newVertex(name(), sortP(comparator));
-        PlannerVertex pv2 = p.addVertex(this, name() + COLLECT_STAGE_SUFFIX, 1, ProcessorMetaSupplier
-                .forceTotalParallelismOne(ProcessorSupplier.of(mapP(identity())), name()));
+        PlannerVertex pv2 = p.addVertex(this, name() + COLLECT_STAGE_SUFFIX, 1,
+                ProcessorMetaSupplier.forceTotalParallelismOne(ProcessorSupplier.of(mapP(identity())), name()));
         p.addEdges(this, v1);
         p.dag.edge(between(v1, pv2.v).distributed()
                                      .allToOne(name())

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream_MergeSortDrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream_MergeSortDrainTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.execution;
 
+import com.hazelcast.function.ComparatorEx;
 import com.hazelcast.internal.util.concurrent.ConcurrentConveyor;
 import com.hazelcast.internal.util.concurrent.OneToOneConcurrentArrayQueue;
 import com.hazelcast.jet.impl.util.ProgressState;
@@ -37,12 +38,12 @@ import static com.hazelcast.jet.impl.execution.DoneItem.DONE_ITEM;
 import static com.hazelcast.jet.impl.util.ProgressState.DONE;
 import static com.hazelcast.jet.impl.util.ProgressState.MADE_PROGRESS;
 import static com.hazelcast.jet.impl.util.ProgressState.NO_PROGRESS;
-import static com.hazelcast.jet.impl.util.ProgressState.WAS_ALREADY_DONE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
 @Category(ParallelJVMTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
-public class ConcurrentInboundEdgeStreamTest {
+public class ConcurrentInboundEdgeStream_MergeSortDrainTest {
 
     private static final Object senderGone = new Object();
 
@@ -60,7 +61,7 @@ public class ConcurrentInboundEdgeStreamTest {
         q2 = new OneToOneConcurrentArrayQueue<>(128);
         conveyor = ConcurrentConveyor.concurrentConveyor(senderGone, q1, q2);
 
-        stream = ConcurrentInboundEdgeStream.create(conveyor, 0, 0, false, "cies", null);
+        stream = ConcurrentInboundEdgeStream.create(conveyor, 0, 0, false, "cies", ComparatorEx.naturalOrder());
     }
 
     @Test
@@ -71,9 +72,6 @@ public class ConcurrentInboundEdgeStreamTest {
 
         add(q2, 7, DONE_ITEM);
         drainAndAssert(DONE, 7);
-
-        // both emitters are now done and made no progress since last call
-        drainAndAssert(WAS_ALREADY_DONE);
     }
 
     @Test
@@ -90,109 +88,32 @@ public class ConcurrentInboundEdgeStreamTest {
         q1.add(DONE_ITEM);
         q2.add(DONE_ITEM);
         drainAndAssert(DONE);
-        drainAndAssert(WAS_ALREADY_DONE);
     }
 
     @Test
     public void when_oneEmitterWithNoProgress_then_noProgress() {
         add(q2, 1, DONE_ITEM);
-        drainAndAssert(MADE_PROGRESS, 1);
-
-        // now emitter2 is done, emitter1 is not but has no progress
+        drainAndAssert(NO_PROGRESS);
         drainAndAssert(NO_PROGRESS);
 
         // now make emitter1 done, without returning anything
         q1.add(DONE_ITEM);
 
-        drainAndAssert(DONE);
-        drainAndAssert(WAS_ALREADY_DONE);
+        drainAndAssert(DONE, 1);
     }
 
     @Test
-    public void when_receivingWatermarks_then_coalesce() {
+    public void when_receivingWatermarks_then_fail() {
         add(q1, wm(1));
-        add(q2, wm(2));
-        drainAndAssert(MADE_PROGRESS, wm(1));
-
-        add(q1, wm(3));
-        add(q2, wm(3));
-        drainAndAssert(MADE_PROGRESS, wm(2));
-        drainAndAssert(MADE_PROGRESS, wm(3));
+        assertThatThrownBy(() -> drainAndAssert(MADE_PROGRESS))
+                .hasMessageContaining("Unexpected item observed: Watermark");
     }
 
     @Test
-    public void when_receivingBarriers_then_coalesce() {
-        add(q1, barrier(0));
-        add(q2, 1);
-        drainAndAssert(MADE_PROGRESS, 1);
-
-        add(q1, 2);
-        add(q2, barrier(0));
-        drainAndAssert(MADE_PROGRESS, 2, barrier(0));
-    }
-
-    @Test
-    public void when_receivingBarriers_then_waitForBarrier() {
-        stream = ConcurrentInboundEdgeStream.create(conveyor, 0, 0, true, "cies", null);
-
-        add(q1, barrier(0));
-        add(q2, 1);
-        drainAndAssert(MADE_PROGRESS, 1);
-
-        add(q1, 2);
-        drainAndAssert(NO_PROGRESS);
-
-        add(q2, barrier(0));
-        drainAndAssert(MADE_PROGRESS, barrier(0));
-        drainAndAssert(MADE_PROGRESS, 2);
-    }
-
-    @Test
-    public void when_receivingBarriersWhileDone_then_coalesce() {
-        stream = ConcurrentInboundEdgeStream.create(conveyor, 0, 0, true, "cies", null);
-
-        add(q1, 1, barrier(0));
-        add(q2, DONE_ITEM);
-        drainAndAssert(MADE_PROGRESS, 1, barrier(0));
-
-        add(q1, DONE_ITEM);
-        drainAndAssert(DONE);
-    }
-
-    @Test
-    public void when_receiveOnlyBarrierAndDoneItemFromSameQueue_then_coalesce() {
-        add(q1, 1, barrier(0), DONE_ITEM);
-        drainAndAssert(MADE_PROGRESS, 1);
-        drainAndAssert(MADE_PROGRESS);
-
-        add(q2, barrier(0));
-        drainAndAssert(MADE_PROGRESS, barrier(0));
-    }
-
-    @Test
-    public void when_barrierAndWmInQueues_then_notReordered() {
-        // When
-        add(q1, wm(1));
-        add(q2, barrier(0));
-        drainAndAssert(MADE_PROGRESS);
-        assertEquals(0, q1.size());
-        assertEquals(0, q2.size());
-
-        add(q1, barrier(0));
-        add(q2, wm(1));
-
-        // Then
-        drainAndAssert(MADE_PROGRESS, barrier(0));
-        drainAndAssert(MADE_PROGRESS, wm(1));
-    }
-
-    @Test
-    public void when_barrierAndDone_then_barrierEmitted() {
-        add(q1, barrier(0), DONE_ITEM);
-        add(q2, barrier(0), DONE_ITEM);
-
-        drainAndAssert(MADE_PROGRESS, barrier(0));
-        drainAndAssert(DONE);
+    public void when_receivingBarriers_then_fail() {
+        add(q1, barrier(1));
+        assertThatThrownBy(() -> drainAndAssert(NO_PROGRESS))
+                .hasMessageContaining("Unexpected item observed: SnapshotBarrier");
     }
 
     @Test
@@ -200,38 +121,19 @@ public class ConcurrentInboundEdgeStreamTest {
         add(q1, DONE_ITEM);
         drainAndAssert(MADE_PROGRESS);
 
-        add(q2, barrier(0));
-        drainAndAssert(MADE_PROGRESS, barrier(0));
+        add(q2, 1);
+        drainAndAssert(MADE_PROGRESS, 1);
 
-        add(q2, wm(0));
-        drainAndAssert(MADE_PROGRESS, wm(0));
+        add(q2, 2);
+        drainAndAssert(MADE_PROGRESS, 2);
     }
 
     @Test
-    public void when_nonSpecificBroadcastItems_then_drainedInOneBatch() {
-        // When
-        BroadcastEntry<String, String> entry = new BroadcastEntry<>("k", "v");
-        add(q1, entry);
-        add(q1, entry);
-
-        // Then
-        drainAndAssert(MADE_PROGRESS, entry, entry);
-    }
-
-    @Test
-    public void when_wmInOneQueueAndTheOtherDoneLater_then_wmEmitted_v1() {
-        add(q1, wm(1));
-        add(q2, DONE_ITEM);
-        drainAndAssert(MADE_PROGRESS, wm(1));
-    }
-
-    @Test
-    public void when_wmInOneQueueAndTheOtherDoneLater_then_wmEmitted_v2() {
-        add(q1, wm(1));
-        drainAndAssert(MADE_PROGRESS);
-
-        add(q2, DONE_ITEM);
-        drainAndAssert(MADE_PROGRESS, wm(1));
+    public void when_disorder_then_throw() {
+        add(q1, 2, 1);
+        add(q2, 3);
+        assertThatThrownBy(() -> drainAndAssert(DONE))
+                .hasMessageContaining("Disorder on a monotonicOrder edge");
     }
 
     private void drainAndAssert(ProgressState expectedState, Object... expectedItems) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream_OrderedDrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream_OrderedDrainTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertEquals;
 
 @Category(ParallelJVMTest.class)
 @RunWith(HazelcastSerialClassRunner.class)
-public class ConcurrentInboundEdgeStream_MergeSortDrainTest {
+public class ConcurrentInboundEdgeStream_OrderedDrainTest {
 
     private static final Object senderGone = new Object();
 


### PR DESCRIPTION
- fix getter name: setter is `Edge.monotonicOrder()` and the getter is
`Edge.getComparator()`

- the getter and setter also use different type: `ComparatorEx<T>` vs
`ComparatorEx<?>`

- fail cleanly on watermarks or barriers

- improve javadoc

- for `SenderTasklet`, use a comparator that handles
`ObjectWithPartitionId` instead of tentatively unwrapping (a.k.a.
_adapted_ comparator)

- when the item was unwrapped, it was returned unwrapped

- use two subclasses to implement the behavior in CIES

- add unit test

- don't add items to exceptions: it can appear in logs, MC, for security
it should not
