### PR TITLE
Cleanup SQL java format/class resolution

### DIFF
--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.AVRO_FORMAT;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JSON_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
@@ -120,24 +121,42 @@ final class PropertiesResolver {
             properties.putIfAbsent(deserializer, AVRO_DESERIALIZER);
         } else if (JSON_FORMAT.equals(format)) {
             properties.putIfAbsent(deserializer, BYTE_ARRAY_DESERIALIZER);
-        } else {
-            String clazz = JavaClassNameResolver.resolveClassName(
-                    format,
-                    options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS)
-            );
-            if (Short.class.getName().equals(clazz) || short.class.getName().equals(clazz)) {
-                properties.putIfAbsent(deserializer, SHORT_DESERIALIZER);
-            } else if (Integer.class.getName().equals(clazz) || int.class.getName().equals(clazz)) {
-                properties.putIfAbsent(deserializer, INT_DESERIALIZER);
-            } else if (Long.class.getName().equals(clazz) || long.class.getName().equals(clazz)) {
-                properties.putIfAbsent(deserializer, LONG_DESERIALIZER);
-            } else if (Float.class.getName().equals(clazz) || float.class.getName().equals(clazz)) {
-                properties.putIfAbsent(deserializer, FLOAT_DESERIALIZER);
-            } else if (Double.class.getName().equals(clazz) || double.class.getName().equals(clazz)) {
-                properties.putIfAbsent(deserializer, DOUBLE_DESERIALIZER);
-            } else if (String.class.getName().equals(clazz)) {
-                properties.putIfAbsent(deserializer, STRING_DESERIALIZER);
+        } else if (JAVA_FORMAT.equals(format)) {
+            String clazz = options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS);
+            String deserializerClass = resolveDeserializer(clazz);
+            if (deserializerClass != null) {
+                properties.putIfAbsent(deserializer, deserializerClass);
             }
+        } else {
+            String resolvedClass = JavaClassNameResolver.resolveClassName(format);
+            if (resolvedClass != null) {
+                String declaredClass =
+                        options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS);
+                if (declaredClass == null || declaredClass.equals(resolvedClass)) {
+                    String deserializerClass = resolveDeserializer(resolvedClass);
+                    if (deserializerClass != null) {
+                        properties.putIfAbsent(deserializer, deserializerClass);
+                    }
+                }
+            }
+        }
+    }
+
+    private static String resolveDeserializer(String clazz) {
+        if (Short.class.getName().equals(clazz) || short.class.getName().equals(clazz)) {
+            return SHORT_DESERIALIZER;
+        } else if (Integer.class.getName().equals(clazz) || int.class.getName().equals(clazz)) {
+            return INT_DESERIALIZER;
+        } else if (Long.class.getName().equals(clazz) || long.class.getName().equals(clazz)) {
+            return LONG_DESERIALIZER;
+        } else if (Float.class.getName().equals(clazz) || float.class.getName().equals(clazz)) {
+            return FLOAT_DESERIALIZER;
+        } else if (Double.class.getName().equals(clazz) || double.class.getName().equals(clazz)) {
+            return DOUBLE_DESERIALIZER;
+        } else if (String.class.getName().equals(clazz)) {
+            return STRING_DESERIALIZER;
+        } else {
+            return null;
         }
     }
 
@@ -155,24 +174,42 @@ final class PropertiesResolver {
             properties.putIfAbsent(serializer, AVRO_SERIALIZER);
         } else if (JSON_FORMAT.equals(format)) {
             properties.putIfAbsent(serializer, BYTE_ARRAY_SERIALIZER);
-        } else {
-            String clazz = JavaClassNameResolver.resolveClassName(
-                    format,
-                    options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS)
-            );
-            if (Short.class.getName().equals(clazz) || short.class.getName().equals(clazz)) {
-                properties.putIfAbsent(serializer, SHORT_SERIALIZER);
-            } else if (Integer.class.getName().equals(clazz) || int.class.getName().equals(clazz)) {
-                properties.putIfAbsent(serializer, INT_SERIALIZER);
-            } else if (Long.class.getName().equals(clazz) || long.class.getName().equals(clazz)) {
-                properties.putIfAbsent(serializer, LONG_SERIALIZER);
-            } else if (Float.class.getName().equals(clazz) || float.class.getName().equals(clazz)) {
-                properties.putIfAbsent(serializer, FLOAT_SERIALIZER);
-            } else if (Double.class.getName().equals(clazz) || double.class.getName().equals(clazz)) {
-                properties.putIfAbsent(serializer, DOUBLE_SERIALIZER);
-            } else if (String.class.getName().equals(clazz)) {
-                properties.putIfAbsent(serializer, STRING_SERIALIZER);
+        } else if (JAVA_FORMAT.equals(format)) {
+            String clazz = options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS);
+            String serializerClass = resolveSerializer(clazz);
+            if (serializerClass != null) {
+                properties.putIfAbsent(serializer, serializerClass);
             }
