### PR TITLE
Kafka fixes

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -386,7 +386,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
         Job job = instance().newJob(p, new JobConfig().setProcessingGuarantee(EXACTLY_ONCE));
         assertTrueEventually(() -> {
-            kafkaTestSupport.produce(topic1Name, 0, "0");
+            kafkaTestSupport.produce(topic1Name, 0, "0").get();
             assertFalse(sinkList.isEmpty());
             assertEquals(entry(0, "0"), sinkList.get(0));
         });

--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -40,7 +40,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -296,7 +295,7 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
 
         // create snapshot
         TestInbox snapshot = saveSnapshot(processor, outbox);
-        Set<Entry<TopicPartition, String>> snapshotItems = unwrapBroadcastKey(snapshot.queue());
+        Set<Entry<Object, Object>> snapshotItems = unwrapBroadcastKey(snapshot.queue());
 
         // consume one more item
         kafkaTestSupport.produce(topic1Name, 1, "1");
@@ -508,12 +507,15 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
     }
 
     @SuppressWarnings("unchecked")
-    private Set<Entry<TopicPartition, String>> unwrapBroadcastKey(Collection c) {
+    private Set<Entry<Object, Object>> unwrapBroadcastKey(Collection c) {
         // BroadcastKey("x") != BroadcastKey("x") ==> we need to extract the key
-        Set<Entry<TopicPartition, String>> res = new HashSet<>();
+        Set<Entry<Object, Object>> res = new HashSet<>();
         for (Object o : c) {
-            Entry<BroadcastKey<TopicPartition>, long[]> entry = (Entry<BroadcastKey<TopicPartition>, long[]>) o;
-            res.add(entry(entry.getKey().key(), Arrays.toString(entry.getValue())));
+            Entry<BroadcastKey<?>, ?> entry = (Entry<BroadcastKey<?>, ?>) o;
+            Object equalsSafeValue = entry.getValue() instanceof long[]
+                    ? Arrays.toString((long[]) entry.getValue())
+                    : entry.getValue();
+            res.add(entry(entry.getKey().key(), equalsSafeValue));
         }
         return res;
     }


### PR DESCRIPTION
* Fix issue with added partitions

This could happen:
- the processor starts with 2 partitions p0 and p1
- p0 has some item, p1 doesn't
- the processor saves a snapshot. It will only save the offset for p0
because it doesn't know it for p1
- the job restarts
- the processor restores offset for p0, but not for p1. Therefore it
will assume the partition count before the restart was 1
- later it will detect that there are 2 partitions and will seek p1 to
the beginning because it will think that p1 was added while the job was
down

The fix is that the processor with global processor index of 0 will save
one additional key to the snapshot, the `PARTITION_COUNTS_SNAPSHOT_KEY`.
Under that key we the known partition count for each topic. That key is
broadcast, every processor will know the partition count before the
restart. After this, the above scenario will not consider p1 as added
and will not seek to the beginning.

* Fix test failure

Fixes #2747