### PR TITLE
Set cluster connection timeout for MulticastDiscoveryTest

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
@@ -114,10 +114,7 @@ public class MulticastDiscoveryTest extends JetTestSupport {
         expectedException.expectMessage(UNABLE_TO_CONNECT_MESSAGE);
 
         ClientConfig clientConfig = JetClientConfig.load();
-        // override default indefinite cluster connection timeout
-        clientConfig.getConnectionStrategyConfig()
-                .getConnectionRetryConfig()
-                .setClusterConnectTimeoutMillis(CLUSTER_CONNECTION_TIMEOUT);
+        configureTimeout(clientConfig);
         Jet.newJetClient(clientConfig);
     }
 
@@ -132,10 +129,7 @@ public class MulticastDiscoveryTest extends JetTestSupport {
         expectedException.expectMessage(UNABLE_TO_CONNECT_MESSAGE);
 
         ClientConfig clientConfig = ClientConfig.load();
-        // override default indefinite cluster connection timeout
-        clientConfig.getConnectionStrategyConfig()
-                    .getConnectionRetryConfig()
-                    .setClusterConnectTimeoutMillis(CLUSTER_CONNECTION_TIMEOUT);
+        configureTimeout(clientConfig);
         HazelcastClient.newHazelcastClient(clientConfig);
     }
 
@@ -152,5 +146,12 @@ public class MulticastDiscoveryTest extends JetTestSupport {
             networkConfig.addAddress(address.getHost() + ":" + address.getPort());
         }
         return jetClientConfig;
+    }
+
+    private void configureTimeout(ClientConfig clientConfig) {
+        // override default indefinite cluster connection timeout
+        clientConfig.getConnectionStrategyConfig()
+                .getConnectionRetryConfig()
+                .setClusterConnectTimeoutMillis(CLUSTER_CONNECTION_TIMEOUT);
     }
 }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertEquals;
 public class MulticastDiscoveryTest extends JetTestSupport {
 
     private static final String UNABLE_TO_CONNECT_MESSAGE = "Unable to connect";
+    private static final int CLUSTER_CONNECTION_TIMEOUT = 20_000;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -111,7 +112,13 @@ public class MulticastDiscoveryTest extends JetTestSupport {
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(UNABLE_TO_CONNECT_MESSAGE);
-        Jet.newJetClient();
+
+        ClientConfig clientConfig = JetClientConfig.load();
+        // override default indefinite cluster connection timeout
+        clientConfig.getConnectionStrategyConfig()
+                .getConnectionRetryConfig()
+                .setClusterConnectTimeoutMillis(CLUSTER_CONNECTION_TIMEOUT);
+        Jet.newJetClient(clientConfig);
     }
 
     @Test
@@ -128,7 +135,7 @@ public class MulticastDiscoveryTest extends JetTestSupport {
         // override default indefinite cluster connection timeout
         clientConfig.getConnectionStrategyConfig()
                     .getConnectionRetryConfig()
-                    .setClusterConnectTimeoutMillis(20_000);
+                    .setClusterConnectTimeoutMillis(CLUSTER_CONNECTION_TIMEOUT);
         HazelcastClient.newHazelcastClient(clientConfig);
     }
 

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/MulticastDiscoveryTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet;
 
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.cluster.Address;
 import com.hazelcast.config.Config;
@@ -122,7 +123,13 @@ public class MulticastDiscoveryTest extends JetTestSupport {
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage(UNABLE_TO_CONNECT_MESSAGE);
-        HazelcastClient.newHazelcastClient();
+
+        ClientConfig clientConfig = ClientConfig.load();
+        // override default indefinite cluster connection timeout
+        clientConfig.getConnectionStrategyConfig()
+                    .getConnectionRetryConfig()
+                    .setClusterConnectTimeoutMillis(20_000);
+        HazelcastClient.newHazelcastClient(clientConfig);
     }
 
     /**


### PR DESCRIPTION
Recently, client started retrying indefinitely.
To fix the test, former cluster connection timeout has been set for the client.

Fixes #2904