### PR TITLE
Simpler syntax for primitive key/value

### DIFF
--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
@@ -154,7 +154,7 @@ public class KvMetadataResolvers {
         if (formatValue == null) {
             return options;
         }
-        String classValue = null;
+        String classValue;
         switch (formatValue) {
             case "varchar":
             case "character varying":
@@ -213,6 +213,9 @@ public class KvMetadataResolvers {
             case "timestamp with time zone":
                 classValue = OffsetDateTime.class.getName();
                 break;
+
+            default:
+                classValue = null;
         }
 
         String classProperty = isKey ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS;

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
@@ -26,16 +26,25 @@ import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.map.MapTableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
+import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static com.hazelcast.sql.impl.extract.QueryPath.KEY;
 import static com.hazelcast.sql.impl.extract.QueryPath.VALUE;
@@ -104,6 +113,9 @@ public class KvMetadataResolvers {
             }
         }
 
+        options = preprocessOptions(options, true);
+        options = preprocessOptions(options, false);
+
         List<MappingField> keyFields = findMetadataResolver(options, true)
                 .resolveAndValidateFields(true, userFields, options, ss);
         List<MappingField> valueFields = findMetadataResolver(options, false)
@@ -129,8 +141,89 @@ public class KvMetadataResolvers {
             Map<String, String> options,
             InternalSerializationService serializationService
     ) {
+        options = preprocessOptions(options, isKey);
         KvMetadataResolver resolver = findMetadataResolver(options, isKey);
         return requireNonNull(resolver.resolveMetadata(isKey, resolvedFields, options, serializationService));
+    }
+
+    @CheckReturnValue
+    private Map<String, String> preprocessOptions(Map<String, String> options, boolean isKey) {
+        String formatProperty = isKey ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT;
+
+        String formatValue = options.get(formatProperty);
+        if (formatValue == null) {
+            return options;
+        }
+        String classValue = null;
+        switch (formatValue) {
+            case "varchar":
+            case "character varying":
+            case "char varying":
+                classValue = String.class.getName();
+                break;
+
+            case "boolean":
+                classValue = Boolean.class.getName();
+                break;
+
+            case "tinyint":
+                classValue = Byte.class.getName();
+                break;
+
+            case "smallint":
+                classValue = Short.class.getName();
+                break;
+
+            case "integer":
+            case "int":
+                classValue = Integer.class.getName();
+                break;
+
+            case "bigint":
+                classValue = Long.class.getName();
+                break;
+
+            case "decimal":
+            case "dec":
+            case "numeric":
+                classValue = BigDecimal.class.getName();
+                break;
+
+            case "real":
+                classValue = Float.class.getName();
+                break;
+
+            case "double":
+            case "double precision":
+                classValue = Double.class.getName();
+                break;
+
+            case "time":
+                classValue = LocalTime.class.getName();
+                break;
+
+            case "date":
+                classValue = LocalDate.class.getName();
+                break;
+
+            case "timestamp":
+                classValue = LocalDateTime.class.getName();
+                break;
+
+            case "timestamp with time zone":
+                classValue = OffsetDateTime.class.getName();
+                break;
+        }
+
+        String classProperty = isKey ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS;
+        if (classValue != null && !options.containsKey(classProperty)) {
+            Map<String, String> newOptions = new HashMap<>(options);
+            newOptions.put(formatProperty, "java");
+            newOptions.put(classProperty, classValue);
+            return newOptions;
+        }
+
+        return options;
     }
 
     private KvMetadataResolver findMetadataResolver(Map<String, String> options, boolean isKey) {

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPrimitiveTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/map/SqlPrimitiveTest.java
@@ -25,6 +25,11 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 
 import static com.hazelcast.jet.core.TestUtil.createMap;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
@@ -265,5 +270,88 @@ public class SqlPrimitiveTest extends SqlTestSupport {
                         + ")"))
                 .hasMessage(
                         "The field '" + fieldName + "' is of type INTEGER, you can't map '" + fieldName + ".field' too");
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_varchar() {
+        test_simplePrimitiveTypeSyntax("varchar", "foo");
+        test_simplePrimitiveTypeSyntax("character varying", "foo");
+        test_simplePrimitiveTypeSyntax("char varying", "foo");
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_boolean() {
+        test_simplePrimitiveTypeSyntax("boolean", true);
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_tinyint() {
+        test_simplePrimitiveTypeSyntax("tinyint", (byte) 42);
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_smallint() {
+        test_simplePrimitiveTypeSyntax("smallint", (short) 42);
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_int() {
+        test_simplePrimitiveTypeSyntax("int", 42);
+        test_simplePrimitiveTypeSyntax("integer", 42);
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_bigint() {
+        test_simplePrimitiveTypeSyntax("bigint", 42L);
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_decimal() {
+        test_simplePrimitiveTypeSyntax("decimal", BigDecimal.valueOf(42));
+        test_simplePrimitiveTypeSyntax("dec", BigDecimal.valueOf(42));
+        test_simplePrimitiveTypeSyntax("numeric", BigDecimal.valueOf(42));
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_real() {
+        test_simplePrimitiveTypeSyntax("real", 42f);
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_double() {
+        test_simplePrimitiveTypeSyntax("double", 42d);
+        test_simplePrimitiveTypeSyntax("double precision", 42d);
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_time() {
+        test_simplePrimitiveTypeSyntax("time", LocalTime.of(10, 42));
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_date() {
+        test_simplePrimitiveTypeSyntax("date", LocalDate.of(1942, 4, 2));
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_timestamp() {
+        test_simplePrimitiveTypeSyntax("timestamp", LocalDateTime.of(1942, 4, 2, 10, 42));
+    }
+
+    @Test
+    public void test_simplePrimitiveTypeSyntax_timestampWithTz() {
+        test_simplePrimitiveTypeSyntax("timestamp with time zone",
+                OffsetDateTime.of(1042, 4, 2, 10, 42, 0, 0, ZoneOffset.ofHours(4)));
+    }
+
+    private void test_simplePrimitiveTypeSyntax(String format, Object testValue) {
+        String mapName = randomName();
+        sqlService.execute("CREATE MAPPING " + mapName + " TYPE IMap " +
+                "OPTIONS ('keyFormat'='" + format + "'," +
+                "'valueFormat'='" + format + "')");
+
+        instance().getMap(mapName).put(testValue, testValue);
+
+        assertRowsAnyOrder("SELECT * FROM " + mapName, singletonList(new Row(testValue, testValue)));
     }
 }


### PR DESCRIPTION
Fixes #2792

I've kept both variants: `keyFormat=bigint` and `keyFormat=java, keyJavaClass=java.lang.Long`. The reason is that there's no type name for all of the supported classes, for example for `java.util.Date`. If you want a `java.util.Date` key, you need to use the longer variant.

This PR doesn't update the refman to avoid conflict with Marko who's working on it.