### PR TITLE
Fix test issue with checking relocated exception

### DIFF
--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/AvroFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/AvroFileFormatTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.jet.pipeline.file.FileFormat;
 import com.hazelcast.jet.pipeline.file.FileSourceBuilder;
 import com.hazelcast.jet.pipeline.file.FileSources;
 import org.apache.avro.AvroTypeException;
+import org.apache.avro.InvalidAvroMagicException;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.commons.io.FileUtils;
@@ -79,7 +80,7 @@ public class AvroFileFormatTest extends BaseFileFormatTest {
                                                     .glob("invalid-data.png")
                                                     .format(FileFormat.avro(User.class));
 
-        assertJobFailed(source, IOException.class, "Not an Avro data file");
+        assertJobFailed(source, InvalidAvroMagicException.class, "Not an Avro data file");
     }
 
     @Test

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/BaseFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/BaseFileFormatTest.java
@@ -112,7 +112,8 @@ public abstract class BaseFileFormatTest extends HadoopTestSupport {
         try {
             assertThatThrownBy(() -> jets[0].newJob(p).join())
                     .hasCauseInstanceOf(JetException.class)
-                    .hasRootCauseInstanceOf(expectedRootException)
+                    // can't use hasRootCauseInstanceOf because of mismatch between shaded/non-shaded version
+                    .hasStackTraceContaining(expectedRootException.getName())
                     .hasMessageContaining(expectedMessage);
         } finally {
             for (JetInstance jet : jets) {

--- a/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/JsonFileFormatTest.java
+++ b/extensions/hadoop/src/test/java/com/hazelcast/jet/hadoop/file/JsonFileFormatTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.jet.hadoop.file;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.io.JsonEOFException;
 import com.google.common.collect.ImmutableMap;
 import com.hazelcast.jet.hadoop.file.model.User;
 import com.hazelcast.jet.pipeline.file.FileFormat;
@@ -150,6 +151,6 @@ public class JsonFileFormatTest extends BaseFileFormatTest {
                                                     .glob("file-multiline.jsonl")
                                                     .format(FileFormat.json(User.class).multiline(false));
 
-        assertJobFailed(source, JsonParseException.class, "");
+        assertJobFailed(source, JsonEOFException.class, "expected close marker for Object");
     }
 }


### PR DESCRIPTION
Check for com.fasterxml.. exception fails because a relocated version
is thrown, but non-relocated version is used in tests.

We can't use relocated version in tests because IDE doesn't see it.

Fixes #2941