+        } else {
+            String resolvedClass = JavaClassNameResolver.resolveClassName(format);
+            if (resolvedClass != null) {
+                String declaredClass =
+                        options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS);
+                if (declaredClass == null || declaredClass.equals(resolvedClass)) {
+                    String serializerClass = resolveSerializer(resolvedClass);
+                    if (serializerClass != null) {
+                        properties.putIfAbsent(serializer, serializerClass);
+                    }
+                }
+            }
+        }
+    }
+
+    private static String resolveSerializer(String clazz) {
+        if (Short.class.getName().equals(clazz) || short.class.getName().equals(clazz)) {
+            return SHORT_SERIALIZER;
+        } else if (Integer.class.getName().equals(clazz) || int.class.getName().equals(clazz)) {
+            return INT_SERIALIZER;
+        } else if (Long.class.getName().equals(clazz) || long.class.getName().equals(clazz)) {
+            return LONG_SERIALIZER;
+        } else if (Float.class.getName().equals(clazz) || float.class.getName().equals(clazz)) {
+            return FLOAT_SERIALIZER;
+        } else if (Double.class.getName().equals(clazz) || double.class.getName().equals(clazz)) {
+            return DOUBLE_SERIALIZER;
+        } else if (String.class.getName().equals(clazz)) {
+            return STRING_SERIALIZER;
+        } else {
+            return null;
         }
     }
 }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
@@ -107,7 +107,6 @@ final class PropertiesResolver {
         return properties;
     }
 
-    @SuppressWarnings("NestedIfDepth")
     private static void withSerdeConsumerProperties(
             boolean isKey,
             Map<String, String> options,
@@ -131,13 +130,9 @@ final class PropertiesResolver {
         } else {
             String resolvedClass = JavaClassNameResolver.resolveClassName(format);
             if (resolvedClass != null) {
-                String declaredClass =
-                        options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS);
-                if (declaredClass == null || declaredClass.equals(resolvedClass)) {
-                    String deserializerClass = resolveDeserializer(resolvedClass);
-                    if (deserializerClass != null) {
-                        properties.putIfAbsent(deserializer, deserializerClass);
-                    }
+                String deserializerClass = resolveDeserializer(resolvedClass);
+                if (deserializerClass != null) {
+                    properties.putIfAbsent(deserializer, deserializerClass);
                 }
             }
         }
@@ -161,7 +156,6 @@ final class PropertiesResolver {
         }
     }
 
