### PR TITLE
Event Reordering Functional Test Improvements

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedBatchProcessingTest.java
@@ -67,7 +67,7 @@ public class OrderedBatchProcessingTest extends JetTestSupport {
     public String transformName;
 
     @BeforeClass
-    public static void setupClass(){
+    public static void setupClass() {
         jet = Jet.newJetInstance();
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMergingStagesTest.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.pipeline;
+
+import com.hazelcast.jet.Jet;
+import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
+import com.hazelcast.jet.Util;
+import com.hazelcast.jet.accumulator.LongAccumulator;
+import com.hazelcast.jet.core.JetTestSupport;
+import com.hazelcast.jet.core.ProcessorMetaSupplier;
+import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
+import com.hazelcast.jet.pipeline.test.AssertionSinks;
+import com.hazelcast.jet.pipeline.test.GeneratorFunction;
+import com.hazelcast.jet.pipeline.test.ParallelStreamP;
+import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+
+import javax.annotation.Nonnull;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionException;
+import java.util.stream.LongStream;
+
+import static com.hazelcast.jet.core.test.JetAssert.assertFalse;
+import static com.hazelcast.jet.core.test.JetAssert.assertTrue;
+import static com.hazelcast.jet.core.test.JetAssert.fail;
+import static java.util.stream.Collectors.toList;
+
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+public class OrderedProcessingMergingStagesTest extends JetTestSupport implements Serializable {
+
+    private static final int ITEM_COUNT = 250;
+    // Used to set the LP of the stage with the higher value than upstream parallelism
+    private static final int HIGH_LOCAL_PARALLELISM = 11;
+    // Used to set the LP of the stage with the smaller value than upstream parallelism
+    private static final int LOW_LOCAL_PARALLELISM = 2;
+    private static Pipeline p;
+    private static JetInstance jet;
+
+
+    @BeforeClass
+    public static void setupClass() {
+        jet = Jet.newJetInstance();
+    }
+
+    @Before
+    public void setup() {
+        p = Pipeline.create().setPreserveOrder(true);
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        jet.shutdown();
+    }
+
+
+    @Test
+    public void when_merge_applied_partial_orders_are_preserved() {
+        int validatedItemCountPerGenerator = ITEM_COUNT;
+        int eventsPerSecondPerGenerator = 5 * ITEM_COUNT;
+        int generatorCount = 4;
+
+        // Generate monotonic increasing items that are distinct for each generator.
+        GeneratorFunction<Long> generator1 = (ts, seq) -> generatorCount * seq;
+        GeneratorFunction<Long> generator2 = (ts, seq) -> generatorCount * seq + 1;
+        GeneratorFunction<Long> generator3 = (ts, seq) -> generatorCount * seq + 2;
+        GeneratorFunction<Long> generator4 = (ts, seq) -> generatorCount * seq + 3;
+
+        List<Long> sequence1 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i).boxed().collect(toList());
+        List<Long> sequence2 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i + 1).boxed().collect(toList());
+        List<Long> sequence3 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i + 2).boxed().collect(toList());
+        List<Long> sequence4 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i + 3).boxed().collect(toList());
+
+        StreamStage<Long> srcStage = p.readFrom(itemsParallel(
+                eventsPerSecondPerGenerator,
+                Arrays.asList(generator1, generator2))
+        ).withIngestionTimestamps()
+                .setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        StreamStage<Long> srcStage2 = p.readFrom(itemsParallel(
+                eventsPerSecondPerGenerator,
+                Arrays.asList(generator3, generator4))
+        ).withIngestionTimestamps()
+                .setLocalParallelism(LOW_LOCAL_PARALLELISM);
+
+
+        StreamStage<Long> merged = srcStage.merge(srcStage2).setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        merged.filter(i -> i % generatorCount == 0)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> Assert.assertArrayEquals(list.toArray(), sequence1.toArray())));
+
+        merged.filter(i -> i % generatorCount == 1)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> Assert.assertArrayEquals(list.toArray(), sequence2.toArray())));
+        merged.filter(i -> i % generatorCount == 2)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> Assert.assertArrayEquals(list.toArray(), sequence3.toArray())));
+        merged.filter(i -> i % generatorCount == 3)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> Assert.assertArrayEquals(list.toArray(), sequence4.toArray())));
+
+        Job job = jet.newJob(p);
+        try {
+            job.join();
+            fail("Job should have completed with an AssertionCompletedException, but completed normally");
+        } catch (CompletionException e) {
+            String errorMsg = e.getCause().getMessage();
+            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
+                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
+        }
+    }
+
+    @Test
+    public void when_hashJoin_applied_primary_stream_order_is_preserved() {
+        int validatedItemCountPerGenerator = ITEM_COUNT;
+        int eventsPerSecondPerGenerator = 5 * ITEM_COUNT;
+        int generatorCount = 2;
+        // Generate monotonic increasing items that are distinct for each generator.
+        GeneratorFunction<Map.Entry<Long, Long>> generator1 = (ts, seq) -> Util.entry(0L, generatorCount * seq);
+        GeneratorFunction<Map.Entry<Long, Long>> generator2 = (ts, seq) ->
+                Util.entry(1L, generatorCount * seq + 1);
+
+        StreamStage<Map.Entry<Long, Long>> srcStage = p.readFrom(itemsParallel(
+                eventsPerSecondPerGenerator,
+                Arrays.asList(generator1, generator2))
+        ).withIngestionTimestamps().setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        BatchStage<Map.Entry<Long, Long>> batchStage = p.readFrom(TestSources.items(Util.entry(0L, 0L),
+                Util.entry(1L, 0L)));
+
+        StreamStage<Map.Entry<Long, Long>> joined = srcStage.hashJoin(batchStage,
+                JoinClause.onKeys(Map.Entry::getKey, Map.Entry::getKey),
+                (primary, stage) -> primary).setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        joined.groupingKey(Map.Entry::getKey)
+                .mapStateful(() -> create(generatorCount), this::orderValidator)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> {
+                            assertTrue("when", validatedItemCountPerGenerator <= list.size());
+                            assertFalse("There is some reordered items in the list", list.contains(false));
+                        }
+                ));
+        Job job = jet.newJob(p);
+        try {
+            job.join();
+            fail("Job should have completed with an AssertionCompletedException, but completed normally");
+        } catch (CompletionException e) {
+            String errorMsg = e.getCause().getMessage();
+            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
+                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
+        }
+    }
+
+    @Test
+    public void when_hashJoin2_applied_primary_stream_order_is_preserved() {
+        int validatedItemCountPerGenerator = ITEM_COUNT;
+        int eventsPerSecondPerGenerator = 5 * ITEM_COUNT;
+        int generatorCount = 2;
+        // Generate monotonic increasing items that are distinct for each generator.
+        GeneratorFunction<Map.Entry<Long, Long>> generator1 = (ts, seq) ->
+                Util.entry(0L, generatorCount * seq);
+        GeneratorFunction<Map.Entry<Long, Long>> generator2 = (ts, seq) ->
+                Util.entry(1L, generatorCount * seq + 1);
+
+        StreamStage<Map.Entry<Long, Long>> srcStage = p.readFrom(itemsParallel(
+                eventsPerSecondPerGenerator,
+                Arrays.asList(generator1, generator2))
+        ).withIngestionTimestamps();
+
+        BatchStage<Map.Entry<Long, Long>> batchStage = p.readFrom(TestSources.items(Util.entry(0L, 0L),
+                Util.entry(1L, 0L)));
+
+        BatchStage<Map.Entry<Long, Long>> batchStage2 = p.readFrom(TestSources.items(Util.entry(0L, 0L),
+                Util.entry(1L, 0L)));
+
+        StreamStage<Map.Entry<Long, Long>> joined = srcStage.hashJoin2(batchStage,
+                JoinClause.onKeys(Map.Entry::getKey, Map.Entry::getKey),
+                batchStage2,
+                JoinClause.onKeys(Map.Entry::getKey, Map.Entry::getKey),
+                (primary, stg1, stg2) -> primary).setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        joined.groupingKey(Map.Entry::getKey)
+                .mapStateful(() -> create(generatorCount), this::orderValidator)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> {
+                            assertTrue("when", validatedItemCountPerGenerator <= list.size());
+                            assertFalse("There is some reordered items in the list", list.contains(false));
+                        }
+                ));
+        Job job = jet.newJob(p);
+        try {
+            job.join();
+            fail("Job should have completed with an AssertionCompletedException, but completed normally");
+        } catch (CompletionException e) {
+            String errorMsg = e.getCause().getMessage();
+            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
+                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
+        }
+    }
+
+    @Test
+    public void when_innerJoin_applied_primary_stream_order_is_preserved() {
+        int validatedItemCountPerGenerator = ITEM_COUNT;
+        int eventsPerSecondPerGenerator = 5 * ITEM_COUNT;
+        int generatorCount = 2;
+        // Generate monotonic increasing items that are distinct for each generator.
+        GeneratorFunction<Map.Entry<Long, Long>> generator1 = (ts, seq) ->
+                Util.entry(0L, generatorCount * seq);
+        GeneratorFunction<Map.Entry<Long, Long>> generator2 = (ts, seq) ->
+                Util.entry(1L, generatorCount * seq + 1);
+
+        StreamStage<Map.Entry<Long, Long>> srcStage = p.readFrom(itemsParallel(
+                eventsPerSecondPerGenerator,
+                Arrays.asList(generator1, generator2))
+        ).withIngestionTimestamps().setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        BatchStage<Map.Entry<Long, Long>> batchStage = p.readFrom(TestSources.items(Util.entry(0L, 0L),
+                Util.entry(1L, 0L)));
+
+        StreamStage<Map.Entry<Long, Long>> joined = srcStage.innerHashJoin(batchStage,
+                JoinClause.onKeys(Map.Entry::getKey, Map.Entry::getKey),
+                (primary, stg) -> primary).setLocalParallelism(LOW_LOCAL_PARALLELISM);
+
+        joined.groupingKey(Map.Entry::getKey)
+                .mapStateful(() -> create(generatorCount), this::orderValidator)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> {
+                            assertTrue("when", validatedItemCountPerGenerator <= list.size());
+                            assertFalse("There is some reordered items in the list", list.contains(false));
+                        }
+                ));
+        Job job = jet.newJob(p);
+        try {
+            job.join();
+            fail("Job should have completed with an AssertionCompletedException, but completed normally");
+        } catch (CompletionException e) {
+            String errorMsg = e.getCause().getMessage();
+            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
+                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
+        }
+    }
+
+    @Test
+    public void when_innerJoin2_applied_primary_stream_order_is_preserved() {
+        int validatedItemCountPerGenerator = ITEM_COUNT;
+        int eventsPerSecondPerGenerator = 5 * ITEM_COUNT;
+        int generatorCount = 2;
+        // Generate monotonic increasing items that are distinct for each generator.
+        GeneratorFunction<Map.Entry<Long, Long>> generator1 = (ts, seq) ->
+                Util.entry(0L, generatorCount * seq);
+        GeneratorFunction<Map.Entry<Long, Long>> generator2 = (ts, seq) ->
+                Util.entry(1L, generatorCount * seq + 1);
+
+        StreamStage<Map.Entry<Long, Long>> srcStage = p.readFrom(itemsParallel(
+                eventsPerSecondPerGenerator,
+                Arrays.asList(generator1, generator2))
+        ).withIngestionTimestamps().setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        BatchStage<Map.Entry<Long, Long>> batchStage = p.readFrom(TestSources.items(Util.entry(0L, 0L),
+                Util.entry(1L, 0L)));
+        BatchStage<Map.Entry<Long, Long>> batchStage2 = p.readFrom(TestSources.items(Util.entry(0L, 0L),
+                Util.entry(1L, 0L)));
+
+        StreamStage<Map.Entry<Long, Long>> joined = srcStage.innerHashJoin2(batchStage,
+                JoinClause.onKeys(Map.Entry::getKey, Map.Entry::getKey),
+                batchStage2,
+                JoinClause.onKeys(Map.Entry::getKey, Map.Entry::getKey),
+                (primary, stg1, stg2) -> primary).setLocalParallelism(HIGH_LOCAL_PARALLELISM);
+
+        joined.groupingKey(Map.Entry::getKey)
+                .mapStateful(() -> create(generatorCount), this::orderValidator)
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> {
+                            assertTrue("when", validatedItemCountPerGenerator <= list.size());
+                            assertFalse("There is some reordered items in the list", list.contains(false));
+                        }
+                ));
+        Job job = jet.newJob(p);
+        try {
+            job.join();
+            fail("Job should have completed with an AssertionCompletedException, but completed normally");
+        } catch (CompletionException e) {
+            String errorMsg = e.getCause().getMessage();
+            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
+                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
+        }
+    }
+
+
+    private static LongAccumulator[] create(int keyCount) {
+        LongAccumulator[] state = new LongAccumulator[keyCount];
+        for (int i = 0; i < keyCount; i++) {
+            state[i] = new LongAccumulator(Long.MIN_VALUE);
+        }
+        return state;
+    }
+
+    private boolean orderValidator(LongAccumulator[] s, Long key, Map.Entry<Long, Long> entry) {
+        LongAccumulator acc = s[key.intValue()];
+        long value = entry.getValue();
+        if (acc.get() >= value) {
+            return false;
+        } else {
+            acc.set(value);
+            return true;
+        }
+    }
+
+    private static <T> StreamSource<T> itemsParallel(
+            long eventsPerSecondPerGenerator, @Nonnull List<? extends GeneratorFunction<T>> generatorFns
+    ) {
+        Objects.requireNonNull(generatorFns, "generatorFns");
+
+        return Sources.streamFromProcessorWithWatermarks("itemsParallel",
+                true,
+                eventTimePolicy -> ProcessorMetaSupplier.of(generatorFns.size(), () ->
+                        new ParallelStreamP<>(eventsPerSecondPerGenerator, eventTimePolicy, generatorFns)));
+    }
+
+}

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -55,6 +55,15 @@ import static com.hazelcast.jet.core.test.JetAssert.assertFalse;
 import static com.hazelcast.jet.core.test.JetAssert.assertTrue;
 import static com.hazelcast.jet.core.test.JetAssert.fail;
 
