### PR TITLE
Update Netty version to 4.1.59.Final

### DIFF
--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -59,16 +59,16 @@ Apache License, Version 2.0
   io.grpc:grpc-protobuf:1.31.0
   io.grpc:grpc-protobuf-lite:1.31.0
   io.grpc:grpc-stub:1.31.0
-  Netty/Buffer:4.1.39.Final
-  Netty/Codec:4.1.39.Final
-  Netty/Codec/HTTP:4.1.39.Final
-  Netty/Codec/HTTP2:4.1.39.Final
-  Netty/Common:4.1.39.Final
-  Netty/Handler:4.1.39.Final
-  Netty/Resolver:4.1.39.Final
-  Netty/Transport:4.1.39.Final
-  Netty/Transport/Native/Epoll:4.1.39.Final
-  Netty/Transport/Native/Unix/Common:4.1.39.Final
+  Netty/Buffer:4.1.59.Final
+  Netty/Codec:4.1.59.Final
+  Netty/Codec/HTTP:4.1.59.Final
+  Netty/Codec/HTTP2:4.1.59.Final
+  Netty/Common:4.1.59.Final
+  Netty/Handler:4.1.59.Final
+  Netty/Resolver:4.1.59.Final
+  Netty/Transport:4.1.59.Final
+  Netty/Transport/Native/Epoll:4.1.59.Final
+  Netty/Transport/Native/Unix/Common:4.1.59.Final
   perfmark:perfmark-api:0.19.0
   jmx_prometheus_javaagent:0.13.0
   Joda-Time:2.10.1

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <classgraph.version>4.8.66</classgraph.version>
         <jackson.version>2.11.4</jackson.version>
         <snakeyaml.version>1.26</snakeyaml.version>
+        <netty.version>4.1.59.Final</netty.version>
 
         <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
 
@@ -207,11 +208,17 @@
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fixes: https://github.com/hazelcast/hazelcast-jet/issues/2916

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
