### PR TITLE
Fix queue size display in Dot representation when default is changed

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/MasterJobContext.java
@@ -125,6 +125,7 @@ public class MasterJobContext {
     private final MasterContext mc;
     private final ILogger logger;
     private final int defaultParallelism;
+    private final int defaultQueueSize;
 
     private volatile long executionStartTime = System.currentTimeMillis();
     private volatile ExecutionFailureCallback executionFailureCallback;
@@ -161,6 +162,8 @@ public class MasterJobContext {
         this.logger = logger;
         this.defaultParallelism = mc.getJetService().getJetInstance().getConfig()
               .getInstanceConfig().getCooperativeThreadCount();
+        this.defaultQueueSize = mc.getJetService().getJetInstance().getConfig()
+              .getDefaultEdgeConfig().getQueueSize();
     }
 
     public CompletableFuture<Void> jobCompletionFuture() {
@@ -199,7 +202,7 @@ public class MasterJobContext {
                 DAG dag = dagAndClassloader.f0();
                 ClassLoader classLoader = dagAndClassloader.f1();
                 // must call this before rewriteDagWithSnapshotRestore()
-                String dotRepresentation = dag.toDotString(defaultParallelism);
+                String dotRepresentation = dag.toDotString(defaultParallelism, defaultQueueSize);
                 long snapshotId = jobExecRec.snapshotId();
                 String snapshotName = mc.jobConfig().getInitialSnapshotName();
                 String mapName =

--- a/hazelcast-jet-distribution/src/root/release_notes.txt
+++ b/hazelcast-jet-distribution/src/root/release_notes.txt
@@ -46,10 +46,12 @@ Thank you for your valuable contributions!
 3. Fixes
 
 [core] Jet now doesn't close System.out during JVM shutdown (#2649)
+[core] Fixed queue size display in `DAG.toDotString()` when default is changed (#2887).
 
 4. Breaking Changes
 
 [jdbc] Added `batchLimit` parameter to `SinkProcessors.writeJdbcP()` method.
+[core] Added `defaultQueueSize` parameter to `DAG.toDotString(int)` method.
 
 <<< END TEMPLATE FOR THE NEXT VERSION
 


### PR DESCRIPTION
Fixes #2878

After studying the codebase and the implications, I decided to implement this fix without passing a `JetConfig` object instance but instead adding a new `defaultQueueSize` method argument. In this way, the `DAG` class remains uncoupled from any Jet instance and the caller is free to pass any value to be used for displaying a default queue size.

The `MasterJobContext.tryStartJob()` method is then adapted to pass the default queue size extracted from the `JetConfig` object of the running instance, similar to how the `defaultParallelism` value is passed.

I also took the opportunity to add some missing `@param` Javadoc annotations and made the `defaultLocalParallelism` argument name consistent across all methods in the `DAG` class.

Breaking changes:

The `DAG.toDotString(int defaultParallelism)` method signature is now `DAG.toDotString(int defaultLocalParallelism, int defaultQueueSize)`. Callers must now supply the queue size that will be shown if not overriden on the edge.

I believe this is a breaking change with very minimal impact as I don't think many users call this method directly.

Checklist:
- [x] Labels and Milestone set
- [x] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
