### PR TITLE
Improve container cleanup, when done explicitly

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -124,7 +124,7 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
      * {@code stop()} method of test containers is implemented via `docker kill`
      * and this matters for some tests.
      */
-    protected static <T> T stopContainer(GenericContainer<?> container) {
+    protected static void stopContainer(GenericContainer<?> container) {
         String containerId = container.getContainerId();
         DockerClient dockerClient = DockerClientFactory.instance().client();
         dockerClient.stopContainerCmd(containerId)
@@ -133,7 +133,6 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
                 .withRemoveVolumes(true)
                 .withForce(true)
                 .exec();
-        return null;
     }
 
 }

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -124,10 +124,16 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
      * {@code stop()} method of test containers is implemented via `docker kill`
      * and this matters for some tests.
      */
-    protected static void stopContainer(GenericContainer<?> container) {
+    protected static <T> T stopContainer(GenericContainer<?> container) {
         String containerId = container.getContainerId();
         DockerClient dockerClient = DockerClientFactory.instance().client();
-        dockerClient.stopContainerCmd(containerId).exec();
+        dockerClient.stopContainerCmd(containerId)
+                .exec();
+        dockerClient.removeContainerCmd(containerId)
+                .withRemoveVolumes(true)
+                .withForce(true)
+                .exec();
+        return null;
     }
 
 }

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -93,6 +93,8 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
     @Parameter(value = 2)
     public String testName;
 
+    private MySQLContainer<?> mysql;
+
     @Parameters(name = "{2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
@@ -101,8 +103,6 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
     }
-
-    private MySQLContainer<?> mysql;
 
     @Before
     public void before() {

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.retry.RetryStrategy;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,7 +58,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -102,6 +102,8 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         });
     }
 
+    private MySQLContainer<?> mysql;
+
     @Before
     public void before() {
         //disable Testcontainer's automatic resource manager
@@ -112,11 +114,18 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }
 
+    @After
+    public void after() {
+        if (mysql != null) {
+            mysql = stopContainer(mysql);
+        }
+    }
+
     @Test
     public void when_noDatabaseToConnectTo() throws Exception {
-        MySQLContainer<?> mysql = initMySql(null, 0);
+        mysql = initMySql(null, 0);
         String containerIpAddress = mysql.getContainerIpAddress();
-        stopContainer(mysql);
+        mysql = stopContainer(mysql);
 
         int port = findRandomOpenPortInRange(MYSQL_PORT + 100, MYSQL_PORT + 1000);
 
@@ -144,7 +153,6 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 assertEquals(RUNNING, job.getStatus());
             } finally {
                 abortJob(job);
-                stopContainer(mysql);
             }
         }
     }
