### PR TITLE
Improve Kafka properties resolution

### DIFF
--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaSqlConnector.java
@@ -110,7 +110,7 @@ public class KafkaSqlConnector implements SqlConnector {
                 fields,
                 new ConstantTableStatistics(0),
                 topicName,
-                PropertiesResolver.resolveProperties(options),
+                options,
                 keyMetadata.getQueryTargetDescriptor(),
                 keyMetadata.getUpsertTargetDescriptor(),
                 valueMetadata.getQueryTargetDescriptor(),
@@ -135,7 +135,7 @@ public class KafkaSqlConnector implements SqlConnector {
         Vertex vStart = dag.newVertex(
                 table.toString(),
                 KafkaProcessors.streamKafkaP(
-                        table.kafkaProperties(),
+                        table.kafkaConsumerProperties(),
                         record -> entry(record.key(), record.value()),
                         noEventTime(),
                         table.topicName()
@@ -188,7 +188,7 @@ public class KafkaSqlConnector implements SqlConnector {
         Vertex vEnd = dag.newVertex(
                 table.toString(),
                 KafkaProcessors.<Entry<Object, Object>, Object, Object>writeKafkaP(
-                        table.kafkaProperties(),
+                        table.kafkaProducerProperties(),
                         table.topicName(),
                         Entry::getKey,
                         Entry::getValue,

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
@@ -27,6 +27,7 @@ import com.hazelcast.sql.impl.schema.map.MapTableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 class KafkaTable extends JetTable {
@@ -38,7 +39,7 @@ class KafkaTable extends JetTable {
     private final UpsertTargetDescriptor valueUpsertDescriptor;
 
     private final String topicName;
-    private final Properties kafkaProperties;
+    private final Map<String, String> options;
 
     @SuppressWarnings("checkstyle:ParameterNumber")
     KafkaTable(
@@ -48,7 +49,7 @@ class KafkaTable extends JetTable {
             List<TableField> fields,
             TableStatistics statistics,
             String topicName,
-            Properties kafkaProperties,
+            Map<String, String> options,
             QueryTargetDescriptor keyQueryDescriptor,
             UpsertTargetDescriptor keyUpsertDescriptor,
             QueryTargetDescriptor valueQueryDescriptor,
@@ -63,15 +64,19 @@ class KafkaTable extends JetTable {
         this.valueUpsertDescriptor = valueUpsertDescriptor;
 
         this.topicName = topicName;
-        this.kafkaProperties = kafkaProperties;
+        this.options = options;
     }
 
     String topicName() {
         return topicName;
     }
 
-    Properties kafkaProperties() {
-        return kafkaProperties;
+    Properties kafkaConsumerProperties() {
+        return PropertiesResolver.resolveConsumerProperties(options);
+    }
+
+    Properties kafkaProducerProperties() {
+        return PropertiesResolver.resolveProducerProperties(options);
     }
 
     QueryTargetDescriptor keyQueryDescriptor() {


### PR DESCRIPTION
Removed Jet specific options from Kafka properties.
Added specific properties resolution for consumer & producer.

Fixes #2715

Checklist:
- [x] Labels and Milestone set