### PR TITLE
Config option to disable the IMDG version check

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -278,7 +278,8 @@ public final class Jet {
     }
 
     private static boolean versionCheckDisabled() {
-        String rawValue = getProperty(JET_IMDG_VERSION_CHECK_DISABLED.getName(), JET_IMDG_VERSION_CHECK_DISABLED.getDefaultValue());
+        String rawValue = getProperty(JET_IMDG_VERSION_CHECK_DISABLED.getName(),
+                JET_IMDG_VERSION_CHECK_DISABLED.getDefaultValue());
         return Boolean.parseBoolean(rawValue);
     }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -54,8 +54,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
 
-import static com.hazelcast.jet.core.JetProperties.JET_SHUTDOWNHOOK_ENABLED;
-import static com.hazelcast.jet.core.JetProperties.JOB_RESULTS_TTL_SECONDS;
+import static com.hazelcast.jet.core.JetProperties.*;
 import static com.hazelcast.jet.impl.JobRepository.INTERNAL_JET_OBJECTS_PREFIX;
 import static com.hazelcast.jet.impl.JobRepository.JOB_METRICS_MAP_NAME;
 import static com.hazelcast.jet.impl.JobRepository.JOB_RESULTS_MAP_NAME;
@@ -63,6 +62,7 @@ import static com.hazelcast.jet.impl.config.ConfigProvider.locateAndGetClientCon
 import static com.hazelcast.jet.impl.config.ConfigProvider.locateAndGetJetConfig;
 import static com.hazelcast.spi.properties.ClusterProperty.SHUTDOWNHOOK_ENABLED;
 import static java.lang.Boolean.parseBoolean;
