### PR TITLE
Fix global aggregation with no input

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperation.java
@@ -235,7 +235,7 @@ public interface AggregateOperation<A, R> extends Serializable {
      * i}, as returned by {@link #accumulateFn(int)}.
      */
     @Nonnull
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("rawtypes")
     AggregateOperation<A, R> withAccumulateFns(BiConsumerEx... accumulateFns);
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
@@ -1794,8 +1794,8 @@ public final class AggregateOperations {
      * calls.
      * <p>
      * Using {@code IMap} aggregations can be desirable when you want to make
-     * use of {@linkplain IMap#addIndex indices} when doing aggregations
-     * and want to use the Jet aggregations API instead of writing a custom
+     * use of {@linkplain IMap#addIndex indices} when doing aggregations and
+     * want to use the Jet aggregations API instead of writing a custom
      * {@link Aggregator}.
      * <p>
      * For example, the following aggregation can be used to group people by

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
@@ -1047,7 +1047,7 @@ public final class AggregateOperations {
      * @see #groupingBy(FunctionEx, AggregateOperation1)
      * @see #toMap(FunctionEx, FunctionEx)
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public static <T, K, R, A, M extends Map<K, R>> AggregateOperation1<T, Map<K, A>, M> groupingBy(
             FunctionEx<? super T, ? extends K> keyFn,
             SupplierEx<M> createMapFn,
@@ -1149,13 +1149,14 @@ public final class AggregateOperations {
         checkSerializable(deductAccValueFn, "deductAccValueFn");
 
         // workaround for spotbugs issue: https://github.com/spotbugs/spotbugs/issues/552
+        @SuppressWarnings("UnnecessaryLocalVariable")
         BinaryOperatorEx<A> deductFn = deductAccValueFn;
         return AggregateOperation
                 .withCreate(() -> new MutableReference<>(emptyAccValue))
                 .andAccumulate((MutableReference<A> a, T t) ->
                         a.set(combineAccValuesFn.apply(a.get(), toAccValueFn.apply(t))))
                 .andCombine((a, b) -> a.set(combineAccValuesFn.apply(a.get(), b.get())))
-                .andDeduct(deductAccValueFn != null
+                .andDeduct(deductFn != null
                         ? (a, b) -> a.set(deductFn.apply(a.get(), b.get()))
                         : null)
                 .andExportFinish(MutableReference::get);
@@ -1793,7 +1794,7 @@ public final class AggregateOperations {
      * calls.
      * <p>
      * Using {@code IMap} aggregations can be desirable when you want to make
-     * use of {@linkplain IMap#addIndex(String, boolean) indices} when doing aggregations
+     * use of {@linkplain IMap#addIndex indices} when doing aggregations
      * and want to use the Jet aggregations API instead of writing a custom
      * {@link Aggregator}.
      * <p>

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
@@ -171,9 +171,13 @@ public final class AggregateOperations {
      * BatchStage<Person> youngestPerson =
      *         people.aggregate(minBy(ComparatorEx.comparing(Person::age)));
      * }</pre>
-     * If the aggregate operation doesn't observe any items, its result will
-     * be {@code null}. If several items tie for the least one, it will choose
      * any one to return and may choose a different one each time.
+     * <strong>NOTE:</strong> if this aggregate operation doesn't observe any
+     * items, its result will be {@code null}. Since the non-keyed {@link
+     * BatchStage#aggregate} emits just the naked aggregation result, and since
+     * a {@code null} cannot travel through a Jet pipeline, you will not get
+     * any output in that case.
+     * <p>
      * <p>
      * <em>Implementation note:</em> this aggregate operation does not
      * implement the {@link AggregateOperation1#deductFn() deduct} primitive.
@@ -199,8 +203,12 @@ public final class AggregateOperations {
      * BatchStage<Person> oldestPerson =
      *         people.aggregate(maxBy(ComparatorEx.comparing(Person::age)));
      * }</pre>
-     * If the aggregate operation doesn't observe any items, its result will
-     * be {@code null}. If several items tie for the greatest one, it will
+     * <strong>NOTE:</strong> if this aggregate operation doesn't observe any
+     * items, its result will be {@code null}. Since the non-keyed {@link
+     * BatchStage#aggregate} emits just the naked aggregation result, and since
+     * a {@code null} cannot travel through a Jet pipeline, you will not get
+     * any output in that case.
+     * <p>
      * choose any one to return and may choose a different one each time.
      * <p>
      * <em>Implementation note:</em> this aggregate operation does not
@@ -315,7 +323,10 @@ public final class AggregateOperations {
      * BatchStage<Double> meanAge = people.aggregate(averagingLong(Person::age));
      * }</pre>
      * <p>
-     * <strong>Note:</strong> this operation accumulates the sum and the
+     * If the aggregate operation does not observe any input, its result is
+     * {@link Double#NaN NaN}.
+     * <p>
+     * <strong>NOTE:</strong> this operation accumulates the sum and the
      * count as separate {@code long} variables and combines them at the end
      * into the mean value. If either of these variables exceeds {@code
      * Long.MAX_VALUE}, the job will fail with an {@link ArithmeticException}.
@@ -361,6 +372,9 @@ public final class AggregateOperations {
      * BatchStage<Person> people = pipeline.readFrom(peopleSource);
      * BatchStage<Double> meanAge = people.aggregate(averagingDouble(Person::age));
      * }</pre>
+     * <p>
+     * If the aggregate operation does not observe any input, its result is
+     * {@link Double#NaN NaN}.
      *
      * @param getDoubleValueFn function that extracts the {@code double} value from the item
      * @param <T> type of the input item
@@ -410,10 +424,12 @@ public final class AggregateOperations {
      *     .window(WindowDefinition.sliding(MINUTES.toMillis(5), SECONDS.toMillis(1)))
      *     .aggregate(linearTrend(Trade::getTimestamp, Trade::getPrice));
      * }</pre>
-     *
      * With the trade price given in cents and the timestamp in milliseconds,
      * the output will be in cents per millisecond. Make sure you apply a
      * scaling factor if you want another, more natural unit of measure.
+     * <p>
+     * If this aggregate operation does not observe any input, its result is
+     * {@link Double#NaN NaN}.
      *
      * @param getXFn a function to extract <strong>x</strong> from the input
      * @param getYFn a function to extract <strong>y</strong> from the input
@@ -1178,7 +1194,11 @@ public final class AggregateOperations {
      *         people.groupingKey(Person::getLastName)
      *               .aggregate(pickAny());
      * }</pre>
-     *
+     * <strong>NOTE:</strong> if this aggregate operation doesn't observe any
+     * items, its result will be {@code null}. Since the non-keyed {@link
+     * BatchStage#aggregate} emits just the naked aggregation result, and since
+     * a {@code null} cannot travel through a Jet pipeline, you will not get
+     * any output in that case.
      * @param <T> type of the input item
      */
     @Nonnull

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/aggregate/AggregateOperations.java
@@ -171,16 +171,20 @@ public final class AggregateOperations {
      * BatchStage<Person> youngestPerson =
      *         people.aggregate(minBy(ComparatorEx.comparing(Person::age)));
      * }</pre>
-     * any one to return and may choose a different one each time.
      * <strong>NOTE:</strong> if this aggregate operation doesn't observe any
      * items, its result will be {@code null}. Since the non-keyed {@link
      * BatchStage#aggregate} emits just the naked aggregation result, and since
      * a {@code null} cannot travel through a Jet pipeline, you will not get
      * any output in that case.
      * <p>
+     * If several items tie for the least one, this aggregate operation will
+     * choose any one to return and may choose a different one each time.
      * <p>
      * <em>Implementation note:</em> this aggregate operation does not
      * implement the {@link AggregateOperation1#deductFn() deduct} primitive.
+     * This has performance implications for <a
+     * href="https://jet-start.sh/docs/architecture/sliding-window">sliding
+     * window aggregation</a>.
      *
      * @param comparator comparator to compare the items
      * @param <T> type of the input item
@@ -209,10 +213,14 @@ public final class AggregateOperations {
      * a {@code null} cannot travel through a Jet pipeline, you will not get
      * any output in that case.
      * <p>
+     * If several items tie for the greatest one, this aggregate operation will
      * choose any one to return and may choose a different one each time.
      * <p>
      * <em>Implementation note:</em> this aggregate operation does not
      * implement the {@link AggregateOperation1#deductFn() deduct} primitive.
+     * This has performance implications for <a
+     * href="https://jet-start.sh/docs/architecture/sliding-window">sliding
+     * window aggregation</a>.
      *
      * @param comparator comparator to compare the items
      * @param <T> type of the input item
@@ -250,6 +258,9 @@ public final class AggregateOperations {
      * }</pre>
      * <em>Implementation note:</em> this aggregate operation does not
      * implement the {@link AggregateOperation1#deductFn() deduct} primitive.
+     * This has performance implications for <a
+     * href="https://jet-start.sh/docs/architecture/sliding-window">sliding
+     * window aggregation</a>.
      *
      * @param n number of top items to find
      * @param comparator compares the items
@@ -300,6 +311,9 @@ public final class AggregateOperations {
      * }</pre>
      * <em>Implementation note:</em> this aggregate operation does not
      * implement the {@link AggregateOperation1#deductFn() deduct} primitive.
+     * This has performance implications for <a
+     * href="https://jet-start.sh/docs/architecture/sliding-window">sliding
+     * window aggregation</a>.
      *
      * @param n number of bottom items to find
      * @param comparator compares the items

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/DAG.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/DAG.java
@@ -79,10 +79,10 @@ import static java.util.stream.Collectors.joining;
  */
 public class DAG implements IdentifiedDataSerializable, Iterable<Vertex> {
 
-    private Set<Edge> edges = new LinkedHashSet<>();
-    private Map<String, Vertex> nameToVertex = new HashMap<>();
+    private final Set<Edge> edges = new LinkedHashSet<>();
+    private final Map<String, Vertex> nameToVertex = new HashMap<>();
     // Transient field:
-    private Set<Vertex> verticesByIdentity = newSetFromMap(new IdentityHashMap<>());
+    private final Set<Vertex> verticesByIdentity = newSetFromMap(new IdentityHashMap<>());
 
     /**
      * Creates a vertex from a {@code Supplier<Processor>} and adds it to this DAG.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -221,7 +221,9 @@ public final class Processors {
      * Returns a supplier of processors for a vertex that performs the provided
      * aggregate operation on all the items it receives. After exhausting all
      * its input, it emits a single item of type {@code R} &mdash; the result of
-     * the aggregate operation.
+     * the aggregate operation's {@link AggregateOperation#finishFn() finish}
+     * primitive. The primitive may return {@code null}, in that case the vertex
+     * will not produce any output.
      * <p>
      * Since the input to this vertex must be bounded, its primary use case are
      * batch jobs.
@@ -272,7 +274,8 @@ public final class Processors {
      * #accumulateP} vertex and combines their state into a single
      * accumulator. After exhausting all its input, it emits a single result
      * of type {@code R} &mdash; the result of applying the {@code finish}
-     * primitive to the combined accumulator.
+     * primitive to the combined accumulator. The primitive may return {@code
+     * null}, in that case the vertex will not produce any output.
      * <p>
      * Since the input to this vertex must be bounded, its primary use case is
      * batch jobs.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/Processors.java
@@ -41,6 +41,7 @@ import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.core.function.KeyedWindowResultFunction;
 import com.hazelcast.jet.datamodel.KeyedWindowResult;
 import com.hazelcast.jet.function.TriFunction;
+import com.hazelcast.jet.impl.processor.AggregateP;
 import com.hazelcast.jet.impl.processor.AsyncTransformUsingServiceOrderedP;
 import com.hazelcast.jet.impl.processor.AsyncTransformUsingServiceUnorderedP;
 import com.hazelcast.jet.impl.processor.GroupP;
@@ -65,7 +66,6 @@ import java.util.function.Supplier;
 import static com.hazelcast.function.FunctionEx.identity;
 import static com.hazelcast.jet.core.TimestampKind.EVENT;
 import static com.hazelcast.jet.impl.util.Util.toList;
-import static java.util.Collections.nCopies;
 import static java.util.Collections.singletonList;
 
 /**
@@ -220,13 +220,13 @@ public final class Processors {
     /**
      * Returns a supplier of processors for a vertex that performs the provided
      * aggregate operation on all the items it receives. After exhausting all
-     * its input it emits a single item of type {@code R} &mdash;the result of
+     * its input, it emits a single item of type {@code R} &mdash; the result of
      * the aggregate operation.
      * <p>
      * Since the input to this vertex must be bounded, its primary use case are
      * batch jobs.
      * <p>
-     * This processor has state, but does not save it to snapshot. On job
+     * This processor has state, but does not save it to the snapshot. On job
      * restart, the state will be lost.
      * @param <A> type of accumulator returned from {@code
      *            aggrOp.createAccumulatorFn()}
@@ -240,19 +240,19 @@ public final class Processors {
     ) {
         // We should use the same constant key as the input edges do, but since
         // the processor doesn't save the state, there's no need to.
-        return () -> new GroupP<>(nCopies(aggrOp.arity(), t -> "ALL"), aggrOp, (k, r) -> r);
+        return () -> new AggregateP<>(aggrOp);
     }
 
     /**
-     * Returns a supplier of processors for a vertex that performs the provided
-     * aggregate operation on all the items it receives. After exhausting all
-     * its input it emits a single item of type {@code R} &mdash;the result of
-     * the aggregate operation.
+     * Returns a supplier of processors for a vertex that performs the
+     * accumulation step of the provided aggregate operation on all the items
+     * it receives. After exhausting all its input, it emits a single item of
+     * type {@code A} &mdash; the accumulator object.
      * <p>
      * Since the input to this vertex must be bounded, its primary use case are
      * batch jobs.
      * <p>
-     * This processor has state, but does not save it to snapshot. On job
+     * This processor has state, but does not save it to the snapshot. On job
      * restart, the state will be lost.
      * @param <A> type of accumulator returned from {@code
      *            aggrOp.createAccumulatorFn()}
@@ -262,24 +262,22 @@ public final class Processors {
      */
     @Nonnull
     public static <A, R> SupplierEx<Processor> accumulateP(@Nonnull AggregateOperation<A, R> aggrOp) {
-        return () -> new GroupP<>(
-                // We should use the same constant key as the input edges do, but since
-                // the processor doesn't save the state, there's no need to.
-                nCopies(aggrOp.arity(), t -> "ALL"),
-                aggrOp.withIdentityFinish(),
-                (k, r) -> r);
+        return () -> new AggregateP<>(aggrOp.withIdentityFinish());
     }
 
     /**
-     * Returns a supplier of processors for a vertex that performs the provided
-     * aggregate operation on all the items it receives. After exhausting all
-     * its input it emits a single item of type {@code R} &mdash; the result of
-     * the aggregate operation.
+     * Returns a supplier of processors for a vertex that performs the
+     * combining and finishing steps of the provided aggregate operation. It
+     * expects to receive the accumulator objects from the upstream {@link
+     * #accumulateP} vertex and combines their state into a single
+     * accumulator. After exhausting all its input, it emits a single result
+     * of type {@code R} &mdash; the result of applying the {@code finish}
+     * primitive to the combined accumulator.
      * <p>
      * Since the input to this vertex must be bounded, its primary use case is
      * batch jobs.
      * <p>
-     * This processor has state, but does not save it to snapshot. On job
+     * This processor has state, but does not save it to the snapshot. On job
      * restart, the state will be lost.
      * @param <A> type of accumulator returned from {@code
      *            aggrOp.createAccumulatorFn()}
@@ -291,12 +289,7 @@ public final class Processors {
     public static <A, R> SupplierEx<Processor> combineP(
             @Nonnull AggregateOperation<A, R> aggrOp
     ) {
-        return () -> new GroupP<>(
-                // We should use the same constant key as the input edges do, but since
-                // the processor doesn't save the state, there's no need to.
-                t -> "ALL",
-                aggrOp.withCombiningAccumulateFn(identity()),
-                (k, r) -> r);
+        return () -> new AggregateP<>(aggrOp.withCombiningAccumulateFn(identity()));
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/ItemsByTag.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/ItemsByTag.java
@@ -47,7 +47,7 @@ public final class ItemsByTag {
      * populated with these pairs.
      */
     @Nonnull
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public static ItemsByTag itemsByTag(@Nonnull Object... tagsAndVals) {
         ItemsByTag ibt = new ItemsByTag();
         for (int i = 0; i < tagsAndVals.length;) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/ItemsByTag.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/ItemsByTag.java
@@ -79,7 +79,7 @@ public final class ItemsByTag {
      * {@code null}, but the value may be, and in that case the tag will be
      * associated with a {@code null} value.
      */
-    public <E> void put(@Nonnull Tag<E> tag, E value) {
+    public <E> void put(@Nonnull Tag<E> tag, @Nullable E value) {
         map.put(tag, value);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/KeyedWindowResult.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/KeyedWindowResult.java
@@ -92,6 +92,7 @@ public final class KeyedWindowResult<K, R> extends WindowResult<R> implements En
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public boolean equals(Object obj) {
         KeyedWindowResult that;
         return this == obj

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
@@ -83,6 +83,7 @@ public final class Tuple2<E0, E1> implements Map.Entry<E0, E1> {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public boolean equals(Object obj) {
         final Tuple2 that;
         return this == obj

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.datamodel;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 
@@ -43,13 +44,14 @@ public final class Tuple2<E0, E1> implements Map.Entry<E0, E1> {
     /**
      * Returns a new 2-tuple with the supplied values.
      */
-    public static <E0, E1> Tuple2<E0, E1> tuple2(E0 f0, E1 f1) {
+    public static <E0, E1> Tuple2<E0, E1> tuple2(@Nullable E0 f0, @Nullable E1 f1) {
         return new Tuple2<>(f0, f1);
     }
 
     /**
      * Returns the value of the field 0.
      */
+    @Nullable
     public E0 f0() {
         return f0;
     }
@@ -57,6 +59,7 @@ public final class Tuple2<E0, E1> implements Map.Entry<E0, E1> {
     /**
      * Returns the value of the field 1.
      */
+    @Nullable
     public E1 f1() {
         return f1;
     }
@@ -64,18 +67,18 @@ public final class Tuple2<E0, E1> implements Map.Entry<E0, E1> {
 
     // Implementation of Map.Entry
 
-    @Override
+    @Nullable @Override
     public E0 getKey() {
         return f0;
     }
 
-    @Override
+    @Nullable @Override
     public E1 getValue() {
         return f1;
     }
 
     @Override
-    public E1 setValue(E1 value) {
+    public E1 setValue(@Nullable E1 value) {
         throw new UnsupportedOperationException("Tuple2 is immutable");
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple2.java
@@ -30,8 +30,8 @@ import java.util.Objects;
  * @since 3.0
  */
 public final class Tuple2<E0, E1> implements Map.Entry<E0, E1> {
-    private E0 f0;
-    private E1 f1;
+    private final E0 f0;
+    private final E1 f1;
 
     /**
      * Constructs a new 2-tuple with the supplied values.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
@@ -29,9 +29,9 @@ import java.util.Objects;
  * @since 3.0
  */
 public final class Tuple3<E0, E1, E2> {
-    private E0 f0;
-    private E1 f1;
-    private E2 f2;
+    private final E0 f0;
+    private final E1 f1;
+    private final E2 f2;
 
     /**
      * Constructs a new 3-tuple with the supplied values.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.datamodel;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -44,13 +45,16 @@ public final class Tuple3<E0, E1, E2> {
     /**
      * Returns a new 3-tuple with the supplied values.
      */
-    public static <E0, E1, E2> Tuple3<E0, E1, E2> tuple3(E0 f0, E1 f1, E2 f2) {
+    public static <E0, E1, E2> Tuple3<E0, E1, E2> tuple3(
+            @Nullable E0 f0, @Nullable E1 f1, @Nullable E2 f2
+    ) {
         return new Tuple3<>(f0, f1, f2);
     }
 
     /**
      * Returns the value of the field 0.
      */
+    @Nullable
     public E0 f0() {
         return f0;
     }
@@ -58,6 +62,7 @@ public final class Tuple3<E0, E1, E2> {
     /**
      * Returns the value of the field 1.
      */
+    @Nullable
     public E1 f1() {
         return f1;
     }
@@ -65,6 +70,7 @@ public final class Tuple3<E0, E1, E2> {
     /**
      * Returns the value of the field 2.
      */
+    @Nullable
     public E2 f2() {
         return f2;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple3.java
@@ -76,6 +76,7 @@ public final class Tuple3<E0, E1, E2> {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public boolean equals(Object obj) {
         final Tuple3 that;
         return this == obj

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple4.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple4.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.datamodel;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -47,13 +48,16 @@ public final class Tuple4<E0, E1, E2, E3> {
     /**
      * Returns a new 5-tuple with the supplied values.
      */
-    public static <E0, E1, E2, E3> Tuple4<E0, E1, E2, E3> tuple4(E0 f0, E1 f1, E2 f2, E3 f3) {
+    public static <E0, E1, E2, E3> Tuple4<E0, E1, E2, E3> tuple4(
+            @Nullable E0 f0, @Nullable E1 f1, @Nullable E2 f2, @Nullable E3 f3
+    ) {
         return new Tuple4<>(f0, f1, f2, f3);
     }
 
     /**
      * Returns the value of the field 0.
      */
+    @Nullable
     public E0 f0() {
         return f0;
     }
@@ -61,6 +65,7 @@ public final class Tuple4<E0, E1, E2, E3> {
     /**
      * Returns the value of the field 1.
      */
+    @Nullable
     public E1 f1() {
         return f1;
     }
@@ -68,6 +73,7 @@ public final class Tuple4<E0, E1, E2, E3> {
     /**
      * Returns the value of the field 2.
      */
+    @Nullable
     public E2 f2() {
         return f2;
     }
@@ -75,6 +81,7 @@ public final class Tuple4<E0, E1, E2, E3> {
     /**
      * Returns the value of the field 3.
      */
+    @Nullable
     public E3 f3() {
         return f3;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple4.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple4.java
@@ -30,10 +30,10 @@ import java.util.Objects;
  * @since 3.0
  */
 public final class Tuple4<E0, E1, E2, E3> {
-    private E0 f0;
-    private E1 f1;
-    private E2 f2;
-    private E3 f3;
+    private final E0 f0;
+    private final E1 f1;
+    private final E2 f2;
+    private final E3 f3;
 
     /**
      * Constructs a new 3-tuple with the supplied values.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple4.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple4.java
@@ -87,6 +87,7 @@ public final class Tuple4<E0, E1, E2, E3> {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public boolean equals(Object obj) {
         final Tuple4 that;
         return this == obj

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple5.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple5.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.datamodel;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 /**
@@ -50,13 +51,16 @@ public final class Tuple5<E0, E1, E2, E3, E4> {
     /**
      * Returns a new 5-tuple with the supplied values.
      */
-    public static <E0, E1, E2, E3, E4> Tuple5<E0, E1, E2, E3, E4> tuple5(E0 f0, E1 f1, E2 f2, E3 f3, E4 f4) {
+    public static <E0, E1, E2, E3, E4> Tuple5<E0, E1, E2, E3, E4> tuple5(
+            @Nullable E0 f0, @Nullable E1 f1, @Nullable E2 f2, @Nullable E3 f3, @Nullable E4 f4
+    ) {
         return new Tuple5<>(f0, f1, f2, f3, f4);
     }
 
     /**
      * Returns the value of the field 0.
      */
+    @Nullable
     public E0 f0() {
         return f0;
     }
@@ -64,6 +68,7 @@ public final class Tuple5<E0, E1, E2, E3, E4> {
     /**
      * Returns the value of the field 1.
      */
+    @Nullable
     public E1 f1() {
         return f1;
     }
@@ -71,6 +76,7 @@ public final class Tuple5<E0, E1, E2, E3, E4> {
     /**
      * Returns the value of the field 2.
      */
+    @Nullable
     public E2 f2() {
         return f2;
     }
@@ -78,6 +84,7 @@ public final class Tuple5<E0, E1, E2, E3, E4> {
     /**
      * Returns the value of the field 3.
      */
+    @Nullable
     public E3 f3() {
         return f3;
     }
@@ -85,11 +92,13 @@ public final class Tuple5<E0, E1, E2, E3, E4> {
     /**
      * Returns the value of the field 4.
      */
+    @Nullable
     public E4 f4() {
         return f4;
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public boolean equals(Object obj) {
         final Tuple5 that;
         return this == obj

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple5.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/Tuple5.java
@@ -30,11 +30,11 @@ import java.util.Objects;
  * @since 3.0
  */
 public final class Tuple5<E0, E1, E2, E3, E4> {
-    private E0 f0;
-    private E1 f1;
-    private E2 f2;
-    private E3 f3;
-    private E4 f4;
+    private final E0 f0;
+    private final E1 f1;
+    private final E2 f2;
+    private final E3 f3;
+    private final E4 f4;
 
     /**
      * Constructs a new 3-tuple with the supplied values.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/WindowResult.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/datamodel/WindowResult.java
@@ -90,6 +90,7 @@ public class WindowResult<R> {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public boolean equals(Object obj) {
         WindowResult that;
         return this == obj

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/AggregateTransform.java
@@ -26,12 +26,10 @@ import com.hazelcast.jet.impl.pipeline.Planner.PlannerVertex;
 import javax.annotation.Nonnull;
 import java.util.List;
 
-import static com.hazelcast.function.FunctionEx.identity;
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.processor.Processors.accumulateP;
 import static com.hazelcast.jet.core.processor.Processors.aggregateP;
 import static com.hazelcast.jet.core.processor.Processors.combineP;
-import static com.hazelcast.jet.core.processor.Processors.mapP;
 
 public class AggregateTransform<A, R> extends AbstractTransform {
     public static final String FIRST_STAGE_VERTEX_NAME_SUFFIX = "-prepare";

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/SortTransform.java
@@ -49,12 +49,15 @@ public class SortTransform<T> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p) {
-        Vertex v1 = p.dag.newVertex(name(), sortP(comparator));
-        PlannerVertex pv2 = p.addVertex(this, name() + COLLECT_STAGE_SUFFIX, 1,
-                ProcessorMetaSupplier.forceTotalParallelismOne(ProcessorSupplier.of(mapP(identity())), name()));
+        String vertexName = name();
+        Vertex v1 = p.dag.newVertex(vertexName, sortP(comparator))
+                         .localParallelism(localParallelism());
+        PlannerVertex pv2 = p.addVertex(this, vertexName + COLLECT_STAGE_SUFFIX, 1,
+                ProcessorMetaSupplier.forceTotalParallelismOne(ProcessorSupplier.of(mapP(identity())), vertexName));
         p.addEdges(this, v1);
-        p.dag.edge(between(v1, pv2.v).distributed()
-                                     .allToOne(name())
-                                     .ordered(comparator));
+        p.dag.edge(between(v1, pv2.v)
+                .distributed()
+                .allToOne(vertexName)
+                .ordered(comparator));
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AggregateP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/AggregateP.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl.processor;
+
+import com.hazelcast.jet.aggregate.AggregateOperation;
+
+import javax.annotation.Nonnull;
+
+import static java.util.Collections.nCopies;
+
+/**
+ * Batch processor that computes the supplied aggregate operation. The
+ * items may originate from one or more inbound edges. The supplied
+ * aggregate operation must have as many accumulation functions as there
+ * are inbound edges.
+ */
+public class AggregateP<A, R> extends GroupP<String, A, R, R> {
+
+    private static final String CONSTANT_KEY = "ALL";
+
+    public AggregateP(@Nonnull AggregateOperation<A, R> aggrOp) {
+        super(nCopies(aggrOp.arity(), t -> CONSTANT_KEY), aggrOp, (k, r) -> r);
+        keyToAcc.put(CONSTANT_KEY, aggrOp.createFn().get());
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/GroupP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/GroupP.java
@@ -44,7 +44,7 @@ public class GroupP<K, A, R, OUT> extends AbstractProcessor {
     @Nonnull private final List<FunctionEx<?, ? extends K>> groupKeyFns;
     @Nonnull private final AggregateOperation<A, R> aggrOp;
 
-    private final Map<K, A> keyToAcc = new HashMap<>();
+    final Map<K, A> keyToAcc = new HashMap<>();
     private Traverser<OUT> resultTraverser;
     private final BiFunction<? super K, ? super R, OUT> mapToOutputFn;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/GroupP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/GroupP.java
@@ -41,10 +41,12 @@ import static java.util.Collections.singletonList;
  * accumulation functions as there are inbound edges.
  */
 public class GroupP<K, A, R, OUT> extends AbstractProcessor {
-    @Nonnull private final List<FunctionEx<?, ? extends K>> groupKeyFns;
-    @Nonnull private final AggregateOperation<A, R> aggrOp;
 
     final Map<K, A> keyToAcc = new HashMap<>();
+    @Nonnull
+    private final List<FunctionEx<?, ? extends K>> groupKeyFns;
+    @Nonnull
+    private final AggregateOperation<A, R> aggrOp;
     private Traverser<OUT> resultTraverser;
     private final BiFunction<? super K, ? super R, OUT> mapToOutputFn;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/BatchStage.java
@@ -23,6 +23,7 @@ import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
 import com.hazelcast.function.SupplierEx;
 import com.hazelcast.jet.Traverser;
+import com.hazelcast.jet.aggregate.AggregateOperation;
 import com.hazelcast.jet.aggregate.AggregateOperation1;
 import com.hazelcast.jet.aggregate.AggregateOperation2;
 import com.hazelcast.jet.aggregate.AggregateOperation3;
@@ -267,11 +268,17 @@ public interface BatchStage<T> extends GeneralStage<T> {
 
     /**
      * Attaches a stage that performs the given aggregate operation over all
-     * the items it receives. The aggregating stage emits a single item.
+     * the items it receives. It emits a single item, the result of the
+     * aggregate operation's {@link AggregateOperation#finishFn() finish}
+     * primitive. The result may be {@code null} (e.g., {@link
+     * AggregateOperations#maxBy} with no input), in that case the stage
+     * does not produce any output.
      * <p>
      * Sample usage:
      * <pre>{@code
-     * stage.aggregate(AggregateOperations.counting())
+     * BatchStage<Integer> stage = pipeline.readFrom(TestSources.items(1, 2));
+     * // Emits a single item, the number 2:
+     * BatchStage<Long> count = stage.aggregate(AggregateOperations.counting());
      * }</pre>
      *
      * @see AggregateOperations AggregateOperations
@@ -294,10 +301,11 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * stage0.aggregate2(aggrOp0, stage1, aggrOp1)} because it offers a simpler
      * API and you can use the already defined single-input operations. Use
      * this variant only when you have the need to implement an aggregate
-     * operation that combines the input streams into the same
-     * accumulator.
+     * operation that combines the input streams into the same accumulator.
      * <p>
-     * The returned stage emits a single item.
+     * The stage emits a single item, the result of the aggregate operation's
+     * {@link AggregateOperation#finishFn() finish} primitive. The result may
+     * be {@code null}, in that case the stage does not produce any output.
      * <p>
      * Sample usage:
      * <pre>{@code
@@ -320,10 +328,8 @@ public interface BatchStage<T> extends GeneralStage<T> {
 
     /**
      * Attaches a stage that co-aggregates the data from this and the supplied
-     * stage by performing a separate aggregate operation on each and emitting
-     * a {@link Tuple2} with their results.
-     * <p>
-     * The returned stage emits a single item.
+     * stage by performing a separate aggregate operation on each and emits a
+     * single {@link Tuple2} with their results.
      * <p>
      * Sample usage:
      * <pre>{@code
@@ -364,7 +370,9 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * aggregate operation that combines the input streams into the same
      * accumulator.
      * <p>
-     * The returned stage emits a single item.
+     * The stage emits a single item, the result of the aggregate operation's
+     * {@link AggregateOperation#finishFn() finish} primitive. The result may
+     * be {@code null}, in that case the stage does not produce any output.
      * <p>
      * Sample usage:
      * <pre>{@code
@@ -393,9 +401,7 @@ public interface BatchStage<T> extends GeneralStage<T> {
     /**
      * Attaches a stage that co-aggregates the data from this and the two
      * supplied stages by performing a separate aggregate operation on each and
-     * emitting a {@link Tuple3} with their results.
-     * <p>
-     * The returned stage emits a single item.
+     * emits a single {@link Tuple3} with their results.
      * <p>
      * Sample usage:
      * <pre>{@code
@@ -438,7 +444,9 @@ public interface BatchStage<T> extends GeneralStage<T> {
      * to retrieve the aggregated result for that stage. Use {@link
      * AggregateBuilder#tag0() builder.tag0()} as the tag of this stage. You
      * will also be able to supply a function to the builder that immediately
-     * transforms the {@code ItemsByTag} to the desired output type.
+     * transforms the {@code ItemsByTag} to the desired output type. Your
+     * function may return {@code null} and in that case the stage will not
+     * emit anything.
      * <p>
      * This example counts the items in stage-0, sums those in stage-1 and takes
      * the average of those in stage-2:
@@ -470,7 +478,10 @@ public interface BatchStage<T> extends GeneralStage<T> {
     /**
      * Offers a step-by-step API to build a pipeline stage that co-aggregates
      * the data from several input stages. The current stage will be already
-     * registered with the builder you get.
+     * registered with the builder you get. The stage it builds will emit a
+     * single item, the one that the aggregate operation's {@link
+     * AggregateOperation#finishFn() finish} primitive returns. If it returns
+     * {@code null}, the stage will not emit any output.
      * <p>
      * This builder requires you to provide a multi-input aggregate operation.
      * If you can express your logic in terms of single-input aggregate

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
@@ -257,7 +257,8 @@ public class AggregateOperationsTest {
     @Test
     public void when_allOfWithoutDeduct_then_noDeduct() {
         validateOpWithoutDeduct(
-                allOf(counting(), AggregateOperations.maxBy(naturalOrder())),
+                // JDK 11 can't infer <Long>
+                allOf(counting(), AggregateOperations.<Long>maxBy(naturalOrder())),
                 identity(), 10L, 11L,
                 tuple2(longAcc(1), new MutableReference<>(10L)),
                 tuple2(longAcc(2), new MutableReference<>(11L)),

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/aggregate/AggregateOperationsTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.aggregate;
 
+import com.hazelcast.function.BiConsumerEx;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.jet.Traversers;
@@ -98,11 +99,6 @@ public class AggregateOperationsTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Test
-    public void when_pickAny() {
-        validateOpWithoutDeduct(pickAny(), MutableReference::get, 1, 2, 1, 1, 1);
-    }
-
-    @Test
     public void when_counting() {
         validateOp(counting(), LongAccumulator::get,
                 null, null, 1L, 2L, 2L);
@@ -127,14 +123,43 @@ public class AggregateOperationsTest {
     }
 
     @Test
-    public void when_averagingLongOverflow_thenException() {
+    public void when_averagingLong_noInput_then_NaN() {
+        // Given
+        AggregateOperation1<Long, LongLongAccumulator, Double> aggrOp = averagingLong(Long::longValue);
+        LongLongAccumulator acc = aggrOp.createFn().get();
+
+        // When
+        double result = aggrOp.finishFn().apply(acc);
+
+        // Then
+        assertEquals(Double.NaN, result, 0.0);
+    }
+
+    @Test
+    public void when_averagingLong_tooManyItems_then_exception() {
         // Given
         AggregateOperation1<Long, LongLongAccumulator, Double> aggrOp = averagingLong(Long::longValue);
         LongLongAccumulator acc = new LongLongAccumulator(Long.MAX_VALUE, 0L);
 
-        // When and Then
+        // Then
         exception.expect(ArithmeticException.class);
+
+        // When
         aggrOp.accumulateFn().accept(acc, 0L);
+    }
+
+    @Test
+    public void when_averagingLong_sumTooLarge_then_exception() {
+        // Given
+        AggregateOperation1<Long, LongLongAccumulator, Double> aggrOp = averagingLong(Long::longValue);
+        LongLongAccumulator acc = aggrOp.createFn().get();
+
+        // Then
+        exception.expect(ArithmeticException.class);
+
+        // When
+        aggrOp.accumulateFn().accept(acc, Long.MAX_VALUE);
+        aggrOp.accumulateFn().accept(acc, 1L);
     }
 
     @Test
@@ -144,20 +169,48 @@ public class AggregateOperationsTest {
     }
 
     @Test
-    public void when_averagingDoubleOverflow_thenException() {
+    public void when_averagingDouble_tooManyItems_then_exception() {
         // Given
         AggregateOperation1<Double, LongDoubleAccumulator, Double> aggrOp = averagingDouble(Double::doubleValue);
         LongDoubleAccumulator acc = new LongDoubleAccumulator(Long.MAX_VALUE, 0.0d);
 
-        // When and Then
+        // Then
         exception.expect(ArithmeticException.class);
+
+        // When
         aggrOp.accumulateFn().accept(acc, 0.0d);
+    }
+
+    @Test
+    public void when_averagingDouble_noInput_then_NaN() {
+        // Given
+        AggregateOperation1<Double, LongDoubleAccumulator, Double> aggrOp = averagingDouble(Double::doubleValue);
+        LongDoubleAccumulator acc = aggrOp.createFn().get();
+
+        // When
+        double result = aggrOp.finishFn().apply(acc);
+
+        // Then
+        assertEquals(Double.NaN, result, 0.0);
     }
 
     @Test
     public void when_maxBy() {
         validateOpWithoutDeduct(maxBy(naturalOrder()), MutableReference::get,
                 10L, 11L, 10L, 11L, 11L);
+    }
+
+    @Test
+    public void when_maxBy_noInput_then_nullResult() {
+        // Given
+        AggregateOperation1<String, MutableReference<String>, String> aggrOp = maxBy(naturalOrder());
+        MutableReference<String> acc = aggrOp.createFn().get();
+
+        // When
+        String result = aggrOp.finishFn().apply(acc);
+
+        // Then
+        assertNull(result);
     }
 
     @Test
@@ -204,7 +257,7 @@ public class AggregateOperationsTest {
     @Test
     public void when_allOfWithoutDeduct_then_noDeduct() {
         validateOpWithoutDeduct(
-                allOf(counting(), AggregateOperations.<Long>maxBy(naturalOrder())),
+                allOf(counting(), AggregateOperations.maxBy(naturalOrder())),
                 identity(), 10L, 11L,
                 tuple2(longAcc(1), new MutableReference<>(10L)),
                 tuple2(longAcc(2), new MutableReference<>(11L)),
@@ -254,20 +307,24 @@ public class AggregateOperationsTest {
         // Given
         AggregateOperation1<Entry<Long, Long>, LinTrendAccumulator, Double> op =
                 linearTrend(Entry::getKey, Entry::getValue);
-        Supplier<LinTrendAccumulator> newFn = op.createFn();
+        Supplier<LinTrendAccumulator> createFn = op.createFn();
         BiConsumer<? super LinTrendAccumulator, ? super Entry<Long, Long>> accFn = op.accumulateFn();
         BiConsumer<? super LinTrendAccumulator, ? super LinTrendAccumulator> combineFn = op.combineFn();
         BiConsumer<? super LinTrendAccumulator, ? super LinTrendAccumulator> deductFn = op.deductFn();
         Function<? super LinTrendAccumulator, ? extends Double> finishFn = op.finishFn();
+        assertNotNull(createFn);
+        assertNotNull(accFn);
+        assertNotNull(combineFn);
         assertNotNull(deductFn);
+        assertNotNull(finishFn);
 
         // When
-        LinTrendAccumulator a1 = newFn.get();
+        LinTrendAccumulator a1 = createFn.get();
         accFn.accept(a1, entry(1L, 3L));
         accFn.accept(a1, entry(2L, 5L));
         assertEquals(2.0, finishFn.apply(a1), Double.MIN_VALUE);
 
-        LinTrendAccumulator a2 = newFn.get();
+        LinTrendAccumulator a2 = createFn.get();
         accFn.accept(a2, entry(5L, 11L));
         accFn.accept(a2, entry(6L, 13L));
         assertEquals(2.0, finishFn.apply(a2), Double.MIN_VALUE);
@@ -282,7 +339,7 @@ public class AggregateOperationsTest {
         assertEquals(Double.valueOf(2), result);
 
         // When
-        LinTrendAccumulator acc = newFn.get();
+        LinTrendAccumulator acc = createFn.get();
         // Then
         assertTrue("NaN expected if nothing accumulated", Double.isNaN(finishFn.apply(acc)));
 
@@ -336,7 +393,7 @@ public class AggregateOperationsTest {
     }
 
     @Test
-    public void when_toMapDuplicateAccumulate_then_fail() {
+    public void when_toMapDuplicateAccumulate_then_exception() {
         AggregateOperation1<Entry<Integer, Integer>, Map<Integer, Integer>, Map<Integer, Integer>> op =
                 toMap(Entry::getKey, Entry::getValue);
 
@@ -348,17 +405,22 @@ public class AggregateOperationsTest {
     }
 
     @Test
-    public void when_toMapDuplicateCombine_then_fail() {
+    public void when_toMapCombinesDuplicates_then_exception() {
+        // Given
         AggregateOperation1<Entry<Integer, Integer>, Map<Integer, Integer>, Map<Integer, Integer>> op =
                 toMap(Entry::getKey, Entry::getValue);
-
+        BiConsumerEx<? super Map<Integer, Integer>, ? super Map<Integer, Integer>> combineFn = op.combineFn();
+        assertNotNull("combineFn", combineFn);
         Map<Integer, Integer> acc1 = op.createFn().get();
         op.accumulateFn().accept(acc1, entry(1, 1));
         Map<Integer, Integer> acc2 = op.createFn().get();
         op.accumulateFn().accept(acc2, entry(1, 2));
 
+        // Then
         exception.expect(IllegalStateException.class);
-        op.combineFn().accept(acc1, acc2);
+
+        // When
+        combineFn.accept(acc1, acc2);
     }
 
     @Test
@@ -572,6 +634,23 @@ public class AggregateOperationsTest {
     }
 
     @Test
+    public void when_pickAny() {
+        validateOpWithoutDeduct(pickAny(), MutableReference::get, 1, 2, 1, 1, 1);
+    }
+
+    @Test
+    public void when_pickAny_noInput_then_nullResult() {
+        // Given
+        AggregateOperation1<Object, MutableReference<Object>, Object> aggrOp = pickAny();
+
+        // When
+        Object result = aggrOp.finishFn().apply(aggrOp.createFn().get());
+
+        // Then
+        assertNull(result);
+    }
+
+    @Test
     public void when_sorting() {
         validateOpWithoutDeduct(
                 sorting(naturalOrder()),
@@ -616,8 +695,10 @@ public class AggregateOperationsTest {
             R expectFinished
     ) {
         // Given
-        BiConsumer<? super A, ? super A> deductAccFn = op.deductFn();
-        assertNotNull("deductAccFn was null", deductAccFn);
+        BiConsumer<? super A, ? super A> deductFn = op.deductFn();
+        BiConsumerEx<? super A, ? super A> combineFn = op.combineFn();
+        assertNotNull("combineFn", combineFn);
+        assertNotNull("deductFn", deductFn);
 
         // When
         A acc1 = op.createFn().get();
@@ -636,7 +717,7 @@ public class AggregateOperationsTest {
         byte[] acc1ExportedSerialized = serialize(acc1Exported);
 
         // When
-        op.combineFn().accept(acc1, acc2);
+        combineFn.accept(acc1, acc2);
         // Then
         assertEqualsOrArrayEquals("combined", expectCombined, getAccValFn.apply(acc1));
 
@@ -656,7 +737,7 @@ public class AggregateOperationsTest {
         assertEqualsOrArrayEquals("finished", expectFinished, finished);
 
         // When
-        deductAccFn.accept(acc1, acc2);
+        deductFn.accept(acc1, acc2);
         // Then
         assertEqualsOrArrayEquals("deducted", expectAcced1, getAccValFn.apply(acc1));
 
@@ -699,8 +780,10 @@ public class AggregateOperationsTest {
             X expectCombined,
             R expectFinished
     ) {
-        // Then
-        assertNull("deductFn must be null", op.deductFn());
+        // Given
+        assertNull("deductFn", op.deductFn());
+        BiConsumerEx<? super A, ? super A> combineFn = op.combineFn();
+        assertNotNull("combineFn", combineFn);
 
         // When
         A acc1 = op.createFn().get();
@@ -719,7 +802,7 @@ public class AggregateOperationsTest {
         byte[] acc1ExportedSerialized = serialize(acc1Exported);
 
         // When
-        op.combineFn().accept(acc1, acc2);
+        combineFn.accept(acc1, acc2);
         // Then
         assertEquals("combined", expectCombined, getAccValFn.apply(acc1));
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchAggregateTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchAggregateTest.java
@@ -36,10 +36,12 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collector;
 
+import static com.hazelcast.function.ComparatorEx.comparingInt;
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.aggregate.AggregateOperations.aggregateOperation2;
 import static com.hazelcast.jet.aggregate.AggregateOperations.aggregateOperation3;
 import static com.hazelcast.jet.aggregate.AggregateOperations.coAggregateOperationBuilder;
+import static com.hazelcast.jet.aggregate.AggregateOperations.maxBy;
 import static com.hazelcast.jet.datamodel.ItemsByTag.itemsByTag;
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
@@ -95,6 +97,20 @@ public class BatchAggregateTest extends PipelineTestSupport {
         execute();
         assertEquals(
                 singletonList(0L),
+                new ArrayList<>(sinkList)
+        );
+    }
+
+    @Test
+    public void when_maxOfZeroItems_then_producesNoOutput() {
+        // When
+        BatchStage<Integer> aggregated = batchStageFromList(emptyList()).aggregate(maxBy(comparingInt(i -> i)));
+
+        // Then
+        aggregated.writeTo(sink);
+        execute();
+        assertEquals(
+                emptyList(),
                 new ArrayList<>(sinkList)
         );
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchAggregateTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/BatchAggregateTest.java
@@ -43,6 +43,7 @@ import static com.hazelcast.jet.aggregate.AggregateOperations.coAggregateOperati
 import static com.hazelcast.jet.datamodel.ItemsByTag.itemsByTag;
 import static com.hazelcast.jet.datamodel.Tuple2.tuple2;
 import static com.hazelcast.jet.datamodel.Tuple3.tuple3;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.summingLong;
@@ -80,6 +81,20 @@ public class BatchAggregateTest extends PipelineTestSupport {
         execute();
         assertEquals(
                 singletonList(input.stream().mapToLong(i -> i).sum()),
+                new ArrayList<>(sinkList)
+        );
+    }
+
+    @Test
+    public void when_aggregateZeroItems_then_producesOutput() {
+        // When
+        BatchStage<Long> aggregated = batchStageFromList(emptyList()).aggregate(SUMMING);
+
+        // Then
+        aggregated.writeTo(sink);
+        execute();
+        assertEquals(
+                singletonList(0L),
                 new ArrayList<>(sinkList)
         );
     }


### PR DESCRIPTION
Even without any input, the aggregation stage must produce its output. 

This PR fixes the behavior of those aggregate operations that can represent an "empty" result (zero sum, empty list), but not of those whose result is `null` without any input (`minBy`, `maxBy`). These operations keep the current behavior of emitting nothing.

Fixes #2560. 

Checklist
- [x] Labels and Milestone set
