### PR TITLE
Add links to EE release notes

### DIFF
--- a/hazelcast-jet-distribution/src/root/release_notes.txt
+++ b/hazelcast-jet-distribution/src/root/release_notes.txt
@@ -27,7 +27,9 @@ https://github.com/hazelcast/hazelcast-jet/issues/<issue number>
 ADD YOUR PR ENTRY IN THIS SECTION: >>>
 
 Hazelcast Jet 4.x is based on IMDG version 4.y. Check out its Release
-Notes here: https://docs.hazelcast.org/docs/rn/index.html#4-y
+Notes here: https://docs.hazelcast.org/docs/rn/index.html#4-y and,
+for the Enterprise Edition,
+here: https://docs.hazelcast.org/docs/ern/index.html#4-0-3
 
 Members of the open source community that appear in these release notes:
 

--- a/site/website/blog/2020-10-23-jet-43-is-released.md
+++ b/site/website/blog/2020-10-23-jet-43-is-released.md
@@ -116,7 +116,9 @@ progress of event time-based pipelines as well.
 ## Full Release Notes
 
 Hazelcast Jet 4.3 is based on IMDG version 4.0.3. Check out its Release
-Notes [here](https://docs.hazelcast.org/docs/rn/index.html#4-0-3).
+Notes [here](https://docs.hazelcast.org/docs/rn/index.html#4-0-3) and,
+for the Enterprise Edition,
+[here](https://docs.hazelcast.org/docs/ern/index.html#4-0-3).
 
 Members of the open source community that appear in these release notes:
 


### PR DESCRIPTION
IMDG has separate release notes for the Enterprise Edition. Added a link to that as well.

Checklist:
- [x] Labels and Milestone set
- [x] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