@@ -155,46 +163,9 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 Network network = initNetwork();
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
-            MySQLContainer<?> mysql = initMySql(network, null);
-            try {
-                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
-                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-                // when job starts
-                JetInstance jet = createJetMembers(2)[0];
-                Job job = jet.newJob(pipeline);
-                assertJobStatusEventually(job, RUNNING);
-
-                // and snapshotting is ongoing (we have no exact way of identifying
-                // the moment, but random sleep will catch it at least some of the time)
-                TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
-
-                // and connection is cut
-                proxy.setConnectionCut(true);
-
-                // and some time passes
-                SECONDS.sleep(2 * MILLISECONDS.toSeconds(RECONNECT_INTERVAL_MS));
-
-                // and connection recovers
-                proxy.setConnectionCut(false);
-
-                // then connector manages to reconnect and finish snapshot
-                try {
-                    assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-                } finally {
-                    abortJob(job);
-                }
-            } finally {
-                stopContainer(mysql);
-            }
-        }
-    }
-
-    @Test
-    public void when_databaseShutdownDuringSnapshotting() throws Exception {
-        int port = findRandomOpenPort();
-        MySQLContainer<?> mysql = initMySql(null, port);
-        Pipeline pipeline = initPipeline(mysql.getContainerIpAddress(), port);
-        try {
+            mysql = initMySql(network, null);
+            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
+            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
             // when job starts
             JetInstance jet = createJetMembers(2)[0];
             Job job = jet.newJob(pipeline);
@@ -202,31 +173,57 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
             // and snapshotting is ongoing (we have no exact way of identifying
             // the moment, but random sleep will catch it at least some of the time)
-            TimeUnit.MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(100, 500));
+            MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
 
-            // and DB is stopped
-            stopContainer(mysql);
-            mysql = null;
+            // and connection is cut
+            proxy.setConnectionCut(true);
 
-            boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
-            if (neverReconnect) {
-                // then job fails
-                assertJobFailsWithConnectException(job, true);
-            } else {
-                // and DB is started anew
-                mysql = initMySql(null, port);
+            // and some time passes
+            MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
 
-                // then snapshotting finishes successfully
-                try {
-                    assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-                    assertEquals(RUNNING, job.getStatus());
-                } finally {
-                    abortJob(job);
-                }
+            // and connection recovers
+            proxy.setConnectionCut(false);
+
+            // then connector manages to reconnect and finish snapshot
+            try {
+                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+            } finally {
+                abortJob(job);
             }
-        } finally {
-            if (mysql != null) {
-                stopContainer(mysql);
+        }
+    }
+
+    @Test
+    public void when_databaseShutdownDuringSnapshotting() throws Exception {
+        int port = findRandomOpenPort();
+        mysql = initMySql(null, port);
+        Pipeline pipeline = initPipeline(mysql.getContainerIpAddress(), port);
+        // when job starts
+        JetInstance jet = createJetMembers(2)[0];
+        Job job = jet.newJob(pipeline);
+        assertJobStatusEventually(job, RUNNING);
+
+        // and snapshotting is ongoing (we have no exact way of identifying
+        // the moment, but random sleep will catch it at least some of the time)
+        MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(100, 500));
+
+        // and DB is stopped
+        mysql = stopContainer(mysql);
+
+        boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
+        if (neverReconnect) {
+            // then job fails
+            assertJobFailsWithConnectException(job, true);
+        } else {
+            // and DB is started anew
+            mysql = initMySql(null, port);
+
+            // then snapshotting finishes successfully
+            try {
+                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                assertEquals(RUNNING, job.getStatus());
+            } finally {
+                abortJob(job);
             }
         }
     }
