### PR TITLE
Fix sql cli crash

### DIFF
--- a/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
+++ b/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
@@ -1128,10 +1128,15 @@ public class JetCommandLine implements Runnable {
         builder.append("|");
         int columnCount = row.getMetadata().getColumnCount();
         for (int i = 0; i < columnCount; i++) {
-            String colValue = row.getObject(i).toString();
-            colValue = sanitize(colValue, colWidths[i]);
+            String colString;
+            Object columnValue = row.getObject(i);
+            if (columnValue != null) {
+                colString = sanitize(columnValue.toString(), colWidths[i]);
+            } else {
+                colString = "NULL";
+            }
             builder.style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR));
-            appendAligned(colWidths[i], colValue, alignments[i], builder);
+            appendAligned(colWidths[i], colString, alignments[i], builder);
             builder.style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));
             builder.append('|');
         }

--- a/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
+++ b/hazelcast-jet-all/src/main/java/com/hazelcast/jet/server/JetCommandLine.java
@@ -1128,13 +1128,7 @@ public class JetCommandLine implements Runnable {
         builder.append("|");
         int columnCount = row.getMetadata().getColumnCount();
         for (int i = 0; i < columnCount; i++) {
-            String colString;
-            Object columnValue = row.getObject(i);
-            if (columnValue != null) {
-                colString = sanitize(columnValue.toString(), colWidths[i]);
-            } else {
-                colString = "NULL";
-            }
+            String colString = row.getObject(i) != null ? sanitize(row.getObject(i).toString(), colWidths[i]) : "NULL";
             builder.style(AttributedStyle.BOLD.foreground(PRIMARY_COLOR));
             appendAligned(colWidths[i], colString, alignments[i], builder);
             builder.style(AttributedStyle.BOLD.foreground(SECONDARY_COLOR));


### PR DESCRIPTION
Formerly, the cli was crashing because of the absence of the null check for the column values. This PR adds null check to solve this issue.

Fixes: #2768 

Checklist:
- [x] Labels and Milestone set
