### PR TITLE
Name containers used in tests

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -26,7 +26,9 @@ import com.hazelcast.jet.core.processor.Processors;
 import com.hazelcast.jet.impl.JetEvent;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import com.hazelcast.map.IMap;
+import org.junit.Rule;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 
@@ -41,6 +43,9 @@ import static org.junit.Assert.assertTrue;
 
 @Category({IgnoreInJenkinsOnWindows.class})
 public class AbstractCdcIntegrationTest extends JetTestSupport {
+
+    @Rule
+    public TestName testName = new TestName();
 
     @Nonnull
     protected static List<String> mapResultsToSortedList(IMap<?, ?> map) {
@@ -133,6 +138,13 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
                 .withRemoveVolumes(true)
                 .withForce(true)
                 .exec();
+    }
+
+    protected <T> T namedTestContainer(GenericContainer<?> container) {
+        return (T) container.withCreateContainerCmdModifier(createContainerCmd -> {
+            String test = AbstractCdcIntegrationTest.this.getClass().getSimpleName() + "." + testName.getMethodName();
+            createContainerCmd.withName(test + "___" + randomName());
+        });
     }
 
 }

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -142,8 +142,9 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
 
     protected <T> T namedTestContainer(GenericContainer<?> container) {
         return (T) container.withCreateContainerCmdModifier(createContainerCmd -> {
-            String test = AbstractCdcIntegrationTest.this.getClass().getSimpleName() + "." + testName.getMethodName();
-            createContainerCmd.withName(test + "___" + randomName());
+            String source = AbstractCdcIntegrationTest.this.getClass().getSimpleName() + "." + testName.getMethodName()
+                .replaceAll("\\[|\\]|\\/| ", "_");
+            createContainerCmd.withName(source + "___" + randomName());
         });
     }
 

--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -209,9 +209,11 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     }
 
     private MySQLContainer<?> mySqlContainer() {
-        return new MySQLContainer<>("debezium/example-mysql")
-                .withUsername("mysqluser")
-                .withPassword("mysqlpw");
+        return namedTestContainer(
+                new MySQLContainer<>("debezium/example-mysql")
+                        .withUsername("mysqluser")
+                        .withPassword("mysqlpw")
+        );
     }
 
     @Test
@@ -363,10 +365,12 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
     }
 
     private PostgreSQLContainer<?> postgresContainer() {
-        return new PostgreSQLContainer<>("debezium/example-postgres:1.2")
-                .withDatabaseName("postgres")
-                .withUsername("postgres")
-                .withPassword("postgres");
+        return namedTestContainer(
+                new PostgreSQLContainer<>("debezium/example-postgres:1.2")
+                        .withDatabaseName("postgres")
+                        .withUsername("postgres")
+                        .withPassword("postgres")
+        );
     }
 
     @Test

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -19,13 +19,13 @@ package com.hazelcast.jet.cdc.mysql;
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import org.junit.Rule;
+import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.MySQLContainer;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import org.junit.experimental.categories.Category;
 
 import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 
@@ -33,9 +33,11 @@ import static org.testcontainers.containers.MySQLContainer.MYSQL_PORT;
 public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Rule
-    public MySQLContainer<?> mysql = new MySQLContainer<>("debezium/example-mysql:1.2")
-            .withUsername("mysqluser")
-            .withPassword("mysqlpw");
+    public MySQLContainer<?> mysql = namedTestContainer(
+            new MySQLContainer<>("debezium/example-mysql:1.2")
+                    .withUsername("mysqluser")
+                    .withPassword("mysqlpw")
+    );
 
     protected MySqlCdcSources.Builder sourceBuilder(String name) {
         return MySqlCdcSources.mysql(name)

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -97,10 +97,10 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Parameters(name = "{2}")
     public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                { RetryStrategies.never(), false, "fail"},
-                { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), false, "reconnect"},
-                { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
+        return Arrays.asList(new Object[][]{
+                {RetryStrategies.never(), false, "fail"},
+                {RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), false, "reconnect"},
+                {RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
     }
 
@@ -344,14 +344,12 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         }
     }
 