@@ -237,48 +234,9 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 Network network = initNetwork();
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
-            MySQLContainer<?> mysql = initMySql(network, null);
-            try {
-                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
-                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-                // when connector is up and transitions to binlog reading
-                JetInstance jet = createJetMembers(2)[0];
-                Job job = jet.newJob(pipeline);
-                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-                SECONDS.sleep(3);
-                insertRecords(mysql, 1005);
-                assertEqualsEventually(() -> jet.getMap("results").size(), 5);
-
-                // and the connection is cut
-                proxy.setConnectionCut(true);
-
-                // and some new events get generated in the DB
-                insertRecords(mysql, 1006, 1007);
-
-                // and some time passes
-                TimeUnit.MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
-
-                // and the connection is re-established
-                proxy.setConnectionCut(false);
-
-                // then the connector catches up
-                try {
-                    assertEqualsEventually(() -> jet.getMap("results").size(), 7);
-                } finally {
-                    abortJob(job);
-                }
-            } finally {
-                stopContainer(mysql);
-            }
-        }
-    }
-
-    @Test
-    public void when_databaseShutdownDuringBinlogReading() throws Exception {
-        int port = findRandomOpenPort();
-        MySQLContainer<?> mysql = initMySql(null, port);
-        Pipeline pipeline = initPipeline(mysql.getContainerIpAddress(), port);
-        try {
+            mysql = initMySql(network, null);
+            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, mysql);
+            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
             // when connector is up and transitions to binlog reading
             JetInstance jet = createJetMembers(2)[0];
             Job job = jet.newJob(pipeline);
@@ -287,39 +245,67 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
             insertRecords(mysql, 1005);
             assertEqualsEventually(() -> jet.getMap("results").size(), 5);
 
-            // and DB is stopped
-            stopContainer(mysql);
-            mysql = null;
+            // and the connection is cut
+            proxy.setConnectionCut(true);
 
-            boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
-            if (neverReconnect) {
-                // then job fails
-                assertJobFailsWithConnectException(job, true);
-            } else {
-                // and results are cleared
-                jet.getMap("results").clear();
-                assertEqualsEventually(() -> jet.getMap("results").size(), 0);
+            // and some new events get generated in the DB
+            insertRecords(mysql, 1006, 1007);
 
-                // and DB is started anew
-                mysql = initMySql(null, port);
-                insertRecords(mysql, 1005, 1006, 1007);
+            // and some time passes
+            MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
 
-                try {
-                    if (resetStateOnReconnect) {
-                        // then job keeps running, connector starts freshly, including snapshotting
-                        assertEqualsEventually(() -> jet.getMap("results").size(), 7);
-                        assertEquals(RUNNING, job.getStatus());
-                    } else {
-                        assertEqualsEventually(() -> jet.getMap("results").size(), 2);
-                        assertEquals(RUNNING, job.getStatus());
-                    }
-                } finally {
-                    abortJob(job);
-                }
+            // and the connection is re-established
+            proxy.setConnectionCut(false);
+
+            // then the connector catches up
+            try {
+                assertEqualsEventually(() -> jet.getMap("results").size(), 7);
+            } finally {
+                abortJob(job);
             }
-        } finally {
-            if (mysql != null) {
-                stopContainer(mysql);
+        }
+    }
+
+    @Test
+    public void when_databaseShutdownDuringBinlogReading() throws Exception {
+        int port = findRandomOpenPort();
+        mysql = initMySql(null, port);
+        Pipeline pipeline = initPipeline(mysql.getContainerIpAddress(), port);
+        // when connector is up and transitions to binlog reading
+        JetInstance jet = createJetMembers(2)[0];
+        Job job = jet.newJob(pipeline);
+        assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+        SECONDS.sleep(3);
+        insertRecords(mysql, 1005);
+        assertEqualsEventually(() -> jet.getMap("results").size(), 5);
+
+        // and DB is stopped
+        mysql = stopContainer(mysql);
+
+        boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
+        if (neverReconnect) {
+            // then job fails
+            assertJobFailsWithConnectException(job, true);
+        } else {
+            // and results are cleared
+            jet.getMap("results").clear();
+            assertEqualsEventually(() -> jet.getMap("results").size(), 0);
+
+            // and DB is started anew
+            mysql = initMySql(null, port);
+            insertRecords(mysql, 1005, 1006, 1007);
+
+            try {
+                if (resetStateOnReconnect) {
+                    // then job keeps running, connector starts freshly, including snapshotting
+                    assertEqualsEventually(() -> jet.getMap("results").size(), 7);
+                    assertEquals(RUNNING, job.getStatus());
+                } else {
+                    assertEqualsEventually(() -> jet.getMap("results").size(), 2);
+                    assertEquals(RUNNING, job.getStatus());
+                }
+            } finally {
+                abortJob(job);
             }
         }
     }
@@ -404,8 +390,6 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
             return socket.getLocalPort();
         }
     }
