### PR TITLE
Fix SqlClientTest failure

### DIFF
--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/SqlClientTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/SqlClientTest.java
@@ -83,7 +83,13 @@ public class SqlClientTest extends SqlTestSupport {
         SqlService sqlService = client.getSql();
 
         sqlService.execute("CREATE MAPPING t TYPE " + FailingTestSqlConnector.TYPE_NAME);
-        assertThatThrownBy(() -> sqlService.execute("SELECT * FROM t"))
+        assertThatThrownBy(
+                () -> {
+                    SqlResult result = sqlService.execute("SELECT * FROM t");
+                    for (SqlRow r : result) {
+                        System.out.println(r);
+                    }
+                })
                 .hasMessageContaining("mock failure");
     }
 


### PR DESCRIPTION
`SqlService.execute()` in jet jobs returns after 1 second if there are
no rows to return. If the failure occurred after that 1 second, then
`execute()` succeeds and the row iteration will fail. This is what
happened here, the fix is to add iteration if the `execute` succeeds.

Fixes #2836