-    private static Network initNetwork() {
-        return Network.newNetwork();
-    }
-
-    private static MySQLContainer<?> initMySql(Network network, Integer fixedExposedPort) {
-        MySQLContainer<?> mysql = new MySQLContainer<>("debezium/example-mysql:1.2")
-                .withUsername("mysqluser")
-                .withPassword("mysqlpw");
+    private MySQLContainer<?> initMySql(Network network, Integer fixedExposedPort) {
+        MySQLContainer<?> mysql = namedTestContainer(
+                new MySQLContainer<>("debezium/example-mysql:1.2")
+                        .withUsername("mysqluser")
+                        .withPassword("mysqlpw")
+        );
         if (fixedExposedPort != null) {
             Consumer<CreateContainerCmd> cmd = e -> e.withPortBindings(
                     new PortBinding(Ports.Binding.bindPort(fixedExposedPort), new ExposedPort(MYSQL_PORT)));
@@ -364,10 +362,14 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
         return mysql;
     }
 
-    private static ToxiproxyContainer initToxiproxy(Network network) {
-        ToxiproxyContainer toxiproxy = new ToxiproxyContainer().withNetwork(network);
+    private ToxiproxyContainer initToxiproxy(Network network) {
+        ToxiproxyContainer toxiproxy = namedTestContainer(new ToxiproxyContainer().withNetwork(network));
         toxiproxy.start();
         return toxiproxy;
+    }
+
+    private static Network initNetwork() {
+        return Network.newNetwork();
     }
 
     private static ToxiproxyContainer.ContainerProxy initProxy(ToxiproxyContainer toxiproxy, MySQLContainer<?> mysql) {
@@ -410,7 +412,7 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
             }
         }
 
-        throw new IOException("No free port in range [" + fromInclusive + ", " +  toExclusive + ")");
+        throw new IOException("No free port in range [" + fromInclusive + ", " + toExclusive + ")");
     }
 
     @SuppressWarnings("StatementWithEmptyBody")

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/AbstractPostgresCdcIntegrationTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
 import org.junit.Rule;
+import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.io.Serializable;
@@ -29,7 +30,6 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import org.junit.experimental.categories.Category;
 
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
@@ -37,10 +37,12 @@ import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 public abstract class AbstractPostgresCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Rule
-    public PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("debezium/example-postgres:1.2")
-            .withDatabaseName("postgres")
-            .withUsername("postgres")
-            .withPassword("postgres");
+    public PostgreSQLContainer<?> postgres = namedTestContainer(
+            new PostgreSQLContainer<>("debezium/example-postgres:1.2")
+                    .withDatabaseName("postgres")
+                    .withUsername("postgres")
+                    .withPassword("postgres")
+    );
 
     protected PostgresCdcSources.Builder sourceBuilder(String name) {
         return PostgresCdcSources.postgres(name)

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -354,15 +354,13 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         }
     }
 
-    private static Network initNetwork() {
-        return Network.newNetwork();
-    }
-
-    private static PostgreSQLContainer<?> initPostgres(Network network, Integer fixedExposedPort) {
-        PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("debezium/example-postgres:1.2")
-                .withDatabaseName("postgres")
-                .withUsername("postgres")
-                .withPassword("postgres");
+    private PostgreSQLContainer<?> initPostgres(Network network, Integer fixedExposedPort) {
+        PostgreSQLContainer<?> postgres = namedTestContainer(
+                new PostgreSQLContainer<>("debezium/example-postgres:1.2")
+                        .withDatabaseName("postgres")
+                        .withUsername("postgres")
+                        .withPassword("postgres")
+        );
         if (fixedExposedPort != null) {
             Consumer<CreateContainerCmd> cmd = e -> e.withPortBindings(
                     new PortBinding(Ports.Binding.bindPort(fixedExposedPort), new ExposedPort(POSTGRESQL_PORT)));
@@ -376,10 +374,14 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
         return postgres;
     }
 
-    private static ToxiproxyContainer initToxiproxy(Network network) {
-        ToxiproxyContainer toxiproxy = new ToxiproxyContainer().withNetwork(network);
+    private ToxiproxyContainer initToxiproxy(Network network) {
+        ToxiproxyContainer toxiproxy = namedTestContainer(new ToxiproxyContainer().withNetwork(network));
         toxiproxy.start();
         return toxiproxy;
+    }
+
+    private static Network initNetwork() {
+        return Network.newNetwork();
     }
 
     private static ToxiproxyContainer.ContainerProxy initProxy(
@@ -442,7 +444,7 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
             }
         }
 
-        throw new IOException("No free port in range [" + fromInclusive + ", " +  toExclusive + ")");
+        throw new IOException("No free port in range [" + fromInclusive + ", " + toExclusive + ")");
     }
 
 }


### PR DESCRIPTION
These changes assign names to containers used instantiated for testing. The names are meant to help identify the tests that start a particular container. This should help with identifying the cause of some containers not being cleaned up on Jenkins. 