+import static java.lang.System.getProperty;
 
 /**
  * Entry point to the Jet product.
@@ -265,8 +265,7 @@ public final class Jet {
                         "version " + hzVersion + " was found in the classpath. " +
                         " As Jet already shades Hazelcast jars there is no need to explicitly " +
                         "add a dependency to it.";
-                String checkDisabledValue = System.getProperty("jet.imdg.version.mismatch.check.disabled", "false");
-                boolean errorOnMismatch = !parseBoolean(checkDisabledValue);
+                boolean errorOnMismatch = !versionCheckDisabled();
                 if (errorOnMismatch) {
                     throw new JetException(message);
                 } else {
@@ -276,6 +275,11 @@ public final class Jet {
         } catch (IOException e) {
             LOGGER.warning("Could not read the file jet-runtime.properties", e);
         }
+    }
+
+    private static boolean versionCheckDisabled() {
+        String rawValue = getProperty(JET_IMDG_VERSION_CHECK_DISABLED.getName(), JET_IMDG_VERSION_CHECK_DISABLED.getDefaultValue());
+        return Boolean.parseBoolean(rawValue);
     }
 
     private static synchronized void configureJetService(JetConfig jetConfig) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -265,7 +265,7 @@ public final class Jet {
                         "version " + hzVersion + " was found in the classpath. " +
                         " As Jet already shades Hazelcast jars there is no need to explicitly " +
                         "add a dependency to it.";
-                boolean errorOnMismatch = parseBoolean(System.getProperty("jet.hazelcast.errorOnMismatch", "true"));
+                boolean errorOnMismatch = !parseBoolean(System.getProperty("jet.imdg.version.mismatch.check.disabled", "false"));
                 if (errorOnMismatch) {
                     throw new JetException(message);
                 } else {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -265,7 +265,8 @@ public final class Jet {
                         "version " + hzVersion + " was found in the classpath. " +
                         " As Jet already shades Hazelcast jars there is no need to explicitly " +
                         "add a dependency to it.";
-                boolean errorOnMismatch = !parseBoolean(System.getProperty("jet.imdg.version.mismatch.check.disabled", "false"));
+                String cbecmDisabledValue = System.getProperty("jet.imdg.version.mismatch.check.disabled", "false");
+                boolean errorOnMismatch = !parseBoolean(cbecmDisabledValue);
                 if (errorOnMismatch) {
                     throw new JetException(message);
                 } else {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -265,8 +265,8 @@ public final class Jet {
                         "version " + hzVersion + " was found in the classpath. " +
                         " As Jet already shades Hazelcast jars there is no need to explicitly " +
                         "add a dependency to it.";
-                String cbecmDisabledValue = System.getProperty("jet.imdg.version.mismatch.check.disabled", "false");
-                boolean errorOnMismatch = !parseBoolean(cbecmDisabledValue);
+                String checkDisabledValue = System.getProperty("jet.imdg.version.mismatch.check.disabled", "false");
+                boolean errorOnMismatch = !parseBoolean(checkDisabledValue);
                 if (errorOnMismatch) {
                     throw new JetException(message);
                 } else {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/Jet.java
@@ -54,7 +54,9 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
 
-import static com.hazelcast.jet.core.JetProperties.*;
+import static com.hazelcast.jet.core.JetProperties.JET_IMDG_VERSION_CHECK_DISABLED;
+import static com.hazelcast.jet.core.JetProperties.JET_SHUTDOWNHOOK_ENABLED;
+import static com.hazelcast.jet.core.JetProperties.JOB_RESULTS_TTL_SECONDS;
 import static com.hazelcast.jet.impl.JobRepository.INTERNAL_JET_OBJECTS_PREFIX;
 import static com.hazelcast.jet.impl.JobRepository.JOB_METRICS_MAP_NAME;
 import static com.hazelcast.jet.impl.JobRepository.JOB_RESULTS_MAP_NAME;
@@ -280,7 +282,7 @@ public final class Jet {
     private static boolean versionCheckDisabled() {
         String rawValue = getProperty(JET_IMDG_VERSION_CHECK_DISABLED.getName(),
                 JET_IMDG_VERSION_CHECK_DISABLED.getDefaultValue());
-        return Boolean.parseBoolean(rawValue);
+        return parseBoolean(rawValue);
     }
 
     private static synchronized void configureJetService(JetConfig jetConfig) {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
@@ -94,6 +94,10 @@ public final class JetProperties {
      * Setting this property to {@code true} allows Jet to start up even on
      * mismatch. This may be helpful if the user needs some slight IMDG version
      * change (eg. to use a hotfix).
+     * <p>
+     * <strong>NOTE:</strong> since Jet must read this property at a very early
+     * point in startup, it doesn't have an effect when you set it in a
+     * Hazelcast configuration file. You must set it as a system property.
      *
      * @since 4.4
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
@@ -89,6 +89,16 @@ public final class JetProperties {
             = new HazelcastProperty("jet.home", "");
 
     /**
+     * If {@code false}, Jet will check during initialization that IMDG module has compatible version.
+     * Changing to {@code true} may be helpful if user needs some slight IMDG version change
+     * (eg. for some hotfix). Default value is false (check will be performed).
+     *
+     * @since 4.4
+     */
+    public static final HazelcastProperty JET_IMDG_VERSION_CHECK_DISABLED
+            = new HazelcastProperty("jet.imdg.version.mismatch.check.disabled", "false");
+
+    /**
      * The minimum time in microseconds the cooperative worker threads will
      * sleep if none of the tasklets made any progress. Lower values increase
      * idle CPU usage but may result in decreased latency. Higher values will

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/JetProperties.java
@@ -45,10 +45,10 @@ public final class JetProperties {
             = new HazelcastProperty("jet.job.scan.period", SECONDS.toMillis(5), MILLISECONDS);
 
     /**
-     * Whether a JVM shutdown hook is registered to shutdown the node gracefully
-     * when the process is terminated. The shutdown hook will terminate all running
-     * jobs and then gracefully terminate the note, in a way that is
-     * equivalent to calling {@link JetInstance#shutdown()}.
+     * Whether a JVM shutdown hook is registered to shutdown the node
+     * gracefully when the process is terminated. The shutdown hook will
+     * terminate all running jobs and then gracefully terminate the note, in a
+     * way that is equivalent to calling {@link JetInstance#shutdown()}.
      *
      * @since 3.2
      */
