### PR TITLE
Use custom CL for Comparator serialization

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -599,11 +599,11 @@ public class Edge implements IdentifiedDataSerializable {
         out.writeUTF(getDestName());
         out.writeInt(getDestOrdinal());
         out.writeInt(getPriority());
-        out.writeObject(getOrderComparator());
         out.writeObject(getDistributedTo());
         out.writeObject(getRoutingPolicy());
-        CustomClassLoadedObject.write(out, getPartitioner());
         out.writeObject(getConfig());
+        CustomClassLoadedObject.write(out, getPartitioner());
+        CustomClassLoadedObject.write(out, getOrderComparator());
     }
 
     @Override
@@ -613,16 +613,16 @@ public class Edge implements IdentifiedDataSerializable {
         destName = in.readUTF();
         destOrdinal = in.readInt();
         priority = in.readInt();
-        comparator = in.readObject();
         distributedTo = in.readObject();
         routingPolicy = in.readObject();
+        config = in.readObject();
         try {
             partitioner = CustomClassLoadedObject.read(in);
+            comparator = CustomClassLoadedObject.read(in);
         } catch (HazelcastSerializationException e) {
             throw new HazelcastSerializationException("Error deserializing edge '" + sourceName + "' -> '"
                     + destName + "': " + e, e);
         }
-        config = in.readObject();
     }
 
     @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
@@ -141,11 +141,11 @@ public class EdgeDef implements IdentifiedDataSerializable {
         out.writeInt(destOrdinal);
         out.writeInt(sourceOrdinal);
         out.writeInt(priority);
-        out.writeObject(comparator);
         out.writeObject(distributedTo);
         out.writeObject(routingPolicy);
-        CustomClassLoadedObject.write(out, partitioner);
         out.writeObject(config);
+        CustomClassLoadedObject.write(out, partitioner);
+        CustomClassLoadedObject.write(out, comparator);
     }
 
     @Override
@@ -154,11 +154,11 @@ public class EdgeDef implements IdentifiedDataSerializable {
         destOrdinal = in.readInt();
         sourceOrdinal = in.readInt();
         priority = in.readInt();
-        comparator = in.readObject();
         distributedTo = in.readObject();
         routingPolicy = in.readObject();
-        partitioner = CustomClassLoadedObject.read(in);
         config = in.readObject();
+        partitioner = CustomClassLoadedObject.read(in);
+        comparator = CustomClassLoadedObject.read(in);
     }
 
     @Override public String toString() {


### PR DESCRIPTION
Fixes a soak test issue indicating a classloader leak.

Breaking changes:
* snapshot format: version 4.3 already changes the snapshot format by introducing `Edge.comparator`, this PR additionally changes the order of serialized components

Checklist:
- [x] Labels and Milestone set
