### PR TITLE
Define package of the class before defining the class in JetClassLoader

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
@@ -103,7 +103,7 @@ public class JetClassLoader extends ClassLoader {
             return;
         }
         try {
-            definePackage(packageName, null, null,null, null,null, null, null);
+            definePackage(packageName, null, null, null, null, null, null, null);
         } catch (IllegalArgumentException ignored) {
         }
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
@@ -80,7 +80,35 @@ public class JetClassLoader extends ClassLoader {
                     + " or start all members with it on classpath");
         }
         byte[] classBytes = uncheckCall(() -> IOUtil.toByteArray(classBytesStream));
+        definePackage(name);
         return defineClass(name, classBytes, 0, classBytes.length);
+    }
+
+    /**
+     * Defines the package if it is not already defined for the given class
+     * name.
+     *
+     * @param className the class name
+     */
+    private void definePackage(String className) {
+        if (isEmpty(className)) {
+            return;
+        }
+        int lastDotIndex = className.lastIndexOf('.');
+        if (lastDotIndex == -1) {
+            return;
+        }
+        String packageName = className.substring(0, lastDotIndex);
+        if (getPackage(packageName) != null) {
+            return;
+        }
+        Package clPackage = JetClassLoader.class.getPackage();
+        try {
+            definePackage(packageName, clPackage.getSpecificationTitle(), clPackage.getSpecificationVersion(),
+                    clPackage.getSpecificationVendor(), clPackage.getImplementationTitle(),
+                    clPackage.getImplementationVersion(), clPackage.getImplementationVendor(), null);
+        } catch (IllegalArgumentException ignored) {
+        }
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/deployment/JetClassLoader.java
@@ -102,11 +102,8 @@ public class JetClassLoader extends ClassLoader {
         if (getPackage(packageName) != null) {
             return;
         }
-        Package clPackage = JetClassLoader.class.getPackage();
         try {
-            definePackage(packageName, clPackage.getSpecificationTitle(), clPackage.getSpecificationVersion(),
-                    clPackage.getSpecificationVendor(), clPackage.getImplementationTitle(),
-                    clPackage.getImplementationVersion(), clPackage.getImplementationVendor(), null);
+            definePackage(packageName, null, null,null, null,null, null, null);
         } catch (IllegalArgumentException ignored) {
         }
     }


### PR DESCRIPTION
Currently JetClassLoader loads the configured classes but does not define their 
packages. According to the javadoc of `ClassLoader#definePackage` it should
be defined prior to definig the class:

```
     * Defines a package by name in this <tt>ClassLoader</tt>.  This allows
     * class loaders to define the packages for their classes. Packages must
     * be created before the class is defined, and package names must be
     * unique within a class loader and cannot be redefined or changed once
     * created.
```

Not defining the package results in issues for the avro, the implementation
relies on that the package of the class while creating the schema.



Checklist
- [X] Labels and Milestone set
- [NA] Breaking changes documented
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] For code samples, code sample main readme is updated

