### PR TITLE
Fix Kafka tests under JDK14+

### DIFF
--- a/extensions/kafka/pom.xml
+++ b/extensions/kafka/pom.xml
@@ -87,6 +87,19 @@
             <artifactId>kafka_${scala.version}</artifactId>
             <version>${kafka.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- override zookeeper version to remediate https://issues.apache.org/jira/browse/ZOOKEEPER-3779 -->
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/hazelcast-jet-sql/pom.xml
+++ b/hazelcast-jet-sql/pom.xml
@@ -144,6 +144,19 @@
             <artifactId>kafka_${scala.version}</artifactId>
             <version>${kafka.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- override zookeeper version to remediate https://issues.apache.org/jira/browse/ZOOKEEPER-3779 -->
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
         <spring.version>4.3.0.RELEASE</spring.version>
         <avro.version>1.8.2</avro.version>
         <scala.version>2.12</scala.version>
+        <zookeeper.version>3.5.8</zookeeper.version>
         <kafka.version>2.2.0</kafka.version>
         <grpc.version>1.31.0</grpc.version>
         <protobuf.version>3.13.0</protobuf.version>


### PR DESCRIPTION
Bumped `zookeper` to version 3.5.8 to remediate https://issues.apache.org/jira/browse/ZOOKEEPER-3779

Fixes #2624

Checklist:
- [x] Labels and Milestone set
