### PR TITLE
Support class-less CSV & JSON file formats

### DIFF
--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/HadoopFileSourceFactory.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/HadoopFileSourceFactory.java
@@ -31,10 +31,15 @@ import com.hazelcast.jet.pipeline.file.TextFileFormat;
 import com.hazelcast.jet.pipeline.file.impl.FileSourceConfiguration;
 import com.hazelcast.jet.pipeline.file.impl.FileSourceFactory;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.avro.mapreduce.AvroJob;
 import org.apache.avro.mapreduce.AvroKeyInputFormat;
 import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
@@ -54,6 +59,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ServiceLoader;
 
+import static com.hazelcast.jet.hadoop.HadoopSources.COPY_ON_READ;
 import static com.hazelcast.jet.hadoop.impl.CsvInputFormat.CSV_INPUT_FORMAT_BEAN_CLASS;
 import static com.hazelcast.jet.hadoop.impl.JsonInputFormat.JSON_INPUT_FORMAT_BEAN_CLASS;
 import static java.util.Objects.requireNonNull;
@@ -144,12 +150,17 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
             if (reflectClass != null) {
                 Schema schema = ReflectData.get().getSchema(reflectClass);
                 AvroJob.setInputKeySchema(job, schema);
+            } else {
+                job.getConfiguration().setBoolean(COPY_ON_READ, Boolean.FALSE);
             }
         }
 
         @Override
         public BiFunctionEx<AvroKey<?>, NullWritable, ?> projectionFn() {
-            return (k, v) -> k.datum();
+            return (k, v) -> {
+                Object record = k.datum();
+                return record instanceof GenericContainer ? copy((GenericContainer) record) : record;
+            };
         }
 
         @Nonnull
@@ -184,7 +195,12 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
         public <T> void configure(Job job, FileFormat<T> format) {
             CsvFileFormat<T> csvFileFormat = (CsvFileFormat<T>) format;
             job.setInputFormatClass(CsvInputFormat.class);
-            job.getConfiguration().set(CSV_INPUT_FORMAT_BEAN_CLASS, csvFileFormat.clazz().getCanonicalName());
+            job.getConfiguration().setBoolean(COPY_ON_READ, Boolean.FALSE);
+
+            Class<?> clazz = csvFileFormat.clazz();
+            if (clazz != null) {
+                job.getConfiguration().set(CSV_INPUT_FORMAT_BEAN_CLASS, clazz.getCanonicalName());
+            }
         }
 
         @Override
@@ -205,7 +221,12 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
         public <T> void configure(Job job, FileFormat<T> format) {
             JsonFileFormat<T> jsonFileFormat = (JsonFileFormat<T>) format;
             job.setInputFormatClass(JsonInputFormat.class);
-            job.getConfiguration().set(JSON_INPUT_FORMAT_BEAN_CLASS, jsonFileFormat.clazz().getCanonicalName());
+            job.getConfiguration().setBoolean(COPY_ON_READ, Boolean.FALSE);
+
+            Class<?> clazz = jsonFileFormat.clazz();
+            if (clazz != null) {
+                job.getConfiguration().set(JSON_INPUT_FORMAT_BEAN_CLASS, clazz.getCanonicalName());
+            }
         }
 
         @Override
@@ -244,11 +265,20 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
         @Override
         public <T> void configure(Job job, FileFormat<T> format) {
             job.setInputFormatClass(AvroParquetInputFormat.class);
+            job.getConfiguration().setBoolean(COPY_ON_READ, Boolean.FALSE);
         }
 
         @Override
         public BiFunctionEx<String, ?, ?> projectionFn() {
-            return (k, v) -> v;
+            return (k, record) -> {
+                if (record == null) {
+                    return null;
+                } else if (record instanceof GenericContainer) {
+                    return copy((GenericContainer) record);
+                } else {
+                    throw new IllegalArgumentException("Unexpected record type: " + record.getClass());
+                }
+            };
         }
 
         @Nonnull
@@ -277,4 +307,19 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
         }
     }
 
