### PR TITLE
Ignore MySql CDC tests with JDK 15

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/DebeziumCdcIntegrationTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.MySQLContainer;
@@ -50,6 +51,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Test
     public void mysql() throws Exception {
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+                System.getProperty("java.version").startsWith("15"));
+
         MySQLContainer<?> container = mySqlContainer();
 
         try {
@@ -133,6 +137,9 @@ public class DebeziumCdcIntegrationTest extends AbstractCdcIntegrationTest {
 
     @Test
     public void mysql_simpleJson() {
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+                System.getProperty("java.version").startsWith("15"));
+
         MySQLContainer<?> container = mySqlContainer();
 
         try {

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/AbstractMySqlCdcIntegrationTest.java
@@ -18,6 +18,8 @@ package com.hazelcast.jet.cdc.mysql;
 
 import com.hazelcast.jet.cdc.AbstractCdcIntegrationTest;
 import com.hazelcast.jet.test.IgnoreInJenkinsOnWindows;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 import org.testcontainers.containers.MySQLContainer;
@@ -38,6 +40,12 @@ public abstract class AbstractMySqlCdcIntegrationTest extends AbstractCdcIntegra
                     .withUsername("mysqluser")
                     .withPassword("mysqlpw")
     );
+
+    @Before
+    public void ignoreOnJdk15() throws SQLException {
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+                System.getProperty("java.version").startsWith("15"));
+    }
 
     protected MySqlCdcSources.Builder sourceBuilder(String name) {
         return MySqlCdcSources.mysql(name)

--- a/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
+++ b/extensions/cdc-mysql/src/test/java/com/hazelcast/jet/cdc/mysql/MySqlCdcNetworkIntegrationTest.java
@@ -34,6 +34,8 @@ import com.hazelcast.jet.test.SerialTest;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -101,6 +103,12 @@ public class MySqlCdcNetworkIntegrationTest extends AbstractCdcIntegrationTest {
                 {RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), false, "reconnect"},
                 {RetryStrategies.indefinitely(RECONNECT_INTERVAL_MS), true, "reconnect w/ state reset"}
         });
+    }
+
+    @Before
+    public void ignoreOnJdk15() throws SQLException {
+        Assume.assumeFalse("https://github.com/hazelcast/hazelcast-jet/issues/2623",
+                System.getProperty("java.version").startsWith("15"));
     }
 
     @After


### PR DESCRIPTION
MySQL CDC connector is not able to work when Zulu JDK 15 is used (https://github.com/hazelcast/hazelcast-jet/issues/2623). This is problematic for nightly profile since it causes those tests take too long (see http://jenkins.hazelcast.com/job/jet-oss-master-nightly-zulu-jdk15/) and make nightly jobs unusable. This PR causes those test be ignored if JDK version contains `15.0.1`. We should remove those `Assume`s once it will be fixed. Job which ran with this change - http://jenkins.hazelcast.com/job/jet-oss-master-nightly-zulu-jdk15-temp/3/

Checklist:
- [x] Labels and Milestone set
- [N/A] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] Updated `examples/README.md` (when adding a new code sample)
