### PR TITLE
Improve safety of working with job suspension cause programmatically

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
@@ -17,7 +17,6 @@
 package com.hazelcast.jet;
 
 import com.hazelcast.config.MetricsConfig;
-import com.hazelcast.jet.annotation.EvolvingApi;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.DAG;
@@ -88,12 +87,11 @@ public interface Job {
 
     /**
      * Return a {@link JobSuspensionCause description of the cause} that has
-     * lead to the suspension of the job. Throws an {@code IllegalStateException}
-     * if the job is not actually suspended.
+     * led to the suspension of the job. Throws an {@code IllegalStateException}
+     * if the job is not currently suspended.
      *
      * @since 4.3
      */
-    @EvolvingApi
     @Nonnull
     JobSuspensionCause getSuspensionCause();
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Job.java
@@ -22,6 +22,7 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.config.ProcessingGuarantee;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.JobSuspensionCause;
 import com.hazelcast.jet.core.metrics.JobMetrics;
 import com.hazelcast.jet.pipeline.Pipeline;
 
@@ -86,21 +87,15 @@ public interface Job {
     JobStatus getStatus();
 
     /**
-     * Return a human-readable description of the cause that led to the
-     * suspension of this job. For example whether the suspension has been
-     * explicitly requested by the user or an error has occurred and the job is
-     * configured to be suspended in such a case (see {@link
-     * JobConfig#setSuspendOnFailure(boolean)}) - in this case the details of
-     * the error are also provided.
-     *
-     * @return cause that led to the job suspension
-     * @throws IllegalStateException if the job is not suspended
+     * Return a {@link JobSuspensionCause description of the cause} that has
+     * lead to the suspension of the job. Throws an {@code IllegalStateException}
+     * if the job is not actually suspended.
      *
      * @since 4.3
      */
     @EvolvingApi
     @Nonnull
-    String getSuspensionCause();
+    JobSuspensionCause getSuspensionCause();
 
     /**
      * Returns a snapshot of the current values of all job-specific metrics.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.core;
+
+import com.hazelcast.jet.config.JobConfig;
+
+import javax.annotation.Nullable;
+
+/**
+ * Description of the cause that has lead to the job being suspended.
+ * <p>
+ * One reason for the job to be suspended is the user explicitly requesting it.
+ * Another reason is encountering an error during execution, while being
+ * configured to get suspended in such cases, instead of just failing. See
+ * {@link JobConfig#setSuspendOnFailure(boolean)}.
+ * <p>
+ * When the job has been suspended due to an error, then the cause of that
+ * error is provided.
+ */
+public interface JobSuspensionCause {
+
+    /**
+     * True if the job has been suspended due to an explicit request from the
+     * user.
+     */
+    boolean requestedByUser();
+
+    /**
+     * True if the job has been suspended due to encountering an error during
+     * execution.
+     */
+    boolean dueToError();
+
+    /**
+     * Provides the error that has lead to the suspension of the job, or returns
+     * null if the cause of the suspension is different.
+     */
+    @Nullable
+    Throwable errorCause();
+
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
  * <p>
  * When the job has been suspended due to an error, then the cause of that
  * error is provided.
+ *
+ * @since 4.4
  */
 public interface JobSuspensionCause {
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
@@ -18,10 +18,10 @@ package com.hazelcast.jet.core;
 
 import com.hazelcast.jet.config.JobConfig;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 
 /**
- * Description of the cause that has lead to the job being suspended.
+ * Description of the cause that has led to the job being suspended.
  * <p>
  * One reason for the job to be suspended is the user explicitly requesting it.
  * Another reason is encountering an error during execution, while being
@@ -36,22 +36,28 @@ import javax.annotation.Nullable;
 public interface JobSuspensionCause {
 
     /**
-     * True if the job has been suspended due to an explicit request from the
-     * user.
+     * True if the user explicitly suspended the job.
      */
     boolean requestedByUser();
 
     /**
-     * True if the job has been suspended due to encountering an error during
+     * True if Jet suspended the job because it encountered an error during
      * execution.
      */
     boolean dueToError();
 
     /**
-     * Provides the error that has lead to the suspension of the job, or returns
-     * null if the cause of the suspension is different.
+     * Describes the error that has led to the suspension of the job. Throws
+     * {@link UnsupportedOperationException} if job was not suspended due to an
+     * error.
      */
-    @Nullable
-    Throwable errorCause();
+    @Nonnull
+    String errorCause();
+
+    /**
+     * Describes the job suspension cause in a human readable form.
+     */
+    @Nonnull
+    String description();
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JobSuspensionCause.java
@@ -55,7 +55,7 @@ public interface JobSuspensionCause {
     String errorCause();
 
     /**
-     * Describes the job suspension cause in a human readable form.
+     * Describes the job suspension cause in a human-readable form.
      */
     @Nonnull
     String description();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/ClientJobProxy.java
@@ -25,6 +25,7 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.JobStateSnapshot;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.JobSuspensionCause;
 import com.hazelcast.jet.core.metrics.JobMetrics;
 import com.hazelcast.jet.impl.client.protocol.codec.JetExportSnapshotCodec;
 import com.hazelcast.jet.impl.client.protocol.codec.JetGetJobConfigCodec;
@@ -81,11 +82,12 @@ public class ClientJobProxy extends AbstractJobProxy<JetClientInstanceImpl> {
 
     @Nonnull
     @Override
-    public String getSuspensionCause() {
+    public JobSuspensionCause getSuspensionCause() {
         return callAndRetryIfTargetNotFound(()  -> {
             ClientMessage request = JetGetJobSuspensionCauseCodec.encodeRequest(getId());
             ClientMessage response = invocation(request, masterUuid()).invoke().get();
-            return JetGetJobSuspensionCauseCodec.decodeResponse(response);
+            Data data = JetGetJobSuspensionCauseCodec.decodeResponse(response);
+            return serializationService().toObject(data);
         });
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -36,6 +36,7 @@ import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JobNotFoundException;
 import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.JobSuspensionCause;
 import com.hazelcast.jet.core.TopologyChangedException;
 import com.hazelcast.jet.core.metrics.MetricNames;
 import com.hazelcast.jet.core.metrics.MetricTags;
@@ -441,9 +442,9 @@ public class JobCoordinationService {
      * Fails with {@link IllegalStateException} if the requested job is not
      * currently in a suspended state.
      */
-    public CompletableFuture<String> getJobSuspensionCause(long jobId) {
-        FunctionEx<JobExecutionRecord, String> jobExecutionRecordHandler = jobExecutionRecord -> {
-            String cause = jobExecutionRecord.getSuspensionCause();
+    public CompletableFuture<JobSuspensionCause> getJobSuspensionCause(long jobId) {
+        FunctionEx<JobExecutionRecord, JobSuspensionCause> jobExecutionRecordHandler = jobExecutionRecord -> {
+            JobSuspensionCause cause = jobExecutionRecord.getSuspensionCause();
             if (cause == null) {
                 throw new IllegalStateException("Job not suspended");
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
@@ -17,13 +17,13 @@
 package com.hazelcast.jet.impl;
 
 import com.hazelcast.internal.util.Clock;
+import com.hazelcast.jet.core.JobSuspensionCause;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Objects;
@@ -51,7 +51,7 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
     private final AtomicInteger quorumSize = new AtomicInteger();
     private long jobId;
     private volatile boolean executed;
-    private volatile String suspensionCause;
+    private volatile JobSuspensionCause suspensionCause;
     private volatile long snapshotId = NO_SNAPSHOT;
     private volatile int dataMapIndex = -1;
     private volatile long ongoingSnapshotId = NO_SNAPSHOT;
@@ -98,7 +98,7 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
      * suspended.
      */
     @Nullable
-    public String getSuspensionCause() {
+    public JobSuspensionCause getSuspensionCause() {
         return suspensionCause;
     }
 
@@ -106,8 +106,8 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
         suspensionCause = null;
     }
 
-    public void setSuspended(@Nonnull String suspensionCause) {
-        this.suspensionCause = Objects.requireNonNull(suspensionCause);
+    public void setSuspended(@Nullable Throwable error) {
+        suspensionCause = JobSuspensionCauseImpl.causedBy(error);
     }
 
     public boolean executed() {
@@ -290,7 +290,7 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
                 "jobId=" + jobId +
                 ", timestamp=" + toLocalTime(timestamp.get()) +
                 ", quorumSize=" + quorumSize +
-                ", suspended=" + (suspensionCause == null ? "false" : "true (" + suspensionCause + ")") +
+                ", suspended=" + (suspensionCause != null) +
                 ", executed=" + executed +
                 ", dataMapIndex=" + dataMapIndex +
                 ", snapshotId=" + snapshotId +

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobExecutionRecord.java
@@ -106,7 +106,7 @@ public class JobExecutionRecord implements IdentifiedDataSerializable {
         suspensionCause = null;
     }
 
-    public void setSuspended(@Nullable Throwable error) {
+    public void setSuspended(@Nullable String error) {
         suspensionCause = JobSuspensionCauseImpl.causedBy(error);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobProxy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobProxy.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.Job;
 import com.hazelcast.jet.JobStateSnapshot;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.JobStatus;
+import com.hazelcast.jet.core.JobSuspensionCause;
 import com.hazelcast.jet.core.metrics.JobMetrics;
 import com.hazelcast.jet.impl.metrics.RawJobMetrics;
 import com.hazelcast.jet.impl.operation.GetJobConfigOperation;
@@ -73,9 +74,9 @@ public class JobProxy extends AbstractJobProxy<NodeEngineImpl> {
 
     @Nonnull
     @Override
-    public String getSuspensionCause() {
+    public JobSuspensionCause getSuspensionCause() {
         try {
-            return this.<String>invokeOp(new GetJobSuspensionCauseOperation(getId())).get();
+            return this.<JobSuspensionCause>invokeOp(new GetJobSuspensionCauseOperation(getId())).get();
         } catch (Throwable t) {
             throw rethrow(t);
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobSuspensionCauseImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobSuspensionCauseImpl.java
@@ -51,7 +51,7 @@ public class JobSuspensionCauseImpl implements JobSuspensionCause, IdentifiedDat
     @Override
     public String errorCause() {
         if (error == null) {
-            throw new UnsupportedOperationException("Suspension not caused by an error");
+            throw new IllegalStateException("Suspension not caused by an error");
         }
         return error;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobSuspensionCauseImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobSuspensionCauseImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.impl;
+
+import com.hazelcast.jet.core.JobSuspensionCause;
+import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class JobSuspensionCauseImpl implements JobSuspensionCause, IdentifiedDataSerializable {
+
+    private static final JobSuspensionCauseImpl REQUESTED_BY_USER = new JobSuspensionCauseImpl(null);
+
+    private Throwable error;
+
+    public JobSuspensionCauseImpl() { //needed for deserialization
+    }
+
+    private JobSuspensionCauseImpl(Throwable error) {
+        this.error = error;
+    }
+
+    @Override
+    public boolean requestedByUser() {
+        return error == null;
+    }
+
+    @Override
+    public boolean dueToError() {
+        return error != null;
+    }
+
+    @Nullable
+    @Override
+    public Throwable errorCause() {
+        return error;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return JetInitDataSerializerHook.FACTORY_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return JetInitDataSerializerHook.JOB_SUSPENSION_CAUSE;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(error);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        error = in.readObject();
+    }
+
+    static JobSuspensionCauseImpl causedBy(Throwable cause) {
+        return cause == null ? REQUESTED_BY_USER : new JobSuspensionCauseImpl(cause);
+    }
+}

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobSuspensionCauseImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobSuspensionCauseImpl.java
@@ -22,19 +22,19 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
 public class JobSuspensionCauseImpl implements JobSuspensionCause, IdentifiedDataSerializable {
 
     private static final JobSuspensionCauseImpl REQUESTED_BY_USER = new JobSuspensionCauseImpl(null);
 
-    private Throwable error;
+    private String error;
 
     public JobSuspensionCauseImpl() { //needed for deserialization
     }
 
-    private JobSuspensionCauseImpl(Throwable error) {
+    private JobSuspensionCauseImpl(String error) {
         this.error = error;
     }
 
@@ -48,10 +48,27 @@ public class JobSuspensionCauseImpl implements JobSuspensionCause, IdentifiedDat
         return error != null;
     }
 
-    @Nullable
     @Override
-    public Throwable errorCause() {
+    public String errorCause() {
+        if (error == null) {
+            throw new UnsupportedOperationException("Suspension not caused by an error");
+        }
         return error;
+    }
+
+    @Nonnull
+    @Override
+    public String description() {
+        if (error == null) {
+            return "Requested by user";
+        } else {
+            return error;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return description();
     }
 
     @Override
@@ -74,7 +91,7 @@ public class JobSuspensionCauseImpl implements JobSuspensionCause, IdentifiedDat
         error = in.readObject();
     }
 
-    static JobSuspensionCauseImpl causedBy(Throwable cause) {
+    static JobSuspensionCauseImpl causedBy(String cause) {
         return cause == null ? REQUESTED_BY_USER : new JobSuspensionCauseImpl(cause);
     }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -44,7 +44,6 @@ import com.hazelcast.jet.impl.operation.GetLocalJobMetricsOperation.ExecutionNot
 import com.hazelcast.jet.impl.operation.InitExecutionOperation;
 import com.hazelcast.jet.impl.operation.StartExecutionOperation;
 import com.hazelcast.jet.impl.operation.TerminateExecutionOperation;
-import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.impl.util.LoggingUtil;
 import com.hazelcast.jet.impl.util.NonCompletableFuture;
 import com.hazelcast.jet.impl.util.Util;
@@ -635,12 +634,11 @@ public class MasterJobContext {
                         && mc.jobConfig().getProcessingGuarantee() != NONE
                 ) {
                     mc.setJobStatus(SUSPENDED);
-                    mc.jobExecutionRecord().setSuspended("Requested by user");
+                    mc.jobExecutionRecord().setSuspended(null);
                     nonSynchronizedAction = () -> mc.writeJobExecutionRecord(false);
                 } else if (failure != null && !isCancelled() && mc.jobConfig().isSuspendOnFailure()) {
                     mc.setJobStatus(SUSPENDED);
-                    mc.jobExecutionRecord().setSuspended("Execution failure:\n" +
-                            ExceptionUtil.stackTraceToString(failure));
+                    mc.jobExecutionRecord().setSuspended(failure);
                     nonSynchronizedAction = () -> mc.writeJobExecutionRecord(false);
                 } else {
                     mc.setJobStatus(isSuccess(failure) ? COMPLETED : FAILED);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -44,6 +44,7 @@ import com.hazelcast.jet.impl.operation.GetLocalJobMetricsOperation.ExecutionNot
 import com.hazelcast.jet.impl.operation.InitExecutionOperation;
 import com.hazelcast.jet.impl.operation.StartExecutionOperation;
 import com.hazelcast.jet.impl.operation.TerminateExecutionOperation;
+import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.impl.util.LoggingUtil;
 import com.hazelcast.jet.impl.util.NonCompletableFuture;
 import com.hazelcast.jet.impl.util.Util;
@@ -638,7 +639,8 @@ public class MasterJobContext {
                     nonSynchronizedAction = () -> mc.writeJobExecutionRecord(false);
                 } else if (failure != null && !isCancelled() && mc.jobConfig().isSuspendOnFailure()) {
                     mc.setJobStatus(SUSPENDED);
-                    mc.jobExecutionRecord().setSuspended(failure);
+                    mc.jobExecutionRecord().setSuspended("Execution failure:\n" +
+                            ExceptionUtil.stackTraceToString(failure));
                     nonSynchronizedAction = () -> mc.writeJobExecutionRecord(false);
                 } else {
                     mc.setJobStatus(isSuccess(failure) ? COMPLETED : FAILED);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/codec/JetGetJobSuspensionCauseCodec.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/codec/JetGetJobSuspensionCauseCodec.java
@@ -18,8 +18,7 @@ package com.hazelcast.jet.impl.client.protocol.codec;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.Generated;
-import com.hazelcast.client.impl.protocol.codec.builtin.*;
-
+import com.hazelcast.client.impl.protocol.codec.builtin.DataCodec;
 
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
@@ -33,12 +32,12 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 
 /**
  */
-@Generated("155623312f42ffb1555c21980a791579")
+@Generated("0baf8f79327012f83aa3d481d363bd87")
 public final class JetGetJobSuspensionCauseCodec {
-    //hex: 0x000E00
-    public static final int REQUEST_MESSAGE_TYPE = 3584;
-    //hex: 0x000E01
-    public static final int RESPONSE_MESSAGE_TYPE = 3585;
+    //hex: 0xFE0E00
+    public static final int REQUEST_MESSAGE_TYPE = 16649728;
+    //hex: 0xFE0E01
+    public static final int RESPONSE_MESSAGE_TYPE = 16649729;
     private static final int REQUEST_JOB_ID_FIELD_OFFSET = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_JOB_ID_FIELD_OFFSET + LONG_SIZE_IN_BYTES;
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
@@ -67,23 +66,23 @@ public final class JetGetJobSuspensionCauseCodec {
         return decodeLong(initialFrame.content, REQUEST_JOB_ID_FIELD_OFFSET);
     }
 
-    public static ClientMessage encodeResponse(java.lang.String response) {
+    public static ClientMessage encodeResponse(com.hazelcast.internal.serialization.Data response) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, RESPONSE_MESSAGE_TYPE);
         clientMessage.add(initialFrame);
 
-        StringCodec.encode(clientMessage, response);
+        DataCodec.encode(clientMessage, response);
         return clientMessage;
     }
 
     /**
     */
-    public static java.lang.String decodeResponse(ClientMessage clientMessage) {
+    public static com.hazelcast.internal.serialization.Data decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         //empty initial frame
         iterator.next();
-        return StringCodec.decode(iterator);
+        return DataCodec.decode(iterator);
     }
 
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobSuspensionCauseMessageTask.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/client/protocol/task/JetGetJobSuspensionCauseMessageTask.java
@@ -19,16 +19,22 @@ package com.hazelcast.jet.impl.client.protocol.task;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.instance.impl.Node;
 import com.hazelcast.internal.nio.Connection;
+import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.jet.impl.client.protocol.codec.JetGetJobSuspensionCauseCodec;
 import com.hazelcast.jet.impl.operation.GetJobSuspensionCauseOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
-public class JetGetJobSuspensionCauseMessageTask extends AbstractJetMessageTask<Long, String> {
+public class JetGetJobSuspensionCauseMessageTask extends AbstractJetMessageTask<Long, Data> {
 
     JetGetJobSuspensionCauseMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection,
                 JetGetJobSuspensionCauseCodec::decodeRequest,
                 JetGetJobSuspensionCauseCodec::encodeResponse);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object o) {
+        return super.encodeResponse(toData(o));
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHook.java
@@ -25,6 +25,7 @@ import com.hazelcast.jet.impl.JobRepository.FilterJobResultByNamePredicate;
 import com.hazelcast.jet.impl.JobRepository.UpdateJobExecutionRecordEntryProcessor;
 import com.hazelcast.jet.impl.JobResult;
 import com.hazelcast.jet.impl.JobSummary;
+import com.hazelcast.jet.impl.JobSuspensionCauseImpl;
 import com.hazelcast.jet.impl.SnapshotValidationRecord;
 import com.hazelcast.jet.impl.aggregate.AggregateOpAggregator;
 import com.hazelcast.jet.impl.connector.WriteFileP;
@@ -99,7 +100,8 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
     public static final int GET_LOCAL_JOB_METRICS_OP = 35;
     public static final int SNAPSHOT_PHASE2_OPERATION = 36;
     public static final int WRITE_FILE_P_FILE_ID = 42;
-    public static final int GET_JOB_SUSPENSION_CAUSE_OP = 43;
+    public static final int JOB_SUSPENSION_CAUSE = 43;
+    public static final int GET_JOB_SUSPENSION_CAUSE_OP = 44;
 
     public static final int FACTORY_ID = FactoryIdHelper.getFactoryId(JET_IMPL_DS_FACTORY, JET_IMPL_DS_FACTORY_ID);
 
@@ -194,6 +196,8 @@ public final class JetInitDataSerializerHook implements DataSerializerHook {
                     return new SnapshotPhase2Operation();
                 case WRITE_FILE_P_FILE_ID:
                     return new WriteFileP.FileId();
+                case JOB_SUSPENSION_CAUSE:
+                    return new JobSuspensionCauseImpl();
                 case GET_JOB_SUSPENSION_CAUSE_OP:
                     return new GetJobSuspensionCauseOperation();
                 default:

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSuspensionCauseOperation.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/operation/GetJobSuspensionCauseOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.impl.operation;
 
+import com.hazelcast.jet.core.JobSuspensionCause;
 import com.hazelcast.jet.impl.execution.init.JetInitDataSerializerHook;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
@@ -31,7 +32,7 @@ public class GetJobSuspensionCauseOperation extends AsyncJobOperation implements
     }
 
     @Override
-    protected CompletableFuture<String> doRun() {
+    protected CompletableFuture<JobSuspensionCause> doRun() {
         return getJobCoordinationService().getJobSuspensionCause(jobId());
     }
 

--- a/hazelcast-jet-core/src/main/resources/client-protocol-definition/Jet.yaml
+++ b/hazelcast-jet-core/src/main/resources/client-protocol-definition/Jet.yaml
@@ -267,7 +267,7 @@ methods:
     response:
       params:
         - name: response
-          type: String
+          type: Data
           nullable: false
           since: 2.0
           doc: ''

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
@@ -29,19 +29,19 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.SourceBuilder;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.map.IMap;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Map;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.core.JobStatus.COMPLETED;
 import static com.hazelcast.jet.core.JobStatus.FAILED;
 import static com.hazelcast.jet.core.JobStatus.RUNNING;
 import static com.hazelcast.jet.core.JobStatus.SUSPENDED;
-import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
 
@@ -113,7 +113,7 @@ public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
         assertJobStatusEventually(job, RUNNING);
         job.suspend();
         assertJobStatusEventually(job, SUSPENDED);
-        assertEquals("Requested by user", job.getSuspensionCause());
+        assertThat(job.getSuspensionCause()).matches(JobSuspensionCause::requestedByUser);
 
         cancelAndJoin(job);
     }
@@ -129,9 +129,12 @@ public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
 
         // Then
         assertJobStatusEventually(job, JobStatus.SUSPENDED);
-        assertTrue(job.getSuspensionCause().matches("(?s)Execution failure:\n" +
-                "com.hazelcast.jet.JetException: Exception in ProcessorTasklet\\{faulty#[0-9]*}: " +
-                "java.lang.AssertionError: mock error.*"));
+
+        assertThat(job.getSuspensionCause()).matches(JobSuspensionCause::dueToError);
+        assertThat(job.getSuspensionCause().errorCause())
+                .isNotNull()
+                .matches(error -> error.getMessage().matches("Exception in ProcessorTasklet\\{faulty#[0-9]*}: " +
+                        "java.lang.AssertionError: mock error"));
 
         cancelAndJoin(job);
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/SuspendExecutionOnFailureTest.java
@@ -114,9 +114,9 @@ public class SuspendExecutionOnFailureTest extends TestInClusterSupport {
         job.suspend();
         assertJobStatusEventually(job, SUSPENDED);
         assertThat(job.getSuspensionCause()).matches(JobSuspensionCause::requestedByUser);
-
+        assertThat(job.getSuspensionCause().description()).isEqualTo("Requested by user");
         assertThatThrownBy(job.getSuspensionCause()::errorCause)
-                .isInstanceOf(UnsupportedOperationException.class)
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Suspension not caused by an error");
 
         cancelAndJoin(job);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/execution/init/JetInitDataSerializerHookTest.java
@@ -34,6 +34,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -45,7 +46,6 @@ import static java.lang.reflect.Modifier.TRANSIENT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
@@ -76,7 +76,7 @@ public class JetInitDataSerializerHookTest {
 
                 new Object[]{
                         "JobExecutionRecord",
-                        populateFields(new JobExecutionRecord(), singletonList("snapshotStats")),
+                        populateFields(new JobExecutionRecord(), Arrays.asList("snapshotStats", "suspensionCause")),
                         emptyList()},
 
                 new Object[]{


### PR DESCRIPTION
Attempting to make working programmatically with job suspension cause, for example in MC, less error prone (than relying on specific formatting of Strings).

Breaking changes:
* API

Checklist:
- [x] Labels and Milestone set
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
