### PR TITLE
Reactivate TestContainers resource reaper in CDC network tests

### DIFF
--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -102,16 +101,6 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 {RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), false, "reconnect"},
                 {RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
-    }
-
-    @Before
-    public void before() {
-        //disable Testcontainer's automatic resource manager
-        //containers are cleaned up explicitly
-        //automatic resource manager is just an extra thing that can break
-        //(have had problems with it not being cleaned up properly itself)
-        environmentVariables.set("TESTCONTAINERS_RYUK_DISABLED", "true");
-        assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }
 
     @After

--- a/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-postgres/src/test/java/com/hazelcast/jet/cdc/postgres/PostgresCdcNetworkIntegrationTest.java
@@ -35,7 +35,6 @@ import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
 import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -101,16 +100,6 @@ public class PostgresCdcNetworkIntegrationTest extends AbstractCdcIntegrationTes
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), false, "reconnect"},
                 { RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
-    }
-
-    @Before
-    public void before() {
-        //disable Testcontainer's automatic resource manager
-        //containers are cleaned up explicitly
-        //automatic resource manager is just an extra thing that can break
-        //(have had problems with it not being cleaned up properly itself)
-        environmentVariables.set("TESTCONTAINERS_RYUK_DISABLED", "true");
-        assertEquals("true", System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
     }
 
     @After


### PR DESCRIPTION
CDC network tests are still leaking containers on Jenkins.... One situation which could lead to this is when the JVM/OS process running the tests is killed. To solve it I'm going to re-activate the Ryuk resource reaper for the tests. It solves the problem locally, let's see. (I can't really tell if this is what is actually going on usually on Jenkins, when containers get leaked.)

Checklist:
- [x] Labels and Milestone set
