### PR TITLE
Improve PythonService init/cleanup

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -15,10 +15,11 @@
  */
 package com.hazelcast.jet.python;
 
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
@@ -31,18 +32,14 @@ import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import static com.hazelcast.jet.impl.util.IOUtil.copyStream;
+import static com.hazelcast.jet.impl.util.Util.editPermissionsRecursively;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
 import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
@@ -81,7 +78,7 @@ class PythonServiceContext {
                         .getLogger(getClass().getPackage().getName());
         try {
             long start = System.nanoTime();
-            runtimeBaseDir = runtimeBaseDir(context, cfg);
+            runtimeBaseDir = recreateRuntimeBaseDir(context, cfg);
             setupBaseDir(cfg);
             synchronized (INIT_LOCK) {
                 // synchronized: the script will run pip which is not concurrency-safe
@@ -93,7 +90,7 @@ class PythonServiceContext {
                 initProcess.waitFor();
                 if (initProcess.exitValue() != 0) {
                     try {
-                        destroy();
+                        performCleanup();
                     } catch (Exception e) {
                         logger.warning("Cleanup failed with exception", e);
                     }
@@ -111,36 +108,35 @@ class PythonServiceContext {
         }
     }
 
-    Path runtimeBaseDir(ProcessorSupplier.Context context, PythonServiceConfig cfg) {
+    private void makeFilesReadOnly(@Nonnull Path basePath) throws IOException {
+        List<String> filesNotMarked = editPermissionsRecursively(
+                basePath, perms -> perms.removeAll(WRITE_PERMISSIONS));
+        if (!filesNotMarked.isEmpty()) {
+            logger.info("Couldn't 'chmod -w' these files: " + filesNotMarked);
+        }
+    }
+
+    private static void makeExecutable(@Nonnull Path path) throws IOException {
+        Util.editPermissions(path, perms -> perms.add(OWNER_EXECUTE));
+    }
+
+    Path recreateRuntimeBaseDir(ProcessorSupplier.Context context, PythonServiceConfig cfg) {
         File baseDir = cfg.baseDir();
         if (baseDir != null) {
-            return context.attachedDirectory(baseDir.toString()).toPath();
+            return context.recreateAttachedDirectory(baseDir.toString()).toPath();
         }
         File handlerFile = cfg.handlerFile();
         if (handlerFile != null) {
-            return context.attachedFile(handlerFile.toString()).toPath().getParent();
+            return context.recreateAttachedFile(handlerFile.toString()).toPath().getParent();
         }
-        throw new IllegalArgumentException("Either base directory or handler file should be configured");
+        throw new IllegalArgumentException("PythonServiceConfig has neither baseDir nor handlerFile set");
     }
 
     void destroy() {
-        File runtimeBaseDirF = runtimeBaseDir.toFile();
         try {
-            makeFilesWritable(runtimeBaseDir);
-            Path cleanupScriptPath = runtimeBaseDir.resolve(USER_CLEANUP_SHELL_SCRIPT);
-            if (Files.exists(cleanupScriptPath)) {
-                Process cleanupProcess = new ProcessBuilder("/bin/sh", "-c", "./" + CLEANUP_SHELL_SCRIPT)
-                        .directory(runtimeBaseDirF)
-                        .redirectErrorStream(true)
-                        .start();
-                logStdOut(logger, cleanupProcess, "python-cleanup-" + cleanupProcess);
-                cleanupProcess.waitFor();
-                if (cleanupProcess.exitValue() != 0) {
-                    logger.warning("Cleanup script finished with non-zero exit code: " + cleanupProcess.exitValue());
-                }
-            }
-        } catch (Exception e) {
-            throw new JetException("PythonService cleanup failed: " + e, e);
+            performCleanup();
+        } finally {
+            IOUtil.delete(runtimeBaseDir);
         }
     }
 
@@ -184,6 +180,29 @@ class PythonServiceContext {
         }
     }
 
+    private void performCleanup() {
+        try {
+            List<String> filesNotMarked = editPermissionsRecursively(runtimeBaseDir, perms -> perms.add(OWNER_WRITE));
+            if (!filesNotMarked.isEmpty()) {
+                logger.info("Couldn't 'chmod u+w' these files: " + filesNotMarked);
+            }
+            Path cleanupScriptPath = runtimeBaseDir.resolve(USER_CLEANUP_SHELL_SCRIPT);
+            if (Files.exists(cleanupScriptPath)) {
+                Process cleanupProcess = new ProcessBuilder("/bin/sh", "-c", "./" + CLEANUP_SHELL_SCRIPT)
+                        .directory(runtimeBaseDir.toFile())
+                        .redirectErrorStream(true)
+                        .start();
+                logStdOut(logger, cleanupProcess, "python-cleanup-" + cleanupProcess);
+                cleanupProcess.waitFor();
+                if (cleanupProcess.exitValue() != 0) {
+                    logger.warning("Cleanup script finished with non-zero exit code: " + cleanupProcess.exitValue());
+                }
+            }
+        } catch (Exception e) {
+            throw new JetException("PythonService cleanup failed: " + e, e);
+        }
+    }
+
     static Thread logStdOut(ILogger logger, Process process, String taskName) {
         Thread thread = new Thread(() -> {
             try (BufferedReader in = new BufferedReader(new InputStreamReader(process.getInputStream(), UTF_8))) {
@@ -217,54 +236,6 @@ class PythonServiceContext {
                     out.println(jetToPython + name + "='" + value + '\'');
                 }
             }
-        }
-    }
-
-    private static void makeExecutable(@Nonnull Path path) throws IOException {
-        editPermissions(path, perms -> perms.add(OWNER_EXECUTE));
-    }
-
-    private void makeFilesReadOnly(@Nonnull Path basePath) throws IOException {
-        editPermissionsRecursively(basePath, "-w", perms -> perms.removeAll(WRITE_PERMISSIONS));
-    }
-
-    private void makeFilesWritable(@Nonnull Path basePath) throws IOException {
-        editPermissionsRecursively(basePath, "u+w", perms -> perms.add(OWNER_WRITE));
-    }
-
-    /**
-     * Return value of {@code editFn} tells whether it actually changed the
-     * supplied permission set. If it returns {@code false}, the file's
-     * permissions won't be changed.
-     */
-    private static void editPermissions(
-            @Nonnull Path path, @Nonnull Predicate<? super Set<PosixFilePermission>> editFn
-    ) throws IOException {
-        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(path, NOFOLLOW_LINKS);
-        if (editFn.test(perms)) {
-            Files.setPosixFilePermissions(path, perms);
-        }
-    }
-
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-            justification = "https://github.com/spotbugs/spotbugs/issues/756")
-    private void editPermissionsRecursively(
-            @Nonnull Path basePath,
-            @Nonnull String chmodOp,
-            @Nonnull Predicate<? super Set<PosixFilePermission>> editFn
-    ) throws IOException {
-        List<String> filesNotMarked = new ArrayList<>();
-        try (Stream<Path> walk = Files.walk(basePath)) {
-            walk.forEach(path -> {
-                try {
-                    editPermissions(path, editFn);
-                } catch (Exception e) {
-                    filesNotMarked.add(basePath.relativize(path).toString());
-                }
-            });
-        }
-        if (!filesNotMarked.isEmpty()) {
-            logger.info("Couldn't 'chmod " + chmodOp + "' these files: " + filesNotMarked);
         }
     }
 }

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
@@ -299,7 +299,9 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items("1"))
-         .<String>map(t -> { throw new Exception("expected failure"); })
+         .<String>map(t -> {
+             throw new Exception("expected failure");
+         })
          .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
          .writeTo(Sinks.logger());
 

--- a/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
+++ b/extensions/python/src/test/java/com/hazelcast/jet/python/PythonInitCleanupTest.java
@@ -21,6 +21,12 @@ import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.annotation.NightlyTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -29,11 +35,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.CompletionException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import static com.hazelcast.jet.python.PythonTransforms.mapUsingPythonBatch;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -73,7 +74,7 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    public void initIsRunBeforeJob() throws IOException {
+    public void initRunsBeforeJob() throws IOException {
         // Given
         String baseDirStr = baseDir.toString();
         String outcomeFilename = "init_outcome.txt";
@@ -91,21 +92,21 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
         Pipeline p = Pipeline.create();
         // When
         p.readFrom(TestSources.items("1"))
-                .map(t -> {
-                    Path expectedInitFile = Paths.get(baseDirStr, outcomeFilename);
-                    // Then
-                    assertTrue("file which should be created by init.sh does not exist",
-                            Files.exists(expectedInitFile));
-                    return t;
-                })
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .map(t -> {
+             Path expectedInitFile = Paths.get(baseDirStr, outcomeFilename);
+             // Then
+             assertTrue("The file that init.sh should have created does not exist",
+                     Files.exists(expectedInitFile));
+             return t;
+         })
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         instance().newJob(p).join();
     }
 
     @Test
-    public void cleanupIsRunAfterJob() throws IOException {
+    public void cleanupRunsAfterJob() throws IOException {
         // Given
         String baseDirStr = baseDir.toString();
         String outcomeFilename = "cleanup_outcome.txt";
@@ -121,16 +122,16 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
         Pipeline p = Pipeline.create();
         // When
         p.readFrom(TestSources.items("1"))
-                .map(t -> {
-                    Thread.sleep(5_000);
-                    Path expectedInitFile = Paths.get(baseDirStr, outcomeFilename);
-                    // Then
-                    assertFalse("file which should be created by cleanup.sh exists during job execution",
-                            Files.exists(expectedInitFile));
-                    return t;
-                })
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .map(t -> {
+             Thread.sleep(5_000);
+             Path expectedInitFile = Paths.get(baseDirStr, outcomeFilename);
+             // Then
+             assertFalse("file which should be created by cleanup.sh exists during job execution",
+                     Files.exists(expectedInitFile));
+             return t;
+         })
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         instance().newJob(p).join();
 
@@ -138,7 +139,7 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    public void initFailureCausesJobFailure() throws IOException {
+    public void when_initFailsRepeatedly_then_jobFails() throws IOException {
         // Given
         installFileToBaseDir("exit 1", "init.sh");
         PythonServiceConfig cfg = new PythonServiceConfig()
@@ -149,8 +150,8 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
         Pipeline p = Pipeline.create();
         // When
         p.readFrom(TestSources.items("1"))
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         // Then
         try {
@@ -162,15 +163,16 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    public void initRetried() throws IOException {
+    public void when_initFailsFirstTime_then_retried() throws IOException {
         // Given
         String baseDirStr = baseDir.toString();
         String outcomeFilename = "init_outcome.txt";
         installFileToBaseDir(String.format(
-                "THE_FILE=%s/%s%n"
-                + "test -f $THE_FILE && exit 0%n"
-                + "echo 'init.sh' executed once > $THE_FILE%n"
-                + "exit 1%n",
+                "RETRY_MARKER=%s/%s%n" +
+                // Then
+                "test -f $RETRY_MARKER && exit 0%n" +
+                "echo 'init.sh' executed first time > $RETRY_MARKER%n" +
+                "exit 1%n",
                 baseDirStr, outcomeFilename), "init.sh");
 
         PythonServiceConfig cfg = new PythonServiceConfig()
@@ -181,14 +183,47 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
         Pipeline p = Pipeline.create();
         // When
         p.readFrom(TestSources.items("1"))
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         instance().newJob(p).join();
     }
 
     @Test
-    public void cleanupExecutedIfInitFailed() throws IOException {
+    public void when_initRetried_then_directoryRecreated() throws IOException {
+        // Given
+        String baseDirStr = baseDir.toString();
+        String outcomeFilename = "init_outcome.txt";
+        installFileToBaseDir(String.format(
+            "RETRY_MARKER=%s/%s%n" +
+            "TEMP_FILE=tmpfile.txt%n" +
+            "if [[ -f $RETRY_MARKER ]]; then%n" +
+            // Then
+            "    test -f $TEMP_FILE || exit 0%n" +
+            "    echo 'ERROR: temp file is still there'%n" +
+            "    exit 1%n" +
+            "fi%n" +
+            "echo 'This temp file should be gone after retry' > $TEMP_FILE%n" +
+            "echo 'init.sh executed the first time' > $RETRY_MARKER%n" +
+            "exit 1%n",
+                baseDirStr, outcomeFilename), "init.sh");
+
+        PythonServiceConfig cfg = new PythonServiceConfig()
+                .setBaseDir(baseDir.toString())
+                .setHandlerModule("echo")
+                .setHandlerFunction("handle");
+
+        Pipeline p = Pipeline.create();
+        // When
+        p.readFrom(TestSources.items("1"))
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
+
+        instance().newJob(p).join();
+    }
+
+    @Test
+    public void when_initFails_then_cleanupExecutes() throws IOException {
         // Given
         installFileToBaseDir("exit 1", "init.sh");
         String baseDirStr = baseDir.toString();
@@ -203,8 +238,8 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items("1"))
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         // When
         try {
@@ -219,7 +254,7 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    public void cleanupExecutedIfPythonFailed() throws IOException {
+    public void when_pythonFails_then_cleanupExecutes() throws IOException {
         // Given
         installFileToBaseDir(FAILING_FUNCTION, "failing.py");
         String baseDirStr = baseDir.toString();
@@ -234,8 +269,8 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items("1"))
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         // When
         try {
@@ -250,7 +285,7 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    public void cleanupExecutedIfJobFailed() throws IOException {
+    public void when_jobFails_then_cleanupExecutes() throws IOException {
         // Given
         String baseDirStr = baseDir.toString();
         String outcomeFilename = "cleanup_outcome.txt";
@@ -264,12 +299,9 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items("1"))
-                .map(t -> {
-                    assertTrue("expected failure", false);
-                    return t;
-                })
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .<String>map(t -> { throw new Exception("expected failure"); })
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         // When
         try {
@@ -284,7 +316,7 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
     }
 
     @Test
-    public void initAndCleanupNotExecutedIfHandlerFileIsUsed() throws IOException {
+    public void when_handlerFileConfigured_then_initAndCleanupDontExecute() throws IOException {
         // Given
         String baseDirStr = baseDir.toString();
         String outcomeInitFilename = "init_outcome.txt";
@@ -301,15 +333,15 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
 
         Pipeline p = Pipeline.create();
         p.readFrom(TestSources.items("1"))
-                .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
-                .writeTo(Sinks.logger());
+         .apply(mapUsingPythonBatch(cfg)).setLocalParallelism(2)
+         .writeTo(Sinks.logger());
 
         // When
         instance().newJob(p).join();
 
         // Then
         assertFalse("init script ran", new File(baseDir, outcomeCleanupFilename).exists());
-        assertFalse("Cleanup script ran", new File(baseDir, outcomeCleanupFilename).exists());
+        assertFalse("cleanup script ran", new File(baseDir, outcomeCleanupFilename).exists());
     }
 
     private String prepareSimpleInitSh(String baseDirStr, String outcomeFilename) {
@@ -329,5 +361,4 @@ public class PythonInitCleanupTest extends SimpleTestInClusterSupport {
             Files.copy(in, new File(baseDir, filename).toPath());
         }
     }
-
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/ProcessorSupplier.java
@@ -120,6 +120,15 @@ public interface ProcessorSupplier extends Serializable {
         File attachedDirectory(@Nonnull String id);
 
         /**
+         * Behaves like {@link #attachedDirectory}, but if the directory already
+         * exists, it deletes and recreates all its contents.
+         *
+         * @since 4.3
+         */
+        @Nonnull
+        File recreateAttachedDirectory(@Nonnull String id);
+
+        /**
          * Uses the supplied ID to look up a file you attached to the current Jet
          * job. Creates a temporary file with the same contents on the local
          * cluster member and returns the location of the created file. If the
@@ -130,6 +139,15 @@ public interface ProcessorSupplier extends Serializable {
          */
         @Nonnull
         File attachedFile(@Nonnull String id);
+
+        /**
+         * Behaves like {@link #attachedFile}, but if the file already exists, it
+         * deletes and recreates it.
+         *
+         * @since 4.3
+         */
+        @Nonnull
+        File recreateAttachedFile(@Nonnull String id);
 
         /**
          * Returns {@link ManagedContext} associated with this job.

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/test/TestProcessorSupplierContext.java
@@ -84,12 +84,22 @@ public class TestProcessorSupplierContext
     }
 
     @Nonnull @Override
+    public File recreateAttachedDirectory(@Nonnull String id) {
+        return attachedDirectory(id);
+    }
+
+    @Nonnull @Override
     public File attachedFile(@Nonnull String id) {
         File file = attached.get(id);
         if (file == null) {
             throw new IllegalArgumentException("File '" + id + "' was not found");
         }
         return file;
+    }
+
+    @Nonnull @Override
+    public File recreateAttachedFile(@Nonnull String id) {
+        return attachedFile(id);
     }
 
     @Nonnull @Override

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.impl.execution.init;
 
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.util.Preconditions;
 import com.hazelcast.jet.JetException;
@@ -29,24 +30,30 @@ import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.core.ProcessorSupplier;
 import com.hazelcast.jet.impl.deployment.IMapInputStream;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
-import com.hazelcast.jet.impl.util.IOUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.IMap;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.config.ResourceType.DIRECTORY;
 import static com.hazelcast.jet.config.ResourceType.FILE;
 import static com.hazelcast.jet.impl.JobRepository.fileKeyName;
 import static com.hazelcast.jet.impl.JobRepository.jobResourcesMapName;
+import static com.hazelcast.jet.impl.util.IOUtil.fileNameFromUrl;
 import static com.hazelcast.jet.impl.util.IOUtil.unzip;
+import static com.hazelcast.jet.impl.util.Util.editPermissionsRecursively;
 import static java.lang.Math.min;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static java.util.Objects.requireNonNull;
 
 public final class Contexts {
@@ -91,8 +98,7 @@ public final class Contexts {
             this.processingGuarantee = processingGuarantee;
         }
 
-        @Nonnull
-        @Override
+        @Nonnull @Override
         public JetInstance jetInstance() {
             return jetInstance;
         }
@@ -107,7 +113,7 @@ public final class Contexts {
             return executionId;
         }
 
-        @Override @Nonnull
+        @Nonnull @Override
         public JobConfig jobConfig() {
             return jobConfig;
         }
@@ -189,7 +195,13 @@ public final class Contexts {
                     "The resource with ID '%s' is not a directory, its type is %s", id, resourceConfig.getResourceType()
                 ));
             }
-            return tempDirectories.computeIfAbsent(id, x -> extractFileToDisk(id));
+            return tempDirectories.computeIfAbsent(id, x -> extractFileToDisk(id, null));
+        }
+
+        @Nonnull @Override
+        public File recreateAttachedDirectory(@Nonnull String id) {
+            recreateIfExists(id);
+            return attachedDirectory(id);
         }
 
         @Nonnull @Override
@@ -204,21 +216,47 @@ public final class Contexts {
                     "The resource with ID '%s' is not a file, its type is %s", id, resourceConfig.getResourceType()
                 ));
             }
-            String fnamePath = requireNonNull(IOUtil.fileNameFromUrl(resourceConfig.getUrl()));
-            return new File(tempDirectories.computeIfAbsent(id, x -> extractFileToDisk(id)), fnamePath);
+            String fnamePath = requireNonNull(fileNameFromUrl(resourceConfig.getUrl()));
+            return new File(tempDirectories.computeIfAbsent(id, x -> extractFileToDisk(id, null)), fnamePath);
+        }
+
+        @Nonnull @Override
+        public File recreateAttachedFile(@Nonnull String id) {
+            recreateIfExists(id);
+            return attachedFile(id);
         }
 
         public ConcurrentHashMap<String, File> tempDirectories() {
             return tempDirectories;
         }
 
-        private File extractFileToDisk(String id) {
+        private File extractFileToDisk(@Nonnull String id, @Nullable File destFile) {
             IMap<String, byte[]> map = jetInstance().getMap(jobResourcesMapName(jobId()));
             try (IMapInputStream inputStream = new IMapInputStream(map, fileKeyName(id))) {
-                Path directory = Files.createTempDirectory(tempDirPrefix(
-                        jetInstance().getName(), idToString(jobId()), id));
-                unzip(inputStream, directory);
-                return directory.toFile();
+                Path destPath = (destFile == null)
+                    ? Files.createTempDirectory(tempDirPrefix(jetInstance().getName(), idToString(jobId()), id))
+                    : destFile.toPath();
+                unzip(inputStream, destPath);
+                return destPath.toFile();
+            } catch (IOException e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        }
+
+        private void recreateIfExists(@Nonnull String id) {
+            File dirFile = tempDirectories.get(id);
+            if (dirFile == null) {
+                return;
+            }
+            try {
+                List<String> filesNotMarked =
+                        editPermissionsRecursively(dirFile.toPath(), perms -> perms.add(OWNER_WRITE));
+                if (!filesNotMarked.isEmpty()) {
+                    logger().info("Couldn't 'chmod u+w' these files: " + filesNotMarked);
+                }
+                Stream.of(Objects.requireNonNull(dirFile.listFiles()))
+                      .forEach(IOUtil::delete);
+                extractFileToDisk(id, dirFile);
             } catch (IOException e) {
                 throw ExceptionUtil.rethrow(e);
             }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/Contexts.java
@@ -32,6 +32,7 @@ import com.hazelcast.jet.impl.deployment.IMapInputStream;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.IMap;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -40,9 +41,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Util.idToString;
 import static com.hazelcast.jet.config.ResourceType.DIRECTORY;
@@ -243,6 +242,8 @@ public final class Contexts {
             }
         }
 
+        @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE",
+            justification = "SpotBugs bug, ignores requireNonNull() https://github.com/spotbugs/spotbugs/issues/651")
         private void recreateIfExists(@Nonnull String id) {
             File dirFile = tempDirectories.get(id);
             if (dirFile == null) {
@@ -254,8 +255,9 @@ public final class Contexts {
                 if (!filesNotMarked.isEmpty()) {
                     logger().info("Couldn't 'chmod u+w' these files: " + filesNotMarked);
                 }
-                Stream.of(Objects.requireNonNull(dirFile.listFiles()))
-                      .forEach(IOUtil::delete);
+                for (File file : requireNonNull(dirFile.listFiles())) {
+                    IOUtil.delete(file);
+                }
                 extractFileToDisk(id, dirFile);
             } catch (IOException e) {
                 throw ExceptionUtil.rethrow(e);

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/Util.java
@@ -40,24 +40,31 @@ import java.io.NotSerializableException;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.Util.idToString;
@@ -66,6 +73,7 @@ import static com.hazelcast.jet.core.processor.SinkProcessors.writeMapP;
 import static com.hazelcast.jet.core.processor.SourceProcessors.readMapP;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static java.lang.Math.abs;
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -463,5 +471,54 @@ public final class Util {
     @Nonnull
     public static <T, R> List<R> toList(@Nonnull Collection<T> coll, Function<? super T, ? extends R> mapFn) {
         return coll.stream().map(mapFn).collect(Collectors.toList());
+    }
+
+    /**
+     * Edits the permissions on the file denoted by {@code path} by calling
+     * {@code editFn} with the set of that file's current permissions. {@code
+     * editFn} should modify that set to the desired permission set, and this
+     * method will propagate them to the file. If {@code editFn} returns {@code
+     * false}, the file will be left untouched. Returning {@code false} is an
+     * optimization feature because it avoids the expensive filesystem
+     * operation; if you always return {@code true}, this method will still
+     * behave correctly.
+     */
+    public static void editPermissions(
+            @Nonnull Path path, @Nonnull Predicate<? super Set<PosixFilePermission>> editFn
+    ) throws IOException {
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(path, NOFOLLOW_LINKS);
+        if (editFn.test(perms)) {
+            Files.setPosixFilePermissions(path, perms);
+        }
+    }
+
+    /**
+     * Edits the permissions on all the files in the {@code basePath} and
+     * its subdirectories. It calls {@link #editPermissions} with every file.
+     *
+     * @param basePath the directory where to edit the file permissions
+     * @param editFn the permission-editing function, described above
+     * @return the list of all relative pathnames of files for which editing
+     *         permissions failed
+     * @throws IOException if the directory's contents cannot be traversed
+     */
+    public static List<String> editPermissionsRecursively(
+            @Nonnull Path basePath,
+            @Nonnull Predicate<? super Set<PosixFilePermission>> editFn
+    ) throws IOException {
+        List<String> filesNotMarked = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(basePath)) {
+            walk.forEach(path -> {
+                try {
+                    editPermissions(path, editFn);
+                } catch (Exception e) {
+                    filesNotMarked.add(basePath.relativize(path).toString());
+                }
+            });
+        }
+        if (!filesNotMarked.isEmpty()) {
+            System.err.println("Couldn't 'chmod " + "chmodOp" + "' these files: " + filesNotMarked);
+        }
+        return filesNotMarked;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
 
         <maven.enforcer.plugin.version>3.0.0-M1</maven.enforcer.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M3</maven.surefire.plugin.version>
-        <maven.spotbugs.plugin.version>4.0.0</maven.spotbugs.plugin.version>
+        <maven.spotbugs.plugin.version>4.1.3</maven.spotbugs.plugin.version>
         <maven.checkstyle.plugin.version>3.1.0</maven.checkstyle.plugin.version>
         <checkstyle.headerLocation>${maven.multiModuleProjectDirectory}/checkstyle/ClassHeaderApache.txt</checkstyle.headerLocation>
         <maven.sonar.plugin.version>3.6.0.1398</maven.sonar.plugin.version>


### PR DESCRIPTION
Adds two new methods to `ProcessorSupplier`: `recreateAttachedDirectory` and `recreateAttachedFile`

Improves on #2586 by recreating the attached directory instead of just repeating the initialization.

Checklist:
- [x] Labels and Milestone set
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
