### PR TITLE
Ensure naming conventions for sources/sinks in the extensions module

### DIFF
--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSinks.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSinks.java
@@ -79,7 +79,8 @@ public final class HadoopSinks {
             @Nonnull FunctionEx<? super E, K> extractKeyF,
             @Nonnull FunctionEx<? super E, V> extractValueF
     ) {
-        return Sinks.fromProcessor("writeHdfs", HadoopProcessors.writeHadoopP(configuration, extractKeyF, extractValueF));
+        return Sinks.fromProcessor("hdfsSink",
+                HadoopProcessors.writeHadoopP(configuration, extractKeyF, extractValueF));
     }
 
     /**

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
@@ -108,7 +108,7 @@ public final class HadoopSources {
             @Nonnull Configuration configuration,
             @Nonnull BiFunctionEx<K, V, E> projectionFn
     ) {
-        return Sources.batchFromProcessor("readHadoop",
+        return Sources.batchFromProcessor("hdfsSource",
                 readHadoopP(SerializableConfiguration.asSerializable(configuration), projectionFn));
     }
 

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSinks.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSinks.java
@@ -102,7 +102,7 @@ public final class KafkaSinks {
             @Nonnull Properties properties,
             @Nonnull FunctionEx<? super E, ProducerRecord<K, V>> toRecordFn
     ) {
-        return Sinks.fromProcessor("writeKafka", writeKafkaP(properties, toRecordFn, true));
+        return Sinks.fromProcessor("kafkaSink", writeKafkaP(properties, toRecordFn, true));
     }
 
     /**
@@ -126,7 +126,7 @@ public final class KafkaSinks {
             @Nonnull FunctionEx<? super E, K> extractKeyFn,
             @Nonnull FunctionEx<? super E, V> extractValueFn
     ) {
-        return Sinks.fromProcessor("writeKafka(" + topic + ")",
+        return Sinks.fromProcessor("kafkaSink(" + topic + ")",
                 writeKafkaP(properties, topic, extractKeyFn, extractValueFn, true));
     }
 
@@ -334,11 +334,11 @@ public final class KafkaSinks {
             if (topic != null) {
                 FunctionEx<? super E, ?> extractKeyFn1 = extractKeyFn != null ? extractKeyFn : t -> null;
                 FunctionEx<? super E, ?> extractValueFn1 = extractValueFn != null ? extractValueFn : t -> t;
-                return Sinks.fromProcessor("writeKafka(" + topic + ")",
+                return Sinks.fromProcessor("kafkaSink(" + topic + ")",
                         writeKafkaP(properties, topic, extractKeyFn1, extractValueFn1, exactlyOnce));
             } else {
                 ProcessorMetaSupplier metaSupplier = writeKafkaP(properties, toRecordFn, exactlyOnce);
-                return Sinks.fromProcessor("writeKafka", metaSupplier);
+                return Sinks.fromProcessor("kafkaSink", metaSupplier);
             }
         }
     }

--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/KafkaSources.java
@@ -133,7 +133,7 @@ public final class KafkaSources {
             @Nonnull String ... topics
     ) {
         checkPositive(topics.length, "At least one topic required");
-        return streamFromProcessorWithWatermarks("streamKafka(" + String.join(",", topics) + ")",
+        return streamFromProcessorWithWatermarks("kafkaSource(" + String.join(",", topics) + ")",
                 true, w -> streamKafkaP(properties, projectionFn, w, topics));
     }
 }

--- a/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sinks.java
+++ b/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sinks.java
@@ -105,7 +105,7 @@ public final class S3Sinks {
     ) {
         String charsetName = charset.name();
         return SinkBuilder
-                .sinkBuilder("s3-sink", context ->
+                .sinkBuilder("s3Sink", context ->
                         new S3SinkContext<>(bucketName, prefix, charsetName, context.globalProcessorIndex(),
                                 toStringFn, clientSupplier))
                 .<T>receiveFn(S3SinkContext::receive)

--- a/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sources.java
+++ b/extensions/s3/src/main/java/com/hazelcast/jet/s3/S3Sources.java
@@ -170,7 +170,7 @@ public final class S3Sources {
             @Nonnull BiFunctionEx<String, ? super I, ? extends T> mapFn
     ) {
         return SourceBuilder
-                .batch("s3-source", context ->
+                .batch("s3Source", context ->
                         new S3SourceContext<I, T>(bucketNames, prefix, context, clientSupplier, readFileFn,
                                 mapFn))
                 .<T>fillBufferFn(S3SourceContext::fillBuffer)

--- a/hazelcast-jet-distribution/src/root/release_notes.txt
+++ b/hazelcast-jet-distribution/src/root/release_notes.txt
@@ -39,6 +39,8 @@ Thank you for your valuable contributions!
 
 2. Enhancements
 
+[extensions] Ensure naming conventions for sources/sinks (#2685)
+
 3. Fixes
 
 [core] Jet now doesn't close System.out during JVM shutdown (#2649)


### PR DESCRIPTION
Sources and sinks in the core module are named `xyzSource` and `xyzSink` respectively.
Use the same convention in the extensions module as well.

NO breaking API changes, only changed default source/sink names in the extensions module.

Checklist:
- [x] Labels and Milestone set
- [x] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
