### PR TITLE
Prevent exception stack trace printing when user cancels the job

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/execution/TaskletExecutionService.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -369,8 +370,14 @@ public class TaskletExecutionService {
                 }
                 progressTracker.mergeWith(result);
             } catch (Throwable e) {
-                logger.warning("Exception in " + t.tasklet, e);
-                t.executionTracker.exception(new JetException("Exception in " + t.tasklet + ": " + e, e));
+                if (e instanceof CancellationException) {
+                    logger.info("Job was cancelled by the user.");
+                    CancellationException ex = (CancellationException) e;
+                    t.executionTracker.exception(ex);
+                } else {
+                    logger.warning("Exception in " + t.tasklet, e);
+                    t.executionTracker.exception(new JetException("Exception in " + t.tasklet + ": " + e, e));
+                }
             } finally {
                 userMetricsContextContainer.setContext(null);
             }

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/RootResultConsumerSink.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/processors/RootResultConsumerSink.java
@@ -27,10 +27,14 @@ import com.hazelcast.jet.core.Watermark;
 import com.hazelcast.jet.sql.impl.JetQueryResultProducer;
 import com.hazelcast.jet.sql.impl.JetSqlCoreBackendImpl;
 import com.hazelcast.sql.impl.JetSqlCoreBackend;
+import com.hazelcast.sql.impl.QueryException;
 
 import javax.annotation.Nonnull;
 
+import java.util.concurrent.CancellationException;
+
 import static com.hazelcast.jet.core.ProcessorMetaSupplier.forceTotalParallelismOne;
+import static com.hazelcast.sql.impl.SqlErrorCode.CANCELLED_BY_USER;
 
 public final class RootResultConsumerSink implements Processor {
 
@@ -49,13 +53,27 @@ public final class RootResultConsumerSink implements Processor {
 
     @Override
     public boolean tryProcess() {
-        rootResultConsumer.ensureNotDone();
+        try {
+            rootResultConsumer.ensureNotDone();
+        } catch (QueryException e) {
+            if (e.getCode() == CANCELLED_BY_USER) {
+                throw new CancellationException();
+            }
+            throw e;
+        }
         return true;
     }
 
     @Override
     public void process(int ordinal, @Nonnull Inbox inbox) {
-        rootResultConsumer.consume(inbox);
+        try {
+            rootResultConsumer.consume(inbox);
+        } catch (QueryException e) {
+            if (e.getCode() == CANCELLED_BY_USER) {
+                throw new CancellationException();
+            }
+            throw e;
+        }
     }
 
     @Override


### PR DESCRIPTION
Many exceptions with a warning level were printed when the job was canceled by the user. 
Job cancellation by user is abnormal, but legal action, and user should see corresponding message, not exception stack traces.
This PR introduces such workaround for catching `QueryException` with `CANCELLED_BY_USER` error code.

Closes #2940.
