### PR TITLE
Add FANOUT routing policy

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -378,6 +378,19 @@ public class Edge implements IdentifiedDataSerializable {
     }
 
     /**
+     * Activates the {@link RoutingPolicy#FANOUT FANOUT} routing policy.
+     * <p>
+     * This policy is allowed only on a distributed edge.
+     *
+     * @since 4.4
+     */
+    @Nonnull
+    public Edge fanout() {
+        routingPolicy = RoutingPolicy.FANOUT;
+        return this;
+    }
+
+    /**
      * Returns the instance encapsulating the partitioning strategy in effect
      * on this edge.
      */
@@ -549,6 +562,9 @@ public class Edge implements IdentifiedDataSerializable {
             case BROADCAST:
                 b.append(".broadcast()");
                 break;
+            case FANOUT:
+                b.append(".fanout()");
+                break;
             default:
         }
         if (DISTRIBUTE_TO_ALL.equals(distributedTo)) {
@@ -676,7 +692,12 @@ public class Edge implements IdentifiedDataSerializable {
         /**
          * This policy sends each item to all candidate processors.
          */
-        BROADCAST
+        BROADCAST,
+        /**
+         * This policy sends each item to a single processor on each of the
+         * cluster members. It is only available on a distributed edge.
+         */
+        FANOUT
     }
 
     private static class Single implements Partitioner<Object> {

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -379,8 +379,6 @@ public class Edge implements IdentifiedDataSerializable {
 
     /**
      * Activates the {@link RoutingPolicy#FANOUT FANOUT} routing policy.
-     * <p>
-     * This policy is allowed only on a distributed edge.
      *
      * @since 4.4
      */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -698,7 +698,8 @@ public class Edge implements IdentifiedDataSerializable {
          * on each member, it is <em>unicast</em> to one processor.
          * <p>
          * If the destination local parallelism is 1, the behavior is equal to
-         * {@link #BROADCAST}.
+         * {@link #BROADCAST}. If the member count in the cluster is 1, the
+         * behavior is equal to {@link #UNICAST}.
          *
          * @since 4.4
          */

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -695,7 +695,8 @@ public class Edge implements IdentifiedDataSerializable {
         BROADCAST,
         /**
          * This policy sends each item to a single processor on each of the
-         * cluster members. It is only available on a distributed edge.
+         * cluster members in a round robin fashion. It is only available
+         * on a distributed edge.
          */
         FANOUT
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/Edge.java
@@ -694,9 +694,15 @@ public class Edge implements IdentifiedDataSerializable {
          */
         BROADCAST,
         /**
-         * This policy sends each item to a single processor on each of the
-         * cluster members in a round robin fashion. It is only available
-         * on a distributed edge.
+         * This policy sends an item to all members, but only to one processor on
+         * each member. It's a combination of {@link #BROADCAST} and {@link
+         * #UNICAST}: an item is first <em>broadcast</em> to all members, and then,
+         * on each member, it is <em>unicast</em> to one processor.
+         * <p>
+         * If the destination local parallelism is 1, the behavior is equal to
+         * {@link #BROADCAST}.
+         *
+         * @since 4.4
          */
         FANOUT
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboundCollector.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/OutboundCollector.java
@@ -57,28 +57,8 @@ public interface OutboundCollector {
     }
 
 
-    static OutboundCollector localCompositeCollector(
-            OutboundCollector[] collectors, EdgeDef outboundEdge, int partitionCount
-    ) {
-        if (collectors.length == 1) {
-            return collectors[0];
-        }
-        switch (outboundEdge.routingPolicy()) {
-            case UNICAST:
-            case ISOLATED:
-            case FANOUT:
-                return new RoundRobin(collectors);
-            case PARTITIONED:
-                return new Partitioned(collectors, outboundEdge.partitioner(), partitionCount);
-            case BROADCAST:
-                return new Broadcast(collectors);
-            default:
-                throw new AssertionError("Missing case label for " + outboundEdge.routingPolicy());
-        }
-    }
-
-    static OutboundCollector distributedCompositeCollector(
-            OutboundCollector[] collectors, EdgeDef outboundEdge, int partitionCount
+    static OutboundCollector compositeCollector(
+            OutboundCollector[] collectors, EdgeDef outboundEdge, int partitionCount, boolean local
     ) {
         if (collectors.length == 1) {
             return collectors[0];
@@ -90,8 +70,9 @@ public interface OutboundCollector {
             case PARTITIONED:
                 return new Partitioned(collectors, outboundEdge.partitioner(), partitionCount);
             case BROADCAST:
-            case FANOUT:
                 return new Broadcast(collectors);
+            case FANOUT:
+                return local ? new RoundRobin(collectors) : new Broadcast(collectors);
             default:
                 throw new AssertionError("Missing case label for " + outboundEdge.routingPolicy());
         }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
@@ -114,6 +114,10 @@ public class EdgeDef implements IdentifiedDataSerializable {
         return distributedTo;
     }
 
+    boolean isDistributed() {
+        return distributedTo != null;
+    }
+
     EdgeConfig getConfig() {
         return config;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
@@ -114,10 +114,6 @@ public class EdgeDef implements IdentifiedDataSerializable {
         return distributedTo;
     }
 
-    boolean isDistributed() {
-        return distributedTo != null;
-    }
-
     EdgeConfig getConfig() {
         return config;
     }

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/EdgeDef.java
@@ -105,6 +105,10 @@ public class EdgeDef implements IdentifiedDataSerializable {
         return priority == MasterJobContext.SNAPSHOT_RESTORE_EDGE_PRIORITY;
     }
 
+    boolean isLocal() {
+        return distributedTo == null;
+    }
+
     /**
      * Note: unlike {@link Edge#getDistributedTo()}, this method always returns
      * null if the DAG is about to be run on a single member. See {@linkplain

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/init/ExecutionPlan.java
@@ -77,7 +77,8 @@ import java.util.stream.Stream;
 import static com.hazelcast.internal.util.concurrent.ConcurrentConveyor.concurrentConveyor;
 import static com.hazelcast.jet.config.EdgeConfig.DEFAULT_QUEUE_SIZE;
 import static com.hazelcast.jet.core.Edge.DISTRIBUTE_TO_ALL;
-import static com.hazelcast.jet.impl.execution.OutboundCollector.compositeCollector;
+import static com.hazelcast.jet.impl.execution.OutboundCollector.localCompositeCollector;
+import static com.hazelcast.jet.impl.execution.OutboundCollector.distributedCompositeCollector;
 import static com.hazelcast.jet.impl.execution.TaskletExecutionService.TASKLET_INIT_CLOSE_EXECUTOR_NAME;
 import static com.hazelcast.jet.impl.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.jet.impl.util.ImdgUtil.getMemberConnection;
@@ -378,23 +379,160 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         return processors;
     }
 
-    /**
-     * Populates {@code localConveyorMap}, {@code edgeSenderConveyorMap}.
-     * Populates {@link #senderMap} and {@link #tasklets} fields.
-     */
-    private List<OutboundEdgeStream> createOutboundEdgeStreams(VertexDef srcVertex, int processorIdx,
-                                                               InternalSerializationService jobSerializationService) {
-        final List<OutboundEdgeStream> outboundStreams = new ArrayList<>();
-        for (EdgeDef edge : srcVertex.outboundEdges()) {
-            Map<Address, ConcurrentConveyor<Object>> memberToSenderConveyorMap = null;
-            if (edge.getDistributedTo() != null) {
-                memberToSenderConveyorMap =
-                        memberToSenderConveyorMap(edgeSenderConveyorMap, edge, jobSerializationService);
-            }
-            outboundStreams.add(createOutboundEdgeStream(edge, processorIdx, memberToSenderConveyorMap,
-                    jobSerializationService));
+    private List<OutboundEdgeStream> createOutboundEdgeStreams(
+            VertexDef vertex,
+            int processorIdx,
+            InternalSerializationService jobSerializationService
+    ) {
+        List<OutboundEdgeStream> outboundStreams = new ArrayList<>();
+        for (EdgeDef edge : vertex.outboundEdges()) {
+            OutboundCollector outboundCollector = createOutboundCollector(edge, processorIdx, jobSerializationService);
+            OutboundEdgeStream outboundEdgeStream = new OutboundEdgeStream(edge.sourceOrdinal(), outboundCollector);
+            outboundStreams.add(outboundEdgeStream);
         }
         return outboundStreams;
+    }
+
+    /**
+     * Each edge is represented by an array of conveyors between the producers and consumers.
+     * There are as many conveyors as there are consumers.
+     * Each conveyor has one queue per producer.
+     *
+     * For a distributed edge, there is one additional producer per member represented
+     * by the ReceiverTasklet.
+     */
+    private OutboundCollector createOutboundCollector(
+            EdgeDef edge,
+            int processorIndex,
+            InternalSerializationService jobSerializationService
+    ) {
+        if (edge.isDistributed() && edge.routingPolicy() == RoutingPolicy.ISOLATED) {
+            throw new IllegalArgumentException("Isolated edges must be local: " + edge);
+        }
+        if ((!edge.isDistributed() || !edge.getDistributedTo().equals(DISTRIBUTE_TO_ALL))
+            && edge.routingPolicy() == RoutingPolicy.FANOUT) {
+            throw new IllegalArgumentException("Fanout edges must be distributed: " + edge);
+        }
+
+        int totalPartitionCount = nodeEngine.getPartitionService().getPartitionCount();
+        int[][] partitionsPerProcessor = getLocalPartitionDistribution(edge, edge.destVertex().localParallelism());
+
+        OutboundCollector localCollector = createLocalOutboundCollector(
+                edge,
+                processorIndex,
+                totalPartitionCount,
+                partitionsPerProcessor
+        );
+        if (!edge.isDistributed()) {
+            return localCollector;
+        }
+
+        OutboundCollector[] remoteCollectors = createRemoteOutboundCollectors(
+                edge,
+                processorIndex,
+                totalPartitionCount,
+                partitionsPerProcessor,
+                jobSerializationService
+        );
+
+        // in a distributed edge, collectors[0] is the composite of local collector, and
+        // collectors[n] where n > 0 is a collector pointing to a remote member _n_.
+        OutboundCollector[] collectors = new OutboundCollector[remoteCollectors.length + 1];
+        collectors[0] = localCollector;
+        System.arraycopy(remoteCollectors, 0, collectors, 1, collectors.length - 1);
+        return distributedCompositeCollector(collectors, edge, totalPartitionCount);
+    }
+
+    private OutboundCollector createLocalOutboundCollector(
+            EdgeDef edge,
+            int processorIndex,
+            int totalPartitionCount,
+            int[][] partitionsPerProcessor
+    ) {
+        int upstreamParallelism = edge.sourceVertex().localParallelism();
+        int downstreamParallelism = edge.destVertex().localParallelism();
+        int queueSize = edge.getConfig().getQueueSize();
+        int numRemoteMembers = ptionArrgmt.getRemotePartitionAssignment().size();
+
+        if (edge.routingPolicy() == RoutingPolicy.ISOLATED) {
+            ConcurrentConveyor<Object>[] localConveyors = localConveyorMap.computeIfAbsent(
+                    edge.edgeId(),
+                    edgeId -> {
+                        int queueCount = upstreamParallelism / downstreamParallelism;
+                        int remainder = upstreamParallelism % downstreamParallelism;
+                        return Stream.concat(
+                                Arrays.stream(createConveyorArray(remainder, queueCount + 1, queueSize)),
+                                Arrays.stream(createConveyorArray(
+                                        downstreamParallelism - remainder, Math.max(1, queueCount), queueSize
+                                ))).toArray((IntFunction<ConcurrentConveyor<Object>[]>) ConcurrentConveyor[]::new);
+                    });
+
+            OutboundCollector[] localCollectors = IntStream.range(0, downstreamParallelism)
+                            .filter(i -> i % upstreamParallelism == processorIndex % downstreamParallelism)
+                            .mapToObj(i -> new ConveyorCollector(localConveyors[i],
+                                    processorIndex / downstreamParallelism, null))
+                            .toArray(OutboundCollector[]::new);
+            return localCompositeCollector(localCollectors, edge, totalPartitionCount);
+        } else {
+            ConcurrentConveyor<Object>[] localConveyors = localConveyorMap.computeIfAbsent(
+                    edge.edgeId(),
+                    edgeId -> {
+                        int queueCount = upstreamParallelism + (edge.isDistributed() ? numRemoteMembers : 0);
+                        return createConveyorArray(downstreamParallelism, queueCount, queueSize);
+                    }
+            );
+
+            OutboundCollector[] localCollectors = new OutboundCollector[downstreamParallelism];
+            Arrays.setAll(
+                    localCollectors,
+                    n -> new ConveyorCollector(localConveyors[n], processorIndex, partitionsPerProcessor[n])
+            );
+            return localCompositeCollector(localCollectors, edge, totalPartitionCount);
+        }
+    }
+
+    private OutboundCollector[] createRemoteOutboundCollectors(
+            EdgeDef edge,
+            int processorIndex,
+            int totalPartitionCount,
+            int[][] partitionsPerProcessor,
+            InternalSerializationService jobSerializationService
+    ) {
+        // the distributed-to-one edge must be partitioned and the target member must be present
+        if (!edge.getDistributedTo().equals(DISTRIBUTE_TO_ALL)) {
+            if (edge.routingPolicy() != RoutingPolicy.PARTITIONED) {
+                throw new JetException("An edge distributing to a specific member must be partitioned: " + edge);
+            }
+            if (!ptionArrgmt.getRemotePartitionAssignment().containsKey(edge.getDistributedTo())
+                && !edge.getDistributedTo().equals(nodeEngine.getThisAddress())) {
+                throw new JetException("The target member of an edge is not present in the cluster or is a lite member: "
+                                       + edge);
+            }
+        }
+
+        Map<Address, ConcurrentConveyor<Object>> senderConveyorMap = memberToSenderConveyorMap(
+                edgeSenderConveyorMap,
+                edge,
+                jobSerializationService
+        );
+        createIfAbsentReceiverTasklet(edge, partitionsPerProcessor, totalPartitionCount, jobSerializationService);
+
+        // assign remote partitions to outbound data collectors
+        Address distributeTo = edge.getDistributedTo();
+        Map<Address, int[]> memberToPartitions = distributeTo.equals(DISTRIBUTE_TO_ALL)
+                ? ptionArrgmt.getRemotePartitionAssignment()
+                : ptionArrgmt.remotePartitionAssignmentToOne(distributeTo);
+
+        OutboundCollector[] remoteCollectors = new OutboundCollector[memberToPartitions.size()];
+        int index = 0;
+        for (Map.Entry<Address, int[]> entry : memberToPartitions.entrySet()) {
+            Address memberAddress = entry.getKey();
+            int[] memberPartitions = entry.getValue();
+            ConcurrentConveyor<Object> conveyor = senderConveyorMap.get(memberAddress);
+
+            remoteCollectors[index++] = new ConveyorCollectorWithPartition(conveyor, processorIndex, memberPartitions);
+        }
+        return remoteCollectors;
     }
 
     /**
@@ -407,7 +545,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             EdgeDef edge,
             InternalSerializationService jobSerializationService
     ) {
-        assert edge.getDistributedTo() != null : "Edge is not distributed";
+        assert edge.isDistributed() : "Edge is not distributed";
         return edgeSenderConveyorMap.computeIfAbsent(edge.edgeId(), x -> {
             final Map<Address, ConcurrentConveyor<Object>> addrToConveyor = new HashMap<>();
             for (Address destAddr : remoteMembers.get()) {
@@ -448,105 +586,6 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
         return concurrentConveyors;
     }
 
-    private OutboundEdgeStream createOutboundEdgeStream(EdgeDef edge,
-                                                        int processorIndex,
-                                                        Map<Address, ConcurrentConveyor<Object>> senderConveyorMap,
-                                                        InternalSerializationService jobSerializationService) {
-        final int totalPtionCount = nodeEngine.getPartitionService().getPartitionCount();
-        OutboundCollector[] outboundCollectors = createOutboundCollectors(
-                edge, processorIndex, senderConveyorMap, jobSerializationService
-        );
-        OutboundCollector compositeCollector = compositeCollector(outboundCollectors, edge, totalPtionCount);
-        return new OutboundEdgeStream(edge.sourceOrdinal(), compositeCollector);
-    }
-
-    private OutboundCollector[] createOutboundCollectors(EdgeDef edge,
-                                                         int processorIndex,
-                                                         Map<Address, ConcurrentConveyor<Object>> senderConveyorMap,
-                                                         InternalSerializationService jobSerializationService) {
-        final int upstreamParallelism = edge.sourceVertex().localParallelism();
-        final int downstreamParallelism = edge.destVertex().localParallelism();
-        final int numRemoteMembers = ptionArrgmt.getRemotePartitionAssignment().size();
-        final int queueSize = edge.getConfig().getQueueSize();
-
-        if (edge.routingPolicy() == RoutingPolicy.ISOLATED) {
-            if (edge.getDistributedTo() != null) {
-                throw new IllegalArgumentException("Isolated edges must be local: " + edge);
-            }
-
-            ConcurrentConveyor<Object>[] localConveyors = localConveyorMap.computeIfAbsent(edge.edgeId(),
-                    e -> {
-                        int queueCount = upstreamParallelism / downstreamParallelism;
-                        int remainder = upstreamParallelism % downstreamParallelism;
-                        return Stream.concat(
-                                Arrays.stream(createConveyorArray(remainder, queueCount + 1, queueSize)),
-                                Arrays.stream(createConveyorArray(
-                                        downstreamParallelism - remainder, Math.max(1, queueCount), queueSize
-                                ))).toArray((IntFunction<ConcurrentConveyor<Object>[]>) ConcurrentConveyor[]::new);
-                    });
-
-                return IntStream.range(0, downstreamParallelism)
-                        .filter(i -> i % upstreamParallelism == processorIndex % downstreamParallelism)
-                        .mapToObj(i -> new ConveyorCollector(localConveyors[i],
-                                processorIndex / downstreamParallelism, null))
-                        .toArray(OutboundCollector[]::new);
-        }
-
-        /*
-         * Each edge is represented by an array of conveyors between the producers and consumers
-         * There are as many conveyors as there are consumers.
-         * Each conveyor has one queue per producer.
-         *
-         * For a distributed edge, there is one additional producer per member represented
-         * by the ReceiverTasklet.
-         */
-        final int[][] ptionsPerProcessor = getLocalPartitionDistribution(edge, downstreamParallelism);
-        final ConcurrentConveyor<Object>[] localConveyors = localConveyorMap.computeIfAbsent(edge.edgeId(),
-                e -> {
-                    int queueCount = upstreamParallelism + (edge.getDistributedTo() != null ? numRemoteMembers : 0);
-                    return createConveyorArray(downstreamParallelism, queueCount, queueSize);
-                });
-        final OutboundCollector[] localCollectors = new OutboundCollector[downstreamParallelism];
-        Arrays.setAll(localCollectors, n ->
-                new ConveyorCollector(localConveyors[n], processorIndex, ptionsPerProcessor[n]));
-
-        // in a local edge, we only have the local collectors.
-        if (edge.getDistributedTo() == null) {
-            return localCollectors;
-        }
-
-        // the distributed-to-one edge must be partitioned and the target member must be present
-        if (!edge.getDistributedTo().equals(DISTRIBUTE_TO_ALL)) {
-            if (edge.routingPolicy() != RoutingPolicy.PARTITIONED) {
-                throw new JetException("An edge distributing to a specific member must be partitioned: " + edge);
-            }
-            if (!ptionArrgmt.getRemotePartitionAssignment().containsKey(edge.getDistributedTo())
-                    && !edge.getDistributedTo().equals(nodeEngine.getThisAddress())) {
-                throw new JetException("The target member of an edge is not present in the cluster or is a lite member: "
-                        + edge);
-            }
-        }
-
-        // in a distributed edge, allCollectors[0] is the composite of local collectors, and
-        // allCollectors[n] where n > 0 is a collector pointing to a remote member _n_.
-        final int totalPtionCount = nodeEngine.getPartitionService().getPartitionCount();
-        final OutboundCollector[] allCollectors;
-        createIfAbsentReceiverTasklet(edge, ptionsPerProcessor, totalPtionCount, jobSerializationService);
-
-        // assign remote partitions to outbound data collectors
-        final Map<Address, int[]> memberToPartitions = edge.getDistributedTo().equals(DISTRIBUTE_TO_ALL)
-                ? ptionArrgmt.getRemotePartitionAssignment()
-                : ptionArrgmt.remotePartitionAssignmentToOne(edge.getDistributedTo());
-        allCollectors = new OutboundCollector[memberToPartitions.size() + 1];
-        allCollectors[0] = compositeCollector(localCollectors, edge, totalPtionCount);
-        int index = 1;
-        for (Map.Entry<Address, int[]> entry : memberToPartitions.entrySet()) {
-            allCollectors[index++] = new ConveyorCollectorWithPartition(senderConveyorMap.get(entry.getKey()),
-                    processorIndex, entry.getValue());
-        }
-        return allCollectors;
-    }
-
     /**
      * Return the partition distribution for local conveyors. The first
      * dimension in the result is the processor index, at that index is the
@@ -558,8 +597,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
             return new int[downstreamParallelism][];
         }
 
-        if (edge.getDistributedTo() == null
-                || nodeEngine.getThisAddress().equals(edge.getDistributedTo())) {
+        if (!edge.isDistributed() || nodeEngine.getThisAddress().equals(edge.getDistributedTo())) {
             // the edge is local-partitioned or it is distributed to one member and this member is the target
             return ptionArrgmt.assignPartitionsToProcessors(downstreamParallelism, false);
         }
@@ -594,7 +632,7 @@ public class ExecutionPlan implements IdentifiedDataSerializable {
                            Arrays.setAll(collectors, n -> new ConveyorCollector(
                                    localConveyors[n], localConveyors[n].queueCount() + queueOffset,
                                    ptionsPerProcessor[n]));
-                           final OutboundCollector collector = compositeCollector(collectors, edge, totalPtionCount);
+                           final OutboundCollector collector = localCompositeCollector(collectors, edge, totalPtionCount);
                            ReceiverTasklet receiverTasklet = new ReceiverTasklet(
                                    collector, jobSerializationService,
                                    edge.getConfig().getReceiveWindowMultiplier(),

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/RoutingPolicyDistributedTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/RoutingPolicyDistributedTest.java
@@ -25,6 +25,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -34,6 +35,7 @@ import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
 import static com.hazelcast.jet.core.Edge.between;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
@@ -102,20 +104,42 @@ public class RoutingPolicyDistributedTest extends SimpleTestInClusterSupport {
         assertEquals("items on member1", setOf(NUMBERS), items1);
     }
 
+    @Test
+    public void when_distributed_fanout() {
+        DAG dag = new DAG();
+        Vertex producer = new Vertex("producer", new ListsSourceP(asList(1, 2), asList(3, 4))).localParallelism(1);
+        Vertex consumer = new Vertex("consumer", consumerSup).localParallelism(2);
+
+        dag.vertex(producer)
+           .vertex(consumer)
+           .edge(between(producer, consumer).distributed().fanout());
+
+        instance().newJob(dag).join();
+
+        assertEquals("items on member0-processor0", ImmutableSet.of(1, 3), new HashSet<>(consumerSup.getListAt(0)));
+        assertEquals("items on member0-processor1", ImmutableSet.of(2, 4), new HashSet<>(consumerSup.getListAt(1)));
+        assertEquals("items on member1-processor0", ImmutableSet.of(1, 3), new HashSet<>(consumerSup.getListAt(2)));
+        assertEquals("items on member1-processor1", ImmutableSet.of(2, 4), new HashSet<>(consumerSup.getListAt(3)));
+    }
 
     @Test
     public void when_distributedToOne_broadcast() {
-        when_distributedToOne_notPartitioned(e -> e.broadcast(), "must be partitioned");
+        when_distributedToOne_notPartitioned(Edge::broadcast, "must be partitioned");
     }
 
     @Test
     public void when_distributedToOne_unicast() {
-        when_distributedToOne_notPartitioned(e -> e.unicast(), "must be partitioned");
+        when_distributedToOne_notPartitioned(Edge::unicast, "must be partitioned");
     }
 
     @Test
     public void when_distributedToOne_isolated() {
-        when_distributedToOne_notPartitioned(e -> e.isolated(), "Isolated edges must be local");
+        when_distributedToOne_notPartitioned(Edge::isolated, "Isolated edges must be local");
+    }
+
+    @Test
+    public void when_distributedToOne_fanout() {
+        when_distributedToOne_notPartitioned(Edge::fanout, "Fanout edges must be distributed");
     }
 
     private void when_distributedToOne_notPartitioned(Consumer<Edge> configureEdgeFn, String expectedError) {
@@ -131,6 +155,21 @@ public class RoutingPolicyDistributedTest extends SimpleTestInClusterSupport {
            .edge(edge);
 
         exception.expectMessage(expectedError);
+        instance().newJob(dag).join();
+    }
+
+    @Test
+    public void when_local_fanout() {
+        DAG dag = new DAG();
+        Vertex producer = producer(NUMBERS);
+        Vertex consumer = consumer();
+
+        dag.vertex(producer)
+           .vertex(consumer)
+           .edge(between(producer, consumer)
+                   .fanout());
+
+        exception.expectMessage("Fanout edges must be distributed");
         instance().newJob(dag).join();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/RoutingPolicyTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/RoutingPolicyTest.java
@@ -193,6 +193,28 @@ public class RoutingPolicyTest extends SimpleTestInClusterSupport {
         assertEquals(setOf(NUMBERS_HIGH), setOf(list2));
     }
 
+    @Test
+    public void when_fanout() throws Throwable {
+        DAG dag = new DAG();
+        Vertex producer = producer(NUMBERS_LOW, NUMBERS_HIGH);
+        Vertex consumer = consumer(2);
+
+        dag.vertex(producer)
+           .vertex(consumer)
+           .edge(between(producer, consumer)
+                   .fanout());
+
+        execute(dag);
+
+        List<Object> combined = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            combined.addAll(consumerSup.getListAt(i));
+        }
+
+        assertEquals(NUMBERS_LOW.size() + NUMBERS_HIGH.size(), combined.size());
+        assertEquals(setOf(NUMBERS_LOW, NUMBERS_HIGH), setOf(combined));
+    }
+
     private void execute(DAG dag) throws Throwable {
         executeAndPeel(instance().newJob(dag));
     }


### PR DESCRIPTION
Added `FANOUT` routing policy.
For distributed edge case it sends each item to a single processor on each of the cluster members - a combination of `BROADCAST` & `ROUND_ROBIN`. For a local edge case it behaves exactly as `ROUND_ROBIN`.

Useful for optimized `IMap` (SQL) join implementations where single item is being joined with local `IMap` partitions.

Checklist:
- [x] Labels and Milestone set
- [x] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
