### PR TITLE
Fix Kafka code sample for JDK14+

### DIFF
--- a/examples/kafka/pom.xml
+++ b/examples/kafka/pom.xml
@@ -53,10 +53,20 @@
             <version>${kafka.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- override zookeeper version to remediate https://issues.apache.org/jira/browse/ZOOKEEPER-3779 -->
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
It's the same fix as https://github.com/hazelcast/hazelcast-jet/commit/360c8ff1.

Checklist:
- [x] Labels and Milestone set
- [N/A] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
- [N/A] Updated `examples/README.md` (when adding a new code sample)