-
-
 
     private static int findRandomOpenPortInRange(int fromInclusive, int toExclusive) throws IOException {
         List<Integer> randomizedPortsInRange = IntStream.range(fromInclusive, toExclusive)

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -117,7 +117,7 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
     @After
     public void after() {
         if (mysql != null) {
-            mysql = stopContainer(mysql);
+            stopContainer(mysql);
         }
     }
 
@@ -125,7 +125,8 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
     public void when_noDatabaseToConnectTo() throws Exception {
         mysql = initMySql(null, 0);
         String containerIpAddress = mysql.getContainerIpAddress();
-        mysql = stopContainer(mysql);
+        stopContainer(mysql);
+        mysql = null;
 
         int port = findRandomOpenPortInRange(MYSQL_PORT + 100, MYSQL_PORT + 1000);
 
@@ -208,7 +209,8 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(100, 500));
 
         // and DB is stopped
-        mysql = stopContainer(mysql);
+        stopContainer(mysql);
+        mysql = null;
 
         boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
         if (neverReconnect) {
@@ -280,7 +282,8 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         assertEqualsEventually(() -> jet.getMap("results").size(), 5);
 
         // and DB is stopped
-        mysql = stopContainer(mysql);
+        stopContainer(mysql);
+        mysql = null;
 
         boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
         if (neverReconnect) {

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -116,7 +116,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
     @After
     public void after() {
         if (postgres != null) {
-            postgres = stopContainer(postgres);
+            stopContainer(postgres);
         }
     }
 
@@ -124,7 +124,8 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
     public void when_noDatabaseToConnectTo() throws Exception {
         postgres = initPostgres(null, 0);
         String containerIpAddress = postgres.getContainerIpAddress();
-        postgres = stopContainer(postgres);
+        stopContainer(postgres);
+        postgres = null;
 
         int port = findRandomOpenPortInRange(POSTGRESQL_PORT + 100, POSTGRESQL_PORT + 1000);
         Pipeline pipeline = initPipeline(containerIpAddress, port);
@@ -209,7 +210,8 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(100, 500));
 
         // and DB is stopped
-        postgres = stopContainer(postgres);
+        stopContainer(postgres);
+        postgres = null;
 
         // then
         boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
@@ -288,7 +290,8 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         assertEqualsEventually(() -> jet.getMap("results").size(), 5);
 
         // and DB is stopped
-        postgres = stopContainer(postgres);
+        stopContainer(postgres);
+        postgres = null;
 
         boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
         if (neverReconnect) {

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -92,6 +92,8 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
     @Parameter(value = 2)
     public String testName;
 
+    private PostgreSQLContainer<?> postgres;
+
     @Parameters(name = "{2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
@@ -100,8 +102,6 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
     }
-
-    private PostgreSQLContainer<?> postgres;
 
     @Before
     public void before() {

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -33,6 +33,7 @@ import com.hazelcast.jet.retry.RetryStrategy;
 import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -100,6 +101,8 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         });
     }
 
+    private PostgreSQLContainer<?> postgres;
+
     @Before
     public void before() {
         //disable Testcontainer's automatic resource manager
@@ -110,11 +113,18 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }
 
+    @After
+    public void after() {
+        if (postgres != null) {
+            postgres = stopContainer(postgres);
+        }
+    }
+
     @Test
     public void when_noDatabaseToConnectTo() throws Exception {
-        PostgreSQLContainer<?> postgres = initPostgres(null, 0);
+        postgres = initPostgres(null, 0);
         String containerIpAddress = postgres.getContainerIpAddress();
-        stopContainer(postgres);
+        postgres = stopContainer(postgres);
 
         int port = findRandomOpenPortInRange(POSTGRESQL_PORT + 100, POSTGRESQL_PORT + 1000);
         Pipeline pipeline = initPipeline(containerIpAddress, port);
@@ -143,7 +153,6 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 assertEquals(RUNNING, job.getStatus());
             } finally {
                 abortJob(job);
-                stopContainer(postgres);
             }
         }
     }
@@ -154,47 +163,9 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 Network network = initNetwork();
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
-            PostgreSQLContainer<?> postgres = initPostgres(network, null);
-            try {
-                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
-                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-                // when job starts
-                JetInstance jet = createJetMembers(2)[0];
-                Job job = jet.newJob(pipeline);
-                assertJobStatusEventually(job, RUNNING);
-
-                // and snapshotting is ongoing (we have no exact way of identifying
-                // the moment, but random sleep will catch it at least some of the time)
-                MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
-
-                // and connection is cut
-                proxy.setConnectionCut(true);
-
-                // and some time passes
-                MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
-                //it takes the bloody thing ages to notice the connection being down, so it won't notice this...
-
-                // and connection recovers
-                proxy.setConnectionCut(false);
-
-                // then connector manages to reconnect and finish snapshot
-                try {
-                    assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-                } finally {
-                    abortJob(job);
-                }
-            } finally {
-                stopContainer(postgres);
-            }
-        }
-    }
-
-    @Test
-    public void when_databaseShutdownOrLongDisconnectDuringSnapshotting() throws Exception {
-        int port = findRandomOpenPort();
-        PostgreSQLContainer<?> postgres = initPostgres(null, port);
-        Pipeline pipeline = initPipeline(postgres.getContainerIpAddress(), port);
-        try {
+            postgres = initPostgres(network, null);
+            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
+            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
             // when job starts
             JetInstance jet = createJetMembers(2)[0];
             Job job = jet.newJob(pipeline);
@@ -202,34 +173,61 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
 
             // and snapshotting is ongoing (we have no exact way of identifying
             // the moment, but random sleep will catch it at least some of the time)
-            MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(100, 500));
+            MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(0, 500));
 
