### PR TITLE
Add `FilterAggregateTransposeRule` rule

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JobConfig.java
@@ -68,6 +68,7 @@ public class JobConfig implements IdentifiedDataSerializable {
     private boolean splitBrainProtectionEnabled;
     private boolean enableMetrics = true;
     private boolean storeMetricsAfterJobCompletion;
+    // Note: new options in JobConfig must also be added to `SqlCreateJob`
 
     private Map<String, ResourceConfig> resourceConfigs = new LinkedHashMap<>();
     private Map<String, String> serializerConfigs = new HashMap<>();

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalRules.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalRules.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.sql.impl.opt.logical;
 
 import com.hazelcast.sql.impl.calcite.opt.logical.FilterIntoScanLogicalRule;
 import com.hazelcast.sql.impl.calcite.opt.logical.ProjectIntoScanLogicalRule;
+import org.apache.calcite.rel.rules.FilterAggregateTransposeRule;
 import org.apache.calcite.rel.rules.FilterMergeRule;
 import org.apache.calcite.rel.rules.FilterProjectTransposeRule;
 import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
@@ -52,6 +53,7 @@ public final class LogicalRules {
 
                 // Aggregate rules
                 AggregateLogicalRule.INSTANCE,
+                FilterAggregateTransposeRule.INSTANCE,
 
                 // Value rules
                 ValuesLogicalRule.INSTANCE,


### PR DESCRIPTION
Roughly saying, the new rule converts HAVING to WHERE, if possible, e.g.:
```sql
SELECT a FROM t GROUP BY a HAVING b=0
```
to 
```sql
SELECT a FROM t WHERE b=0 GROUP BY a
```
As a result, filtering isn't applied after aggregation, but pushed down to the source.