### PR TITLE
Adapt docs to distribution changes

### DIFF
--- a/site/docs/api/sources-sinks.md
+++ b/site/docs/api/sources-sinks.md
@@ -108,8 +108,8 @@ BatchSource<String> source = FileSources.files("/path/to/my/directory")
 
 Avro format allows to read data from _Avro Object Container File_
 format. To use the Avro format you additionally need the
-`hazelcast-jet-avro` module, located in the distribution in the `lib`
-folder, or available as a dependency:
+`hazelcast-jet-avro` module, located in the fat distribution in the
+`lib` folder, or available as a dependency:
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/site/docs/api/sources-sinks.md
+++ b/site/docs/api/sources-sinks.md
@@ -108,7 +108,7 @@ BatchSource<String> source = FileSources.files("/path/to/my/directory")
 
 Avro format allows to read data from _Avro Object Container File_
 format. To use the Avro format you additionally need the
-`hazelcast-jet-avro` module, located in the distribution in the `opt`
+`hazelcast-jet-avro` module, located in the distribution in the `lib`
 folder, or available as a dependency:
 
 <!--DOCUSAURUS_CODE_TABS-->
@@ -360,11 +360,11 @@ For additional ways to authenticate see
 
 Alternatively to using one of the modules with all the dependencies
 included, you may use `hazelcast-jet-hadoop` module and configure the
-classpath manually.
+classpath manually. The module is enabled by default (the
+`hazelcast-jet-hadoop-{jet-version}.jar` is in the `lib/` directory
+).
 
-Enable the module by moving the jar
-`opt/hazelcast-jet-hadoop-{jet-version}.jar` to `lib/` directory and
-configure the classpath in the following way, using the
+Configure the classpath in the following way, using the
 `hadoop classpath` command:
 
 ```bash

--- a/site/docs/design-docs/005-cdc-sources.md
+++ b/site/docs/design-docs/005-cdc-sources.md
@@ -284,11 +284,7 @@ distribution. The `cdc-mysql` and `cdc-postgres` jars are also in the
 `lib` folder of the distribution, but they don't contain dependencies,
 so have to be put on the classpath together with the `cdc-debezium` jar.
 
-For example to make members of a cluster able to work with MySQL CDC
-sources, what one needs to do is to move both the
-`hazelcast-jet-cdc-mysql-VERSION.jar` and the
-`hazelcast-jet-cdc-debezium-VERSION.jar` from the member's `opt` folder
-to the `lib` folder. That will take care of all external dependencies
+The above mentioned jars will take care of all external dependencies
 too, no need to explicitly deal with Debezium connector jars or anything
 else.
 

--- a/site/docs/design-docs/005-cdc-sources.md
+++ b/site/docs/design-docs/005-cdc-sources.md
@@ -286,7 +286,8 @@ so have to be put on the classpath together with the `cdc-debezium` jar.
 
 The above mentioned jars will take care of all external dependencies
 too, no need to explicitly deal with Debezium connector jars or anything
-else.
+else. Just take care that these jars aren't included in the slim
+distribution of Jet, only the fat one.
 
 ## Serialization
 

--- a/site/docs/sql/kafka-connector.md
+++ b/site/docs/sql/kafka-connector.md
@@ -225,3 +225,7 @@ compile 'com.hazelcast.jet:hazelcast-jet-kafka:{jet-version}'
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
+
+If you're using the distribution package make sure use the fat one,
+because the `hazelcast-jet-kafka-{jet-version}.jar` you need is not
+contained in the slim one.

--- a/site/docs/sql/kafka-connector.md
+++ b/site/docs/sql/kafka-connector.md
@@ -225,7 +225,3 @@ compile 'com.hazelcast.jet:hazelcast-jet-kafka:{jet-version}'
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
-
-If you're using the distribution package, make sure to move the
-`hazelcast-jet-kafka-{jet-version}.jar` file from the `opt/` to the
-`lib/` directory.

--- a/site/docs/tutorials/kafka.md
+++ b/site/docs/tutorials/kafka.md
@@ -27,7 +27,9 @@ tar zxvf hazelcast-jet-{jet-version}.tar.gz && cd hazelcast-jet-{jet-version}
 ```
 
 If you already have Jet, and you skipped the above steps, make sure to
-follow from here on.
+follow from here on (just check that
+`hazelcast-jet-kafka-{jet-version}.jar` is in the `lib/` folder of your
+distribution, because you might have the slim distribution).
 
 2. Start Jet:
 

