### PR TITLE
Fix javadoc generation under JDK 11+.

### DIFF
--- a/hazelcast-jet-all/pom.xml
+++ b/hazelcast-jet-all/pom.xml
@@ -207,6 +207,15 @@
             <optional>true</optional>
         </dependency>
 
+        <!-- optional IMDG dependencies: required for javadoc generation, optional at runtime -->
+        <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>affinity</artifactId>
+            <version>${affinity.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
         <!-- logging -->
         <dependency>
             <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
         <classgraph.version>4.8.66</classgraph.version>
         <jackson.jr.version>2.11.2</jackson.jr.version>
         <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
+        <affinity.version>3.2.3</affinity.version>
 
         <!-- test dependencies -->
         <activemq.version>5.15.11</activemq.version>


### PR DESCRIPTION
Added `net.openhft:affinity` as optional dependency to fix javadoc generation.

Checklist:
- [x] Labels and Milestone set
