### PR TITLE
Fix HazelcastConnector_RestartTest

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/ExecutionContext.java
@@ -346,4 +346,8 @@ public class ExecutionContext implements DynamicMetricsProvider {
     public void setCompletionTime() {
         completionTime.set(System.currentTimeMillis());
     }
+
+    public CompletableFuture<Void> getExecutionFuture() {
+        return executionFuture;
+    }
 }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/RetryStrategies.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/RetryStrategies.java
@@ -70,10 +70,10 @@ public final class RetryStrategies {
         }
 
         /**
-         * Sets the maximum number of reconnect attempts.
+         * Sets the maximum number of retry attempts.
          */
-        public Builder maxAttempts(int maxAttempts) {
-            this.maxAttempts = maxAttempts;
+        public Builder maxAttempts(int maxRetryAttempts) {
+            this.maxAttempts = maxRetryAttempts;
             return this;
         }
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/RetryStrategy.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/RetryStrategy.java
@@ -19,16 +19,16 @@ package com.hazelcast.jet.retry;
 import java.io.Serializable;
 
 /**
- * Description of a strategy to be followed when retrying a failed action, like
- * connecting to a server. A typical strategy for this scenario could be for
- * example: "attempt to reconnect 3 times, wait 5 seconds between each attempt,
- * if all of them fail, then give up".
+ * Description of a strategy to take when an action fails, like when
+ * connecting to a server. An example strategy for this scenario can be:
+ * "attempt to reconnect 3 times, wait 5 seconds between each attempt, if
+ * all of them fail, give up".
  * <p>
- * The lifecycle of a retry strategy begins whenever its covered action fails
- * and ends in one of two ways: either a retry of the action is successful (the
- * action is successfully undertaken, for example reconnect to a server
- * succeeds) or the strategy gives up (for example it had a specified maximum
- * number of retries, all of them had been attempted and none was successful).
+ * The lifecycle of a retry strategy begins whenever an action fails and
+ * ends in one of two ways: either a retry of the action is successful (for
+ * example reconnection attempt to a server succeeds) or the strategy gives
+ * up (for example it did a specified maximum number of retries, all of
+ * them failed).
  *
  * @since 4.3
  */
@@ -37,11 +37,10 @@ public interface RetryStrategy extends Serializable {
     /**
      * Maximum number of retry attempt that should be made before giving up.
      * <p>
-     * A value of 0 should be interpreted as "give up on first failure, without
-     * any retries".
+     * A value of 0 should be interpreted as "never retry". Action is performed
+     * once.
      * <p>
-     * A negative value should be interpreted as "retry indefinitely, until
-     * success".
+     * A negative value is interpreted as "retry indefinitely, until success".
      */
     int getMaxAttempts();
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/impl/RetryStrategyImpl.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/retry/impl/RetryStrategyImpl.java
@@ -41,6 +41,6 @@ public class RetryStrategyImpl implements RetryStrategy {
 
     @Override
     public String toString() {
-        return "max attempt = " + maxAttempts + ", interval function = " + intervalFunction;
+        return "max attempts = " + maxAttempts + ", interval function = " + intervalFunction;
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnector_RestartTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/impl/connector/HazelcastConnector_RestartTest.java
@@ -27,12 +27,16 @@ import com.hazelcast.internal.partition.PartitionMigrationEvent;
 import com.hazelcast.internal.partition.PartitionReplicationEvent;
 import com.hazelcast.internal.services.CoreService;
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
 import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.config.JobConfig;
 import com.hazelcast.jet.core.DAG;
 import com.hazelcast.jet.core.JetTestSupport;
 import com.hazelcast.jet.core.TestProcessors.ListSource;
 import com.hazelcast.jet.core.Vertex;
+import com.hazelcast.jet.impl.JetService;
+import com.hazelcast.jet.impl.JobExecutionService;
+import com.hazelcast.jet.impl.execution.ExecutionContext;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import org.junit.Before;
@@ -41,6 +45,7 @@ import org.junit.runner.RunWith;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.jet.core.Edge.between;
 import static com.hazelcast.jet.core.TestUtil.throttle;
@@ -84,7 +89,7 @@ public class HazelcastConnector_RestartTest extends JetTestSupport {
         dag.edge(between(source, sink));
         source.localParallelism(1);
 
-        instance1.newJob(dag, new JobConfig().setAutoScaling(true));
+        Job job = instance1.newJob(dag, new JobConfig().setAutoScaling(true));
         // wait for the job to start producing
         IList<Integer> sinkList = instance1.getHazelcastInstance().getList("sink");
         assertTrueEventually(() -> assertTrue("no output to sink", sinkList.size() >= 4), 5);
@@ -92,18 +97,19 @@ public class HazelcastConnector_RestartTest extends JetTestSupport {
         // When
         // initiate the shutdown. Thanks to the MigrationBlockingService migration will not finish
         // before the latch is counted down.
-        Future shutdownFuture = spawn(() -> instance2.shutdown());
+        Future<?> shutdownFuture = spawn(() -> instance2.shutdown());
 
         // Then - assert that the job stopped producing output
-        sleepSeconds(4);
-        assertFalse("node engine is running",
-                ((HazelcastInstanceImpl) instance2.getHazelcastInstance()).node.nodeEngine.isRunning());
+        waitExecutionDoneOnMember(instance1, job);
+        waitExecutionDoneOnMember(instance2, job);
+        assertTrueEventually(() -> assertFalse("node engine is running",
+                ((HazelcastInstanceImpl) instance2.getHazelcastInstance()).node.nodeEngine.isRunning()));
         int sizeAfterShutdown = sinkList.size();
-        assertTrueAllTheTime(() -> assertEquals("output continues after shutdown", sizeAfterShutdown, sinkList.size()), 5);
+        assertTrueAllTheTime(() -> assertEquals("output continues after shutdown", sizeAfterShutdown, sinkList.size()), 3);
 
         // When2 - allow the migration and shutdown to complete
         MigrationBlockingService.migrationDoneLatch.countDown();
-        System.out.println("Latch counted down");
+        logger.info("Latch counted down");
         // wait for the shutdown to finish
         shutdownFuture.get();
 
@@ -112,16 +118,27 @@ public class HazelcastConnector_RestartTest extends JetTestSupport {
                 assertTrue("no output after migration completed", sinkList.size() > sizeAfterShutdown + 4), 10);
     }
 
+    private void waitExecutionDoneOnMember(JetInstance instance, Job job) {
+        JetService jetService = getNodeEngineImpl(instance).getService(JetService.SERVICE_NAME);
+        JobExecutionService executionService = jetService.getJobExecutionService();
+        Long executionId = executionService.getExecutionIdForJobId(job.getId());
+        ExecutionContext execCtx = executionId == null ? null : executionService.getExecutionContext(executionId);
+        assertTrueEventually(() -> assertTrue(execCtx == null || execCtx.getExecutionFuture().isDone()));
+    }
+
     // A CoreService with a slow post-join op. Its post-join operation will be executed before map's
     // post-join operation so we can ensure indexes are created via MapReplicationOperation,
     // even though PostJoinMapOperation has not yet been executed.
     private static class MigrationBlockingService implements CoreService, MigrationAwareService {
         static CountDownLatch migrationDoneLatch = new CountDownLatch(1);
+        private final AtomicBoolean blocked = new AtomicBoolean();
 
         @Override
         public void beforeMigration(PartitionMigrationEvent event) {
             try {
-                migrationDoneLatch.await();
+                if (blocked.compareAndSet(false, true)) {
+                    migrationDoneLatch.await();
+                }
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
My theory on what happened is this: The `MigrationBlockingService`
blocks in the `beforeMigration()` method. It could happen that all
partition threads were blocked and progress was stalled, which would
cause that the `IList.size()` operation will retry many times and
ultimately fail with "Wrong target". I saw the blocked partitions
threads in the thread dump. However, I don't understand why it got stuck
in only about 10% of cases. Also it wasn't failing before. The fix is to
block at most one thread in the `MigrationBlockingService`.

After the fix, second issue happened

Fixes #2657