--- a/site/docs/tutorials/kafka.md
+++ b/site/docs/tutorials/kafka.md
@@ -29,19 +29,13 @@ tar zxvf hazelcast-jet-{jet-version}.tar.gz && cd hazelcast-jet-{jet-version}
 If you already have Jet, and you skipped the above steps, make sure to
 follow from here on.
 
-2. Activate the Apache Kafka Connector plugin:
-
-```bash
-mv opt/hazelcast-jet-kafka-{jet-version}.jar lib/
-```
-
-3. Start Jet:
+2. Start Jet:
 
 ```bash
 bin/jet-start
 ```
 
-4. When you see output like this, Hazelcast Jet is up:
+3. When you see output like this, Hazelcast Jet is up:
 
 ```text
 Members {size:1, ver:1} [

--- a/site/docs/tutorials/kinesis.md
+++ b/site/docs/tutorials/kinesis.md
@@ -63,7 +63,10 @@ tar zxvf hazelcast-jet-{jet-version}.tar.gz && cd hazelcast-jet-{jet-version}
 ```
 
 If you already have Jet, and you skipped the above steps, make sure to
-follow from here on.
+follow from here on (just check that
+`hazelcast-jet-kinesis-{jet-version}.jar` is in the `lib/` folder of
+ your
+distribution, because you might have the slim distribution).
 
 2. Start Jet:
 

--- a/site/docs/tutorials/kinesis.md
+++ b/site/docs/tutorials/kinesis.md
@@ -65,19 +65,13 @@ tar zxvf hazelcast-jet-{jet-version}.tar.gz && cd hazelcast-jet-{jet-version}
 If you already have Jet, and you skipped the above steps, make sure to
 follow from here on.
 
-2. Activate the Amazon Kinesis Connector plugin:
-
-```bash
-mv opt/hazelcast-jet-kinesis-{jet-version}.jar lib/
-```
-
-3. Start Jet:
+2. Start Jet:
 
 ```bash
 bin/jet-start
 ```
 
-4. When you see output like this, Hazelcast Jet is up:
+3. When you see output like this, Hazelcast Jet is up:
 
 ```text
 Members {size:1, ver:1} [

--- a/site/docs/tutorials/python.md
+++ b/site/docs/tutorials/python.md
@@ -52,8 +52,11 @@ wget https://github.com/hazelcast/hazelcast-jet/releases/download/v{jet-version}
 tar zxvf hazelcast-jet-{jet-version}.tar.gz && cd hazelcast-jet-{jet-version}
 ```
 
-If you already have Jet and you skipped the above steps, make sure to
-follow from here on.
+If you already have Jet, and you skipped the above steps, make sure to
+follow from here on (just check that
+`hazelcast-jet-python-{jet-version}.jar` is in the `lib/` folder of
+ your
+distribution, because you might have the slim distribution).
 
 2. Start Jet:
 

--- a/site/docs/tutorials/python.md
+++ b/site/docs/tutorials/python.md
@@ -55,19 +55,13 @@ tar zxvf hazelcast-jet-{jet-version}.tar.gz && cd hazelcast-jet-{jet-version}
 If you already have Jet and you skipped the above steps, make sure to
 follow from here on.
 
-2. Activate the Python plugin:
-
-```bash
-mv opt/hazelcast-jet-python-{jet-version}.jar lib/
-```
-
-3. Start Jet:
+2. Start Jet:
 
 ```bash
 bin/jet-start
 ```
 
