### PR TITLE
Fix double __key column

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/KafkaTestSupport.java
@@ -81,6 +81,7 @@ public class KafkaTestSupport {
 
     private KafkaServer kafkaServer;
     private KafkaProducer<Integer, String> producer;
+    private KafkaProducer<String, String> stringStringProducer;
     private int brokerPort = -1;
     private String brokerConnectionString;
 
@@ -175,6 +176,10 @@ public class KafkaTestSupport {
         return getProducer().send(new ProducerRecord<>(topic, key, value));
     }
 
+    public Future<RecordMetadata> produce(String topic, String key, String value) {
+        return getStringStringProducer().send(new ProducerRecord<>(topic, key, value));
+    }
+
     Future<RecordMetadata> produce(String topic, int partition, Long timestamp, Integer key, String value) {
         return getProducer().send(new ProducerRecord<>(topic, partition, timestamp, key, value));
     }
@@ -188,6 +193,17 @@ public class KafkaTestSupport {
             producer = new KafkaProducer<>(producerProps);
         }
         return producer;
+    }
+
+    private KafkaProducer<String, String> getStringStringProducer() {
+        if (stringStringProducer == null) {
+            Properties producerProps = new Properties();
+            producerProps.setProperty("bootstrap.servers", BROKER_HOST + ':' + brokerPort);
+            producerProps.setProperty("key.serializer", StringSerializer.class.getCanonicalName());
+            producerProps.setProperty("value.serializer", StringSerializer.class.getCanonicalName());
+            stringStringProducer = new KafkaProducer<>(producerProps);
+        }
+        return stringStringProducer;
     }
 
     public void resetProducer() {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
@@ -95,7 +95,7 @@ public final class KvMetadataAvroResolver implements KvMetadataResolver {
             fields.add(new MapTableField(name, type, false, path));
         }
 
-        maybeAddDefaultField(isKey, externalFieldsByPath, fields);
+        maybeAddDefaultField(isKey, resolvedFields, fields);
         return new KvMetadata(
                 fields,
                 AvroQueryTargetDescriptor.INSTANCE,

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
@@ -200,7 +200,8 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
 
     private KvMetadata resolveObjectMetadata(
             boolean isKey,
-            List<MappingField> resolvedFields, Map<QueryPath, MappingField> externalFieldsByPath,
+            List<MappingField> resolvedFields,
+            Map<QueryPath, MappingField> externalFieldsByPath,
             Class<?> clazz
     ) {
         Map<String, Class<?>> typesByNames = FieldsUtil.resolveClass(clazz);

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
@@ -44,6 +44,7 @@ import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers.
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers.maybeAddDefaultField;
 import static com.hazelcast.sql.impl.extract.QueryPath.KEY;
 import static com.hazelcast.sql.impl.extract.QueryPath.VALUE;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 /**
@@ -101,6 +102,11 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
                     + mappingField.name() + "'");
         }
         String name = mappingField == null ? (isKey ? KEY : VALUE) : mappingField.name();
+        if (mappingField == null && userFields.stream().anyMatch(f -> f.name().equals(name))) {
+            // The user didn't specify the column himself, but he specified some other column under
+            // the name we would like to specify our column - we can't resolve any columns
+            return emptyList();
+        }
 
         MappingField field = new MappingField(name, type, path.toString());
 
@@ -175,7 +181,7 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
         if (type != QueryDataType.OBJECT) {
             return resolvePrimitiveMetadata(isKey, externalFieldsByPath);
         } else {
-            return resolveObjectMetadata(isKey, externalFieldsByPath, clazz);
+            return resolveObjectMetadata(isKey, resolvedFields, externalFieldsByPath, clazz);
         }
     }
 
@@ -183,10 +189,10 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
         QueryPath path = isKey ? QueryPath.KEY_PATH : QueryPath.VALUE_PATH;
         MappingField mappingField = externalFieldsByPath.get(path);
 
-        TableField field = new MapTableField(mappingField.name(), mappingField.type(), false, path);
-
         return new KvMetadata(
-                singletonList(field),
+                mappingField != null
+                        ? singletonList(new MapTableField(mappingField.name(), mappingField.type(), false, path))
+                        : emptyList(),
                 GenericQueryTargetDescriptor.DEFAULT,
                 PrimitiveUpsertTargetDescriptor.INSTANCE
         );
@@ -194,7 +200,7 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
 
     private KvMetadata resolveObjectMetadata(
             boolean isKey,
-            Map<QueryPath, MappingField> externalFieldsByPath,
+            List<MappingField> resolvedFields, Map<QueryPath, MappingField> externalFieldsByPath,
             Class<?> clazz
     ) {
         Map<String, Class<?>> typesByNames = FieldsUtil.resolveClass(clazz);
@@ -212,7 +218,7 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
             }
         }
 
-        maybeAddDefaultField(isKey, externalFieldsByPath, fields);
+        maybeAddDefaultField(isKey, resolvedFields, fields);
         return new KvMetadata(
                 fields,
                 GenericQueryTargetDescriptor.DEFAULT,

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJsonResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJsonResolver.java
@@ -92,7 +92,7 @@ public final class KvMetadataJsonResolver implements KvMetadataResolver {
             fields.add(new MapTableField(name, type, false, path));
         }
 
-        maybeAddDefaultField(isKey, externalFieldsByPath, fields);
+        maybeAddDefaultField(isKey, resolvedFields, fields);
         return new KvMetadata(
                 fields,
                 JsonQueryTargetDescriptor.INSTANCE,

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
@@ -165,7 +165,7 @@ public class KvMetadataResolvers {
             @Nonnull List<MappingField> resolvedFields,
             @Nonnull List<TableField> tableFields
     ) {
-        // Add the default `__key` or `this` field as hidden, if  present neither in the external
+        // Add the default `__key` or `this` field as hidden, if present neither in the external
         // names, nor in the field names
         String fieldName = isKey ? KEY : VALUE;
         if (resolvedFields.stream().noneMatch(f -> f.externalName().equals(fieldName) || f.name().equals(fieldName))) {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
@@ -162,15 +162,14 @@ public class KvMetadataResolvers {
 
     public static void maybeAddDefaultField(
             boolean isKey,
-            @Nonnull Map<QueryPath, MappingField> externalFieldsByPath,
+            @Nonnull List<MappingField> resolvedFields,
             @Nonnull List<TableField> tableFields
     ) {
-        // Add the default `__key` or `this` field as hidden, if not present in the external
-        // names (the path), nor in the field names
-        QueryPath path = isKey ? QueryPath.KEY_PATH : QueryPath.VALUE_PATH;
-        if (!externalFieldsByPath.containsKey(path)
-                && tableFields.stream().noneMatch(f -> f.getName().equals(path.toString()))) {
-            tableFields.add(new MapTableField(path.toString(), QueryDataType.OBJECT, true, path));
+        // Add the default `__key` or `this` field as hidden, if  present neither in the external
+        // names, nor in the field names
+        String fieldName = isKey ? KEY : VALUE;
+        if (resolvedFields.stream().noneMatch(f -> f.externalName().equals(fieldName) || f.name().equals(fieldName))) {
+            tableFields.add(new MapTableField(fieldName, QueryDataType.OBJECT, true, QueryPath.create(fieldName)));
         }
     }
 }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataJsonResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataJsonResolver.java
@@ -94,7 +94,7 @@ final class MetadataJsonResolver implements KvMetadataResolver {
             fields.add(new MapTableField(name, type, false, path));
         }
 
-        maybeAddDefaultField(isKey, externalFieldsByPath, fields);
+        maybeAddDefaultField(isKey, resolvedFields, fields);
         return new KvMetadata(
                 fields,
                 HazelcastJsonQueryTargetDescriptor.INSTANCE,

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolver.java
@@ -168,7 +168,7 @@ final class MetadataPortableResolver implements KvMetadataResolver {
             fields.add(new MapTableField(name, type, false, path));
         }
 
-        maybeAddDefaultField(isKey, externalFieldsByPath, fields);
+        maybeAddDefaultField(isKey, resolvedFields, fields);
         return new KvMetadata(
                 fields,
                 GenericQueryTargetDescriptor.DEFAULT,

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -56,6 +56,8 @@ import java.util.Properties;
 
 import static com.hazelcast.jet.core.TestUtil.createMap;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.AVRO_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static java.time.ZoneOffset.UTC;
@@ -280,7 +282,7 @@ public class SqlAvroTest extends SqlTestSupport {
         when_explicitTopLevelField_then_fail("this", "__key");
     }
 
-    public void when_explicitTopLevelField_then_fail(String field, String otherField) {
+    private void when_explicitTopLevelField_then_fail(String field, String otherField) {
         String name = randomName();
         assertThatThrownBy(() ->
                 sqlService.execute("CREATE MAPPING " + name + " ("
@@ -295,6 +297,31 @@ public class SqlAvroTest extends SqlTestSupport {
                         + ")"))
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasMessage("Cannot use the '" + field + "' field with Avro serialization");
+    }
+
+    @Test
+    public void test_valueFieldMappedUnderTopLevelKeyName() {
+        String name = createRandomTopic();
+        sqlService.execute("CREATE MAPPING " + name + "(\n"
+                + "__key INT EXTERNAL NAME id\n"
+                + ", name VARCHAR\n"
+                + ')' + "TYPE " + KafkaSqlConnector.TYPE_NAME + " \n"
+                + "OPTIONS (\n"
+                + '\'' + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "'\n"
+                + ", '" + OPTION_KEY_CLASS + "'='" + String.class.getName() + "'\n"
+                + ", '" + OPTION_VALUE_FORMAT + "'='" + AVRO_FORMAT + "'\n"
+                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "'\n"
+                + ", 'schema.registry.url'='" + schemaRegistry.getURI() + "'\n"
+                + ", 'auto.offset.reset'='earliest'"
+                + ")"
+        );
+
+        sqlService.execute("INSERT INTO " + name + " VALUES(123, 'foo')");
+
+        assertRowsEventuallyInAnyOrder(
+                "select __key, name from " + name,
+                singletonList(new Row(123, "foo"))
+        );
     }
 
     @Test
@@ -417,28 +444,6 @@ public class SqlAvroTest extends SqlTestSupport {
             }
             assertEquals("The schemaIds of the two records don't match", schemaIds.get(0), schemaIds.get(1));
         }
-    }
-
-    @Test
-    public void test_valueFieldMappedUnderTopLevelKeyName() {
-        String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + "(\n" +
-                "__key INT EXTERNAL NAME id,\n" +
-                "name VARCHAR\n" +
-                ")\n" +
-                "TYPE kafka\n" +
-                "OPTIONS (\n" +
-                "   'keyFormat'='java',\n" +
-                "   'keyJavaClass'='java.lang.String',\n" +
-                "   'valueFormat'='avro',\n" +
-                "   'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "',\n" +
-                "   'schema.registry.url'='" + schemaRegistry.getURI() + "',\n" +
-                "   'auto.offset.reset'='earliest')");
-
-        sqlService.execute("INSERT INTO " + name + " VALUES(123, 'foo')");
-
-        assertRowsEventuallyInAnyOrder("select __key, name from " + name,
-                singletonList(new Row(123, "foo")));
     }
 
     private static String createRandomTopic() {

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlAvroTest.java
@@ -419,6 +419,28 @@ public class SqlAvroTest extends SqlTestSupport {
         }
     }
 
+    @Test
+    public void test_valueFieldMappedUnderTopLevelKeyName() {
+        String name = createRandomTopic();
+        sqlService.execute("CREATE MAPPING " + name + "(\n" +
+                "__key INT EXTERNAL NAME id,\n" +
+                "name VARCHAR\n" +
+                ")\n" +
+                "TYPE kafka\n" +
+                "OPTIONS (\n" +
+                "   'keyFormat'='java',\n" +
+                "   'keyJavaClass'='java.lang.String',\n" +
+                "   'valueFormat'='avro',\n" +
+                "   'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "',\n" +
+                "   'schema.registry.url'='" + schemaRegistry.getURI() + "',\n" +
+                "   'auto.offset.reset'='earliest')");
+
+        sqlService.execute("INSERT INTO " + name + " VALUES(123, 'foo')");
+
+        assertRowsEventuallyInAnyOrder("select __key, name from " + name,
+                singletonList(new Row(123, "foo")));
+    }
+
     private static String createRandomTopic() {
         String topicName = "t_" + randomString().replace('-', '_');
         kafkaTestSupport.createTopic(topicName, INITIAL_PARTITION_COUNT);

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
@@ -337,6 +337,26 @@ public class SqlJsonTest extends SqlTestSupport {
         );
     }
 
+    @Test
+    public void test_valueFieldMappedUnderTopLevelKeyName() {
+        String name = createRandomTopic();
+        sqlService.execute("CREATE MAPPING " + name + "(\n" +
+                "__key BIGINT EXTERNAL NAME id,\n" +
+                "field BIGINT\n" +
+                ")\n" +
+                "TYPE kafka\n" +
+                "OPTIONS (\n" +
+                "   'keyFormat'='json',\n" +
+                "   'valueFormat'='json',\n" +
+                "   'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "',\n" +
+                "   'auto.offset.reset'='earliest')");
+
+        kafkaTestSupport.produce(name, "{}", "{\"id\":123,\"field\":456}");
+
+        assertRowsEventuallyInAnyOrder("select __key, field from " + name,
+                singletonList(new Row(123L, 456L)));
+    }
+
     private static String createRandomTopic() {
         String topicName = "t_" + randomString().replace('-', '_');
         kafkaTestSupport.createTopic(topicName, INITIAL_PARTITION_COUNT);

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlJsonTest.java
@@ -239,7 +239,7 @@ public class SqlJsonTest extends SqlTestSupport {
         when_explicitTopLevelField_then_fail("this", "__key");
     }
 
-    public void when_explicitTopLevelField_then_fail(String field, String otherField) {
+    private void when_explicitTopLevelField_then_fail(String field, String otherField) {
         String name = randomName();
         assertThatThrownBy(() ->
                 sqlService.execute("CREATE MAPPING " + name + " ("
@@ -254,6 +254,29 @@ public class SqlJsonTest extends SqlTestSupport {
                         + ")"))
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasMessage("Cannot use the '" + field + "' field with JSON serialization");
+    }
+
+    @Test
+    public void test_valueFieldMappedUnderTopLevelKeyName() {
+        String name = createRandomTopic();
+        sqlService.execute("CREATE MAPPING " + name + "(\n"
+                + "__key BIGINT EXTERNAL NAME id\n"
+                + ", field BIGINT\n"
+                + ')' + "TYPE " + KafkaSqlConnector.TYPE_NAME + " \n"
+                + "OPTIONS (\n"
+                + '\'' + OPTION_KEY_FORMAT + "'='" + JSON_FORMAT + "'\n"
+                + ", '" + OPTION_VALUE_FORMAT + "'='" + JSON_FORMAT + "'\n"
+                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "'\n"
+                + ", 'auto.offset.reset'='earliest'"
+                + ")"
+        );
+
+        kafkaTestSupport.produce(name, "{}", "{\"id\":123,\"field\":456}");
+
+        assertRowsEventuallyInAnyOrder(
+                "select __key, field from " + name,
+                singletonList(new Row(123L, 456L))
+        );
     }
 
     @Test
@@ -335,26 +358,6 @@ public class SqlJsonTest extends SqlTestSupport {
                 "SELECT * FROM " + name,
                 singletonList(new Row("Alice", "Bob"))
         );
-    }
-
-    @Test
-    public void test_valueFieldMappedUnderTopLevelKeyName() {
-        String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + "(\n" +
-                "__key BIGINT EXTERNAL NAME id,\n" +
-                "field BIGINT\n" +
-                ")\n" +
-                "TYPE kafka\n" +
-                "OPTIONS (\n" +
-                "   'keyFormat'='json',\n" +
-                "   'valueFormat'='json',\n" +
-                "   'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "',\n" +
-                "   'auto.offset.reset'='earliest')");
-
-        kafkaTestSupport.produce(name, "{}", "{\"id\":123,\"field\":456}");
-
-        assertRowsEventuallyInAnyOrder("select __key, field from " + name,
-                singletonList(new Row(123L, 456L)));
     }
 
     private static String createRandomTopic() {

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPojoTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPojoTest.java
@@ -252,6 +252,33 @@ public class SqlPojoTest extends SqlTestSupport {
     }
 
     @Test
+    public void test_valueFieldMappedUnderTopLevelKeyName() {
+        String name = createRandomTopic();
+        sqlService.execute("CREATE MAPPING " + name + "(\n"
+                + "__key INT EXTERNAL NAME id\n"
+                + ", name VARCHAR\n"
+                + ')' + "TYPE " + KafkaSqlConnector.TYPE_NAME + " \n"
+                + "OPTIONS (\n"
+                + '\'' + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "'\n"
+                + ", '" + OPTION_KEY_CLASS + "'='" + String.class.getName() + "'\n"
+                + ", '" + OPTION_VALUE_FORMAT + "'='" + JAVA_FORMAT + "'\n"
+                + ", '" + OPTION_VALUE_CLASS + "'='" + Person.class.getName() + "'\n"
+                + ", 'value.serializer'='" + PersonSerializer.class.getCanonicalName() + "'\n"
+                + ", 'value.deserializer'='" + PersonDeserializer.class.getCanonicalName() + "'\n"
+                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "'\n"
+                + ", 'auto.offset.reset'='earliest'"
+                + ")"
+        );
+
+        sqlService.execute("INSERT INTO " + name + " VALUES(123, 'foo')");
+
+        assertRowsEventuallyInAnyOrder(
+                "select __key, name from " + name,
+                singletonList(new Row(123, "foo"))
+        );
+    }
+
+    @Test
     public void test_writingToTopLevelWhileNestedFieldMapped_explicit() {
         test_writingToTopLevel(true);
     }
@@ -324,30 +351,6 @@ public class SqlPojoTest extends SqlTestSupport {
                 "SELECT __key, this FROM " + name,
                 singletonList(new Row(new PersonId(1), new Person(null, "Alice")))
         );
-    }
-
-    @Test
-    public void test_valueFieldMappedUnderTopLevelKeyName() {
-        String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + "(\n" +
-                "__key INT EXTERNAL NAME id,\n" +
-                "name VARCHAR\n" +
-                ")\n" +
-                "TYPE kafka\n" +
-                "OPTIONS (\n" +
-                "   'keyFormat'='java',\n" +
-                "   'keyJavaClass'='java.lang.String',\n" +
-                "   'valueFormat'='java',\n" +
-                "   'valueJavaClass'='" + Person.class.getName() + "',\n" +
-                "   'value.serializer'='" + PersonSerializer.class.getCanonicalName() + "',\n" +
-                "   'value.deserializer'='" + PersonDeserializer.class.getCanonicalName() + "',\n" +
-                "   'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "',\n" +
-                "   'auto.offset.reset'='earliest')");
-
-        sqlService.execute("INSERT INTO " + name + " VALUES(123, 'foo')");
-
-        assertRowsEventuallyInAnyOrder("select __key, name from " + name,
-                singletonList(new Row(123, "foo")));
     }
 
     private static String createRandomTopic() {

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
@@ -361,6 +361,27 @@ public class SqlPrimitiveTest extends SqlTestSupport {
         test_multipleFieldsForPrimitive("this");
     }
 
+    @Test
+    public void test_valueFieldMappedUnderTopLevelKeyName() {
+        String name = createRandomTopic();
+        sqlService.execute("CREATE MAPPING " + name + "(\n" +
+                "__key BIGINT EXTERNAL NAME id,\n" +
+                "field BIGINT\n" +
+                ")\n" +
+                "TYPE kafka\n" +
+                "OPTIONS (\n" +
+                "   'keyFormat'='java',\n" +
+                "   'keyJavaClass'='java.lang.Integer',\n" +
+                "   'valueFormat'='json',\n" +
+                "   'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "',\n" +
+                "   'auto.offset.reset'='earliest')");
+
+        kafkaTestSupport.produce(name, 1, "{\"id\":123,\"field\":456}");
+
+        assertRowsEventuallyInAnyOrder("select __key, field from " + name,
+                singletonList(new Row(123L, 456L)));
+    }
+
     private void test_multipleFieldsForPrimitive(String fieldName) {
         String mapName = randomName();
         assertThatThrownBy(

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/kafka/SqlPrimitiveTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static com.hazelcast.jet.core.TestUtil.createMap;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JSON_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLASS;
@@ -361,27 +362,6 @@ public class SqlPrimitiveTest extends SqlTestSupport {
         test_multipleFieldsForPrimitive("this");
     }
 
-    @Test
-    public void test_valueFieldMappedUnderTopLevelKeyName() {
-        String name = createRandomTopic();
-        sqlService.execute("CREATE MAPPING " + name + "(\n" +
-                "__key BIGINT EXTERNAL NAME id,\n" +
-                "field BIGINT\n" +
-                ")\n" +
-                "TYPE kafka\n" +
-                "OPTIONS (\n" +
-                "   'keyFormat'='java',\n" +
-                "   'keyJavaClass'='java.lang.Integer',\n" +
-                "   'valueFormat'='json',\n" +
-                "   'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "',\n" +
-                "   'auto.offset.reset'='earliest')");
-
-        kafkaTestSupport.produce(name, 1, "{\"id\":123,\"field\":456}");
-
-        assertRowsEventuallyInAnyOrder("select __key, field from " + name,
-                singletonList(new Row(123L, 456L)));
-    }
-
     private void test_multipleFieldsForPrimitive(String fieldName) {
         String mapName = randomName();
         assertThatThrownBy(
@@ -394,9 +374,32 @@ public class SqlPrimitiveTest extends SqlTestSupport {
                         + '\'' + OPTION_VALUE_CLASS + "'='" + Integer.class.getName() + "',"
                         + '\'' + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "',"
                         + '\'' + OPTION_KEY_CLASS + "'='" + Integer.class.getName() + "'"
-                        + ")"))
-                .hasMessage(
-                        "The field '" + fieldName + "' is of type INTEGER, you can't map '" + fieldName + ".field' too");
+                        + ")")
+        ).hasMessage("The field '" + fieldName + "' is of type INTEGER, you can't map '" + fieldName + ".field' too");
+    }
+
+    @Test
+    public void test_valueFieldMappedUnderTopLevelKeyName() {
+        String name = createRandomTopic();
+        sqlService.execute("CREATE MAPPING " + name + "(\n"
+                + "__key BIGINT EXTERNAL NAME id\n"
+                + ", field BIGINT\n"
+                + ')' + "TYPE " + KafkaSqlConnector.TYPE_NAME + " \n"
+                + "OPTIONS (\n"
+                + '\''  + OPTION_KEY_FORMAT + "'='" + JAVA_FORMAT + "'\n"
+                + ", '" + OPTION_KEY_CLASS + "'='" + Integer.class.getName() + "'\n"
+                + ", '" + OPTION_VALUE_FORMAT + "'='" + JSON_FORMAT + "'\n"
+                + ", 'bootstrap.servers'='" + kafkaTestSupport.getBrokerConnectionString() + "'\n"
+                + ", 'auto.offset.reset'='earliest'"
+                + ")"
+        );
+
+        kafkaTestSupport.produce(name, 1, "{\"id\":123,\"field\":456}");
+
+        assertRowsEventuallyInAnyOrder(
+                "select __key, field from " + name,
+                singletonList(new Row(123L, 456L))
+        );
     }
 
     private static String createRandomTopic() {


### PR DESCRIPTION
Multiple issues fixed:

- maybeAddDefaultField() only looked ad key's or value's fields, not at
all user fields. It would add __key for a second time if it is mapped to
value

- if __key is added as a value field, resolvePrimitiveSchema() will just
add it again. Not it leaves the key unmapped (which will fail in case of
imap because it's mandatory, but not in case of kafka)

Fixes #2793