+
+/**
+ *  The tests of this class run on the same Jet cluster. In order for
+ *  the tests to run quickly, we do not start a new cluster after each
+ *  test. But if some test spoils the cluster, it may also cause other
+ *  tests to fail. But since we did not expect this case, we preferred
+ *  performance in this tradeoff. Isolation between tests is provided
+ *  by using different mapJournals in each test.
+ */
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 public class OrderedProcessingMultipleMemberTest extends JetTestSupport implements Serializable {
@@ -250,7 +259,6 @@ public class OrderedProcessingMultipleMemberTest extends JetTestSupport implemen
 
         applied.groupingKey(Map.Entry::getKey)
                 .mapStateful(() -> create(keyCount), this::orderValidator)
-                .peek()
                 .writeTo(AssertionSinks.assertCollectedEventually(60,
                         list -> {
                             assertTrue("when", itemCount <= list.size());

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -51,7 +51,9 @@ import java.util.concurrent.CompletionException;
 import java.util.stream.LongStream;
 
 import static com.hazelcast.function.Functions.wholeItem;
-import static com.hazelcast.jet.core.test.JetAssert.*;
+import static com.hazelcast.jet.core.test.JetAssert.assertFalse;
+import static com.hazelcast.jet.core.test.JetAssert.assertTrue;
+import static com.hazelcast.jet.core.test.JetAssert.fail;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
@@ -241,8 +243,9 @@ public class OrderedProcessingMultipleMemberTest extends JetTestSupport implemen
         int keyCount = 8;
 
         String mapName = "test-map-" + idx;
-        StreamStage<Map.Entry<Long, Long>> srcStage = p.readFrom(Sources.<Long, Long>mapJournal(mapName, JournalInitialPosition.START_FROM_OLDEST))
-                .withoutTimestamps();
+        StreamStage<Map.Entry<Long, Long>> srcStage = p.readFrom(
+                Sources.<Long, Long>mapJournal(mapName, JournalInitialPosition.START_FROM_OLDEST)
+        ).withoutTimestamps();
         StreamStage<Map.Entry<Long, Long>> applied = srcStage.apply(transform);
 
         applied.groupingKey(Map.Entry::getKey)

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedProcessingMultipleMemberTest.java
@@ -16,18 +16,21 @@
 
 package com.hazelcast.jet.pipeline;
 
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
 import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
+import com.hazelcast.jet.Job;
 import com.hazelcast.jet.Traversers;
 import com.hazelcast.jet.accumulator.LongAccumulator;
+import com.hazelcast.jet.config.JetConfig;
 import com.hazelcast.jet.core.JetTestSupport;
-import com.hazelcast.jet.core.ProcessorMetaSupplier;
+
 import com.hazelcast.jet.core.processor.Processors;
-import com.hazelcast.jet.pipeline.test.Assertions;
-import com.hazelcast.jet.pipeline.test.ParallelBatchP;
-import com.hazelcast.jet.pipeline.test.TestSources;
+import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
+import com.hazelcast.jet.pipeline.test.AssertionSinks;
+import com.hazelcast.map.IMap;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -35,40 +38,58 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import javax.annotation.Nonnull;
+import java.io.Serializable;
+
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.IntStream;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.stream.LongStream;
 
 import static com.hazelcast.function.Functions.wholeItem;
-import static java.util.stream.Collectors.toList;
+import static com.hazelcast.jet.core.test.JetAssert.*;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
-public class OrderedBatchProcessingTest extends JetTestSupport {
+public class OrderedProcessingMultipleMemberTest extends JetTestSupport implements Serializable {
 
     // Used to set the LP of the stage with the higher value than upstream parallelism
     private static final int HIGH_LOCAL_PARALLELISM = 11;
     // Used to set the LP of the stage with the smaller value than upstream parallelism
     private static final int LOW_LOCAL_PARALLELISM = 2;
+    private static final int INSTANCE_COUNT = 2;
+
     private static Pipeline p;
-    private static JetInstance jet;
+    private static JetInstance[] instances;
 
     @Parameter(value = 0)
-    public FunctionEx<BatchStage<Integer>, BatchStage<Integer>> transform;
+    public int idx;
 
     @Parameter(value = 1)
+    public FunctionEx<StreamStage<Map.Entry<Long, Long>>, StreamStage<Map.Entry<Long, Long>>> transform;
+
+    @Parameter(value = 2)
     public String transformName;
 
     @BeforeClass
-    public static void setupClass(){
-        jet = Jet.newJetInstance();
+    public static void setupClass() {
+        int testCount = 16;
+        JetConfig config = new JetConfig();
+        for (int idx = 0; idx < testCount; idx++) {
+            EventJournalConfig eventJournalConfig = config.getHazelcastConfig()
+                    .getMapConfig("test-map-" + idx)
+                    .getEventJournalConfig();
+            eventJournalConfig.setEnabled(true);
+            eventJournalConfig.setCapacity(30000); // 30000/271 ~= 111 item per partition
+        }
+        instances = new JetInstance[INSTANCE_COUNT];
+        for (int i = 0; i < INSTANCE_COUNT; i++) {
+            instances[i] = Jet.newJetInstance(config);
+        }
     }
 
     @Before
@@ -78,99 +99,116 @@ public class OrderedBatchProcessingTest extends JetTestSupport {
 
     @AfterClass
     public static void cleanup() {
-        jet.shutdown();
+        for (int i = 0; i < INSTANCE_COUNT; i++) {
+            instances[i].shutdown();
+        }
     }
 
-    @Parameters(name = "{index}: transform={1}")
+    @Parameters(name = "{index}: transform={2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 createParamSet(
+                        0,
                         stage -> stage
                                 .map(FunctionEx.identity())
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "map-high"
                 ),
                 createParamSet(
+                        1,
                         stage -> stage
                                 .flatMap(Traversers::singleton)
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "flat-map-high"
                 ),
                 createParamSet(
+                        2,
                         stage -> stage
                                 .mapUsingIMap("test-map", wholeItem(), (x, ignored) -> x)
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "map-using-imap-high"
                 ),
                 createParamSet(
+                        3,
                         stage -> stage
                                 .mapUsingReplicatedMap("test-map", wholeItem(), (x, ignored) -> x)
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "map-using-replicated-map-high"
                 ),
                 createParamSet(
+                        4,
                         stage -> stage
                                 .filter(PredicateEx.alwaysTrue())
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "filter-high"
                 ),
                 createParamSet(
+                        5,
                         stage -> stage
                                 .mapStateful(LongAccumulator::new, (s, x) -> x)
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "map-stateful-global-high"
                 ),
                 createParamSet(
+                        6,
                         stage -> stage
-                                .<Integer>customTransform("custom-transform",
+                                .<Map.Entry<Long, Long>>customTransform("custom-transform",
                                         Processors.mapP(FunctionEx.identity()))
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "custom-transform-high"
                 ),
                 createParamSet(
+                        7,
                         stage -> stage
                                 .map(FunctionEx.identity())
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "map-low"
                 ),
                 createParamSet(
+                        8,
                         stage -> stage
                                 .flatMap(Traversers::singleton)
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "flat-map-low"
                 ),
                 createParamSet(
+                        9,
                         stage -> stage
                                 .mapUsingIMap("test-map", wholeItem(), (x, ignored) -> x)
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "map-using-imap-low"
                 ),
                 createParamSet(
+                        10,
                         stage -> stage
                                 .mapUsingReplicatedMap("test-map", wholeItem(), (x, ignored) -> x)
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "map-using-replicated-map-low"
                 ),
                 createParamSet(
+                        11,
                         stage -> stage
                                 .filter(PredicateEx.alwaysTrue())
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "filter-low"
                 ),
                 createParamSet(
+                        12,
                         stage -> stage
                                 .mapStateful(LongAccumulator::new, (s, x) -> x)
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "map-stateful-global-low"
                 ),
                 createParamSet(
+                        13,
                         stage -> stage
-                                .<Integer>customTransform("custom-transform",
+                                .<Map.Entry<Long, Long>>customTransform("custom-transform",
                                         Processors.mapP(FunctionEx.identity()))
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "custom-transform-low"
                 ),
                 createParamSet(
+                        14,
                         stage -> stage
                                 .map(FunctionEx.identity())
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM)
@@ -178,6 +216,7 @@ public class OrderedBatchProcessingTest extends JetTestSupport {
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "map-high-filter-low"
                 ), createParamSet(
+                        15,
                         stage -> stage
                                 .map(FunctionEx.identity())
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM)
@@ -189,66 +228,66 @@ public class OrderedBatchProcessingTest extends JetTestSupport {
     }
 
     private static Object[] createParamSet(
-            FunctionEx<BatchStage<Integer>, BatchStage<Integer>> transform,
+            int idx,
+            FunctionEx<StreamStage<Map.Entry<Long, Long>>, StreamStage<Map.Entry<Long, Long>>> transform,
             String transformName
     ) {
-        return new Object[]{transform, transformName};
+        return new Object[]{idx, transform, transformName};
     }
 
     @Test
-    public void when_source_is_non_partitioned() {
-        int itemCount = 250;
-        List<Integer> sequence = IntStream.range(0, itemCount).boxed().collect(toList());
+    public void multiple_nodes() {
+        int itemCount = 250; // because of mapJournal's capacity, increasing this value too much can break the test
+        int keyCount = 8;
 
+        String mapName = "test-map-" + idx;
+        StreamStage<Map.Entry<Long, Long>> srcStage = p.readFrom(Sources.<Long, Long>mapJournal(mapName, JournalInitialPosition.START_FROM_OLDEST))
+                .withoutTimestamps();
+        StreamStage<Map.Entry<Long, Long>> applied = srcStage.apply(transform);
 
-        BatchStage<Integer> srcStage = p.readFrom(TestSources.items(sequence));
+        applied.groupingKey(Map.Entry::getKey)
+                .mapStateful(() -> create(keyCount), this::orderValidator)
+                .peek()
+                .writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> {
+                            assertTrue("when", itemCount <= list.size());
+                            assertFalse("There is some reordered items in the list", list.contains(false));
+                        }
+                ));
 
-        BatchStage<Integer> applied = srcStage.apply(transform);
+        IMap<Long, Long> testMap = instances[0].getMap(mapName);
+        LongStream.range(0, itemCount)
+                .boxed()
+                .forEachOrdered(i -> testMap.put(i % keyCount, i));
 
-        applied.filter(i -> i < itemCount)
-                .apply(Assertions.assertOrdered(sequence));
-
-        jet.newJob(p).join();
+        Job job = instances[0].newJob(p);
+        try {
+            job.join();
+            fail("Job should have completed with an AssertionCompletedException, but completed normally");
+        } catch (CompletionException e) {
+            testMap.clear();
+            String errorMsg = e.getCause().getMessage();
+            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
+                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
+        }
     }
 
-    @Test
-    public void when_source_is_parallel() {
-        int itemCount = 250;
-        List<Integer> sequence1 = IntStream.range(0, itemCount).boxed().collect(toList());
-        List<Integer> sequence2 = IntStream.range(itemCount, 2 * itemCount).boxed().collect(toList());
-        List<Integer> sequence3 = IntStream.range(2 * itemCount, 3 * itemCount).boxed().collect(toList());
-        List<Integer> sequence4 = IntStream.range(3 * itemCount, 4 * itemCount).boxed().collect(toList());
-
-        BatchStage<Integer> srcStage = p.readFrom(
-                itemsParallel(Arrays.asList(sequence1, sequence2, sequence3, sequence4))
-        );
-
-        BatchStage<Integer> applied = srcStage.apply(transform);
-
-        applied.filter(i -> i < itemCount)
-                .apply(Assertions.assertOrdered(sequence1));
-        applied.filter(i -> itemCount <= i && i < 2 * itemCount)
-                .apply(Assertions.assertOrdered(sequence2));
-        applied.filter(i -> 2 * itemCount <= i && i < 3 * itemCount)
-                .apply(Assertions.assertOrdered(sequence3));
-        applied.filter(i -> 3 * itemCount <= i && i < 4 * itemCount)
-                .apply(Assertions.assertOrdered(sequence4));
-
-        jet.newJob(p).join();
+    private static LongAccumulator[] create(int keyCount) {
+        LongAccumulator[] state = new LongAccumulator[keyCount];
+        for (int i = 0; i < keyCount; i++) {
+            state[i] = new LongAccumulator(Long.MIN_VALUE);
+        }
+        return state;
     }
 
-    /**
-     * Returns a batch source that emits the items supplied in the iterables.
-     * It emits the items from different iterables in parallel, but preserves
-     * the order within each iterable.
-     *
-     * @since 4.4
-     */
-    @Nonnull
-    public static <T> BatchSource<T> itemsParallel(@Nonnull List<? extends Iterable<T>> iterables) {
-        Objects.requireNonNull(iterables, "iterables");
-        return Sources.batchFromProcessor("itemsParallel",
-                ProcessorMetaSupplier.of(iterables.size(), () -> new ParallelBatchP<>(iterables))
-        );
+    private boolean orderValidator(LongAccumulator[] s, Long key, Map.Entry<Long, Long> entry) {
+        LongAccumulator acc = s[key.intValue()];
+        long value = entry.getValue();
+        if (acc.get() >= value) {
+            return false;
+        } else {
+            acc.set(value);
+            return true;
+        }
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
@@ -79,7 +79,7 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
     public String transformName;
 
     @BeforeClass
-    public static void setupClass(){
+    public static void setupClass() {
         jet = Jet.newJetInstance();
     }
 
@@ -228,7 +228,8 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
 
         List<Long> sequence = LongStream.range(0, validatedItemCount).boxed().collect(toList());
 
-        StreamStage<Long> srcStage = p.readFrom(TestSources.itemStream(itemsPerSecond, (ts, seq) -> seq)).withIngestionTimestamps();
+        StreamStage<Long> srcStage = p.readFrom(TestSources.itemStream(itemsPerSecond, (ts, seq) -> seq))
+                .withIngestionTimestamps();
 
         StreamStage<Long> applied = srcStage.apply(transform);
 
@@ -296,10 +297,14 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
         GeneratorFunction<Long> generator3 = (ts, seq) -> generatorCount * seq + 2;
         GeneratorFunction<Long> generator4 = (ts, seq) -> generatorCount * seq + 3;
 
-        List<Long> sequence1 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i).boxed().collect(toList());
-        List<Long> sequence2 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i + 1).boxed().collect(toList());
-        List<Long> sequence3 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i + 2).boxed().collect(toList());
-        List<Long> sequence4 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i + 3).boxed().collect(toList());
+        List<Long> sequence1 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i).boxed().collect(toList());
+        List<Long> sequence2 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i + 1).boxed().collect(toList());
+        List<Long> sequence3 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i + 2).boxed().collect(toList());
+        List<Long> sequence4 = LongStream.range(0, validatedItemCountPerGenerator)
+                .map(i -> generatorCount * i + 3).boxed().collect(toList());
 
         StreamStage<Long> srcStage = p.readFrom(itemsParallel(
                 eventsPerSecondPerGenerator,

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
@@ -85,7 +85,7 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
 
     @Before
     public void setup() {
-        p = Pipeline.create();
+        p = Pipeline.create().setPreserveOrder(true);
     }
 
     @AfterClass
@@ -235,7 +235,6 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
         applied.writeTo(AssertionSinks.assertCollectedEventually(60,
                         list -> Assert.assertArrayEquals(list.toArray(), sequence.toArray())));
 
-        p.setPreserveOrder(true);
         Job job = jet.newJob(p);
         try {
             job.join();
@@ -274,7 +273,6 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
                         }
                 ));
 
-        p.setPreserveOrder(true);
         Job job = jet.newJob(p);
         try {
             job.join();
@@ -323,8 +321,6 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
         applied.filter(i -> i % generatorCount == 3)
                 .writeTo(AssertionSinks.assertCollectedEventually(60,
                         list -> Assert.assertArrayEquals(list.toArray(), sequence4.toArray())));
-
-        p.setPreserveOrder(true);
 
         Job job = jet.newJob(p);
         try {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
@@ -119,8 +119,7 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
                                 .mapStateful(LongAccumulator::new, (s, x) -> x)
                                 .setLocalParallelism(HIGH_LOCAL_PARALLELISM),
                         "map-stateful-global-high"
-                )
-                ,
+                ),
                 createParamSet(
                         stage -> stage
                                 .mapStateful(LongAccumulator::new, (s, x) -> x)
@@ -169,8 +168,7 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
                                 .mapStateful(LongAccumulator::new, (s, x) -> x)
                                 .setLocalParallelism(LOW_LOCAL_PARALLELISM),
                         "map-stateful-global-low"
-                )
-                ,
+                ),
                 createParamSet(
                         stage -> stage
                                 .mapStateful(LongAccumulator::new, (s, x) -> x)
@@ -355,7 +353,6 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
      * the generator functions are reset and emit everything from the start.
      *
      */
-    @Nonnull
     private static <T> StreamSource<T> itemsParallel(
             long eventsPerSecondPerGenerator, @Nonnull List<? extends GeneratorFunction<T>> generatorFns
     ) {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/OrderedStreamProcessingTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.jet.pipeline;
 
 import com.hazelcast.function.FunctionEx;
 import com.hazelcast.function.PredicateEx;
+import com.hazelcast.jet.Jet;
 import com.hazelcast.jet.JetInstance;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.Traversers;
@@ -29,10 +30,12 @@ import com.hazelcast.jet.pipeline.test.AssertionCompletedException;
 import com.hazelcast.jet.pipeline.test.AssertionSinks;
 import com.hazelcast.jet.pipeline.test.GeneratorFunction;
 import com.hazelcast.jet.pipeline.test.ParallelStreamP;
+import com.hazelcast.jet.pipeline.test.TestSources;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -64,6 +67,8 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
     private static final int HIGH_LOCAL_PARALLELISM = 11;
     // Used to set the LP of the stage with the smaller value than upstream parallelism
     private static final int LOW_LOCAL_PARALLELISM = 2;
+    private static final int ITEM_COUNT = 250;
+
     private static Pipeline p;
     private static JetInstance jet;
 
@@ -73,14 +78,18 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
     @Parameter(value = 1)
     public String transformName;
 
+    @BeforeClass
+    public static void setupClass(){
+        jet = Jet.newJetInstance();
+    }
+
     @Before
     public void setup() {
-        jet = createJetMember();
         p = Pipeline.create();
     }
 
-    @After
-    public void after() {
+    @AfterClass
+    public static void cleanup() {
         jet.shutdown();
     }
 
@@ -212,11 +221,36 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
         return new Object[]{transform, transformName};
     }
 
+    @Test
+    public void when_source_is_non_partitioned() {
+        int validatedItemCount = ITEM_COUNT;
+        int itemsPerSecond = 5 * ITEM_COUNT;
+
+        List<Long> sequence = LongStream.range(0, validatedItemCount).boxed().collect(toList());
+
+        StreamStage<Long> srcStage = p.readFrom(TestSources.itemStream(itemsPerSecond, (ts, seq) -> seq)).withIngestionTimestamps();
+
+        StreamStage<Long> applied = srcStage.apply(transform);
+
+        applied.writeTo(AssertionSinks.assertCollectedEventually(60,
+                        list -> Assert.assertArrayEquals(list.toArray(), sequence.toArray())));
+
+        p.setPreserveOrder(true);
+        Job job = jet.newJob(p);
+        try {
+            job.join();
+            fail("Job should have completed with an AssertionCompletedException, but completed normally");
+        } catch (CompletionException e) {
+            String errorMsg = e.getCause().getMessage();
+            assertTrue("Job was expected to complete with AssertionCompletedException, but completed with: "
+                    + e.getCause(), errorMsg.contains(AssertionCompletedException.class.getName()));
+        }
+    }
 
     @Test
-    public void ordered_stream_processing_test() {
-        int itemCount = 250;
-        int eventsPerSecondPerGenerator = 25;
+    public void when_source_is_parallel() {
+        int validatedItemCountPerGenerator = ITEM_COUNT;
+        int eventsPerSecondPerGenerator = 5 * ITEM_COUNT;
         int generatorCount = 4;
 
         // Generate monotonic increasing items that are distinct for each generator.
@@ -235,7 +269,7 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
         applied.mapStateful(() -> create(generatorCount), this::orderValidator)
                 .writeTo(AssertionSinks.assertCollectedEventually(60,
                         list -> {
-                            assertTrue("when", itemCount <= list.size());
+                            assertTrue("when", validatedItemCountPerGenerator <= list.size());
                             assertFalse("There is some reordered items in the list", list.contains(false));
                         }
                 ));
@@ -253,10 +287,10 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
     }
 
     @Test
-    public void ordered_stream_processing_test2() {
-        int eventsPerSecondPerGenerator = 30;
+    public void when_source_is_parallel_2() {
+        int validatedItemCountPerGenerator = ITEM_COUNT;
+        int eventsPerSecondPerGenerator = 5 * ITEM_COUNT;
         int generatorCount = 4;
-        int itemCount = 200;
 
         // Generate monotonic increasing items that are distinct for each generator.
         GeneratorFunction<Long> generator1 = (ts, seq) -> generatorCount * seq;
@@ -264,10 +298,10 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
         GeneratorFunction<Long> generator3 = (ts, seq) -> generatorCount * seq + 2;
         GeneratorFunction<Long> generator4 = (ts, seq) -> generatorCount * seq + 3;
 
-        List<Long> sequence1 = LongStream.range(0, itemCount).map(i -> generatorCount * i).boxed().collect(toList());
-        List<Long> sequence2 = LongStream.range(0, itemCount).map(i -> generatorCount * i + 1).boxed().collect(toList());
-        List<Long> sequence3 = LongStream.range(0, itemCount).map(i -> generatorCount * i + 2).boxed().collect(toList());
-        List<Long> sequence4 = LongStream.range(0, itemCount).map(i -> generatorCount * i + 3).boxed().collect(toList());
+        List<Long> sequence1 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i).boxed().collect(toList());
+        List<Long> sequence2 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i + 1).boxed().collect(toList());
+        List<Long> sequence3 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i + 2).boxed().collect(toList());
+        List<Long> sequence4 = LongStream.range(0, validatedItemCountPerGenerator).map(i -> generatorCount * i + 3).boxed().collect(toList());
 
         StreamStage<Long> srcStage = p.readFrom(itemsParallel(
                 eventsPerSecondPerGenerator,
@@ -319,7 +353,6 @@ public class OrderedStreamProcessingTest extends JetTestSupport implements Seria
      * generated. The source is not fault-tolerant. If the job restarts, all
      * the generator functions are reset and emit everything from the start.
      *
-     * @since 4.4
      */
     @Nonnull
     private static <T> StreamSource<T> itemsParallel(


### PR DESCRIPTION
This PR aims to improve event reordering functional test suite.
Improvements:
- [x] Add tests showing that events in not partitioned source are not reordered in pipeline
- [x] Events with the same partition key are not reordered even on cluster with more nodes
- [x] Fix: Remove unnecessary instance restarts between tests
- [ ] Add tests for some more pipeline stages -  Added tests for hashJoin*, innerHashJoin*, merge.
 Missing stages are aggregate, and rollingAggregate. Since I don't know how to test the order after the aggregate stages, I will not add tests for them. All of our current aggregate operations are order independent (commutative, associative), therefore I am unable to check whether the order of items entering these stage has changed or not.

Checklist:
- [x] Labels and Milestone set