-4. When you see output like this, Hazelcast Jet is up:
+3. When you see output like this, Hazelcast Jet is up:
 
 ```text
 Members {size:1, ver:1} [

--- a/site/website/blog/2021-02-03-jet-44-is-released.md
+++ b/site/website/blog/2021-02-03-jet-44-is-released.md
@@ -184,7 +184,6 @@ See the
 [instructions](/docs/operations/docker#build-a-custom-image-from-the-slim-image)
 in our docs for more details.
 
-
 ## Full Release Notes
 
 Hazelcast Jet 4.4 is based on IMDG version 4.1.1. Check out its Release
@@ -214,7 +213,6 @@ Thank you for your valuable contributions!
   data for performance, now you can disable this to get strict event
   order where you need it.
 
-
 ### Enhancements
 
 - [connectors] @hhromic improved the naming of source and sink stages
@@ -242,7 +240,6 @@ Thank you for your valuable contributions!
 - [kafka] Improved the performance of the Kafka source by fine-tuning
   some timeouts. (#2732)
 
-
 ### Fixes
 
 - [core] Fixed a problem where Jet would close `System.out` during JVM
@@ -261,7 +258,6 @@ Thank you for your valuable contributions!
 
 - [hadoop] Fixed a problem when using Hadoop for local files, it behaved
   as if the files were shared. (#2764)
-
 
 ### Breaking Changes
 

--- a/site/website/versioned_docs/version-4.4/api/sources-sinks.md
+++ b/site/website/versioned_docs/version-4.4/api/sources-sinks.md
@@ -110,8 +110,8 @@ BatchSource<String> source = FileSources.files("/path/to/my/directory")
 
 Avro format allows to read data from _Avro Object Container File_
 format. To use the Avro format you additionally need the
-`hazelcast-jet-avro` module, located in the distribution in the `lib`
-folder, or available as a dependency:
+`hazelcast-jet-avro` module, located in the fat distribution in the
+`lib` folder, or available as a dependency:
 
 <!--DOCUSAURUS_CODE_TABS-->
 

--- a/site/website/versioned_docs/version-4.4/api/sources-sinks.md
+++ b/site/website/versioned_docs/version-4.4/api/sources-sinks.md
@@ -110,7 +110,7 @@ BatchSource<String> source = FileSources.files("/path/to/my/directory")
 
 Avro format allows to read data from _Avro Object Container File_
 format. To use the Avro format you additionally need the
-`hazelcast-jet-avro` module, located in the distribution in the `opt`
+`hazelcast-jet-avro` module, located in the distribution in the `lib`
 folder, or available as a dependency:
 
 <!--DOCUSAURUS_CODE_TABS-->
@@ -362,11 +362,11 @@ For additional ways to authenticate see
 
 Alternatively to using one of the modules with all the dependencies
 included, you may use `hazelcast-jet-hadoop` module and configure the
-classpath manually.
+classpath manually. The module is enabled by default (the
+`hazelcast-jet-hadoop-{jet-version}.jar` is in the `lib/` directory
+).
 
-Enable the module by moving the jar
-`opt/hazelcast-jet-hadoop-4.4.jar` to `lib/` directory and
-configure the classpath in the following way, using the
+Configure the classpath in the following way, using the
 `hadoop classpath` command:
 
 ```bash

--- a/site/website/versioned_docs/version-4.4/design-docs/005-cdc-sources.md
+++ b/site/website/versioned_docs/version-4.4/design-docs/005-cdc-sources.md
@@ -288,7 +288,8 @@ so have to be put on the classpath together with the `cdc-debezium` jar.
 
 The above mentioned jars will take care of all external dependencies
 too, no need to explicitly deal with Debezium connector jars or anything
-else.
+else. Just take care that these jars aren't included in the slim
+distribution of Jet, only the fat one.
 
 ## Serialization
 

--- a/site/website/versioned_docs/version-4.4/design-docs/005-cdc-sources.md
+++ b/site/website/versioned_docs/version-4.4/design-docs/005-cdc-sources.md
@@ -286,11 +286,7 @@ distribution. The `cdc-mysql` and `cdc-postgres` jars are also in the
 `lib` folder of the distribution, but they don't contain dependencies,
 so have to be put on the classpath together with the `cdc-debezium` jar.
 
-For example to make members of a cluster able to work with MySQL CDC
-sources, what one needs to do is to move both the
-`hazelcast-jet-cdc-mysql-VERSION.jar` and the
-`hazelcast-jet-cdc-debezium-VERSION.jar` from the member's `opt` folder
-to the `lib` folder. That will take care of all external dependencies
+The above mentioned jars will take care of all external dependencies
 too, no need to explicitly deal with Debezium connector jars or anything
 else.
 

--- a/site/website/versioned_docs/version-4.4/sql/kafka-connector.md
+++ b/site/website/versioned_docs/version-4.4/sql/kafka-connector.md
@@ -227,7 +227,3 @@ compile 'com.hazelcast.jet:hazelcast-jet-kafka:4.4'
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
-
-If you're using the distribution package, make sure to move the
-`hazelcast-jet-kafka-4.4.jar` file from the `opt/` to the
-`lib/` directory.

--- a/site/website/versioned_docs/version-4.4/sql/kafka-connector.md
+++ b/site/website/versioned_docs/version-4.4/sql/kafka-connector.md
@@ -227,3 +227,7 @@ compile 'com.hazelcast.jet:hazelcast-jet-kafka:4.4'
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->
+
+If you're using the distribution package make sure use the fat one,
+because the `hazelcast-jet-kafka-4.4.jar` you need is not
+contained in the slim one.

