### PR TITLE
Retry initialization of PythonService context

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
@@ -16,6 +16,7 @@
 package com.hazelcast.jet.python;
 
 import com.hazelcast.jet.JetException;
+import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.grpc.impl.GrpcUtil;
 import com.hazelcast.jet.pipeline.ServiceFactory;
 import com.hazelcast.jet.python.impl.grpc.InputMessage;
@@ -49,6 +50,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 final class PythonService {
 
+    private static final int CREATE_CONTEXT_RETRY_COUNT = 3;
+    private static final int CREATE_CONTEXT_SLEEP_TIME_MILLIS = 1000;
     private static final String JET_TO_PYTHON_PREFIX = "jet_to_python_";
     static final String MAIN_SHELL_SCRIPT = JET_TO_PYTHON_PREFIX + "main.sh";
 
@@ -84,7 +87,7 @@ final class PythonService {
     static ServiceFactory<?, PythonService> factory(@Nonnull PythonServiceConfig cfg) {
         cfg.validate();
         ServiceFactory<PythonServiceContext, PythonService> fac = ServiceFactory
-                .withCreateContextFn(ctx -> new PythonServiceContext(ctx, cfg))
+                .withCreateContextFn(ctx -> createContextWithRetry(ctx, cfg))
                 .withDestroyContextFn(PythonServiceContext::destroy)
                 .withCreateServiceFn((procCtx, serviceCtx) -> new PythonService(serviceCtx))
                 .withDestroyServiceFn(PythonService::destroy);
@@ -95,6 +98,28 @@ final class PythonService {
             File handlerFile = Objects.requireNonNull(cfg.handlerFile());
             return fac.withAttachedFile(handlerFile.toString(), handlerFile);
         }
+    }
+
+    private static PythonServiceContext createContextWithRetry(
+            ProcessorSupplier.Context context,
+            PythonServiceConfig cfg
+    ) {
+        JetException jetException = null;
+        for (int i = 0; i < CREATE_CONTEXT_RETRY_COUNT; i++) {
+            try {
+                return new PythonServiceContext(context, cfg);
+            } catch (JetException exception) {
+                jetException = exception;
+                context.logger().warning("PythonService context creation failed", exception);
+                try {
+                    Thread.sleep(CREATE_CONTEXT_SLEEP_TIME_MILLIS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new JetException(e);
+                }
+            }
+        }
+        throw jetException;
     }
 
     CompletableFuture<List<String>> sendRequest(List<String> inputBatch) {

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonService.java
@@ -50,8 +50,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  */
 final class PythonService {
 
-    private static final int CREATE_CONTEXT_RETRY_COUNT = 3;
-    private static final int CREATE_CONTEXT_SLEEP_TIME_MILLIS = 1000;
+    private static final int CREATE_CONTEXT_RETRY_COUNT = 2;
+    private static final int CREATE_CONTEXT_RETRY_SLEEP_TIME_MILLIS = 1000;
     private static final String JET_TO_PYTHON_PREFIX = "jet_to_python_";
     static final String MAIN_SHELL_SCRIPT = JET_TO_PYTHON_PREFIX + "main.sh";
 
@@ -105,14 +105,16 @@ final class PythonService {
             PythonServiceConfig cfg
     ) {
         JetException jetException = null;
-        for (int i = 0; i < CREATE_CONTEXT_RETRY_COUNT; i++) {
+        for (int i = CREATE_CONTEXT_RETRY_COUNT; i >= 0 ; i--) {
             try {
                 return new PythonServiceContext(context, cfg);
             } catch (JetException exception) {
                 jetException = exception;
-                context.logger().warning("PythonService context creation failed", exception);
+                context.logger().warning(
+                        "PythonService context creation failed, " + (i > 0 ? " will retry" : " giving up"),
+                        exception);
                 try {
-                    Thread.sleep(CREATE_CONTEXT_SLEEP_TIME_MILLIS);
+                    Thread.sleep(CREATE_CONTEXT_RETRY_SLEEP_TIME_MILLIS);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new JetException(e);

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -81,9 +81,7 @@ class PythonServiceContext {
                         .getLogger(getClass().getPackage().getName());
         try {
             long start = System.nanoTime();
-            runtimeBaseDir = cfg.baseDir() != null
-                    ? context.attachedDirectory(cfg.baseDir().toString()).toPath()
-                    : context.attachedFile(cfg.handlerFile().toString()).toPath().getParent();
+            runtimeBaseDir = runtimeBaseDir(context, cfg);
             setupBaseDir(cfg);
             synchronized (INIT_LOCK) {
                 // synchronized: the script will run pip which is not concurrency-safe
@@ -111,6 +109,18 @@ class PythonServiceContext {
         } catch (Exception e) {
             throw new JetException("PythonService initialization failed: " + e, e);
         }
+    }
+
+    Path runtimeBaseDir(ProcessorSupplier.Context context, PythonServiceConfig cfg) {
+        File baseDir = cfg.baseDir();
+        if (baseDir != null) {
+            return context.attachedDirectory(baseDir.toString()).toPath();
+        }
+        File handlerFile = cfg.handlerFile();
+        if (handlerFile != null) {
+            return context.attachedDirectory(handlerFile.toString()).toPath().getParent();
+        }
+        throw new IllegalArgumentException("Either base directory or handler file should be configured");
     }
 
     void destroy() {

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -74,8 +74,7 @@ class PythonServiceContext {
     private static final Object INIT_LOCK = new Object();
 
     private final ILogger logger;
-
-    private Path runtimeBaseDir;
+    private final Path runtimeBaseDir;
 
     PythonServiceContext(ProcessorSupplier.Context context, PythonServiceConfig cfg) {
         logger = context.jetInstance().getHazelcastInstance().getLoggingService()

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -15,7 +15,6 @@
  */
 package com.hazelcast.jet.python;
 
-import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.logging.ILogger;
@@ -133,8 +132,6 @@ class PythonServiceContext {
             }
         } catch (Exception e) {
             throw new JetException("PythonService cleanup failed: " + e, e);
-        } finally {
-            IOUtil.delete(runtimeBaseDir);
         }
     }
 

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -118,7 +118,7 @@ class PythonServiceContext {
         }
         File handlerFile = cfg.handlerFile();
         if (handlerFile != null) {
-            return context.attachedDirectory(handlerFile.toString()).toPath().getParent();
+            return context.attachedFile(handlerFile.toString()).toPath().getParent();
         }
         throw new IllegalArgumentException("Either base directory or handler file should be configured");
     }


### PR DESCRIPTION
Retry initialization of PythonService context

Fixes https://github.com/hazelcast/hazelcast-jet/issues/2585

Breaking changes (list specific methods/types/messages):
* After job finished, the base directory for python is not deleted

Checklist:
- [X] Labels and Milestone set
- [x] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [NA] New public APIs have `@Nonnull/@Nullable` annotations
- [NA] New public APIs have `@since` tags in Javadoc
- [NA] Updated `examples/README.md` (when adding a new code sample)
