### PR TITLE
Avoid closing System.out in JetConsoleLogHandler

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetConsoleLogHandler.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/util/JetConsoleLogHandler.java
@@ -41,8 +41,17 @@ public class JetConsoleLogHandler extends StreamHandler {
 
     @Override
     public void publish(LogRecord record) {
-        // sync method call, we should implement own logger here.
+        // synchronized method call!
         super.publish(record);
+        flush();
+    }
+
+    /**
+     * Since this handler uses {@code System.out}, just flush it without
+     * closing.
+     */
+    @Override
+    public void close() {
         flush();
     }
 

--- a/hazelcast-jet-distribution/src/root/release_notes.txt
+++ b/hazelcast-jet-distribution/src/root/release_notes.txt
@@ -36,6 +36,8 @@ Thank you for your valuable contributions!
 
 3. Fixes
 
+[core] Jet now doesn't close System.out during JVM shutdown (#2649)
+
 4. Breaking Changes
 
 <<< END PR SECTION


### PR DESCRIPTION
Jet configures JUL logging with its own console log handler that writes to `System.out`. The handler doesn't override `close()`, so it closes `System.out` when closing itself. Most importantly, this happens during JVM shutdown in a shutdown hook, so other shutdown hooks lose the ability to print messages to the console.

This PR overrides `JetConsoleLogHandler#close()` so it doesn't close its output stream.

Fixes #2649 

Checklist:
- [x] Labels and Milestone set
- [x] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