--- a/site/website/versioned_docs/version-4.4/tutorials/kafka.md
+++ b/site/website/versioned_docs/version-4.4/tutorials/kafka.md
@@ -29,7 +29,9 @@ tar zxvf hazelcast-jet-4.4.tar.gz && cd hazelcast-jet-4.4
 ```
 
 If you already have Jet, and you skipped the above steps, make sure to
-follow from here on.
+follow from here on (just check that `hazelcast-jet-kafka-4.4.jar` is
+in the `lib/` folder of your distribution, because you might have
+the slim distribution).
 
 2. Start Jet:
 

--- a/site/website/versioned_docs/version-4.4/tutorials/kafka.md
+++ b/site/website/versioned_docs/version-4.4/tutorials/kafka.md
@@ -31,19 +31,13 @@ tar zxvf hazelcast-jet-4.4.tar.gz && cd hazelcast-jet-4.4
 If you already have Jet, and you skipped the above steps, make sure to
 follow from here on.
 
-2. Activate the Apache Kafka Connector plugin:
-
-```bash
-mv opt/hazelcast-jet-kafka-4.4.jar lib/
-```
-
-3. Start Jet:
+2. Start Jet:
 
 ```bash
 bin/jet-start
 ```
 
-4. When you see output like this, Hazelcast Jet is up:
+3. When you see output like this, Hazelcast Jet is up:
 
 ```text
 Members {size:1, ver:1} [

--- a/site/website/versioned_docs/version-4.4/tutorials/kinesis.md
+++ b/site/website/versioned_docs/version-4.4/tutorials/kinesis.md
@@ -65,7 +65,9 @@ tar zxvf hazelcast-jet-4.4.tar.gz && cd hazelcast-jet-4.4
 ```
 
 If you already have Jet, and you skipped the above steps, make sure to
-follow from here on.
+follow from here on (just check that `hazelcast-jet-kinesis-4.4.jar` is
+in the `lib/` folder of your distribution, because you might have
+the slim distribution).
 
 2. Start Jet:
 

--- a/site/website/versioned_docs/version-4.4/tutorials/kinesis.md
+++ b/site/website/versioned_docs/version-4.4/tutorials/kinesis.md
@@ -67,19 +67,13 @@ tar zxvf hazelcast-jet-4.4.tar.gz && cd hazelcast-jet-4.4
 If you already have Jet, and you skipped the above steps, make sure to
 follow from here on.
 
-2. Activate the Amazon Kinesis Connector plugin:
-
-```bash
-mv opt/hazelcast-jet-kinesis-4.4.jar lib/
-```
-
-3. Start Jet:
+2. Start Jet:
 
 ```bash
 bin/jet-start
 ```
 
-4. When you see output like this, Hazelcast Jet is up:
+3. When you see output like this, Hazelcast Jet is up:
 
 ```text
 Members {size:1, ver:1} [

--- a/site/website/versioned_docs/version-4.4/tutorials/python.md
+++ b/site/website/versioned_docs/version-4.4/tutorials/python.md
@@ -57,19 +57,13 @@ tar zxvf hazelcast-jet-4.4.tar.gz && cd hazelcast-jet-4.4
 If you already have Jet and you skipped the above steps, make sure to
 follow from here on.
 
-2. Activate the Python plugin:
-
-```bash
-mv opt/hazelcast-jet-python-4.4.jar lib/
-```
-
-3. Start Jet:
+2. Start Jet:
 
 ```bash
 bin/jet-start
 ```
 
-4. When you see output like this, Hazelcast Jet is up:
+3. When you see output like this, Hazelcast Jet is up:
 
 ```text
 Members {size:1, ver:1} [

--- a/site/website/versioned_docs/version-4.4/tutorials/python.md
+++ b/site/website/versioned_docs/version-4.4/tutorials/python.md
@@ -54,8 +54,10 @@ wget https://github.com/hazelcast/hazelcast-jet/releases/download/v4.4/hazelcast
 tar zxvf hazelcast-jet-4.4.tar.gz && cd hazelcast-jet-4.4
 ```
 
-If you already have Jet and you skipped the above steps, make sure to
-follow from here on.
+If you already have Jet, and you skipped the above steps, make sure to
+follow from here on (just check that `hazelcast-jet-python-4.4.jar` is
+in the `lib/` folder of your distribution, because you might have
+the slim distribution).
 
 2. Start Jet:
 


### PR DESCRIPTION
Parts of the documentation were still referencing the `opt` folder of the distribution, which doesn't exist anymore. This PR fixes it.

Checklist:
- [x] Labels and Milestone set