### PR TITLE
Simplify ConcurrentInboundEdgeStream structure

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -411,7 +411,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                 ComparatorEx<ObjectWithPartitionId> adaptedComparator = origComparator == null ? null
                         : (l, r) -> origComparator.compare(l.getItem(), r.getItem());
 
-                final ConcurrentInboundEdgeStream inboundEdgeStream = newEdgeStream(edge, conveyor,
+                final InboundEdgeStream inboundEdgeStream = newEdgeStream(edge, conveyor,
                         "sender-toVertex:" + edge.destVertex().name() + "-toMember:"
                                 + destAddr.toString().replace('.', '-'), adaptedComparator);
                 final int destVertexId = edge.destVertex().vertexId();
@@ -614,7 +614,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         return inboundStreams;
     }
 
-    private ConcurrentInboundEdgeStream newEdgeStream(
+    private InboundEdgeStream newEdgeStream(
             EdgeDef inEdge, ConcurrentConveyor<Object> conveyor, String debugName, ComparatorEx<?> comparator
     ) {
         return ConcurrentInboundEdgeStream.create(conveyor, inEdge.destOrdinal(), inEdge.priority(),

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStreamTest.java
@@ -51,7 +51,7 @@ public class ConcurrentInboundEdgeStreamTest {
 
     private OneToOneConcurrentArrayQueue<Object> q1;
     private OneToOneConcurrentArrayQueue<Object> q2;
-    private ConcurrentInboundEdgeStream stream;
+    private InboundEdgeStream stream;
     private ConcurrentConveyor<Object> conveyor;
 
     @Before

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream_OrderedDrainTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/ConcurrentInboundEdgeStream_OrderedDrainTest.java
@@ -52,14 +52,13 @@ public class ConcurrentInboundEdgeStream_OrderedDrainTest {
 
     private OneToOneConcurrentArrayQueue<Object> q1;
     private OneToOneConcurrentArrayQueue<Object> q2;
-    private ConcurrentInboundEdgeStream stream;
-    private ConcurrentConveyor<Object> conveyor;
+    private InboundEdgeStream stream;
 
     @Before
     public void setUp() {
         q1 = new OneToOneConcurrentArrayQueue<>(128);
         q2 = new OneToOneConcurrentArrayQueue<>(128);
-        conveyor = ConcurrentConveyor.concurrentConveyor(senderGone, q1, q2);
+        ConcurrentConveyor<Object> conveyor = ConcurrentConveyor.concurrentConveyor(senderGone, q1, q2);
 
         stream = ConcurrentInboundEdgeStream.create(conveyor, 0, 0, false, "cies", ComparatorEx.naturalOrder());
     }


### PR DESCRIPTION
Remove the need to qualify superclass fields with `super` or make them visible to the whole package.