### PR TITLE
Don't reuse operations and fix error handling

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -602,7 +602,8 @@ public class JobCoordinationService {
                     membersShuttingDown.keySet());
             return false;
         }
-        PartitionServiceState state = getInternalPartitionService().getPartitionReplicaStateChecker().getPartitionServiceState();
+        PartitionServiceState state =
+                getInternalPartitionService().getPartitionReplicaStateChecker().getPartitionServiceState();
         if (state != PartitionServiceState.SAFE) {
             logger.fine("Not starting jobs because partition replication is not in safe state, but in " + state);
             return false;

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.metrics.MetricDescriptor;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.internal.partition.impl.PartitionServiceState;
 import com.hazelcast.internal.serialization.Data;
 import com.hazelcast.internal.util.counters.Counter;
 import com.hazelcast.internal.util.counters.MwCounter;
@@ -601,8 +602,9 @@ public class JobCoordinationService {
                     membersShuttingDown.keySet());
             return false;
         }
-        if (!getInternalPartitionService().isMemberStateSafe()) {
-            logger.fine("Not starting jobs because master is not in safe state.");
+        PartitionServiceState state = getInternalPartitionService().getPartitionReplicaStateChecker().getPartitionServiceState();
+        if (state != PartitionServiceState.SAFE) {
+            logger.fine("Not starting jobs because partition replication is not in safe state, but in " + state);
             return false;
         }
         if (!getInternalPartitionService().getPartitionStateManager().isInitialized()) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/MemberReconnectionStressTest.java
@@ -54,7 +54,7 @@ public class MemberReconnectionStressTest extends JetTestSupport {
     public void test() {
         /*
         The test will start 2 thread:
-        - one will submit short batch jobs, serially, joining the previous job
+        - one will submit short batch jobs, serially, after joining the previous job
         - the other will keep dropping the member-to-member connection.
 
         The small jobs will often fail due to the reconnection, we check
@@ -100,7 +100,7 @@ public class MemberReconnectionStressTest extends JetTestSupport {
                     logger.info("job completed");
                     jobCount.incrementAndGet();
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    logger.info("Job failed, ignoring it", e);
                 }
             }
         }).start();


### PR DESCRIPTION
There were two issues:

1. A race when reusing the same `Operation` instance: the
`InvocationRegistry.deactivate` inverts the `Operation.callId` to a
negative number. But this happens after the invocation future is
completed. We had action hooked to the future that sent the operation
again. In most times it managed to deregister the operation before we
tried to set it again, but if not, the invocation failed with "Attempt
to reuse the same operation in multiple invocations." A retry wasn't
sent and the job got stuck.

The fix is to create a new Operation instance for each invocation.

2. The issue would be easy to spot if the exception wasn't swallowed: it
was another instance of using `whenComplete` without logging the
exception in the callback - the `whenComplete` doesn't log the exception
anywhere, we must take care that the handler never throws.

However, I observed other possible causes too. This test can cause a
failure in any operation involved in the job lifecycle, not covered by
any other test or even soak test. So future failures are not ruled out,
but we fixed at least one of them.

Fixes #2600
