### PR TITLE
Forbid OR REPLACE & IF NOT EXISTS to be used together while creating mapping

### DIFF
--- a/hazelcast-jet-sql/src/main/codegen/config.fmpp
+++ b/hazelcast-jet-sql/src/main/codegen/config.fmpp
@@ -37,8 +37,6 @@ data: {
       "com.hazelcast.jet.sql.impl.parse.SqlShowStatement.ShowStatementTarget"
       "com.hazelcast.sql.impl.QueryException"
       "com.hazelcast.sql.impl.type.QueryDataType"
-      "java.util.LinkedHashMap"
-      "java.util.Map"
       "org.apache.calcite.sql.SqlCreate"
       "org.apache.calcite.sql.SqlDrop"
     ]

--- a/hazelcast-jet-sql/src/main/codegen/includes/parserImpls.ftl
+++ b/hazelcast-jet-sql/src/main/codegen/includes/parserImpls.ftl
@@ -63,27 +63,25 @@ SqlNodeList MappingColumns():
     SqlParserPos pos = getPos();
 
     SqlMappingColumn column;
-    Map<String, SqlNode> columns = new LinkedHashMap<String, SqlNode>();
+    List<SqlNode> columns = new ArrayList<SqlNode>();
 }
 {
     [
         <LPAREN> {  pos = getPos(); }
         column = MappingColumn()
         {
-            columns.put(column.name(), column);
+            columns.add(column);
         }
         (
             <COMMA> column = MappingColumn()
             {
-                if (columns.putIfAbsent(column.name(), column) != null) {
-                   throw SqlUtil.newContextException(getPos(), ParserResource.RESOURCE.duplicateColumn(column.name()));
-                }
+                columns.add(column);
             }
         )*
         <RPAREN>
     ]
     {
-        return new SqlNodeList(columns.values(), pos.plus(getPos()));
+        return new SqlNodeList(columns, pos.plus(getPos()));
     }
 }
 
@@ -240,11 +238,7 @@ SqlCreate SqlCreateJob(Span span, boolean replace) :
     SqlIdentifier name;
     boolean ifNotExists = false;
     SqlNodeList sqlOptions = SqlNodeList.EMPTY;
-    SqlExtendedInsert sqlInsert = null;
-
-    if (replace) {
-        throw SqlUtil.newContextException(getPos(), ParserResource.RESOURCE.notSupported("OR REPLACE", "CREATE JOB"));
-    }
+    SqlExtendedInsert sqlInsert;
 }
 {
     <JOB>
@@ -263,6 +257,7 @@ SqlCreate SqlCreateJob(Span span, boolean replace) :
             name,
             sqlOptions,
             sqlInsert,
+            replace,
             ifNotExists,
             startPos.plus(getPos())
         );
@@ -379,27 +374,25 @@ SqlNodeList SqlOptions():
     Span span;
 
     SqlOption sqlOption;
