### PR TITLE
Reduce poll and init timeout in Kafka source

### DIFF
--- a/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
+++ b/extensions/kafka/src/main/java/com/hazelcast/jet/kafka/impl/StreamKafkaP.java
@@ -150,7 +150,7 @@ public final class StreamKafkaP<K, V, T> extends AbstractProcessor {
         if (newAssignments.isEmpty()) {
             return;
         }
-        getLogger().info("New partition(s) handled: " + newAssignments);
+        getLogger().info("New partition(s) assigned: " + newAssignments);
         eventTimeMapper.addPartitions(newAssignments.size());
         consumer.assign(currentAssignment.keySet());
         if (oldTopicOffsets.length > 0 && !isRestoring) {

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaPartitionAssignmentTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaPartitionAssignmentTest.java
@@ -29,7 +29,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-public class KafkaPartitionAssignerTest {
+public class KafkaPartitionAssignmentTest {
 
     @Test
     public void when_singleTopicMultiplePartitions() {
@@ -113,7 +113,8 @@ public class KafkaPartitionAssignerTest {
         Set<Tuple2<Integer, Integer>> actualAssignment = new HashSet<>();
         for (int topicIdx = 0; topicIdx < partitionCounts.length; topicIdx++) {
             for (int partition = 0; partition < partitionCounts[topicIdx]; partition++) {
-                if (StreamKafkaP.handledByThisProcessor(totalParallelism, partitionCounts.length, processorIdx, topicIdx, partition)) {
+                if (StreamKafkaP.handledByThisProcessor(
+                        totalParallelism, partitionCounts.length, processorIdx, topicIdx, partition)) {
                     actualAssignment.add(tp(topicIdx, partition));
                 }
             }

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -175,8 +175,8 @@ public class KafkaTestSupport {
         return getProducer().send(new ProducerRecord<>(topic, key, value));
     }
 
-    void produce(String topic, int partition, Long timestamp, Integer key, String value) {
-        getProducer().send(new ProducerRecord<>(topic, partition, timestamp, key, value));
+    Future<RecordMetadata> produce(String topic, int partition, Long timestamp, Integer key, String value) {
+        return getProducer().send(new ProducerRecord<>(topic, partition, timestamp, key, value));
     }
 
     private KafkaProducer<Integer, String> getProducer() {

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -48,9 +48,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import javax.annotation.Nonnull;
@@ -69,6 +67,7 @@ import java.util.Set;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.jet.Util.entry;
+import static com.hazelcast.jet.config.ProcessingGuarantee.EXACTLY_ONCE;
 import static com.hazelcast.jet.core.EventTimePolicy.eventTimePolicy;
 import static com.hazelcast.jet.core.WatermarkPolicy.limitingLag;
 import static com.hazelcast.jet.impl.execution.WatermarkCoalescer.IDLE_MESSAGE;
@@ -91,9 +90,6 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
     private static final long LAG = 3;
 
     private static KafkaTestSupport kafkaTestSupport;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private String topic1Name;
     private String topic2Name;
@@ -149,7 +145,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
     @Test
     public void integrationTest_withSnapshotting() throws Exception {
-        integrationTest(ProcessingGuarantee.EXACTLY_ONCE);
+        integrationTest(EXACTLY_ONCE);
     }
 
     private void integrationTest(ProcessingGuarantee guarantee) throws Exception {
@@ -293,14 +289,14 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
     public void when_snapshotSaved_then_offsetsRestored() throws Exception {
         StreamKafkaP processor = createProcessor(properties(), 2, r -> entry(r.key(), r.value()), 10_000);
         TestOutbox outbox = new TestOutbox(new int[]{10}, 10);
-        processor.init(outbox, new TestProcessorContext().setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE));
+        processor.init(outbox, new TestProcessorContext().setProcessingGuarantee(EXACTLY_ONCE));
 
         kafkaTestSupport.produce(topic1Name, 0, "0");
         assertEquals(entry(0, "0"), consumeEventually(processor, outbox));
 
         // create snapshot
         TestInbox snapshot = saveSnapshot(processor, outbox);
-        Set snapshotItems = unwrapBroadcastKey(snapshot.queue());
+        Set<Entry<TopicPartition, String>> snapshotItems = unwrapBroadcastKey(snapshot.queue());
 
         // consume one more item
         kafkaTestSupport.produce(topic1Name, 1, "1");
@@ -309,7 +305,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         // create new processor and restore snapshot
         processor = createProcessor(properties(), 2, r -> entry(r.key(), r.value()), 10_000);
         outbox = new TestOutbox(new int[]{10}, 10);
-        processor.init(outbox, new TestProcessorContext().setProcessingGuarantee(ProcessingGuarantee.EXACTLY_ONCE));
+        processor.init(outbox, new TestProcessorContext().setProcessingGuarantee(EXACTLY_ONCE));
 
         // restore snapshot
         processor.restoreFromSnapshot(snapshot);
@@ -357,7 +353,6 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         assertEquals(entry(0, "0"), consumeEventually(processor, outbox));
 
         kafkaTestSupport.setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT + 2);
-        Thread.sleep(1000);
         kafkaTestSupport.resetProducer(); // this allows production to the added partition
 
         boolean somethingInPartition1 = false;
@@ -377,6 +372,54 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
             }
         }
         assertEquals(range(1, 11).mapToObj(i -> entry(i, Integer.toString(i))).collect(toSet()), receivedEvents);
+    }
+
+    @Test
+    public void when_partitionAddedWhileJobDown_then_consumedFromBeginning() throws Exception {
+        IList<Entry<Integer, String>> sinkList = instance().getList("sinkList");
+        Pipeline p = Pipeline.create();
+        Properties properties = properties();
+        properties.setProperty("auto.offset.reset", "latest");
+        p.readFrom(KafkaSources.<Integer, String>kafka(properties, topic1Name))
+         .withoutTimestamps()
+         .writeTo(Sinks.list(sinkList));
+
+        Job job = instance().newJob(p, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
+        assertTrueEventually(() -> {
+            kafkaTestSupport.produce(topic1Name, 0, "0");
+            assertFalse(sinkList.isEmpty());
+            assertEquals(entry(0, "0"), sinkList.get(0));
+        });
+        job.suspend();
+        sinkList.clear();
+
+        // When
+        kafkaTestSupport.setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT + 2);
+        kafkaTestSupport.resetProducer(); // this allows production to the added partition
+
+        kafkaTestSupport.produce(topic1Name, INITIAL_PARTITION_COUNT, null, 1, "1")
+                        .get();
+
+        job.resume();
+        assertTrueEventually(() -> {
+            assertEquals(1, sinkList.size());
+            assertEquals(entry(1, "1"), sinkList.get(0));
+        });
+    }
+
+    @Test
+    public void when_autoOffsetResetLatest_then_doesNotReadOldMessages() throws Exception {
+        IList<Entry<Integer, String>> sinkList = instance().getList("sinkList");
+        Pipeline p = Pipeline.create();
+        Properties properties = properties();
+        properties.setProperty("auto.offset.reset", "latest");
+        p.readFrom(KafkaSources.<Integer, String>kafka(properties, topic1Name))
+         .withoutTimestamps()
+         .writeTo(Sinks.list(sinkList));
+
+        kafkaTestSupport.produce(topic1Name, 0, "0").get();
+        instance().newJob(p);
+        assertTrueAllTheTime(() -> assertTrue(sinkList.isEmpty()), 2);
     }
 
     @Test
@@ -437,7 +480,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
         KafkaConsumer<Integer, String> c = kafkaTestSupport.createConsumer("non-existing-topic");
         assertGreaterOrEquals("partition count", c.partitionsFor("non-existing-topic", Duration.ofSeconds(2)).size(), 1);
     }
-    
+
     @Test
     public void when_consumerCannotConnect_then_partitionForTimeout() {
         Map<String, Object> properties = new HashMap<>();

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -246,7 +246,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
                 .setTotalParallelism(INITIAL_PARTITION_COUNT + 1)
                 .setGlobalProcessorIndex(INITIAL_PARTITION_COUNT));
 
-        assertTrue(processor.   currentAssignment.isEmpty());
+        assertTrue(processor.currentAssignment.isEmpty());
         assertEquals(IDLE_MESSAGE, consumeEventually(processor, outbox));
 
         kafkaTestSupport.setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT + 1);

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/MockLoggingFactory.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/MockLoggingFactory.java
@@ -63,4 +63,9 @@ public class MockLoggingFactory implements LoggerFactory {
 
         };
     }
+
+    @Override
+    public void removeLogger(String name) {
+
+    }
 }


### PR DESCRIPTION
We reduced the `poll` timeout from 50ms to 0ms. The consumer receives
records on the background, there's no need to block for more records,
just grab those that are immediately available. This reduces snapshot
latency.

Secondly, it fixes the issue when the `consumer.partitionsFor()` can
block for up to 60 seconds waiting for the metadata in the `init()`
method. We reduced the waiting to 1 second, which can easily not be
enough. As as consequence, we had to adapt the processor to live without
partition information and try to get it later (we already did that when
checking for partitions added at runtime). The major change was that
now, when restoring offsets from the snapshot, we can't rely on
`currentAssignment`, but we'll simply assume the topic has at least as
many partitions as the number of offsets we restored for that topic.

As a side effect, this also fixes the issue when a partition was added
while the job was down. Take this scenario:
- topic T has 1 partition
- the job is suspended
- while suspended, another partition is added
- the job wakes up

Now there's the change: Previously, the processor found out in the
`init` method that there are 2 partitions. These partitions would start
at default positions. Then, offset for partition 1 was restored, but no
offset for partition 2. If the `auto.offset.reset` parameter was
`latest` (the default), we could miss the messages in partition 2 before
the job restarted.

With current implementation we don't check partition counts in `init`.
When the job restarts, it will restore offsets for partition 1, but not
for 2. The partition count for the topic will be inferred to 1. Later,
after the snapshot is restored, it will query the metadata for the topic
and find out there are 2 partitions. The 2nd partition will be added and
sought to the beginning and all items from it will be consumed.

Fixes #2724