### PR TITLE
Add Pipeline.isEmpty

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/PipelineImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/PipelineImpl.java
@@ -189,6 +189,11 @@ public class PipelineImpl implements Pipeline {
         return builder.toString();
     }
 
+    @Override
+    public boolean isEmpty() {
+        return adjacencyMap.isEmpty();
+    }
+
     Map<Transform, List<Transform>> adjacencyMap() {
         Map<Transform, List<Transform>> safeCopy = new LinkedHashMap<>();
         adjacencyMap.forEach((k, v) -> safeCopy.put(k, new ArrayList<>(v)));

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Pipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Pipeline.java
@@ -109,7 +109,7 @@ public interface Pipeline extends Serializable {
     String toDotString();
 
     /**
-     * Returns {@code true} if pipeline has no vertices nor edges attached.
+     * Returns {@code true} if there are no stages in the pipeline.
      *
      * @since 4.4
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Pipeline.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/Pipeline.java
@@ -107,4 +107,11 @@ public interface Pipeline extends Serializable {
      */
     @Nonnull
     String toDotString();
+
+    /**
+     * Returns {@code true} if pipeline has no vertices nor edges attached.
+     *
+     * @since 4.4
+     */
+    boolean isEmpty();
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.jet.pipeline.test.TestSources;

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/PipelineTest.java
@@ -1,0 +1,27 @@
+package com.hazelcast.jet.pipeline;
+
+import com.hazelcast.jet.pipeline.test.TestSources;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PipelineTest {
+
+    @Test
+    public void isEmpty() {
+        // given
+        Pipeline p1 = Pipeline.create();
+        Pipeline p2 = Pipeline.create();
+
+        p2.readFrom(TestSources.items(1, 2, 3));
+
+        // when
+        boolean p1Empty = p1.isEmpty();
+        boolean p2Empty = p2.isEmpty();
+
+        // then
+        assertThat(p1Empty).isTrue();
+        assertThat(p2Empty).isFalse();
+    }
+
+}


### PR DESCRIPTION
Very simple PR which adds Pipeline.isEmpty() method to check if any transformations were added to Pipeline.

Breaking changes (list specific methods/types/messages):
* API - added Pipeline.isEmpty

Checklist:
- [ ] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Updated `examples/README.md` (when adding a new code sample)
