### PR TITLE
Fix peek after rebalance issue

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -88,7 +88,7 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     static final FunctionAdapter DO_NOT_ADAPT = new FunctionAdapter();
 
     @Nonnull
-    public FunctionAdapter fnAdapter;
+    public final FunctionAdapter fnAdapter;
     boolean isRebalanceOutput;
     FunctionEx<? super T, ?> rebalanceKeyFn;
 

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/pipeline/ComputeStageImplBase.java
@@ -89,8 +89,8 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
 
     @Nonnull
     public FunctionAdapter fnAdapter;
-    final boolean isRebalanceOutput;
-    final FunctionEx<? super T, ?> rebalanceKeyFn;
+    boolean isRebalanceOutput;
+    FunctionEx<? super T, ?> rebalanceKeyFn;
 
     private ComputeStageImplBase(
             @Nonnull Transform transform,
@@ -517,9 +517,12 @@ public abstract class ComputeStageImplBase<T> extends AbstractStage {
     ) {
         checkSerializable(shouldLogFn, "shouldLogFn");
         checkSerializable(toStringFn, "toStringFn");
-        return attach(new PeekTransform(transform, fnAdapter.adaptFilterFn(shouldLogFn),
+        ComputeStageImplBase peekStage = attach(new PeekTransform(transform, fnAdapter.adaptFilterFn(shouldLogFn),
                 fnAdapter.adaptToStringFn(toStringFn)
         ), fnAdapter);
+        peekStage.isRebalanceOutput = isRebalanceOutput;
+        peekStage.rebalanceKeyFn = rebalanceKeyFn;
+        return (RET) peekStage;
     }
 
     @Nonnull

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/RebalanceStreamStageTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/pipeline/RebalanceStreamStageTest.java
@@ -79,6 +79,45 @@ public class RebalanceStreamStageTest extends PipelineStreamTestSupport {
     }
 
     @Test
+    public void when_rebalanceAndPeekAndMap_then_dagEdgeDistributed() {
+        // Given
+        List<Integer> input = sequence(itemCount);
+        StreamStage<Integer> srcStage = streamStageFromList(input);
+        FunctionEx<Integer, String> formatFn = i -> String.format("%04d-string", i);
+
+        // When
+        StreamStage<String> mapped = srcStage.rebalance().peek().map(formatFn);
+
+        // Then
+        mapped.writeTo(sink);
+        DAG dag = p.toDag();
+        Edge srcToMap = dag.getInboundEdges("map").get(0);
+        assertTrue("Rebalancing should make the edge distributed", srcToMap.isDistributed());
+        assertNull("Didn't rebalance by key, the edge must not be partitioned", srcToMap.getPartitioner());
+        execute();
+        assertEquals(streamToString(input.stream(), formatFn),
+                streamToString(sinkStreamOf(String.class), identity()));
+    }
+
+    @Test
+    public void when_rebalanceByKeyAndPeekAndMap_then_dagEdgePartitionedDistributed() {
+        // Given
+        List<Integer> input = sequence(itemCount);
+        StreamStage<Integer> srcStage = streamStageFromList(input);
+        FunctionEx<Integer, String> formatFn = i -> String.format("%04d-string", i);
+
+        // When
+        StreamStage<String> mapped = srcStage.rebalance(i -> i).peek().map(formatFn);
+
+        // Then
+        mapped.writeTo(sink);
+        DAG dag = p.toDag();
+        Edge srcToMap = dag.getInboundEdges("map").get(0);
+        assertTrue("Rebalancing should make the edge distributed", srcToMap.isDistributed());
+        assertNotNull("Rebalanced by key, the edge must be partitioned", srcToMap.getPartitioner());
+    }
+
+    @Test
     public void when_rebalanceAndWindowAggregate_then_unicastDistributedEdgeAndTwoStageAggregation() {
         List<Integer> input = sequence(itemCount);
         StreamStage<Integer> srcStage = streamStageFromList(input);


### PR DESCRIPTION
There was a problem if peek was called after rebalance. This pr solves that issue.

Fixes #2760

Checklist:
- [x] Labels and Milestone set