-            // and DB is stopped
-            stopContainer(postgres);
-            postgres = null;
+            // and connection is cut
+            proxy.setConnectionCut(true);
 
-            // then
-            boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
-            if (neverReconnect) {
-                // then job fails
-                assertThatThrownBy(job::join)
-                        .hasRootCauseInstanceOf(JetException.class)
-                        .hasStackTraceContaining("Failed to connect to database");
-            } else {
-                // and DB is started anew
-                postgres = initPostgres(null, port);
+            // and some time passes
+            MILLISECONDS.sleep(2 * RECONNECT_INTERVAL_MS);
+            //it takes the bloody thing ages to notice the connection being down, so it won't notice this...
 
-                // then snapshotting finishes successfully
-                try {
-                    assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-                    assertEquals(RUNNING, job.getStatus());
-                } finally {
-                    abortJob(job);
-                }
+            // and connection recovers
+            proxy.setConnectionCut(false);
+
+            // then connector manages to reconnect and finish snapshot
+            try {
+                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+            } finally {
+                abortJob(job);
             }
-        } finally {
-            if (postgres != null) {
-                stopContainer(postgres);
+        }
+    }
+
+    @Test
+    public void when_databaseShutdownOrLongDisconnectDuringSnapshotting() throws Exception {
+        int port = findRandomOpenPort();
+        postgres = initPostgres(null, port);
+        Pipeline pipeline = initPipeline(postgres.getContainerIpAddress(), port);
+        // when job starts
+        JetInstance jet = createJetMembers(2)[0];
+        Job job = jet.newJob(pipeline);
+        assertJobStatusEventually(job, RUNNING);
+
+        // and snapshotting is ongoing (we have no exact way of identifying
+        // the moment, but random sleep will catch it at least some of the time)
+        MILLISECONDS.sleep(ThreadLocalRandom.current().nextInt(100, 500));
+
+        // and DB is stopped
+        postgres = stopContainer(postgres);
+
+        // then
+        boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
+        if (neverReconnect) {
+            // then job fails
+            assertThatThrownBy(job::join)
+                    .hasRootCauseInstanceOf(JetException.class)
+                    .hasStackTraceContaining("Failed to connect to database");
+        } else {
+            // and DB is started anew
+            postgres = initPostgres(null, port);
+
+            // then snapshotting finishes successfully
+            try {
+                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+                assertEquals(RUNNING, job.getStatus());
+            } finally {
+                abortJob(job);
             }
         }
     }
@@ -240,40 +238,36 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 Network network = initNetwork();
                 ToxiproxyContainer toxiproxy = initToxiproxy(network);
         ) {
-            PostgreSQLContainer<?> postgres = initPostgres(network, null);
+            postgres = initPostgres(network, null);
+            ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
+            Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
+            // when connector is up and transitions to binlog reading
+            JetInstance jet = createJetMembers(2)[0];
+            Job job = jet.newJob(pipeline);
+            assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+            SECONDS.sleep(3);
+            insertRecords(postgres, 1005);
+            assertEqualsEventually(() -> jet.getMap("results").size(), 5);
+
+            // and the connection is cut
+            proxy.setConnectionCut(true);
+
+            // and some new events get generated in the DB
+            insertRecords(postgres, 1006, 1007);
+
+            // and some time passes
+            MILLISECONDS.sleep(5 * RECONNECT_INTERVAL_MS);
+
+            // and the connection is re-established
+            proxy.setConnectionCut(false);
+
+            // then
             try {
-                ToxiproxyContainer.ContainerProxy proxy = initProxy(toxiproxy, postgres);
-                Pipeline pipeline = initPipeline(proxy.getContainerIpAddress(), proxy.getProxyPort());
-                // when connector is up and transitions to binlog reading
-                JetInstance jet = createJetMembers(2)[0];
-                Job job = jet.newJob(pipeline);
-                assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-                SECONDS.sleep(3);
-                insertRecords(postgres, 1005);
-                assertEqualsEventually(() -> jet.getMap("results").size(), 5);
-
-                // and the connection is cut
-                proxy.setConnectionCut(true);
-
-                // and some new events get generated in the DB
-                insertRecords(postgres, 1006, 1007);
-
-                // and some time passes
-                MILLISECONDS.sleep(5 * RECONNECT_INTERVAL_MS);
-
-                // and the connection is re-established
-                proxy.setConnectionCut(false);
-
-                // then
-                try {
-                    // then job keeps running, connector starts freshly, including snapshotting
-                    assertEqualsEventually(() -> jet.getMap("results").size(), 7);
-                    assertEquals(RUNNING, job.getStatus());
-                } finally {
-                    abortJob(job);
-                }
+                // then job keeps running, connector starts freshly, including snapshotting
+                assertEqualsEventually(() -> jet.getMap("results").size(), 7);
+                assertEquals(RUNNING, job.getStatus());
             } finally {
-                stopContainer(postgres);
+                abortJob(job);
             }
         }
     }
