### PR TITLE
Fix nullability annotation in EventTimeMapper

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/EventTimeMapper.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/EventTimeMapper.java
@@ -182,14 +182,15 @@ public class EventTimeMapper<T> {
      *                 event, event.getPartition(), nativeEventTime));
      * }</pre>
      *
-     * @param event           the event
+     * @param event           the event to flat-map.
+     *                        If {@code null}, it's equivalent to the behavior of {@link #flatMapIdle()}
      * @param partitionIndex  the source partition index the event came from
      * @param nativeEventTime native event time in case no {@code timestampFn} was supplied or
      *                        {@link #NO_NATIVE_TIME} if the event has no native timestamp
      * @return a traverser over the given event and the watermark (if it was due)
      */
     @Nonnull
-    public Traverser<Object> flatMapEvent(@Nonnull T event, int partitionIndex, long nativeEventTime) {
+    public Traverser<Object> flatMapEvent(@Nullable T event, int partitionIndex, long nativeEventTime) {
         return flatMapEvent(System.nanoTime(), event, partitionIndex, nativeEventTime);
     }
 


### PR DESCRIPTION
1. It's called from https://github.com/hazelcast/hazelcast-jet/blob/2797c7ad3cecffa673e2d6f7ae276777885ad155/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/processor/InsertWatermarksP.java#L63 which accepts Null items

2. It delegates to https://github.com/hazelcast/hazelcast-jet/blob/2797c7ad3cecffa673e2d6f7ae276777885ad155/hazelcast-jet-core/src/main/java/com/hazelcast/jet/core/EventTimeMapper.java#L211 where the item is already annotated with @Nullable
