### PR TITLE
Unregister manually stopped container from resource reaper

### DIFF
--- a/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
+++ b/extensions/cdc-debezium/src/test/java/com/hazelcast/jet/cdc/AbstractCdcIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.ResourceReaper;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -138,6 +139,7 @@ public class AbstractCdcIntegrationTest extends JetTestSupport {
                 .withRemoveVolumes(true)
                 .withForce(true)
                 .exec();
+        ResourceReaper.instance().unregisterContainer(containerId);
     }
 
     protected <T> T namedTestContainer(GenericContainer<?> container) {


### PR DESCRIPTION
The "network" CDC tests still experience various container start/stop related failures. While I have no idea of the exact cause (since I can't reproduce the problem), I have found an extra step we can take in these tests, maybe that will help... Lame, but nothing to loose at this point.

Checklist:
- [x] Labels and Milestone set