### PR TITLE
Add MaxMetaspaceSize to jvm.options

### DIFF
--- a/hazelcast-jet-distribution/src/root/config/jvm.options
+++ b/hazelcast-jet-distribution/src/root/config/jvm.options
@@ -7,6 +7,7 @@
 #-Xms4g
 #-Xmx4g
 #-XX:+AlwaysPreTouch
+#-XX:MaxMetaspaceSize=128m
 
 # Generate heap dump on out-of-memory error
 # Uncomment to enable


### PR DESCRIPTION
Saves time to lookup the exact name of the option, both for the users
and us.
