### PR TITLE
Fix peek transform that previously disrupts LP propagation

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/transform/PeekTransform.java
@@ -24,6 +24,7 @@ import com.hazelcast.jet.impl.pipeline.PipelineImpl.Context;
 
 import javax.annotation.Nonnull;
 
+import static com.hazelcast.jet.core.Vertex.LOCAL_PARALLELISM_USE_DEFAULT;
 import static com.hazelcast.jet.core.processor.DiagnosticProcessors.peekOutputP;
 
 public class PeekTransform<T> extends AbstractTransform {
@@ -44,6 +45,7 @@ public class PeekTransform<T> extends AbstractTransform {
 
     @Override
     public void addToDag(Planner p, Context context) {
+        determineLocalParallelism(LOCAL_PARALLELISM_USE_DEFAULT, context, p.isPreserveOrder());
         PlannerVertex peekedPv = p.xform2vertex.get(this.upstream().get(0));
         // Peeking transform doesn't add a vertex, so point to the upstream
         // transform's vertex:

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchParallelismTest.java
@@ -162,6 +162,15 @@ public class OrderedBatchParallelismTest {
                         Arrays.asList("map", "aggregate-prepare", "aggregate", "flat-map"),
                         Arrays.asList(UPSTREAM_PARALLELISM, UPSTREAM_PARALLELISM, 1, 1),
                         "map+aggregate+flat-map"
+                ),
+                createParamSet(
+                        stage -> stage
+                                .peek()
+                                .map(x -> x)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        Collections.singletonList("map"),
+                        Collections.singletonList(UPSTREAM_PARALLELISM),
+                        "map-after-peek"
                 )
         );
     }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamParallelismTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamParallelismTest.java
@@ -89,6 +89,15 @@ public class OrderedStreamParallelismTest {
                         Collections.singletonList("map-stateful-global"),
                         Collections.singletonList(1),
                         "map-stateful-global"
+                ),
+                createParamSet(
+                        stage -> stage
+                                .peek()
+                                .map(x -> x)
+                                .setLocalParallelism(LOCAL_PARALLELISM),
+                        Collections.singletonList("map"),
+                        Collections.singletonList(UPSTREAM_PARALLELISM),
+                        "map-after-peek"
                 )
         );
     }


### PR DESCRIPTION
Fixes #2738 

Since this transform does not generate its own vertex, it got me wrong before. At first, I thought it would be okay if we did not determine LP in this transform, but this broke up LP propagation. I fixed it in this PR.

Checklist:
- [x] Labels and Milestone set
