### PR TITLE
Fix config.attachAll(...) is calling twice when the job is submitted via newJobIfAbsent

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/AbstractJetInstance.java
@@ -112,7 +112,6 @@ public abstract class AbstractJetInstance implements JetInstance {
 
     @Nonnull @Override
     public Job newJobIfAbsent(@Nonnull Pipeline pipeline, @Nonnull JobConfig config) {
-        config = config.attachAll(((PipelineImpl) pipeline).attachedFiles());
         return newJobIfAbsent((Object) pipeline, config);
     }
 


### PR DESCRIPTION
Remove the first config.attachAll() call that is not needed. 

Fixes #2562

Checklist
- [x] Labels and Milestone set
