### PR TITLE
Change hazelcast-sql dependency to use the new non-shaded hazelcast-sql-core

### DIFF
--- a/hazelcast-jet-sql/pom.xml
+++ b/hazelcast-jet-sql/pom.xml
@@ -57,9 +57,8 @@
 
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-sql</artifactId>
+            <artifactId>hazelcast-sql-core</artifactId>
             <version>${hazelcast.version}</version>
-            <classifier>original</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>com.hazelcast</groupId>


### PR DESCRIPTION
Change the `hazelcast-sql` dependency to the new `hazelcast-sql-core` in `hazelcast-jet-sql` module. The `hazelcast-sql-core` doesn't use the Maven shade plugin with package relocations.

Related Hazelcast PRs:
- hazelcast/hazelcast#17921 (`master`)
- hazelcast/hazelcast#17922 (`4.1.z`)

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Updated `examples/README.md` (when adding a new code sample)
