### PR TITLE
Check if python3 is available before initializing python service context

### DIFF
--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.python;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.ProcessorSupplier;
+import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
 
@@ -76,6 +77,7 @@ class PythonServiceContext {
     PythonServiceContext(ProcessorSupplier.Context context, PythonServiceConfig cfg) {
         logger = context.jetInstance().getHazelcastInstance().getLoggingService()
                         .getLogger(getClass().getPackage().getName());
+        checkIfPythonIsAvailable();
         try {
             long start = System.nanoTime();
             runtimeBaseDir = recreateRuntimeBaseDir(context, cfg);
@@ -105,6 +107,14 @@ class PythonServiceContext {
                     TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)));
         } catch (Exception e) {
             throw new JetException("PythonService initialization failed: " + e, e);
+        }
+    }
+
+    private void checkIfPythonIsAvailable() {
+        try {
+            new ProcessBuilder("python3", "--version").start().waitFor();
+        } catch (Exception e) {
+            throw ExceptionUtil.sneakyThrow(new Exception("python3 is not available", e));
         }
     }
 

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;

--- a/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
+++ b/extensions/python/src/main/java/com/hazelcast/jet/python/PythonServiceContext.java
@@ -18,7 +18,6 @@ package com.hazelcast.jet.python;
 import com.hazelcast.internal.nio.IOUtil;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.ProcessorSupplier;
-import com.hazelcast.jet.impl.util.ExceptionUtil;
 import com.hazelcast.jet.impl.util.Util;
 import com.hazelcast.logging.ILogger;
 
@@ -114,7 +113,7 @@ class PythonServiceContext {
         try {
             new ProcessBuilder("python3", "--version").start().waitFor();
         } catch (Exception e) {
-            throw ExceptionUtil.sneakyThrow(new Exception("python3 is not available", e));
+            throw new IllegalStateException("python3 is not available", e);
         }
     }
 


### PR DESCRIPTION
Fixes #2615

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Updated `examples/README.md` (when adding a new code sample)
