### PR TITLE
Increase default reconnect interval, improve docs

### DIFF
--- a/extensions/cdc-mysql/src/main/java/com/hazelcast/jet/cdc/mysql/MySqlCdcSources.java
+++ b/extensions/cdc-mysql/src/main/java/com/hazelcast/jet/cdc/mysql/MySqlCdcSources.java
@@ -64,10 +64,11 @@ public final class MySqlCdcSources {
      * {@code setShouldStateBeResetOnReconnect()}. The boolean flag passed in
      * specifies what should happen to the connector's state on reconnect,
      * whether it should be kept or reset. If the state is kept, then
-     * snapshotting should not be repeated and streaming the binlog should
-     * resume at the position where it left off. If the state is reset, then the
-     * source will behave as on its initial start, so will do a snapshot and
-     * will start trailing the binlog where it syncs with the snapshot's end.
+     * database snapshotting should not be repeated and streaming the binlog
+     * should resume at the position where it left off. If the state is reset,
+     * then the source will behave as on its initial start, so will do a
+     * database snapshot and will start trailing the binlog where it syncs with
+     * the database snapshot's end.
      *
      * @param name name of this source, needs to be unique, will be passed to
      *             the underlying Kafka Connect source
@@ -334,11 +335,11 @@ public final class MySqlCdcSources {
         /**
          * Specifies if the source's state should be kept or discarded during
          * reconnect attempts to the database. If the state is kept, then
-         * snapshotting should not be repeated and streaming the binlog should
-         * resume at the position where it left off. If the state is reset, then
-         * the source will behave as if it were its initial start, so will do a
-         * snapshot and will start trailing the binlog where it syncs with the
-         * snapshot's end.
+         * database snapshotting should not be repeated and streaming the binlog
+         * should resume at the position where it left off. If the state is
+         * reset, then the source will behave as if it were its initial start,
+         * so will do a database snapshot and will start trailing the binlog
+         * where it syncs with the database snapshot's end.
          */
         @Nonnull
         public Builder setShouldStateBeResetOnReconnect(boolean reset) {

--- a/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
+++ b/extensions/cdc-postgres/src/main/java/com/hazelcast/jet/cdc/postgres/PostgresCdcSources.java
@@ -63,10 +63,11 @@ public final class PostgresCdcSources {
      * the {@code setShouldStateBeResetOnReconnect()}. The boolean flag passed
      * in specifies what should happen to the connector's state on reconnect,
      * whether it should be kept or reset. If the state is kept, then
-     * snapshotting should not be repeated and streaming the WAL should resume
-     * at the position where it left off. If the state is reset, then the source
-     * will behave as on its initial start, so will do a snapshot and will start
-     * trailing the WAL where it syncs with the snapshot's end.
+     * database snapshotting should not be repeated and streaming the WAL should
+     * resume at the position where it left off. If the state is reset, then the
+     * source will behave as on its initial start, so will do a database
+     * snapshot and will start trailing the WAL where it syncs with the database
+     * snapshot's end.
      *
      * @param name name of this source, needs to be unique, will be passed to
      *             the underlying Kafka Connect source
@@ -390,11 +391,11 @@ public final class PostgresCdcSources {
         /**
          * Specifies if the source's state should be kept or discarded during
          * reconnect attempts to the database. If the state is kept, then
-         * snapshotting should not be repeated and streaming the binlog should
-         * resume at the position where it left off. If the state is reset, then
-         * the source will behave as if it were its initial start, so will do a
-         * snapshot and will start trailing the binlog where it syncs with the
-         * snapshot's end.
+         * database snapshotting should not be repeated and streaming the binlog
+         * should resume at the position where it left off. If the state is
+         * reset, then the source will behave as if it were its initial start,
+         * so will do a database snapshot and will start trailing the binlog
+         * where it syncs with the database snapshot's end.
          */
         @Nonnull
         public Builder setShouldStateBeResetOnReconnect(boolean reset) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/RetryStrategies.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/RetryStrategies.java
@@ -18,6 +18,8 @@ package com.hazelcast.jet.retry;
 
 import com.hazelcast.jet.retry.impl.RetryStrategyImpl;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /**
  * Collection of factory methods for creating the most frequently used
  * {@link RetryStrategy RetryStrategies}.
@@ -27,7 +29,7 @@ import com.hazelcast.jet.retry.impl.RetryStrategyImpl;
 public final class RetryStrategies {
 
     private static final int DEFAULT_MAX_ATTEMPTS = -1;
-    private static final long DEFAULT_WAIT_DURATION_MS = 500;
+    private static final long DEFAULT_WAIT_DURATION_MS = SECONDS.toMillis(5);
     private static final IntervalFunction DEFAULT_INTERVAL_FUNCTION = IntervalFunction.constant(DEFAULT_WAIT_DURATION_MS);
 
     private RetryStrategies() {


### PR DESCRIPTION
Turns out that the default reconnect interval is too small and can cause problems with the MySQL binary log client. Increased it to 5 seconds.

Also made some wording changes in the CDC source javadoc, to make the distinction between database snapshotting and Jet's snapshotting clearer.

Checklist:
- [x] Labels and Milestone set