-    @SuppressWarnings("NestedIfDepth")
     private static void withSerdeProducerProperties(
             boolean isKey,
             Map<String, String> options,
@@ -185,13 +179,9 @@ final class PropertiesResolver {
         } else {
             String resolvedClass = JavaClassNameResolver.resolveClassName(format);
             if (resolvedClass != null) {
-                String declaredClass =
-                        options.get(isKey ? SqlConnector.OPTION_KEY_CLASS : SqlConnector.OPTION_VALUE_CLASS);
-                if (declaredClass == null || declaredClass.equals(resolvedClass)) {
-                    String serializerClass = resolveSerializer(resolvedClass);
-                    if (serializerClass != null) {
-                        properties.putIfAbsent(serializer, serializerClass);
-                    }
+                String serializerClass = resolveSerializer(resolvedClass);
+                if (serializerClass != null) {
+                    properties.putIfAbsent(serializer, serializerClass);
                 }
             }
         }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/kafka/PropertiesResolver.java
@@ -107,6 +107,7 @@ final class PropertiesResolver {
         return properties;
     }
 
+    @SuppressWarnings("NestedIfDepth")
     private static void withSerdeConsumerProperties(
             boolean isKey,
             Map<String, String> options,
@@ -160,6 +161,7 @@ final class PropertiesResolver {
         }
     }
 
+    @SuppressWarnings("NestedIfDepth")
     private static void withSerdeProducerProperties(
             boolean isKey,
             Map<String, String> options,

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/JavaClassNameResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/JavaClassNameResolver.java
@@ -27,27 +27,30 @@ import java.util.stream.Stream;
 
 public final class JavaClassNameResolver {
 
-    private static final Map<String, String> CLASS_NAMES_BY_FORMAT = new HashMap<String, String>() {{
-        put("varchar", String.class.getName());
-        put("character varying", String.class.getName());
-        put("char varying", String.class.getName());
-        put("boolean", Boolean.class.getName());
-        put("tinyint", Byte.class.getName());
-        put("smallint", Short.class.getName());
-        put("integer", Integer.class.getName());
-        put("int", Integer.class.getName());
-        put("bigint", Long.class.getName());
-        put("decimal", BigDecimal.class.getName());
-        put("dec", BigDecimal.class.getName());
-        put("numeric", BigDecimal.class.getName());
-        put("real", Float.class.getName());
-        put("double", Double.class.getName());
-        put("double precision", Double.class.getName());
-        put("time", LocalTime.class.getName());
-        put("date", LocalDate.class.getName());
-        put("timestamp", LocalDateTime.class.getName());
-        put("timestamp with time zone", OffsetDateTime.class.getName());
-    }};
+    private static final Map<String, String> CLASS_NAMES_BY_FORMAT;
+
+    static {
+        CLASS_NAMES_BY_FORMAT = new HashMap<>();
+        CLASS_NAMES_BY_FORMAT.put("varchar", String.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("character varying", String.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("char varying", String.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("boolean", Boolean.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("tinyint", Byte.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("smallint", Short.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("integer", Integer.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("int", Integer.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("bigint", Long.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("decimal", BigDecimal.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("dec", BigDecimal.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("numeric", BigDecimal.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("real", Float.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("double", Double.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("double precision", Double.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("time", LocalTime.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("date", LocalDate.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("timestamp", LocalDateTime.class.getName());
+        CLASS_NAMES_BY_FORMAT.put("timestamp with time zone", OffsetDateTime.class.getName());
+    }
 
     private JavaClassNameResolver() {
     }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/JavaClassNameResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/JavaClassNameResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.jet.sql.impl.connector.keyvalue;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public final class JavaClassNameResolver {
+
+    private static final Map<String, String> CLASS_NAMES_BY_FORMAT = new HashMap<String, String>() {{
+        put("varchar", String.class.getName());
+        put("character varying", String.class.getName());
+        put("char varying", String.class.getName());
+        put("boolean", Boolean.class.getName());
+        put("tinyint", Byte.class.getName());
+        put("smallint", Short.class.getName());
+        put("integer", Integer.class.getName());
+        put("int", Integer.class.getName());
+        put("bigint", Long.class.getName());
+        put("decimal", BigDecimal.class.getName());
+        put("dec", BigDecimal.class.getName());
+        put("numeric", BigDecimal.class.getName());
+        put("real", Float.class.getName());
+        put("double", Double.class.getName());
+        put("double precision", Double.class.getName());
+        put("time", LocalTime.class.getName());
+        put("date", LocalDate.class.getName());
+        put("timestamp", LocalDateTime.class.getName());
+        put("timestamp with time zone", OffsetDateTime.class.getName());
+    }};
+
+    private JavaClassNameResolver() {
+    }
+
+    public static String resolveClassName(String format, String className) {
+        return className == null ? CLASS_NAMES_BY_FORMAT.get(format) : className;
+    }
+
+    static Stream<String> formats() {
+        return CLASS_NAMES_BY_FORMAT.keySet().stream();
+    }
+}

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/JavaClassNameResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/JavaClassNameResolver.java
@@ -52,8 +52,8 @@ public final class JavaClassNameResolver {
     private JavaClassNameResolver() {
     }
 
-    public static String resolveClassName(String format, String className) {
-        return className == null ? CLASS_NAMES_BY_FORMAT.get(format) : className;
+    public static String resolveClassName(String format) {
+        return CLASS_NAMES_BY_FORMAT.get(format);
     }
 
     static Stream<String> formats() {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataAvroResolver.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.AVRO_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers.extractFields;
@@ -47,8 +48,8 @@ public final class KvMetadataAvroResolver implements KvMetadataResolver {
     }
 
     @Override
-    public String supportedFormat() {
-        return AVRO_FORMAT;
+    public Stream<String> supportedFormats() {
+        return Stream.of(AVRO_FORMAT);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
@@ -238,18 +238,11 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
         String className;
         if (JAVA_FORMAT.equals(formatProperty)) {
             className = options.get(classNameProperty);
-        } else {
-            String declaredClassName = options.get(classNameProperty);
-            String resolvedClassName = JavaClassNameResolver.resolveClassName(formatProperty);
-            if (declaredClassName != null && !declaredClassName.equals(resolvedClassName)) {
-                throw QueryException.error("Mismatch between declared and resolved class for format '"
-                        + formatProperty + "'");
+            if (className == null) {
+                throw QueryException.error("Unable to resolve table metadata. Missing '" + classNameProperty + "' option");
             }
-            className = resolvedClassName;
-        }
-
-        if (className == null) {
-            throw QueryException.error("Unable to resolve table metadata. Missing '" + classNameProperty + "' option");
+        } else {
+            className = JavaClassNameResolver.resolveClassName(formatProperty);
         }
 
         try {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
@@ -235,14 +235,12 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
         String formatProperty = options.get(isKey ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT);
         String classNameProperty = isKey ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS;
 
-        String className;
-        if (JAVA_FORMAT.equals(formatProperty)) {
-            className = options.get(classNameProperty);
-            if (className == null) {
-                throw QueryException.error("Unable to resolve table metadata. Missing '" + classNameProperty + "' option");
-            }
-        } else {
-            className = JavaClassNameResolver.resolveClassName(formatProperty);
+        String className = JAVA_FORMAT.equals(formatProperty)
+                ? options.get(classNameProperty)
+                : JavaClassNameResolver.resolveClassName(formatProperty);
+
+        if (className == null) {
+            throw QueryException.error("Unable to resolve table metadata. Missing '" + classNameProperty + "' option");
         }
 
         try {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
@@ -36,10 +36,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLASS;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers.extractFields;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers.maybeAddDefaultField;
 import static com.hazelcast.sql.impl.extract.QueryPath.KEY;
@@ -59,8 +62,8 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
     }
 
     @Override
-    public String supportedFormat() {
-        return JAVA_FORMAT;
+    public Stream<String> supportedFormats() {
+        return Stream.concat(Stream.of(JAVA_FORMAT), JavaClassNameResolver.formats());
     }
 
     @Override
@@ -229,9 +232,10 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
     }
 
     private Class<?> loadClass(boolean isKey, Map<String, String> options) {
-        String classNameProperty = isKey ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS;
-        String className = options.get(classNameProperty);
+        String format = options.get(isKey ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT);
 
+        String classNameProperty = isKey ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS;
+        String className = JavaClassNameResolver.resolveClassName(format, options.get(classNameProperty));
         if (className == null) {
             throw QueryException.error("Unable to resolve table metadata. Missing '" + classNameProperty + "' option");
         }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolver.java
@@ -232,10 +232,22 @@ public final class KvMetadataJavaResolver implements KvMetadataResolver {
     }
 
     private Class<?> loadClass(boolean isKey, Map<String, String> options) {
-        String format = options.get(isKey ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT);
-
+        String formatProperty = options.get(isKey ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT);
         String classNameProperty = isKey ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS;
-        String className = JavaClassNameResolver.resolveClassName(format, options.get(classNameProperty));
+
+        String className;
+        if (JAVA_FORMAT.equals(formatProperty)) {
+            className = options.get(classNameProperty);
+        } else {
+            String declaredClassName = options.get(classNameProperty);
+            String resolvedClassName = JavaClassNameResolver.resolveClassName(formatProperty);
+            if (declaredClassName != null && !declaredClassName.equals(resolvedClassName)) {
+                throw QueryException.error("Mismatch between declared and resolved class for format '"
+                        + formatProperty + "'");
+            }
+            className = resolvedClassName;
+        }
+
         if (className == null) {
             throw QueryException.error("Unable to resolve table metadata. Missing '" + classNameProperty + "' option");
         }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJsonResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJsonResolver.java
@@ -31,6 +31,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JSON_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers.extractFields;
@@ -44,8 +45,8 @@ public final class KvMetadataJsonResolver implements KvMetadataResolver {
     }
 
     @Override
-    public String supportedFormat() {
-        return JSON_FORMAT;
+    public Stream<String> supportedFormats() {
+        return Stream.of(JSON_FORMAT);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataNullResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataNullResolver.java
@@ -33,6 +33,7 @@ import com.hazelcast.sql.impl.type.QueryDataType;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 
@@ -63,8 +64,8 @@ public class KvMetadataNullResolver implements KvMetadataResolver {
     }
 
     @Override
-    public String supportedFormat() {
-        return null;
+    public Stream<String> supportedFormats() {
+        return Stream.of((String) null);
     }
 
     private static class NullQueryTargetDescriptor implements QueryTargetDescriptor {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolver.java
@@ -21,6 +21,7 @@ import com.hazelcast.jet.sql.impl.schema.MappingField;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Interface for key-value resolution of fields for a particular
@@ -28,7 +29,7 @@ import java.util.Map;
  */
 public interface KvMetadataResolver {
 
-    String supportedFormat();
+    Stream<String> supportedFormats();
 
     List<MappingField> resolveAndValidateFields(
             boolean isKey,

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolvers.java
@@ -26,25 +26,16 @@ import com.hazelcast.sql.impl.schema.TableField;
 import com.hazelcast.sql.impl.schema.map.MapTableField;
 import com.hazelcast.sql.impl.type.QueryDataType;
 
-import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.regex.Pattern;
 
-import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
+import static com.hazelcast.jet.Util.entry;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
-import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLASS;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static com.hazelcast.sql.impl.extract.QueryPath.KEY;
 import static com.hazelcast.sql.impl.extract.QueryPath.VALUE;
@@ -79,7 +70,8 @@ public class KvMetadataResolvers {
 
     private Map<String, KvMetadataResolver> resolversMap(KvMetadataResolver[] resolvers) {
         return Arrays.stream(resolvers)
-                .collect(toMap(KvMetadataResolver::supportedFormat, Function.identity()));
+                .flatMap(resolver -> resolver.supportedFormats().map(format -> entry(format, resolver)))
+                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     /**
@@ -113,9 +105,6 @@ public class KvMetadataResolvers {
             }
         }
 
-        options = preprocessOptions(options, true);
-        options = preprocessOptions(options, false);
-
         List<MappingField> keyFields = findMetadataResolver(options, true)
                 .resolveAndValidateFields(true, userFields, options, ss);
         List<MappingField> valueFields = findMetadataResolver(options, false)
@@ -141,103 +130,8 @@ public class KvMetadataResolvers {
             Map<String, String> options,
             InternalSerializationService serializationService
     ) {
-        options = preprocessOptions(options, isKey);
         KvMetadataResolver resolver = findMetadataResolver(options, isKey);
         return requireNonNull(resolver.resolveMetadata(isKey, resolvedFields, options, serializationService));
-    }
-
-    /**
-     * Pre-process the options before they are used.
-     * <p>
-     * Currently replaces the simplified primitive representation with full
-     * representation, for example {@code 'keyFormat'='int'} with {@code
-     * 'keyFormat'='java', 'keyJavaClass'='java.lang.Integer}.
-     *
-     * @param options input options, this map is not modified
-     * @param isKey whether to preprocess key format or value format
-     * @return new, possibly modified options
-     */
-    @CheckReturnValue
-    public static Map<String, String> preprocessOptions(Map<String, String> options, boolean isKey) {
-        String formatProperty = isKey ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT;
-
-        String formatValue = options.get(formatProperty);
-        if (formatValue == null) {
-            return options;
-        }
-        String classValue;
-        switch (formatValue) {
-            case "varchar":
-            case "character varying":
-            case "char varying":
-                classValue = String.class.getName();
-                break;
-
-            case "boolean":
-                classValue = Boolean.class.getName();
-                break;
-
-            case "tinyint":
-                classValue = Byte.class.getName();
-                break;
-
-            case "smallint":
-                classValue = Short.class.getName();
-                break;
-
-            case "integer":
-            case "int":
-                classValue = Integer.class.getName();
-                break;
-
-            case "bigint":
-                classValue = Long.class.getName();
-                break;
-
-            case "decimal":
-            case "dec":
-            case "numeric":
-                classValue = BigDecimal.class.getName();
-                break;
-
-            case "real":
-                classValue = Float.class.getName();
-                break;
-
-            case "double":
-            case "double precision":
-                classValue = Double.class.getName();
-                break;
-
-            case "time":
-                classValue = LocalTime.class.getName();
-                break;
-
-            case "date":
-                classValue = LocalDate.class.getName();
-                break;
-
-            case "timestamp":
-                classValue = LocalDateTime.class.getName();
-                break;
-
-            case "timestamp with time zone":
-                classValue = OffsetDateTime.class.getName();
-                break;
-
-            default:
-                classValue = null;
-        }
-
-        String classProperty = isKey ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS;
-        if (classValue != null && !options.containsKey(classProperty)) {
-            Map<String, String> newOptions = new HashMap<>(options);
-            newOptions.put(formatProperty, "java");
-            newOptions.put(classProperty, classValue);
-            return newOptions;
-        }
-
-        return options;
     }
 
     private KvMetadataResolver findMetadataResolver(Map<String, String> options, boolean isKey) {

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataJsonResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataJsonResolver.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JSON_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataResolvers.extractFields;
@@ -46,8 +47,8 @@ final class MetadataJsonResolver implements KvMetadataResolver {
     }
 
     @Override
-    public String supportedFormat() {
-        return JSON_FORMAT;
+    public Stream<String> supportedFormats() {
+        return Stream.of(JSON_FORMAT);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolver.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/map/MetadataPortableResolver.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS_ID;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS_VERSION;
@@ -57,8 +58,8 @@ final class MetadataPortableResolver implements KvMetadataResolver {
     }
 
     @Override
-    public String supportedFormat() {
-        return PORTABLE_FORMAT;
+    public Stream<String> supportedFormats() {
+        return Stream.of(PORTABLE_FORMAT);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolverTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataJavaResolverTest.java
@@ -33,8 +33,11 @@ import org.junit.runner.RunWith;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_CLASS;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_CLASS;
+import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_VALUE_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.keyvalue.KvMetadataJavaResolver.INSTANCE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -51,7 +54,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void test_resolvePrimitiveField(boolean key, String path) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName()
+        );
 
         List<MappingField> fields = INSTANCE.resolveAndValidateFields(key, emptyList(), options, null);
 
@@ -64,7 +70,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void when_userDeclaresPrimitiveField_then_itsNameHasPrecedenceOverResolvedOne(boolean key, String path) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName()
+        );
 
         List<MappingField> fields = INSTANCE.resolveAndValidateFields(
                 key,
@@ -82,7 +91,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void when_typeMismatchBetweenPrimitiveDeclaredAndSchemaField_then_throws(boolean key, String path) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName()
+        );
 
         assertThatThrownBy(() -> INSTANCE.resolveAndValidateFields(
                 key,
@@ -90,7 +102,7 @@ public class KvMetadataJavaResolverTest {
                 options,
                 null
         )).isInstanceOf(QueryException.class)
-          .hasMessageMatching("Mismatch between declared and resolved type for field '(__key|this)'");
+                .hasMessageMatching("Mismatch between declared and resolved type for field '(__key|this)'");
     }
 
     @Test
@@ -99,7 +111,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void when_userDeclaresPrimitiveAdditionalField_then_throws(boolean key, String prefix) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName()
+        );
 
         assertThatThrownBy(() -> INSTANCE.resolveAndValidateFields(
                 key,
@@ -107,7 +122,7 @@ public class KvMetadataJavaResolverTest {
                 options,
                 null
         )).isInstanceOf(QueryException.class)
-          .hasMessage("The field '" + prefix + "' is of type INTEGER, you can't map '" + prefix + ".field' too");
+                .hasMessage("The field '" + prefix + "' is of type INTEGER, you can't map '" + prefix + ".field' too");
     }
 
     @Test
@@ -116,7 +131,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void test_resolvePrimitiveMetadata(boolean key, String path) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), int.class.getName()
+        );
 
         KvMetadata metadata = INSTANCE.resolveMetadata(
                 key,
@@ -138,7 +156,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void test_resolveObjectFields(boolean key, String prefix) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName()
+        );
 
         List<MappingField> fields = INSTANCE.resolveAndValidateFields(key, emptyList(), options, null);
 
@@ -151,7 +172,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void when_userDeclaresObjectField_then_itsNameHasPrecedenceOverResolvedOne(boolean key, String prefix) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName()
+        );
 
         List<MappingField> fields = INSTANCE.resolveAndValidateFields(
                 key,
@@ -171,7 +195,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void when_userDeclaresFields_then_fieldsFromClassNotAdded(boolean key, String prefix) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName()
+        );
 
         List<MappingField> fields = INSTANCE.resolveAndValidateFields(
                 key,
@@ -191,7 +218,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void when_typeMismatchBetweenObjectDeclaredAndSchemaField_then_throws(boolean key, String prefix) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName()
+        );
 
         assertThatThrownBy(() -> INSTANCE.resolveAndValidateFields(
                 key,
@@ -199,7 +229,7 @@ public class KvMetadataJavaResolverTest {
                 options,
                 null
         )).isInstanceOf(QueryException.class)
-          .hasMessageContaining("Mismatch between declared and resolved type for field 'field'");
+                .hasMessageContaining("Mismatch between declared and resolved type for field 'field'");
     }
 
     @Test
@@ -208,8 +238,10 @@ public class KvMetadataJavaResolverTest {
             "false"
     })
     public void when_noKeyOrThisPrefixInExternalName_then_usesValue(boolean key) {
-        Map<String, String> options =
-                ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Object.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Object.class.getName()
+        );
 
         KvMetadata metadata = INSTANCE.resolveMetadata(
                 key,
@@ -234,7 +266,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void when_userDeclaresObjectDuplicateExternalName_then_throws(boolean key, String prefix) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName()
+        );
 
         assertThatThrownBy(() -> INSTANCE.resolveAndValidateFields(
                 key,
@@ -245,7 +280,7 @@ public class KvMetadataJavaResolverTest {
                 options,
                 null
         )).isInstanceOf(QueryException.class)
-          .hasMessageMatching("Duplicate external name: (__key|this).field");
+                .hasMessageMatching("Duplicate external name: (__key|this).field");
     }
 
     @Test
@@ -254,7 +289,10 @@ public class KvMetadataJavaResolverTest {
             "false, this"
     })
     public void test_resolveMetadata(boolean key, String prefix) {
-        Map<String, String> options = ImmutableMap.of((key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName());
+        Map<String, String> options = ImmutableMap.of(
+                (key ? OPTION_KEY_FORMAT : OPTION_VALUE_FORMAT), JAVA_FORMAT,
+                (key ? OPTION_KEY_CLASS : OPTION_VALUE_CLASS), Type.class.getName()
+        );
 
         KvMetadata metadata = INSTANCE.resolveMetadata(
                 key,

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolversTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/keyvalue/KvMetadataResolversTest.java
@@ -29,9 +29,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.JAVA_FORMAT;
 import static com.hazelcast.jet.sql.impl.connector.SqlConnector.OPTION_KEY_FORMAT;
@@ -60,10 +62,11 @@ public class KvMetadataResolversTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         given(nodeEngine.getSerializationService()).willReturn(ss);
-        given(resolver.supportedFormat()).willReturn(JAVA_FORMAT);
+        given(resolver.supportedFormats())
+                .willAnswer((Answer<Stream<String>>) invocationOnMock -> Stream.of(JAVA_FORMAT));
 
         resolvers = new KvMetadataResolvers(resolver);
     }


### PR DESCRIPTION
Removed java serialization specific code from generic `KvMetadataResolvers`.
Removed the necessity to copy (preprocess) options.