### PR TITLE
fix security vulnerabilities

### DIFF
--- a/examples/hadoop/pom.xml
+++ b/examples/hadoop/pom.xml
@@ -131,7 +131,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.0-jre</version>
         </dependency>
         <!-- Azure Cloud Storage -->
         <dependency>

--- a/examples/python/pom.xml
+++ b/examples/python/pom.xml
@@ -37,7 +37,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>25.1-android</version>
         </dependency>
     </dependencies>
 

--- a/examples/source-sink-builder/pom.xml
+++ b/examples/source-sink-builder/pom.xml
@@ -42,7 +42,6 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>

--- a/extensions/elasticsearch/elasticsearch-5/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-5/pom.xml
@@ -112,7 +112,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/elasticsearch/elasticsearch-6/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-6/pom.xml
@@ -136,7 +136,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
+++ b/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
@@ -31,7 +31,7 @@ Apache License, Version 2.0
   Commons Logging:1.1.3
   Joda-Time:2.10.1
   Apache HttpAsyncClient:4.1.2
-  Apache HttpClient:4.5.2
+  Apache HttpClient:4.5.13
   Apache HttpCore:4.4.5
   Apache HttpCore NIO:4.4.5
   Apache Log4j API:2.13.3

--- a/extensions/elasticsearch/elasticsearch-7/pom.xml
+++ b/extensions/elasticsearch/elasticsearch-7/pom.xml
@@ -101,7 +101,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/grpc/pom.xml
+++ b/extensions/grpc/pom.xml
@@ -20,9 +20,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hazelcast-jet-grpc</artifactId>
-    <properties>
-        <guava.version>28.1-android</guava.version>
-    </properties>
 
     <parent>
         <groupId>com.hazelcast.jet</groupId>
@@ -99,12 +96,6 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
             <version>${grpc.version}</version>
-        </dependency>
-        <!-- required for transitive deps to work -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>

--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -38,7 +38,7 @@ Apache License, Version 2.0
   Gson:2.8.6
   error-prone annotations:2.3.4
   Guava InternalFutureFailureAccess and InternalFutures:1.0.1
-  Guava: Google Core Libraries for Java:28.1-android
+  Guava: Google Core Libraries for Java:30.1-jre
   Guava ListenableFuture only:9999.0-empty-to-avoid-conflict-with-guava
   J2ObjC Annotations:1.3
   T-Digest:3.2
@@ -75,7 +75,7 @@ Apache License, Version 2.0
   Apache Avro:1.10.1
   Apache Commons Compress:1.20
   Apache HttpAsyncClient:4.1.4
-  Apache HttpClient:4.5.10
+  Apache HttpClient:4.5.13
   Apache HttpCore:4.4.12
   Apache HttpCore NIO:4.4.12
   Apache Kafka:2.2.2
@@ -141,20 +141,18 @@ CC0
   reactive-streams:1.0.2
 EPL 2.0
   javax.ws.rs-api:2.1.1
-GNU General Public License, version 2 (GPL2), with the classpath exception
-  Checker Qual:2.5.5
 GPL2 w/ CPE
   javax.ws.rs-api:2.1.1
 MIT License
   ClassGraph:4.8.66
   JOpt Simple:5.0.2
-  Checker Qual:2.5.5
+  Checker Qual:3.5.0
   Animal Sniffer Annotations:1.18
   SLF4J API Module:1.7.25
 Public Domain, per Creative Commons CC0
   HdrHistogram:2.1.9
 The GNU General Public License, v2 with FOSS exception
-  MySQL Connector/J:8.0.16
+  MySQL Connector/J:8.0.20
 
 -----
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
         <jackson.version>2.11.4</jackson.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <netty.version>4.1.59.Final</netty.version>
+        <mysql.connector.version>8.0.20</mysql.connector.version>
+        <apache.httpclient.version>4.5.13</apache.httpclient.version>
+        <guava.version>30.1-jre</guava.version>
+        <apache.commons.version>1.20</apache.commons.version>
 
         <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
 
@@ -219,6 +223,26 @@
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql.connector.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${apache.httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${apache.commons.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Update MySQL Connector to 8.0.20
Update Apache Httpclient to 4.5.13
Update Guava to 30.1-jre
Update Apache Commons Compress to 1.20

Fixes #2915 
Fixes #2911 
Fixes #2910 
Fixes #2908 

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
