### PR TITLE
Fix ParquetFileFormatTest.shouldThrowWhenIncorrectSchema

### DIFF
--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/ParquetFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/ParquetFileFormatTest.java
@@ -109,8 +109,8 @@ public class ParquetFileFormatTest extends BaseFileFormatTest {
             assertThatThrownBy(() -> jets[0].newJob(p).join())
                     .hasCauseInstanceOf(JetException.class)
                     .hasRootCauseInstanceOf(ClassCastException.class)
-                    .hasMessageContaining("com.hazelcast.jet.hadoop.file.generated.SpecificUser cannot be cast to "
-                            + "com.hazelcast.jet.hadoop.file.model.IncorrectUser");
+                    .hasMessageContaining("com.hazelcast.jet.hadoop.file.generated.SpecificUser")
+                    .hasMessageContaining("com.hazelcast.jet.hadoop.file.model.IncorrectUser");
         } finally {
             for (JetInstance jet : jets) {
                 jet.shutdown();


### PR DESCRIPTION
Fixes #2748 

Checklist:
- [x] Labels and Milestone set
- [N/A] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] Updated `examples/README.md` (when adding a new code sample)
