### PR TITLE
Increase the timeout in the test that uses observable

### DIFF
--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
@@ -200,7 +200,7 @@ public class JobSerializerTest extends SimpleTestInClusterSupport {
 
         // Then
         client().newJob(pipeline, jobConfig()).join();
-        assertThat(counter.get(120, TimeUnit.SECONDS).intValue()).isEqualTo(2);
+        assertThat(counter.get(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS).intValue()).isEqualTo(2);
     }
 
     private static JobConfig jobConfig() {

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
+import javax.annotation.Nonnull;
 import javax.cache.Cache;
 import java.io.IOException;
 import java.util.AbstractMap.SimpleEntry;
@@ -192,6 +193,7 @@ public class JobSerializerTest extends SimpleTestInClusterSupport {
         pipeline.readFrom(TestSources.items(1, 2))
                 .map(Value::new)
                 .writeTo(Sinks.observable(OBSERVABLE_NAME));
+        long timeout = 120;
 
         // When
         Observable<Value> observable = client().getObservable(OBSERVABLE_NAME);
@@ -199,7 +201,7 @@ public class JobSerializerTest extends SimpleTestInClusterSupport {
 
         // Then
         client().newJob(pipeline, jobConfig()).join();
-        assertThat(counter.get(5, TimeUnit.SECONDS).intValue()).isEqualTo(2);
+        assertThat(counter.get(timeout, TimeUnit.SECONDS).intValue()).isEqualTo(2);
     }
 
     private static JobConfig jobConfig() {
@@ -249,6 +251,7 @@ public class JobSerializerTest extends SimpleTestInClusterSupport {
         }
 
         @Override
+        @Nonnull
         public Value read(ObjectDataInput input) throws IOException {
             return new Value(input.readInt());
         }

--- a/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
+++ b/hazelcast-jet-core/src/test/java/com/hazelcast/jet/core/JobSerializerTest.java
@@ -193,7 +193,6 @@ public class JobSerializerTest extends SimpleTestInClusterSupport {
         pipeline.readFrom(TestSources.items(1, 2))
                 .map(Value::new)
                 .writeTo(Sinks.observable(OBSERVABLE_NAME));
-        long timeout = 120;
 
         // When
         Observable<Value> observable = client().getObservable(OBSERVABLE_NAME);
@@ -201,7 +200,7 @@ public class JobSerializerTest extends SimpleTestInClusterSupport {
 
         // Then
         client().newJob(pipeline, jobConfig()).join();
-        assertThat(counter.get(timeout, TimeUnit.SECONDS).intValue()).isEqualTo(2);
+        assertThat(counter.get(120, TimeUnit.SECONDS).intValue()).isEqualTo(2);
     }
 
     private static JobConfig jobConfig() {


### PR DESCRIPTION
I increased the timeout in this test to make sure something went wrong
when this test fails. This test won't take long when it passes anyway.

Also, added missing Nonnull annotation

Checklist:
- [x] Labels and Milestone set

