### PR TITLE
Link to IMDG Release Notes from Jet's

### DIFF
--- a/hazelcast-jet-distribution/src/root/release_notes.txt
+++ b/hazelcast-jet-distribution/src/root/release_notes.txt
@@ -26,6 +26,9 @@ https://github.com/hazelcast/hazelcast-jet/issues/<issue number>
 
 ADD YOUR PR ENTRY IN THIS SECTION: >>>
 
+Hazelcast Jet 4.x is based on IMDG version 4.y. Check out its Release
+Notes here: https://docs.hazelcast.org/docs/rn/index.html#4-y
+
 Members of the open source community that appear in these release notes:
 
 Thank you for your valuable contributions!

--- a/site/website/blog/2020-10-23-jet-43-is-released.md
+++ b/site/website/blog/2020-10-23-jet-43-is-released.md
@@ -115,6 +115,9 @@ progress of event time-based pipelines as well.
 
 ## Full Release Notes
 
+Hazelcast Jet 4.3 is based on IMDG version 4.0.3. Check out its Release
+Notes [here](https://docs.hazelcast.org/docs/rn/index.html#4-0-3).
+
 Members of the open source community that appear in these release notes:
 
 - @caioguedes


### PR DESCRIPTION
Every version of Jet inherits all the enhancements and fixes done in the IMDG. So our Release Notes should link to IMDG's.

Checklist:
- [x] Labels and Milestone set
- [x] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