@@ -79,9 +79,9 @@ public final class JetProperties {
             = new HazelcastProperty("jet.job.results.max.size", 1_000);
 
     /**
-     * Root of Jet installation. Used as default location for the lossless restart
-     * store. By default it will be automatically set to the start of the Jet
-     * installation path.
+     * Root of Jet installation. Used as default location for the lossless
+     * restart store. By default it will be automatically set to the start of
+     * the Jet installation path.
      *
      * @since 3.2
      */
@@ -89,9 +89,11 @@ public final class JetProperties {
             = new HazelcastProperty("jet.home", "");
 
     /**
-     * If {@code false}, Jet will check during initialization that IMDG module has compatible version.
-     * Changing to {@code true} may be helpful if user needs some slight IMDG version change
-     * (eg. for some hotfix). Default value is false (check will be performed).
+     * Hazelcast Jet normally checks that the version of IMDG on the classpath
+     * matches exactly the version it is built for, and fails on mismatch.
+     * Setting this property to {@code true} allows Jet to start up even on
+     * mismatch. This may be helpful if the user needs some slight IMDG version
+     * change (eg. to use a hotfix).
      *
      * @since 4.4
      */
@@ -102,13 +104,15 @@ public final class JetProperties {
      * The minimum time in microseconds the cooperative worker threads will
      * sleep if none of the tasklets made any progress. Lower values increase
      * idle CPU usage but may result in decreased latency. Higher values will
-     * increase latency and very high values (>10000µs) will also limit throughput.
+     * increase latency and very high values (>10000µs) will also limit the
+     * throughput.
      * <p>
      * The default is value is {@code 25µs}.
      * <p>
-     * Note: the underlying {@link LockSupport#parkNanos(long)} call may actually
-     * sleep longer depending on the operating system (up to 15000µs on Windows).
-     * See the <a href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
+     * Note: the underlying {@link LockSupport#parkNanos(long)} call may
+     * actually sleep longer depending on the operating system (up to 15000µs
+     * on Windows). See the <a
+     * href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_COOPERATIVE_MAX_MICROSECONDS}
@@ -122,13 +126,15 @@ public final class JetProperties {
      * The maximum time in microseconds the cooperative worker threads will
      * sleep if none of the tasklets made any progress. Lower values increase
      * idle CPU usage but may result in decreased latency. Higher values will
-     * increase latency and very high values (>10000µs) will also limit throughput.
+     * increase latency and very high values (>10000µs) will also limit the
+     * throughput.
      * <p>
      * The default is value is {@code 500µs}.
      * <p>
-     * Note: the underlying {@link LockSupport#parkNanos(long)} call may actually
-     * sleep longer depending on the operating system (up to 15000µs on Windows).
-     * See the <a href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
+     * Note: the underlying {@link LockSupport#parkNanos(long)} call may
+     * actually sleep longer depending on the operating system (up to 15000µs on
+     * Windows). See the <a
+     * href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_COOPERATIVE_MIN_MICROSECONDS}
@@ -142,13 +148,15 @@ public final class JetProperties {
      * The minimum time in microseconds the non-cooperative worker threads will
      * sleep if none of the tasklets made any progress. Lower values increase
      * idle CPU usage but may result in decreased latency. Higher values will
-     * increase latency and very high values (>10000µs) will also limit throughput.
+     * increase latency and very high values (>10000µs) will also limit the
+     * throughput.
      * <p>
      * The default is value is {@code 25µs}.
      * <p>
      * Note: the underlying {@link LockSupport#parkNanos(long)} call may actually
      * sleep longer depending on the operating system (up to 15000µs on Windows).
-     * See the <a href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
+     * See the <a
+     * href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_NONCOOPERATIVE_MAX_MICROSECONDS}
@@ -162,13 +170,15 @@ public final class JetProperties {
      * The maximum time in microseconds the non-cooperative worker threads will
      * sleep if none of the tasklets made any progress. Lower values increase
      * idle CPU usage but may result in decreased latency. Higher values will
-     * increase latency and very high values (>10000µs) will also limit throughput.
+     * increase latency and very high values (>10000µs) will also limit the
+     * throughput.
      * <p>
      * The default is value is {@code 5000µs}.
      * <p>
      * Note: the underlying {@link LockSupport#parkNanos(long)} call may actually
      * sleep longer depending on the operating system (up to 15000µs on Windows).
-     * See the <a href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
+     * See the <a
+     * href="https://hazelcast.com/blog/locksupport-parknanos-under-the-hood-and-the-curious-case-of-parking/">
      * Hazelcast blog post about this subject</a> for more details.
      * <p>
      * See also: {@link #JET_IDLE_NONCOOPERATIVE_MIN_MICROSECONDS}


### PR DESCRIPTION
Jet is normally used as the `hazelcast-jet` artifact, but `hazelcast-jet-core` is also available, and the user can combine it with any version of the `hazelcast` artifact.

Some users want to use this in order to benefit from a bug fix in IMDG that doesn't influence interoperability with Jet, but the version check in Jet prevents them.

This PR adds a system property that disables the version check.

Checklist:
- [ ] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Updated `examples/README.md` (when adding a new code sample)
