### PR TITLE
Remove reflections test dependency

### DIFF
--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -114,6 +114,7 @@ Apache License, Version 2.0
   lang-mustache:7.0.0
   parent-join:7.0.0
   rank-eval:7.0.0
+  Javassist:3.26.0-GA
   LZ4 and xxHash:1.5.0
   SnakeYAML Engine:1.0
   snappy-java:1.1.1.3
@@ -140,6 +141,7 @@ BSD 3-Clause License
   Protocol Buffers [Core]:3.13.0
   ParaNamer Core:2.7
   ANTLR 4 Runtime:4.7.2
+  Reflections:0.9.12
 CC0
   reactive-streams:1.0.2
 EPL 2.0
@@ -148,18 +150,24 @@ GNU General Public License, version 2 (GPL2), with the classpath exception
   Checker Qual:2.5.5
 GPL2 w/ CPE
   javax.ws.rs-api:2.1.1
+LGPL 2.1
+  Javassist:3.26.0-GA
 MIT License
   ClassGraph:4.8.66
   JOpt Simple:5.0.2
   Checker Qual:2.5.5
   Animal Sniffer Annotations:1.18
   SLF4J API Module:1.7.25
+MPL 1.1
+  Javassist:3.26.0-GA
 Public Domain
   XZ for Java:1.5
 Public Domain, per Creative Commons CC0
   HdrHistogram:2.1.9
 The GNU General Public License, v2 with FOSS exception
   MySQL Connector/J:8.0.16
+WTFPL
+  Reflections:0.9.12
 
 -----
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
         <log4j.version>1.2.17</log4j.version>
         <log4j2.version>2.13.3</log4j2.version>
         <slf4j.api.version>1.7.28</slf4j.api.version>
-        <reflections.version>0.9.10</reflections.version>
         <osgi.version>4.2.0</osgi.version>
         <prometheus.version>0.13.0</prometheus.version>
         <hadoop.version>2.10.0</hadoop.version>
@@ -254,22 +253,6 @@
             <artifactId>cache-api</artifactId>
             <version>${jsr107.api.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.reflections</groupId>
-            <artifactId>reflections</artifactId>
-            <version>${reflections.version}</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-simple</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 
@@ -554,7 +537,10 @@
                                 Apache 2|Apache 2.0|Apache-2.0|Apache License 2.0|The Apache License, Version 2.0
                             </licenseMerge>
                             <licenseMerge>BSD 2-Clause License|BSD-2-Clause</licenseMerge>
-                            <licenseMerge>BSD 3-Clause License|BSD License|BSD|BSD licence|The BSD License|3-Clause BSD License| New BSD License</licenseMerge>
+                            <licenseMerge>
+                                BSD 3-Clause License|BSD License|BSD|BSD licence|The BSD License|3-Clause BSD License|
+                                New BSD License|The New BSD License
+                            </licenseMerge>
                             <licenseMerge>CC0|CC0 1.0 Universal License</licenseMerge>
                             <licenseMerge>MIT License|MIT|The MIT License|MIT license|The MIT License (MIT)</licenseMerge>
                         </licenseMerges>


### PR DESCRIPTION
Causes incorrect dependency resolution for hadoop module fat jar.
Causes incorrect dependency resolution for distribution,
resulting in missing reflections library and its dependencies
in NOTICE.
