### PR TITLE
Update aws skd version to 2.16.8 for s3 module

### DIFF
--- a/examples/files/pom.xml
+++ b/examples/files/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/extensions/cdc-debezium/pom.xml
+++ b/extensions/cdc-debezium/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
 
         <!-- TEST -->

--- a/extensions/cdc-mysql/pom.xml
+++ b/extensions/cdc-mysql/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/cdc-postgres/pom.xml
+++ b/extensions/cdc-postgres/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
+++ b/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
@@ -21,7 +21,7 @@ This product includes the following libraries with the following licenses:
 
 Apache License, Version 2.0
   HPPC Collections:0.7.1
-  Jackson-core:2.11.2
+  Jackson-core:2.11.4
   Jackson dataformat: CBOR:2.8.10
   Jackson dataformat: Smile:2.8.10
   Jackson-dataformat-YAML:2.8.10

--- a/extensions/s3/pom.xml
+++ b/extensions/s3/pom.xml
@@ -35,6 +35,7 @@
 
     <properties>
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <aws.sdk.version>2.16.8</aws.sdk.version>
     </properties>
 
     <build>
@@ -77,7 +78,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.8.3</version>
+                <version>${aws.sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/hazelcast-jet-core/pom.xml
+++ b/hazelcast-jet-core/pom.xml
@@ -110,17 +110,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-objects</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-annotation-support</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.cache</groupId>

--- a/hazelcast-jet-distribution/pom.xml
+++ b/hazelcast-jet-distribution/pom.xml
@@ -157,17 +157,17 @@
                         <dependency>
                             <groupId>com.fasterxml.jackson.jr</groupId>
                             <artifactId>jackson-jr-objects</artifactId>
-                            <version>${jackson.jr.version}</version>
+                            <version>${jackson.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>com.fasterxml.jackson.jr</groupId>
                             <artifactId>jackson-jr-annotation-support</artifactId>
-                            <version>${jackson.jr.version}</version>
+                            <version>${jackson.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>com.fasterxml.jackson.core</groupId>
                             <artifactId>jackson-core</artifactId>
-                            <version>${jackson.jr.version}</version>
+                            <version>${jackson.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>org.apache.hadoop</groupId>
@@ -328,20 +328,20 @@
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-objects</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.jr</groupId>
             <artifactId>jackson-jr-annotation-support</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
         <!-- shaded in hazelcast.jar, still needs to mentioned -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.jr.version}</version>
+            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -21,15 +21,15 @@ This product includes the following libraries with the following licenses:
 
 Apache License, Version 2.0
   HPPC Collections:0.7.1
-  Jackson-annotations:2.11.2
-  Jackson-core:2.11.2
-  jackson-databind:2.10.0
+  Jackson-annotations:2.11.4
+  Jackson-core:2.11.4
+  jackson-databind:2.11.4
   Jackson dataformat: CBOR:2.8.11
   Jackson dataformat: Smile:2.8.11
   Jackson-dataformat-YAML:2.8.11
   Jackson datatype: JSR310:2.10.0
-  jackson-jr-annotation-support:2.11.2
-  jackson-jr-objects:2.11.2
+  jackson-jr-annotation-support:2.11.4
+  jackson-jr-objects:2.11.4
   mysql-binlog-connector-java:0.20.1
   compiler:0.9.3
   Google Android Annotations Library:4.1.1.4

--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -42,8 +42,8 @@ Apache License, Version 2.0
   Guava ListenableFuture only:9999.0-empty-to-avoid-conflict-with-guava
   J2ObjC Annotations:1.3
   T-Digest:3.2
-  Netty Reactive Streams Implementation:2.0.3
-  Netty Reactive Streams HTTP support:2.0.3
+  Netty Reactive Streams Implementation:2.0.4
+  Netty Reactive Streams HTTP support:2.0.4
   Apache Commons Codec:1.11
   Commons Logging:1.1.3
   picocli - a mighty tiny Command Line Interface:3.9.0
@@ -59,16 +59,16 @@ Apache License, Version 2.0
   io.grpc:grpc-protobuf:1.31.0
   io.grpc:grpc-protobuf-lite:1.31.0
   io.grpc:grpc-stub:1.31.0
-  Netty/Buffer:4.1.39.Final
-  Netty/Codec:4.1.39.Final
-  Netty/Codec/HTTP:4.1.39.Final
-  Netty/Codec/HTTP2:4.1.39.Final
-  Netty/Common:4.1.39.Final
-  Netty/Handler:4.1.39.Final
-  Netty/Resolver:4.1.39.Final
-  Netty/Transport:4.1.39.Final
-  Netty/Transport/Native/Epoll:4.1.39.Final
-  Netty/Transport/Native/Unix/Common:4.1.39.Final
+  Netty/Buffer:4.1.59.Final
+  Netty/Codec:4.1.59.Final
+  Netty/Codec/HTTP:4.1.59.Final
+  Netty/Codec/HTTP2:4.1.59.Final
+  Netty/Common:4.1.59.Final
+  Netty/Handler:4.1.59.Final
+  Netty/Resolver:4.1.59.Final
+  Netty/Transport:4.1.59.Final
+  Netty/Transport/Native/Epoll:4.1.59.Final
+  Netty/Transport/Native/Unix/Common:4.1.59.Final
   perfmark:perfmark-api:0.19.0
   jmx_prometheus_javaagent:0.13.0
   Joda-Time:2.10.1
@@ -118,20 +118,22 @@ Apache License, Version 2.0
   SnakeYAML Engine:1.0
   snappy-java:1.1.1.3
   SnakeYAML:1.17
-  AWS Java SDK :: Annotations:2.8.3
-  AWS Java SDK :: HTTP Clients :: Apache:2.8.3
-  AWS Java SDK :: Auth:2.8.3
-  AWS Java SDK :: AWS Core:2.8.3
-  AWS Java SDK :: Core :: Protocols :: AWS Query Protocol:2.8.3
-  AWS Java SDK :: Core :: Protocols :: AWS Xml Protocol:2.8.3
-  AWS Java SDK :: HTTP Client Interface:2.8.3
-  AWS Java SDK :: HTTP Clients :: Netty Non-Blocking I/O:2.8.3
-  AWS Java SDK :: Profiles:2.8.3
-  AWS Java SDK :: Core :: Protocols :: Protocol Core:2.8.3
-  AWS Java SDK :: Regions:2.8.3
-  AWS Java SDK :: Services :: Amazon S3:2.8.3
-  AWS Java SDK :: SDK Core:2.8.3
-  AWS Java SDK :: Utilities:2.8.3
+  AWS Java SDK :: Annotations:2.16.8
+  AWS Java SDK :: HTTP Clients :: Apache:2.16.8
+  AWS Java SDK :: Arns:2.16.8
+  AWS Java SDK :: Auth:2.16.8
+  AWS Java SDK :: AWS Core:2.16.8
+  AWS Java SDK :: Core :: Protocols :: AWS Query Protocol:2.16.8
+  AWS Java SDK :: Core :: Protocols :: AWS Xml Protocol:2.16.8
+  AWS Java SDK :: HTTP Client Interface:2.16.8
+  AWS Java SDK :: Metrics SPI:2.16.8
+  AWS Java SDK :: HTTP Clients :: Netty Non-Blocking I/O:2.16.8
+  AWS Java SDK :: Profiles:2.16.8
+  AWS Java SDK :: Core :: Protocols :: Protocol Core:2.16.8
+  AWS Java SDK :: Regions:2.16.8
+  AWS Java SDK :: Services :: Amazon S3:2.16.8
+  AWS Java SDK :: SDK Core:2.16.8
+  AWS Java SDK :: Utilities:2.16.8
   AWS Event Stream:1.0.1
 BSD 2-Clause License
   zstd-jni:1.3.8-1

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,8 @@
         <protobuf.version>3.13.0</protobuf.version>
         <picocli.version>3.9.0</picocli.version>
         <classgraph.version>4.8.66</classgraph.version>
-        <jackson.jr.version>2.11.2</jackson.jr.version>
+        <jackson.version>2.11.4</jackson.version>
+
         <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
 
         <!-- test dependencies -->
@@ -193,6 +194,17 @@
                 <groupId>com.hazelcast</groupId>
                 <artifactId>hazelcast</artifactId>
                 <version>${hazelcast.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,11 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Fixes #2916

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