+    /**
+     * Copies Avro record.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends GenericContainer> T copy(T record) {
+        if (record instanceof SpecificRecord) {
+            SpecificRecord specificRecord = (SpecificRecord) record;
+            return (T) SpecificData.get().deepCopy(specificRecord.getSchema(), specificRecord);
+        } else if (record instanceof GenericRecord) {
+            GenericRecord genericRecord = (GenericRecord) record;
+            return (T) GenericData.get().deepCopy(genericRecord.getSchema(), genericRecord);
+        } else {
+            throw new IllegalArgumentException("Unexpected record type: " + record.getClass());
+        }
+    }
 }

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/AvroFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/AvroFileFormatTest.java
@@ -42,7 +42,6 @@ public class AvroFileFormatTest extends BaseFileFormatTest {
                 new SpecificUser("Frantisek", 7),
                 new SpecificUser("Ali", 42)
         );
-
     }
 
     @Test

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/BaseFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/BaseFileFormatTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 @RunWith(Parameterized.class)
 public abstract class BaseFileFormatTest extends JetTestSupport {
 
@@ -49,7 +48,7 @@ public abstract class BaseFileFormatTest extends JetTestSupport {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         currentDir = Paths.get(".").toAbsolutePath().normalize().toString();
         if (useHadoop) {
             assumeThatNoWindowsOS();

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/CsvFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/CsvFileFormatTest.java
@@ -25,7 +25,20 @@ import org.junit.Test;
 public class CsvFileFormatTest extends BaseFileFormatTest {
 
     @Test
-    public void shouldReadCsvFile() throws Exception {
+    public void shouldReadCsvFile() {
+
+        FileSourceBuilder<String[]> source = FileSources.files(currentDir + "/src/test/resources")
+                                                    .glob("file.csv")
+                                                    .format(FileFormat.csv());
+
+        assertItemsInSource(source,
+                new String[]{"Frantisek", "7"},
+                new String[]{"Ali", "42"}
+        );
+    }
+
+    @Test
+    public void shouldReadCsvFileToObject() {
 
         FileSourceBuilder<User> source = FileSources.files(currentDir + "/src/test/resources")
                                                     .glob("file.csv")
@@ -38,7 +51,7 @@ public class CsvFileFormatTest extends BaseFileFormatTest {
     }
 
     @Test
-    public void shouldReadCsvFileWithMoreColumnsThanTargetClass() throws Exception {
+    public void shouldReadCsvFileWithMoreColumnsThanTargetClass() {
 
         FileSourceBuilder<User> source = FileSources.files(currentDir + "/src/test/resources")
                                                     .glob("file-more-columns.csv")

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/JsonFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/JsonFileFormatTest.java
@@ -16,16 +16,43 @@
 
 package com.hazelcast.jet.hadoop.file;
 
+import com.fasterxml.jackson.jr.stree.JrsNumber;
+import com.fasterxml.jackson.jr.stree.JrsObject;
+import com.fasterxml.jackson.jr.stree.JrsString;
+import com.google.common.collect.ImmutableMap;
 import com.hazelcast.jet.hadoop.file.model.User;
 import com.hazelcast.jet.pipeline.file.FileFormat;
 import com.hazelcast.jet.pipeline.file.FileSourceBuilder;
 import com.hazelcast.jet.pipeline.file.FileSources;
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class JsonFileFormatTest extends BaseFileFormatTest {
 
     @Test
-    public void shouldReadJsonLinesFile() throws Exception {
+    public void shouldReadJsonLinesFile() {
+        FileSourceBuilder<JrsObject> source = FileSources.files(currentDir + "/src/test/resources")
+                                                         .glob("file.jsonl")
+                                                         .format(FileFormat.json());
+
+        assertItemsInSource(source,
+                collected -> assertThat(collected).usingRecursiveFieldByFieldElementComparator()
+                                                  .containsOnly(
+                                                          new JrsObject(ImmutableMap.of(
+                                                                  "name", new JrsString("Frantisek"),
+                                                                  "favoriteNumber", new JrsNumber(7))
+                                                          ),
+                                                          new JrsObject(ImmutableMap.of(
+                                                                  "name", new JrsString("Ali"),
+                                                                  "favoriteNumber", new JrsNumber(42))
+                                                          )
+                                                  )
+        );
+    }
+
+    @Test
+    public void shouldReadJsonLinesFileToObject() {
         FileSourceBuilder<User> source = FileSources.files(currentDir + "/src/test/resources")
                                                     .glob("file.jsonl")
                                                     .format(FileFormat.json(User.class));

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/ParquetFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/ParquetFileFormatTest.java
@@ -30,14 +30,14 @@ import org.junit.Test;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 
 public class ParquetFileFormatTest extends BaseFileFormatTest {
 
     // Parquet has a dependency on Hadoop so it does not make sense to run it without it
     @Parameters(name = "{index}: useHadoop={0}")
     public static Iterable<?> parameters() {
-        return Arrays.asList(true);
+        return Collections.singletonList(true);
     }
 
     @Test

--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -109,6 +109,11 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
+            <artifactId>jackson-jr-stree</artifactId>
+            <version>${jackson.jr.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-objects</artifactId>
             <version>${jackson.jr.version}</version>
         </dependency>

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/json/JsonUtil.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.jet.json;
 
+import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.jr.annotationsupport.JacksonAnnotationExtension;
 import com.fasterxml.jackson.jr.ob.JSON;
+import com.fasterxml.jackson.jr.stree.JacksonJrsTreeCodec;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.jet.pipeline.Sources;
 
@@ -59,7 +61,7 @@ public final class JsonUtil {
         JSON.Builder builder = JSON.builder();
         try {
             Class.forName("com.fasterxml.jackson.annotation.JacksonAnnotation", false, JsonUtil.class.getClassLoader());
-            builder.register(JacksonAnnotationExtension.std);
+            builder.register(JacksonAnnotationExtension.std).treeCodec(new JacksonJrsTreeCodec());
         } catch (ClassNotFoundException ignored) {
         }
         JSON_JR = builder.build();
@@ -75,6 +77,14 @@ public final class JsonUtil {
     @Nonnull
     public static HazelcastJsonValue hazelcastJsonValue(@Nonnull Object object) {
         return new HazelcastJsonValue(object.toString());
+    }
+
+    /**
+     * Converts a JSON object to a {@link TreeNode}.
+     */
+    @Nullable
+    public static <T extends TreeNode> T treeFrom(@Nonnull Object source) throws IOException {
+        return JSON_JR.treeFrom(source);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/file/CsvFileFormat.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/file/CsvFileFormat.java
@@ -17,8 +17,7 @@
 package com.hazelcast.jet.pipeline.file;
 
 import javax.annotation.Nonnull;
-
-import static java.util.Objects.requireNonNull;
+import javax.annotation.Nullable;
 
 /**
  * {@link FileFormat} for CSV files. See {@link FileFormat#csv} for more
@@ -34,23 +33,33 @@ public class CsvFileFormat<T> implements FileFormat<T> {
      */
     public static final String FORMAT_CSV = "csv";
 
-    private final Class<T> clazz;
+    private Class<T> clazz;
 
     /**
-     * Creates a {@code CsvFileFormat}. See {@link FileFormat#csv} for more
+     * Creates {@link CsvFileFormat}. See {@link FileFormat#csv} for more
      * details.
-     *
-     * @param clazz type of the object to deserialize CSV lines into
      */
-    CsvFileFormat(@Nonnull Class<T> clazz) {
-        this.clazz = requireNonNull(clazz, "clazz must not be null");
+    CsvFileFormat() {
     }
 
     /**
-     * Returns the type of the object the data source using this format will
-     * emit.
+     * Specifies class that data will be deserialized into.
+     * If parameter is {@code null} data is deserialized into
+     * {@code String[]}.
+     *
+     * @param clazz type of the object to deserialize CSV lines into
      */
     @Nonnull
+    public CsvFileFormat<T> withClass(@Nullable Class<T> clazz) {
+        this.clazz = clazz;
+        return this;
+    }
+
+    /**
+     * Returns the class Jet will deserialize data into.
+     * Null if not set.
+     */
+    @Nullable
     public Class<T> clazz() {
         return clazz;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/file/FileFormat.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/file/FileFormat.java
@@ -39,7 +39,6 @@ public interface FileFormat<T> extends Serializable {
     @Nonnull
     String format();
 
-
     // Factory methods for supported file formats are here for easy discoverability.
 
     /**
@@ -64,14 +63,32 @@ public interface FileFormat<T> extends Serializable {
     }
 
     /**
+     * Returns a file format for Avro files.
+     */
+    @Nonnull
+    static <T> CsvFileFormat<T> csv() {
+        return csv(null);
+    }
+
+    /**
      * Returns a file format for CSV files which specifies to deserialize each
      * line into an instance of the given class. It assumes the CSV has a
      * header line and specifies to use it as the column names that map to the
-     * object's fields.
+     * object's fields. If parameter is {@code null} data is deserialized into
+     * {@code String[]} but for that case you should prefer the no-argument
+     * {@link #csv()} call.
      */
     @Nonnull
-    static <T> CsvFileFormat<T> csv(@Nonnull Class<T> clazz) {
-        return new CsvFileFormat<T>(clazz);
+    static <T> CsvFileFormat<T> csv(@Nullable Class<T> clazz) {
+        return new CsvFileFormat<T>().withClass(clazz);
+    }
+
+    /**
+     * Returns a file format for JSON Lines files.
+     */
+    @Nonnull
+    static <T> JsonFileFormat<T> json() {
+        return json(null);
     }
 
     /**
@@ -81,10 +98,13 @@ public interface FileFormat<T> extends Serializable {
      * href="https://github.com/FasterXML/jackson-jr">Jackson jr</a>, which
      * supports the basic data types such as strings, numbers, lists and maps,
      * objects with JavaBeans-style getters/setters, as well as public fields.
+     * If parameter is {@code null} data is deserialized into
+     * {@link com.fasterxml.jackson.jr.stree.JrsObject} but for that case you
+     * should prefer the no-argument {@link #json()} call.
      */
     @Nonnull
-    static <T> JsonFileFormat<T> json(@Nonnull Class<T> clazz) {
-        return new JsonFileFormat<>(clazz);
+    static <T> JsonFileFormat<T> json(@Nullable Class<T> clazz) {
+        return new JsonFileFormat<T>().withClass(clazz);
     }
 
     /**

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/file/JsonFileFormat.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/file/JsonFileFormat.java
@@ -17,8 +17,7 @@
 package com.hazelcast.jet.pipeline.file;
 
 import javax.annotation.Nonnull;
-
-import static java.util.Objects.requireNonNull;
+import javax.annotation.Nullable;
 
 /**
  * {@code FileFormat} for the JSON Lines files. See {@link FileFormat#json}
@@ -34,23 +33,33 @@ public class JsonFileFormat<T> implements FileFormat<T> {
      */
     public static final String FORMAT_JSONL = "jsonl";
 
-    private final Class<T> clazz;
+    private Class<T> clazz;
 
     /**
-     * Creates a {@code JsonFileFormat}. See {@link FileFormat#json} for
-     * more details.
-     *
-     * @param clazz the type of the object to deserialize JSON into
+     * Creates {@link JsonFileFormat}. See {@link FileFormat#json} for more
+     * details.
      */
-    JsonFileFormat(@Nonnull Class<T> clazz) {
-        this.clazz = requireNonNull(clazz, "class must not be null");
+    JsonFileFormat() {
     }
 
     /**
-     * Returns the type of the object the data source using this format will
-     * emit.
+     * Specifies class that data will be deserialized into.
+     * If parameter is {@code null} data is deserialized into
+     * {@link com.fasterxml.jackson.jr.stree.JrsObject}.
+     *
+     * @param clazz type of the object to deserialize JSON lines into
      */
     @Nonnull
+    public JsonFileFormat<T> withClass(@Nullable Class<T> clazz) {
+        this.clazz = clazz;
+        return this;
+    }
+
+    /**
+     * Returns the class Jet will deserialize data into.
+     * Null if not set.
+     */
+    @Nullable
     public Class<T> clazz() {
         return clazz;
     }

--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -31,6 +31,7 @@ Apache License, Version 2.0
   Jackson datatype: JSR310:2.10.0
   jackson-jr-annotation-support:2.11.2
   jackson-jr-objects:2.11.2
+  jackson-jr-stree:2.11.2
   mysql-binlog-connector-java:0.20.1
   compiler:0.9.3
   Google Android Annotations Library:4.1.1.4

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/infoschema/InfoSchemaConnector.java
@@ -43,12 +43,14 @@ final class InfoSchemaConnector implements SqlConnector {
 
     public static final InfoSchemaConnector INSTANCE = new InfoSchemaConnector();
 
+    private static final String TYPE_NAME = "InformationSchema";
+
     private InfoSchemaConnector() {
     }
 
     @Override
     public String typeName() {
-        throw new UnsupportedOperationException();
+        return TYPE_NAME;
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/KafkaTable.java
@@ -102,9 +102,4 @@ class KafkaTable extends JetTable {
     QueryDataType[] types() {
         return getFields().stream().map(TableField::getType).toArray(QueryDataType[]::new);
     }
-
-    @Override
-    public String toString() {
-        return "Kafka[" + getSchemaName() + "." + getSqlName() + "]";
-    }
 }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/IMapSqlConnector.java
@@ -163,6 +163,6 @@ public class IMapSqlConnector implements SqlConnector {
     }
 
     private static String toString(PartitionedMapTable table) {
-        return "IMap" + "[" + table.getSchemaName() + "." + table.getSqlName() + "]";
+        return TYPE_NAME + "[" + table.getSchemaName() + "." + table.getSqlName() + "]";
     }
 }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/JetTable.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/JetTable.java
@@ -63,6 +63,6 @@ public class JetTable extends Table {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "[" + getSchemaName() + "." + getSqlName() + ']';
+        return getSqlConnector().typeName() + "[" + getSchemaName() + "." + getSqlName() + ']';
     }
 }

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/SqlTestSupport.java
@@ -70,6 +70,26 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
      * @param expectedRows Expected rows
      */
     public static void assertRowsEventuallyInAnyOrder(String sql, Collection<Row> expectedRows) {
+        List<Row> actualRows = awaitRows(sql, expectedRows.size());
+        assertThat(actualRows).containsExactlyInAnyOrderElementsOf(expectedRows);
+    }
+
+    /**
+     * Execute a query and wait for the results to contain all the {@code
+     * expectedRows} using a recursive field by field comparison. If
+     * there are more rows in the result, they are ignored.
+     * Suitable for streaming queries that don't terminate.
+     *
+     * @param sql          The query
+     * @param expectedRows Expected rows
+     */
+    public static void assertComparingFieldByFieldRowsEventuallyInAnyOrder(String sql, Collection<Row> expectedRows) {
+        List<Row> actualRows = awaitRows(sql, expectedRows.size());
+        assertThat(actualRows).usingRecursiveFieldByFieldElementComparator()
+                              .containsExactlyInAnyOrderElementsOf(expectedRows);
+    }
+
+    public static List<Row> awaitRows(String sql, int numberOfRows) {
         SqlService sqlService = instance().getSql();
         CompletableFuture<Void> future = new CompletableFuture<>();
         Deque<Row> rows = new ArrayDeque<>();
@@ -77,7 +97,7 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
         Thread thread = new Thread(() -> {
             try (SqlResult result = sqlService.execute(sql)) {
                 Iterator<SqlRow> iterator = result.iterator();
-                for (int i = 0; i < expectedRows.size() && iterator.hasNext(); i++) {
+                for (int i = 0; i < numberOfRows && iterator.hasNext(); i++) {
                     rows.add(new Row(iterator.next()));
                 }
                 future.complete(null);
@@ -100,8 +120,7 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
             throw sneakyThrow(e);
         }
 
-        List<Row> actualRows = new ArrayList<>(rows);
-        assertThat(actualRows).containsExactlyInAnyOrderElementsOf(expectedRows);
+        return new ArrayList<>(rows);
     }
 
     /**
@@ -112,10 +131,27 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
      * @param expectedRows Expected rows
      */
     public static void assertRowsAnyOrder(String sql, Collection<Row> expectedRows) {
+        assertThat(fetchRows(sql)).containsExactlyInAnyOrderElementsOf(expectedRows);
+    }
+
+    /**
+     * Execute a query and wait until it completes. Assert using a recursive
+     * field by field comparison that the returned rows contain the expected
+     * rows, in any order.
+     *
+     * @param sql          The query
+     * @param expectedRows Expected rows
+     */
+    public static void assertComparingFieldByFieldRowsAnyOrder(String sql, Collection<Row> expectedRows) {
+        assertThat(fetchRows(sql)).usingRecursiveFieldByFieldElementComparator()
+                                  .containsExactlyInAnyOrderElementsOf(expectedRows);
+    }
+
+    private static List<Row> fetchRows(String sql) {
         SqlService sqlService = instance().getSql();
-        List<Row> actualRows = new ArrayList<>();
-        sqlService.execute(sql).iterator().forEachRemaining(r -> actualRows.add(new Row(r)));
-        assertThat(actualRows).containsExactlyInAnyOrderElementsOf(expectedRows);
+        List<Row> rows = new ArrayList<>();
+        sqlService.execute(sql).iterator().forEachRemaining(row -> rows.add(new Row(row)));
+        return rows;
     }
 
     /**
@@ -124,12 +160,12 @@ public abstract class SqlTestSupport extends SimpleTestInClusterSupport {
      */
     public static String javaSerializableMapDdl(String name, Class<?> keyClass, Class<?> valueClass) {
         return "CREATE MAPPING " + name + " TYPE " + IMapSqlConnector.TYPE_NAME + "\n"
-                + "OPTIONS (\n"
-                + '\'' + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "',\n"
-                + '\'' + OPTION_KEY_CLASS + "'='" + keyClass.getName() + "',\n"
-                + '\'' + OPTION_VALUE_FORMAT + "'='" + JAVA_FORMAT + "',\n"
-                + '\'' + OPTION_VALUE_CLASS + "'='" + valueClass.getName() + "'\n"
-                + ")";
+               + "OPTIONS (\n"
+               + '\'' + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "',\n"
+               + '\'' + OPTION_KEY_CLASS + "'='" + keyClass.getName() + "',\n"
+               + '\'' + OPTION_VALUE_FORMAT + "'='" + JAVA_FORMAT + "',\n"
+               + '\'' + OPTION_VALUE_CLASS + "'='" + valueClass.getName() + "'\n"
+               + ")";
     }
 
     public static String randomName() {

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.jet.sql.impl.connector.kafka;
 
-import com.fasterxml.jackson.databind.node.IntNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.jr.stree.JrsNumber;
+import com.fasterxml.jackson.jr.stree.JrsObject;
+import com.fasterxml.jackson.jr.stree.JrsString;
 import com.hazelcast.jet.kafka.impl.KafkaTestSupport;
 import com.hazelcast.jet.sql.SqlTestSupport;
 import com.hazelcast.jet.sql.impl.connector.test.AllTypesSqlConnector;
@@ -47,6 +46,7 @@ import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FOR
 import static java.time.ZoneOffset.UTC;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SqlJsonTest extends SqlTestSupport {
@@ -264,11 +264,11 @@ public class SqlJsonTest extends SqlTestSupport {
         );
         sqlService.execute("INSERT INTO " + name + " VALUES (1, 'Alice')");
 
-        assertRowsEventuallyInAnyOrder(
+        assertComparingFieldByFieldRowsEventuallyInAnyOrder(
                 "SELECT __key, this FROM " + name,
                 singletonList(new Row(
-                        new ObjectNode(JsonNodeFactory.instance).set("id", new IntNode(1)),
-                        new ObjectNode(JsonNodeFactory.instance).set("name", new TextNode("Alice"))
+                        new JrsObject(singletonMap("id", new JrsNumber(1))),
+                        new JrsObject(singletonMap("name", new JrsString("Alice")))
                 ))
         );
     }

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/JsonQueryTargetTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/extract/JsonQueryTargetTest.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.jet.sql.impl.extract;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.TreeNode;
+import com.hazelcast.jet.json.JsonUtil;
 import com.hazelcast.sql.impl.extract.QueryExtractor;
 import com.hazelcast.sql.impl.extract.QueryTarget;
 import junitparams.JUnitParamsRunner;
@@ -74,7 +74,7 @@ public class JsonQueryTargetTest {
                 + "}";
         return new Object[]{
                 new Object[]{json.getBytes(StandardCharsets.UTF_8)},
-                new Object[]{new ObjectMapper().readTree(json)}
+                new Object[]{JsonUtil.treeFrom(json)}
         };
     }
 
@@ -102,7 +102,7 @@ public class JsonQueryTargetTest {
 
         target.setTarget(value);
 
-        assertThat(topExtractor.get()).isInstanceOf(JsonNode.class);
+        assertThat(topExtractor.get()).isInstanceOf(TreeNode.class);
         assertThat(nonExistingExtractor.get()).isNull();
         assertThat(stringExtractor.get()).isEqualTo("string");
         assertThat(booleanExtractor.get()).isEqualTo(true);


### PR DESCRIPTION
Added the possibility to work with CSV & JSON formats without supplied class.

Checklist:
- [x] Labels and Milestone set
- [x] New public APIs have `@Nonnull/@Nullable` annotations
