### PR TITLE
Modify peek javadoc to show peek after rebalance isn't supported

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -1184,6 +1184,8 @@ public interface GeneralStage<T> extends Stage {
      * receive it. Its primary purpose is for development use, when running Jet
      * on a local machine.
      * <p>
+     * Note that peek() after rebalance() operation is not supported.
+     * <p>
      * Sample usage:
      * <pre>{@code
      * users.peek(

--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/pipeline/GeneralStage.java
@@ -1184,7 +1184,7 @@ public interface GeneralStage<T> extends Stage {
      * receive it. Its primary purpose is for development use, when running Jet
      * on a local machine.
      * <p>
-     * Note that peek() after rebalance() operation is not supported.
+     * Note that peek after {@link #rebalance(FunctionEx)} operation is not supported.
      * <p>
      * Sample usage:
      * <pre>{@code
@@ -1225,6 +1225,8 @@ public interface GeneralStage<T> extends Stage {
      * receive it. Its primary purpose is for development use, when running Jet
      * on a local machine.
      * <p>
+     * Note that peek after {@link #rebalance(FunctionEx)} operation is not supported.
+     * <p>
      * Sample usage:
      * <pre>{@code
      * users.peek(User::getName)
@@ -1251,6 +1253,8 @@ public interface GeneralStage<T> extends Stage {
      * The stage logs each item on whichever cluster member it happens to
      * receive it. Its primary purpose is for development use, when running Jet
      * on a local machine.
+     * <p>
+     * Note that peek after {@link #rebalance(FunctionEx)} is not supported.
      *
      * @return the newly attached stage
      * @see #peek(PredicateEx, FunctionEx)


### PR DESCRIPTION
After #2765 peek is not supported if used after rebalance. This pull request modify peek Javadoc so it's now properly documented that peek after rebalance isn't supported.

Checklist:
- [x] Labels and Milestone set
