### PR TITLE
Fix when_partitionAddedWhileJobDown test failure

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -390,19 +390,19 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
             assertEquals(entry(0, "0"), sinkList.get(0));
         });
         job.suspend();
-        sinkList.clear();
 
         // When
         kafkaTestSupport.setPartitionCount(topic1Name, INITIAL_PARTITION_COUNT + 2);
         kafkaTestSupport.resetProducer(); // this allows production to the added partition
 
+        // We synchronously produce to a partition that didn't exist during the previous job execution.
+        // The job must start to read the new partition from the beginning, otherwise it would miss this item.
         kafkaTestSupport.produce(topic1Name, INITIAL_PARTITION_COUNT, null, 1, "1")
                         .get();
 
         job.resume();
         assertTrueEventually(() -> {
-            assertEquals(1, sinkList.size());
-            assertEquals(entry(1, "1"), sinkList.get(0));
+            assertEquals(entry(1, "1"), sinkList.get(sinkList.size() - 1));
         });
     }
 


### PR DESCRIPTION
This happened:

- assertTrueEventually calls the given lambda repeatedly, until no
assert fails. Therefore it could produce multiple records. This is
intentional because our auto.offset.reset is latest and we don't know
where the consumer starts

- on one iteration a record is produced, but sinkList is still empty (it
didn't yet made its way through the pipeline). On a next iteration,
another record was produced, but sinkList contained 1 item, so the
`assertTrueEventually` method returned

- then we suspended the job and cleared the list. However, `job.suspend`
returns before the execution actually terminates. We cleared the list,
but the job was still running and inserted one more item into it

- the test then failed because of an unexpected item in the list

The fix is to not rely on a cleared list, but just check the last item
in the `sinkList`.

Fixes #2747