@@ -283,51 +277,44 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         Assume.assumeFalse(reconnectBehavior.getMaxAttempts() < 0 && !resetStateOnReconnect);
 
         int port = findRandomOpenPort();
-        PostgreSQLContainer<?> postgres = initPostgres(null, port);
+        postgres = initPostgres(null, port);
         Pipeline pipeline = initPipeline(postgres.getContainerIpAddress(), port);
-        try {
-            // when connector is up and transitions to binlog reading
-            JetInstance jet = createJetMembers(2)[0];
-            Job job = jet.newJob(pipeline);
-            assertEqualsEventually(() -> jet.getMap("results").size(), 4);
-            SECONDS.sleep(3);
+        // when connector is up and transitions to binlog reading
+        JetInstance jet = createJetMembers(2)[0];
+        Job job = jet.newJob(pipeline);
+        assertEqualsEventually(() -> jet.getMap("results").size(), 4);
+        SECONDS.sleep(3);
+        insertRecords(postgres, 1005);
+        assertEqualsEventually(() -> jet.getMap("results").size(), 5);
+
+        // and DB is stopped
+        postgres = stopContainer(postgres);
+
+        boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
+        if (neverReconnect) {
+            // then job fails
+            assertThatThrownBy(job::join)
+                    .hasRootCauseInstanceOf(JetException.class)
+                    .hasStackTraceContaining("Failed to connect to database");
+        } else {
+            // and results are cleared
+            jet.getMap("results").clear();
+            assertEqualsEventually(() -> jet.getMap("results").size(), 0);
+
+            // and DB is started anew
+            postgres = initPostgres(null, port);
             insertRecords(postgres, 1005);
-            assertEqualsEventually(() -> jet.getMap("results").size(), 5);
 
-            // and DB is stopped
-            stopContainer(postgres);
-            postgres = null;
+            // and some time passes
+            SECONDS.sleep(3);
+            insertRecords(postgres, 1006, 1007);
 
-            boolean neverReconnect = reconnectBehavior.getMaxAttempts() == 0;
-            if (neverReconnect) {
-                // then job fails
-                assertThatThrownBy(job::join)
-                        .hasRootCauseInstanceOf(JetException.class)
-                        .hasStackTraceContaining("Failed to connect to database");
-            } else {
-                // and results are cleared
-                jet.getMap("results").clear();
-                assertEqualsEventually(() -> jet.getMap("results").size(), 0);
-
-                // and DB is started anew
-                postgres = initPostgres(null, port);
-                insertRecords(postgres, 1005);
-
-                // and some time passes
-                SECONDS.sleep(3);
-                insertRecords(postgres, 1006, 1007);
-
-                try {
-                    // then job keeps running, connector starts freshly, including snapshotting
-                    assertEqualsEventually(() -> jet.getMap("results").size(), 7);
-                    assertEquals(RUNNING, job.getStatus());
-                } finally {
-                    abortJob(job);
-                }
-            }
-        } finally {
-            if (postgres != null) {
-                stopContainer(postgres);
+            try {
+                // then job keeps running, connector starts freshly, including snapshotting
+                assertEqualsEventually(() -> jet.getMap("results").size(), 7);
+                assertEquals(RUNNING, job.getStatus());
+            } finally {
+                abortJob(job);
             }
         }
     }


### PR DESCRIPTION
In our CDC network tests we are doing manual container lifecycle management, for more control. It turned out to be flawed. It was stopping the containers used by the tests, but it wasn't also removing them nor the volumes they created. This PR fixes the problem and also improves the test code a bit. 

Checklist:
- [x] Labels and Milestone set