-    Map<String, SqlNode> sqlOptions = new LinkedHashMap<String, SqlNode>();
+    List<SqlNode> sqlOptions = new ArrayList<SqlNode>();
 }
 {
     <LPAREN> { span = span(); }
     [
         sqlOption = SqlOption()
         {
-            sqlOptions.put(sqlOption.keyString(), sqlOption);
+            sqlOptions.add(sqlOption);
         }
         (
             <COMMA> sqlOption = SqlOption()
             {
-                if (sqlOptions.putIfAbsent(sqlOption.keyString(), sqlOption) != null) {
-                    throw SqlUtil.newContextException(getPos(), ParserResource.RESOURCE.duplicateOption(sqlOption.keyString()));
-                }
+                sqlOptions.add(sqlOption);
             }
         )*
     ]
     <RPAREN>
     {
-        return new SqlNodeList(sqlOptions.values(), span.end(this));
+        return new SqlNodeList(sqlOptions, span.end(this));
     }
 }
 

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/ParserResource.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/ParserResource.java
@@ -28,11 +28,20 @@ public interface ParserResource {
     @BaseMessage("{0} is not supported for {1}")
     ExInst<SqlValidatorException> notSupported(String option, String statement);
 
+    @BaseMessage("OR REPLACE in conjunction with IF NOT EXISTS not supported")
+    ExInst<SqlValidatorException> orReplaceWithIfNotExistsNotSupported();
+
+    @BaseMessage("The mapping must be created in the \"public\" schema")
+    ExInst<SqlValidatorException> mappingIncorrectSchema();
+
     @BaseMessage("Column ''{0}'' specified more than once")
     ExInst<SqlValidatorException> duplicateColumn(String columnName);
 
     @BaseMessage("Option ''{0}'' specified more than once")
     ExInst<SqlValidatorException> duplicateOption(String optionName);
+
+    @BaseMessage("Mapping does not exist: {0}")
+    ExInst<SqlValidatorException> droppedMappingDoesNotExist(String mappingName);
 
     @BaseMessage("SINK INTO clause is not supported for {0}")
     ExInst<SqlValidatorException> sinkIntoNotSupported(String connectorName);
@@ -40,8 +49,8 @@ public interface ParserResource {
     @BaseMessage("INSERT INTO clause is not supported for {0}, use SINK INTO")
     ExInst<SqlValidatorException> insertIntoNotSupported(String connectorName);
 
-    @BaseMessage("The OR REPLACE option is required for CREATE SNAPSHOT")
-    ExInst<SqlValidatorException> createSnapshotWithoutReplace();
+    @BaseMessage("Writing to top-level fields of type OBJECT not supported")
+    ExInst<SqlValidatorException> insertToTopLevelObject();
 
     @BaseMessage("Unsupported value for {0}: {1}")
     ExInst<SqlValidatorException> processingGuaranteeBadValue(String key, String value);
@@ -52,12 +61,6 @@ public interface ParserResource {
     @BaseMessage("Unknown job option: {0}")
     ExInst<SqlValidatorException> unknownJobOption(String key);
 
-    @BaseMessage("The mapping must be created in the \"public\" schema")
-    ExInst<SqlValidatorException> mappingIncorrectSchema();
-
-    @BaseMessage("Mapping does not exist: {0}")
-    ExInst<SqlValidatorException> droppedMappingDoesNotExist(String mappingName);
-
-    @BaseMessage("Writing to top-level fields of type OBJECT not supported")
-    ExInst<SqlValidatorException> insertToTopLevelObject();
+    @BaseMessage("The OR REPLACE option is required for CREATE SNAPSHOT")
+    ExInst<SqlValidatorException> createSnapshotWithoutReplace();
 }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateJob.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/parse/SqlCreateJob.java
@@ -56,10 +56,11 @@ public class SqlCreateJob extends SqlCreate {
             SqlIdentifier name,
             SqlNodeList options,
             SqlExtendedInsert sqlInsert,
+            boolean replace,
             boolean ifNotExists,
             SqlParserPos pos
     ) {
-        super(OPERATOR, pos, false, ifNotExists);
+        super(OPERATOR, pos, replace, ifNotExists);
 
         this.name = requireNonNull(name, "Name should not be null");
         this.options = requireNonNull(options, "Options should not be null");
@@ -129,6 +130,10 @@ public class SqlCreateJob extends SqlCreate {
 
     @Override
     public void validate(SqlValidator validator, SqlValidatorScope scope) {
+        if (getReplace()) {
+            throw validator.newValidationError(this, RESOURCE.notSupported("OR REPLACE", "CREATE JOB"));
+        }
+
         for (SqlNode option0 : options.getList()) {
             SqlOption option = (SqlOption) option0;
             String key = option.keyString();

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlJobManagementTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/SqlJobManagementTest.java
@@ -73,7 +73,7 @@ public class SqlJobManagementTest extends SimpleTestInClusterSupport {
 
     @Test
     public void when_createOrReplaceJob_then_fail() {
-        assertThatThrownBy(() -> sqlService.execute("CREATE OR REPLACE JOB fooJob AS INSERT INTO t1 SELECT FROM t2"))
+        assertThatThrownBy(() -> sqlService.execute("CREATE OR REPLACE JOB fooJob AS INSERT INTO t1 SELECT * FROM t2"))
                 .hasMessageContaining("OR REPLACE is not supported for CREATE JOB");
     }
 

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/JetSqlParserTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/parse/JetSqlParserTest.java
@@ -140,21 +140,6 @@ public class JetSqlParserTest {
     }
 
     @Test
-    public void test_createMappingRequiresUniqueColumnName() {
-        // given
-        String sql = "CREATE MAPPING "
-                + "mapping_name ("
-                + "column_name INT"
-                + ", column_name VARCHAR"
-                + ")"
-                + "TYPE mapping_type";
-
-        // when
-        assertThatThrownBy(() -> parse(sql))
-                .hasMessageContaining("Column 'column_name' specified more than once");
-    }
-
-    @Test
     public void test_createMappingRequiresColumnType() {
         // given
         String sql = "CREATE MAPPING "
@@ -191,22 +176,6 @@ public class JetSqlParserTest {
         // when
         assertThatThrownBy(() -> parse(sql))
                 .hasMessageContaining("Encountered \".\" at line 1, column 41");
-    }
-
-    @Test
-    public void test_createMappingRequiresUniqueOptionKey() {
-        // given
-        String sql = "CREATE MAPPING "
-                + "mapping_name "
-                + "TYPE mapping_type "
-                + "OPTIONS("
-                + "'option.key'='value1'"
-                + ", 'option.key'='value2'"
-                + ")";
-
-        // when
-        assertThatThrownBy(() -> parse(sql))
-                .hasMessageContaining("Option 'option.key' specified more than once");
     }
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/SqlMappingTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/schema/SqlMappingTest.java
@@ -102,7 +102,19 @@ public class SqlMappingTest extends SqlTestSupport {
     }
 
     @Test
-    public void when_emptyColumnList_then_fails() {
+    public void when_orReplaceAndIfNotExistsUsedTogether_then_fail() {
+        assertThatThrownBy(() -> sqlService.execute("CREATE OR REPLACE MAPPING IF NOT EXISTS t TYPE TestBatch"))
+                .hasMessageContaining("OR REPLACE in conjunction with IF NOT EXISTS not supported");
+    }
+
+    @Test
+    public void when_duplicateColumn_then_fail() {
+        assertThatThrownBy(() -> sqlService.execute("CREATE MAPPING t (a INT, a BIGINT) TYPE TestBatch"))
+                .hasMessageContaining("Column 'a' specified more than once");
+    }
+
+    @Test
+    public void when_emptyColumnList_then_fail() {
         assertThatThrownBy(() -> sqlService.execute("create mapping t () type TestBatch"))
                 .isInstanceOf(HazelcastSqlException.class)
                 .hasMessageStartingWith("Encountered \")\" at line 1, column 19.");
@@ -171,6 +183,12 @@ public class SqlMappingTest extends SqlTestSupport {
         sqlService.execute("CREATE MAPPING t2 TYPE teststream");
         sqlService.execute("CREATE MAPPING t3 TYPE TESTSTREAM");
         sqlService.execute("CREATE MAPPING t4 TYPE tEsTsTrEaM");
+    }
+
+    @Test
+    public void when_duplicateOption_then_fail() {
+        assertThatThrownBy(() -> sqlService.execute("CREATE MAPPING t TYPE TestBatch OPTIONS('o'='1', 'o'='2')"))
+                .hasMessageContaining("Option 'o' specified more than once");
     }
 
     @Test


### PR DESCRIPTION
Forbade `CREATE OR REPLACE MAPPING IF NOT EXISTS`.
Moved validations from `parseImpls.ftl` to respective `validate()`'s.

Fixes #2918