### PR TITLE
Follow IMDG change: Allow disabling XXE protection

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfigXmlGenerator.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/config/JetConfigXmlGenerator.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.config;
 
 import com.hazelcast.config.ConfigXmlGenerator.XmlGenerator;
 import com.hazelcast.internal.util.Preconditions;
+import com.hazelcast.internal.util.XmlUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
@@ -29,7 +30,6 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import java.io.StringReader;
 import java.io.StringWriter;
-import javax.xml.XMLConstants;
 
 import static com.hazelcast.internal.nio.IOUtil.closeResource;
 
@@ -88,9 +88,7 @@ public final class JetConfigXmlGenerator {
         try {
             Source xmlInput = new StreamSource(new StringReader(input));
             xmlOutput = new StreamResult(new StringWriter());
-            TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            TransformerFactory transformerFactory = XmlUtil.getTransformerFactory();
             /*
              * Older versions of Xalan still use this method of setting indent values.
              * Attempt to make this work but don't completely fail if it's a problem.


### PR DESCRIPTION
Apply changes from https://github.com/hazelcast/hazelcast/pull/17842 to Jet config. See IMDG PR for more details.

Checklist:
- [x] Labels and Milestone set
- [N/A] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] Updated `examples/README.md` (when adding a new code sample)
