### PR TITLE
Re-assign InputSplits on members for LocalFileSystem

### DIFF
--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
@@ -71,7 +71,7 @@ public final class HadoopSources {
     /**
      * When reading files from local file system using Hadoop, each processor
      * reads files from its own local file system. If the local file system
-     * is shared between members, e.g multiple members on a machine, you should
+     * is shared between members, e.g NFS mounted filesystem, you should
      * configure this property as {@code true}.
      * <p>
      * Here is how you can configure the source. Default value is {@code false}:

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
@@ -62,11 +62,27 @@ public final class HadoopSources {
      *
      * <pre>{@code
      *     Configuration conf = new Configuration();
-     *     conf.set(HadoopSources.COPY_ON_READ, "false");
+     *     conf.setBoolean(HadoopSources.COPY_ON_READ, false);
      *     BatchSource<Entry<K, V>> source = HadoopSources.inputFormat(conf);
      * }</pre>
      */
     public static final String COPY_ON_READ = "jet.source.copyonread";
+
+    /**
+     * When reading files from local file system using Hadoop, each processor
+     * reads files from its own local file system. If the local file system
+     * is shared between members, e.g multiple members on a machine, you should
+     * configure this property as {@code true}.
+     * <p>
+     * Here is how you can configure the source. Default value is {@code false}:
+     *
+     * <pre>{@code
+     *     Configuration conf = new Configuration();
+     *     conf.setBoolean(HadoopSources.SHARED_LOCAL_FS, true);
+     *     BatchSource<Entry<K, V>> source = HadoopSources.inputFormat(conf);
+     * }</pre>
+     */
+    public static final String SHARED_LOCAL_FS = "jet.source.sharedlocalfs";
 
     private HadoopSources() {
     }

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/HadoopSources.java
@@ -81,6 +81,8 @@ public final class HadoopSources {
      *     conf.setBoolean(HadoopSources.SHARED_LOCAL_FS, true);
      *     BatchSource<Entry<K, V>> source = HadoopSources.inputFormat(conf);
      * }</pre>
+     *
+     * @since 4.4
      */
     public static final String SHARED_LOCAL_FS = "jet.source.sharedlocalfs";
 

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/HadoopFileSourceFactory.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/HadoopFileSourceFactory.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.hadoop.impl;
 import com.hazelcast.function.BiFunctionEx;
 import com.hazelcast.jet.JetException;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
+import com.hazelcast.jet.hadoop.HadoopSources;
 import com.hazelcast.jet.pipeline.file.AvroFileFormat;
 import com.hazelcast.jet.pipeline.file.CsvFileFormat;
 import com.hazelcast.jet.pipeline.file.FileFormat;
@@ -104,6 +105,7 @@ public class HadoopFileSourceFactory implements FileSourceFactory {
             Configuration configuration = job.getConfiguration();
             configuration.setBoolean(FileInputFormat.INPUT_DIR_NONRECURSIVE_IGNORE_SUBDIRS, true);
             configuration.setBoolean(FileInputFormat.INPUT_DIR_RECURSIVE, false);
+            configuration.setBoolean(HadoopSources.SHARED_LOCAL_FS, fsc.isSharedFileSystem());
             for (Entry<String, String> option : fsc.getOptions().entrySet()) {
                 configuration.set(option.getKey(), option.getValue());
             }

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopNewApiP.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopNewApiP.java
@@ -247,21 +247,21 @@ public final class ReadHadoopNewApiP<K, V, R> extends AbstractProcessor {
             return false;
         }
         // Local file system is not marked as shared, throw exception if
-        // there are local file system and shared file system in the inputs.
+        // there are local file system and remote file system in the inputs.
         Job job = uncheckCall(() -> Job.getInstance(configuration));
         Path[] inputPaths = FileInputFormat.getInputPaths(job);
         boolean hasLocalFileSystem = false;
-        boolean hasSharedFileSystem = false;
+        boolean hasRemoteFileSystem = false;
         for (Path inputPath : inputPaths) {
             if (isLocalFileSystem(inputPath, configuration)) {
                 hasLocalFileSystem = true;
             } else {
-                hasSharedFileSystem = true;
+                hasRemoteFileSystem = true;
             }
         }
-        if (hasLocalFileSystem && hasSharedFileSystem) {
+        if (hasLocalFileSystem && hasRemoteFileSystem) {
             throw new IllegalArgumentException(
-                    "LocalFileSystem should be marked as shared when used with other shared file systems");
+                    "LocalFileSystem should be marked as shared when used with other remote file systems");
         }
         return hasLocalFileSystem;
     }

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopOldApiP.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHadoopOldApiP.java
@@ -170,20 +170,20 @@ public final class ReadHadoopOldApiP<K, V, R> extends AbstractProcessor {
             return false;
         }
         // Local file system is not marked as shared, throw exception if
-        // there are local file system and shared file system in the inputs.
+        // there are local file system and remote file system in the inputs.
         Path[] inputPaths = FileInputFormat.getInputPaths(jobConf);
         boolean hasLocalFileSystem = false;
-        boolean hasSharedFileSystem = false;
+        boolean hasRemoteFileSystem = false;
         for (Path inputPath : inputPaths) {
             if (isLocalFileSystem(inputPath, jobConf)) {
                 hasLocalFileSystem = true;
             } else {
-                hasSharedFileSystem = true;
+                hasRemoteFileSystem = true;
             }
         }
-        if (hasLocalFileSystem && hasSharedFileSystem) {
+        if (hasLocalFileSystem && hasRemoteFileSystem) {
             throw new IllegalArgumentException(
-                    "LocalFileSystem should be marked as shared when used with other shared file systems");
+                    "LocalFileSystem should be marked as shared when used with other remote file systems");
         }
         return hasLocalFileSystem;
     }

