### PR TITLE
Support byte[] json objects

### DIFF
--- a/hazelcast-jet-sql/pom.xml
+++ b/hazelcast-jet-sql/pom.xml
@@ -159,12 +159,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>connect-json</artifactId>
-            <version>${kafka.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${confluent.version}</version>

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/extract/JsonQueryTarget.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/extract/JsonQueryTarget.java
@@ -38,7 +38,9 @@ public class JsonQueryTarget implements QueryTarget {
     @Override
     public void setTarget(Object target) {
         try {
-            json = (ObjectNode) (target instanceof ObjectNode ? target : MAPPER.readTree((String) target));
+            json = (ObjectNode) (target instanceof ObjectNode ? target
+                    : target instanceof String ? MAPPER.readTree((String) target)
+                    : MAPPER.readTree((byte[]) target));
         } catch (IOException e) {
             throw sneakyThrow(e);
         }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTarget.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTarget.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.jet.sql.impl.inject;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -25,6 +26,7 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.sql.impl.inject.UpsertInjector.FAILING_TOP_LEVEL_INJECTOR;
 
 @NotThreadSafe
@@ -114,6 +116,10 @@ class JsonUpsertTarget implements UpsertTarget {
     public Object conclude() {
         ObjectNode json = this.json;
         this.json = null;
-        return json;
+        try {
+            return MAPPER.writeValueAsBytes(json);
+        } catch (JsonProcessingException jpe) {
+            throw sneakyThrow(jpe);
+        }
     }
 }

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
@@ -25,9 +25,9 @@ import com.hazelcast.jet.sql.SqlTestSupport;
 import com.hazelcast.jet.sql.impl.connector.test.AllTypesSqlConnector;
 import com.hazelcast.sql.HazelcastSqlException;
 import com.hazelcast.sql.SqlService;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.apache.kafka.connect.json.JsonDeserializer;
-import org.apache.kafka.connect.json.JsonSerializer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -82,10 +82,10 @@ public class SqlJsonTest extends SqlTestSupport {
                 + '"' + OPTION_KEY_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"" + OPTION_VALUE_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"bootstrap.servers\" '" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", \"key.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"key.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
-                + ", \"value.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"value.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
+                + ", \"key.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"key.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
+                + ", \"value.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"value.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
                 + ", \"auto.offset.reset\" 'earliest'"
                 + ")"
         );
@@ -112,10 +112,10 @@ public class SqlJsonTest extends SqlTestSupport {
                 + '"' + OPTION_KEY_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"" + OPTION_VALUE_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"bootstrap.servers\" '" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", \"key.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"key.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
-                + ", \"value.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"value.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
+                + ", \"key.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"key.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
+                + ", \"value.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"value.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
                 + ", \"auto.offset.reset\" 'earliest'"
                 + ")"
         );
@@ -142,10 +142,10 @@ public class SqlJsonTest extends SqlTestSupport {
                 + '"' + OPTION_KEY_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"" + OPTION_VALUE_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"bootstrap.servers\" '" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", \"key.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"key.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
-                + ", \"value.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"value.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
+                + ", \"key.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"key.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
+                + ", \"value.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"value.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
                 + ", \"auto.offset.reset\" 'earliest'"
                 + ")"
         );
@@ -163,10 +163,10 @@ public class SqlJsonTest extends SqlTestSupport {
                 + '"' + OPTION_KEY_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"" + OPTION_VALUE_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"bootstrap.servers\" '" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", \"key.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"key.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
-                + ", \"value.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"value.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
+                + ", \"key.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"key.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
+                + ", \"value.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"value.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
                 + ", \"auto.offset.reset\" 'earliest'"
                 + ")"
         );
@@ -211,10 +211,10 @@ public class SqlJsonTest extends SqlTestSupport {
                 + '"' + OPTION_KEY_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"" + OPTION_VALUE_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"bootstrap.servers\" '" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", \"key.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"key.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
-                + ", \"value.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"value.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
+                + ", \"key.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"key.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
+                + ", \"value.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"value.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
                 + ", \"auto.offset.reset\" 'earliest'"
                 + ")"
         );
@@ -279,10 +279,10 @@ public class SqlJsonTest extends SqlTestSupport {
                 + '"' + OPTION_KEY_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"" + OPTION_VALUE_FORMAT + "\" '" + JSON_FORMAT + '\''
                 + ", \"bootstrap.servers\" '" + kafkaTestSupport.getBrokerConnectionString() + '\''
-                + ", \"key.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"key.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
-                + ", \"value.serializer\" '" + JsonSerializer.class.getCanonicalName() + '\''
-                + ", \"value.deserializer\" '" + JsonDeserializer.class.getCanonicalName() + '\''
+                + ", \"key.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"key.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
+                + ", \"value.serializer\" '" + ByteArraySerializer.class.getCanonicalName() + '\''
+                + ", \"value.deserializer\" '" + ByteArrayDeserializer.class.getCanonicalName() + '\''
                 + ", \"auto.offset.reset\" 'earliest'"
                 + ")"
         );

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/JsonQueryTargetTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/JsonQueryTargetTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -71,7 +72,11 @@ public class JsonQueryTargetTest {
                 + ", \"null\": null"
                 + ", \"object\": {}"
                 + "}";
-        return new Object[]{new Object[]{json}, new Object[]{new ObjectMapper().readTree(json)}};
+        return new Object[]{
+                new Object[]{json},
+                new Object[]{json.getBytes(StandardCharsets.UTF_8)},
+                new Object[]{new ObjectMapper().readTree(json)}
+        };
     }
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTargetTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/inject/JsonUpsertTargetTest.java
@@ -74,7 +74,7 @@ public class JsonUpsertTargetTest {
         timestampTzInjector.set(OffsetDateTime.of(2020, 9, 9, 12, 23, 34, 200_000_000, UTC));
         Object json = target.conclude();
 
-        assertThat(json.toString()).isEqualTo("{"
+        assertThat(new String((byte[]) json)).isEqualTo("{"
                 + "\"null\":null"
                 + ",\"object\":{}"
                 + ",\"string\":\"string\""
@@ -125,6 +125,6 @@ public class JsonUpsertTargetTest {
         injector.set(value);
         Object json = target.conclude();
 
-        assertThat(json.toString()).isEqualTo("{\"object\":" + expected + "}");
+        assertThat(new String((byte[]) json)).isEqualTo("{\"object\":" + expected + "}");
     }
 }


### PR DESCRIPTION
Added support for json as `byte[]`.
Removed dependency to `org.apache.kafka:connect-json`.

Checklist:
- [x] Labels and Milestone set
