### PR TITLE
Fix race in MetricsContext

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/MetricsContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/metrics/MetricsContext.java
@@ -210,7 +210,7 @@ public class MetricsContext implements DynamicMetricsProvider {
 
         void threadSafeForEach(BiConsumer<? super String, ? super AbstractMetric> consumer) {
             if (threadSafeStore != null) {
-                threadLocalStore.forEach(consumer);
+                threadSafeStore.forEach(consumer);
             }
         }
     }


### PR DESCRIPTION
Turns out the failures observed in issue #2572 are caused by an exception thrown in `MetricsContext`. It's a NPE caused by non-thread safe data being accessed from multiple threads (one is the thread executing the tasklet, another is the thread doing dynamic metrics collection). This PR attempts to fix the problem.

Fixes #2572 

Checklist:
- [x] Labels and Milestone set