--- a/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHdfsMetaSupplierBase.java
+++ b/extensions/hadoop/src/main/java/com/hazelcast/jet/hadoop/impl/ReadHdfsMetaSupplierBase.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.hadoop.impl;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.jet.core.ProcessorMetaSupplier;
 import com.hazelcast.jet.impl.util.ExceptionUtil;
+import com.hazelcast.jet.pipeline.file.impl.FileProcessorMetaSupplier;
 import com.hazelcast.logging.ILogger;
 
 import javax.annotation.Nonnull;
@@ -50,7 +51,7 @@ import static java.util.stream.Stream.concat;
  * Base class that contains shared logic between HDFS processor meta suppliers
  * which are using the old and the new MapReduce API.
  */
-public abstract class ReadHdfsMetaSupplierBase implements ProcessorMetaSupplier {
+public abstract class ReadHdfsMetaSupplierBase<R> implements ProcessorMetaSupplier, FileProcessorMetaSupplier<R> {
 
     protected transient ILogger logger;
 

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/SharedFilesystemFileTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/SharedFilesystemFileTest.java
@@ -22,15 +22,11 @@ import com.hazelcast.jet.pipeline.file.FileSources;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class SharedFilesystemFileTest extends BaseFileFormatTest {
 
-
     @Test
     public void shouldReadFileOnlyOnceOnSharedFilesystem() {
-        assumeThat(useHadoop).isFalse();
-
         FileSourceBuilder<String> source = FileSources.files(currentDir + "/src/test/resources/directory/")
                                                       .format(FileFormat.lines())
                                                       .sharedFileSystem(true);

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/WriteHadoopPTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/impl/WriteHadoopPTest.java
@@ -130,17 +130,20 @@ public class WriteHadoopPTest extends HadoopTestSupport {
     }
 
     private Configuration getReadJobConf(org.apache.hadoop.fs.Path path) throws IOException {
+        Configuration configuration;
         if (inputFormatClass.getPackage().getName().contains("mapreduce")) {
             Job job = Job.getInstance();
             job.setInputFormatClass(inputFormatClass);
             org.apache.hadoop.mapreduce.lib.input.FileInputFormat.addInputPath(job, path);
-            return job.getConfiguration();
+            configuration = job.getConfiguration();
         } else {
             JobConf conf = new JobConf();
             conf.setInputFormat(inputFormatClass);
             FileInputFormat.addInputPath(conf, path);
-            return conf;
+            configuration = conf;
         }
+        configuration.setBoolean(HadoopSources.SHARED_LOCAL_FS, true);
+        return configuration;
     }
 
     private Configuration getSinkConf(org.apache.hadoop.fs.Path path) throws IOException {


### PR DESCRIPTION
When reading local files using Hadoop, the source splits the input on one of the members and distributes those splits to other members, ignoring the files on other members. With the fix, source splits the input on all members if the input belongs to local file system. 

We've also introduced a property `HadoopSources.SHARED_LOCAL_FS`. It can be used to mark the local file system as shared (e.g multiple members on a machine).

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [x] New public APIs have `@since` tags in Javadoc
- [ ] Updated `examples/README.md` (when adding a new code sample)
