### PR TITLE
Implement configurable batch size limit in JDBC sink processor

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/processor/SinkProcessors.java
@@ -49,6 +49,7 @@ import java.util.Map;
 
 import static com.hazelcast.function.FunctionEx.identity;
 import static com.hazelcast.internal.util.Preconditions.checkNotNull;
+import static com.hazelcast.internal.util.Preconditions.checkPositive;
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.preferLocalParallelismOne;
 import static com.hazelcast.jet.impl.util.Util.checkSerializable;
 
@@ -367,18 +368,26 @@ public final class SinkProcessors {
 
     /**
      * Returns a supplier of processors for {@link Sinks#jdbcBuilder()}.
+     * <p>
+     * <b>Notes</b>
+     * <p>
+     * Until Jet 4.4, the batch size limit for the supplied processors used to
+     * be hard-coded to 50. Since Jet 4.5, this limit is now configurable and
+     * must be explicitly set using the {@code batchLimit} parameter.
      */
     @Nonnull
     public static <T> ProcessorMetaSupplier writeJdbcP(
             @Nonnull String updateQuery,
             @Nonnull SupplierEx<? extends CommonDataSource> dataSourceSupplier,
             @Nonnull BiConsumerEx<? super PreparedStatement, ? super T> bindFn,
-            boolean exactlyOnce
+            boolean exactlyOnce,
+            int batchLimit
     ) {
         checkNotNull(updateQuery, "updateQuery");
         checkNotNull(dataSourceSupplier, "dataSourceSupplier");
         checkNotNull(bindFn, "bindFn");
-        return WriteJdbcP.metaSupplier(updateQuery, dataSourceSupplier, bindFn, exactlyOnce);
+        checkPositive(batchLimit, "batchLimit");
+        return WriteJdbcP.metaSupplier(updateQuery, dataSourceSupplier, bindFn, exactlyOnce, batchLimit);
     }
 
     /**

--- a/hazelcast-jet-distribution/src/root/release_notes.txt
+++ b/hazelcast-jet-distribution/src/root/release_notes.txt
@@ -41,12 +41,15 @@ Thank you for your valuable contributions!
 
 [extensions] Ensure naming conventions for sources/sinks (#2685)
 [pipeline-api] Improved the pickAny aggregate operation by supporting the deduct primitive (#2917)
+[jdbc] Make the batch size limit configurable in the JDBC sink processor (#2888).
 
 3. Fixes
 
 [core] Jet now doesn't close System.out during JVM shutdown (#2649)
 
 4. Breaking Changes
+
+[jdbc] Added `batchLimit` parameter to `SinkProcessors.writeJdbcP()` method.
 
 <<< END TEMPLATE FOR THE NEXT VERSION
 


### PR DESCRIPTION
Fixes #2879

The implementation adds a new `batchLimit()` builder method to the `JdbcSinkBuilder` class and the corresponding constructor arguments to the underlying implementation class and meta-suppliers.

I also took the opportunity to add public constants for default values in the `JdbcSinkBuilder` class and improve its Javadoc.

Breaking changes (list specific methods/types/messages):

* The `SinkProcessors.writeJdbcP()` method gained a new argument: `batchLimit`.
* The `WriteJdbcP.metaSupplier()` method gained a new argument `batchLimit`.

I believe the above breaking changes have very minimal impact as I don't think many users call these methods directly.

Checklist:
- [x] Labels and Milestone set
- [x] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [X] New public APIs have `@Nonnull/@Nullable` annotations
- [X] New public APIs have `@since` tags in Javadoc
