### PR TITLE
Fix JDBC driver initialization deadlock

### DIFF
--- a/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSource.java
+++ b/extensions/cdc-debezium/src/main/java/com/hazelcast/jet/cdc/impl/CdcSource.java
@@ -39,6 +39,7 @@ import org.apache.kafka.connect.storage.OffsetStorageReader;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.sql.DriverManager;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -74,6 +75,8 @@ public abstract class CdcSource<T> {
     private SourceTask task;
 
     CdcSource(Processor.Context context, Properties properties) {
+        // workaround for https://github.com/hazelcast/hazelcast-jet/issues/2603
+        DriverManager.getDrivers();
         this.logger = context.logger();
         this.properties = properties;
         this.reconnectTracker = new RetryTracker(getRetryStrategy(properties));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterSnapshotContext.java
@@ -250,7 +250,7 @@ class MasterSnapshotContext {
                         stats.duration(), stats.numBytes(), stats.numKeys(), stats.numChunks(), snapshotMapName));
             }
             if (!isSuccess) {
-                logger.warning(mc.jobIdString() + " snapshot " + snapshotId + " failed on some member(s), " +
+                logger.warning(mc.jobIdString() + " snapshot " + snapshotId + " phase 1 failed on some member(s), " +
                         "one of the failures: " + mergedResult.getError());
                 try {
                     snapshotMap.clear();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadJdbcP.java
@@ -107,6 +107,8 @@ public final class ReadJdbcP<T> extends AbstractProcessor {
 
     @Override
     protected void init(@Nonnull Context context) {
+        // workaround for https://github.com/hazelcast/hazelcast-jet/issues/2603
+        DriverManager.getDrivers();
         this.connection = newConnectionFn.get();
         this.parallelism = context.totalParallelism();
         this.index = context.globalProcessorIndex();

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/WriteJdbcP.java
@@ -37,6 +37,7 @@ import javax.sql.DataSource;
 import javax.sql.XAConnection;
 import javax.sql.XADataSource;
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientException;
@@ -115,6 +116,8 @@ public final class WriteJdbcP<T> extends XaSinkProcessorBase {
     @Override
     public void init(@Nonnull Outbox outbox, @Nonnull Context context) throws Exception {
         super.init(outbox, context);
+        // workaround for https://github.com/hazelcast/hazelcast-jet/issues/2603
+        DriverManager.getDrivers();
         logger = context.logger();
         connectAndPrepareStatement();
     }


### PR DESCRIPTION
Fixes #2603

To avoid the deadlock we need to ensure `java.sql.DriverManager` has initialized the drivers before trying to use them.