### PR TITLE
Ignore StreamKafkaPTest#when_partitionAddedWhileJobDown_then_consumedFromBeginning

### DIFF
--- a/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
+++ b/extensions/kafka/src/test/java/com/hazelcast/jet/kafka/impl/StreamKafkaPTest.java
@@ -47,6 +47,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -374,6 +375,8 @@ public class StreamKafkaPTest extends SimpleTestInClusterSupport {
     }
 
     @Test
+    @Ignore("Failing periodically, needs more investigation to fix. " +
+            "More Context here: https://github.com/hazelcast/hazelcast-jet/issues/2810")
     public void when_partitionAddedWhileJobDown_then_consumedFromBeginning() throws Exception {
         IList<Entry<Integer, String>> sinkList = instance().getList("sinkList");
         Pipeline p = Pipeline.create();


### PR DESCRIPTION
The test fails periodically and needs more investigation to fix it.

The issue is here https://github.com/hazelcast/hazelcast-jet/issues/2810



Breaking changes (list specific methods/types/messages):
* API
* client protocol format
* serialized form
* snapshot format

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
- [ ] Updated `examples/README.md` (when adding a new code sample)
