### PR TITLE
Use FilterReduceRule

### DIFF
--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalRules.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/opt/logical/LogicalRules.java
@@ -25,6 +25,7 @@ import org.apache.calcite.rel.rules.ProjectFilterTransposeRule;
 import org.apache.calcite.rel.rules.ProjectMergeRule;
 import org.apache.calcite.rel.rules.ProjectRemoveRule;
 import org.apache.calcite.rel.rules.PruneEmptyRules;
+import org.apache.calcite.rel.rules.ReduceExpressionsRule;
 import org.apache.calcite.tools.RuleSet;
 import org.apache.calcite.tools.RuleSets;
 
@@ -40,6 +41,7 @@ public final class LogicalRules {
                 FilterMergeRule.INSTANCE,
                 FilterProjectTransposeRule.INSTANCE,
                 FilterIntoScanLogicalRule.INSTANCE,
+                ReduceExpressionsRule.FILTER_INSTANCE,
 
                 // Project rules
                 ProjectLogicalRule.INSTANCE,


### PR DESCRIPTION
Added `ReduceExpressionsRule.FILTER_INSTANCE` to the set of logical rules so for instance:
```
LogicalProject(v=[$0])
  LogicalFilter(condition=[AND(=($0, 10), IS NULL($0))])
    LogicalTableScan(table=[[hazelcast, public, t[projects=[0]]]])
```
results now in:
```
ValuesPhysicalRel(tuples=[[]])
```
instead of:
```
FullScanPhysicalRel(table=[[hazelcast, public, t[projects=[0], filter=AND(=($0, 10), IS NULL($0))]]])
```

Checklist:
- [x] Labels and Milestone set
