### PR TITLE
Adapt CDC join tutorial to API change

### DIFF
--- a/site/docs/tutorials/cdc-join.md
+++ b/site/docs/tutorials/cdc-join.md
@@ -431,7 +431,6 @@ package org.example;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.cdc.ChangeRecord;
 import com.hazelcast.jet.cdc.RecordPart;
-import com.hazelcast.jet.cdc.impl.ChangeRecordImpl;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.pipeline.StreamStage;
 
@@ -446,7 +445,7 @@ public class Ordering {
                         TimeUnit.SECONDS.toMillis(10),
                         () -> new LongAccumulator(0),
                         (lastSequence, key, record) -> {
-                            long sequence = ((ChangeRecordImpl) record).getSequenceValue();
+                            long sequence = record.sequenceValue();
                             if (lastSequence.get() < sequence) {
                                 lastSequence.set(sequence);
                                 return record;

--- a/site/website/versioned_docs/version-4.3/tutorials/cdc-join.md
+++ b/site/website/versioned_docs/version-4.3/tutorials/cdc-join.md
@@ -433,7 +433,6 @@ package org.example;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.cdc.ChangeRecord;
 import com.hazelcast.jet.cdc.RecordPart;
-import com.hazelcast.jet.cdc.impl.ChangeRecordImpl;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.pipeline.StreamStage;
 
@@ -448,7 +447,7 @@ public class Ordering {
                         TimeUnit.SECONDS.toMillis(10),
                         () -> new LongAccumulator(0),
                         (lastSequence, key, record) -> {
-                            long sequence = ((ChangeRecordImpl) record).getSequenceValue();
+                            long sequence = record.sequenceValue();
                             if (lastSequence.get() < sequence) {
                                 lastSequence.set(sequence);
                                 return record;

--- a/site/website/versioned_docs/version-4.4/tutorials/cdc-join.md
+++ b/site/website/versioned_docs/version-4.4/tutorials/cdc-join.md
@@ -433,7 +433,6 @@ package org.example;
 import com.hazelcast.jet.accumulator.LongAccumulator;
 import com.hazelcast.jet.cdc.ChangeRecord;
 import com.hazelcast.jet.cdc.RecordPart;
-import com.hazelcast.jet.cdc.impl.ChangeRecordImpl;
 import com.hazelcast.jet.function.TriFunction;
 import com.hazelcast.jet.pipeline.StreamStage;
 
@@ -448,7 +447,7 @@ public class Ordering {
                         TimeUnit.SECONDS.toMillis(10),
                         () -> new LongAccumulator(0),
                         (lastSequence, key, record) -> {
-                            long sequence = ((ChangeRecordImpl) record).getSequenceValue();
+                            long sequence = record.sequenceValue();
                             if (lastSequence.get() < sequence) {
                                 lastSequence.set(sequence);
                                 return record;


### PR DESCRIPTION
In version 4.3 the CDC event sequence number have been made public in `ChangeRecord`. The CDC tutorials weren't updated accordingly. This is what current PR fixes.
