### PR TITLE
Enable the usage of ExpressionEvalContext while evaluating table function arguments

### DIFF
--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/ExpressionUtil.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/ExpressionUtil.java
@@ -39,6 +39,7 @@ public final class ExpressionUtil {
      * Useful when evaluating expressions in planning phase where these are not
      * available.
      */
+    @Deprecated
     public static final ExpressionEvalContext NOT_IMPLEMENTED_ARGUMENTS_CONTEXT = new ExpressionEvalContext() {
 
         @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/SeriesSqlConnector.java
@@ -78,8 +78,8 @@ class SeriesSqlConnector implements SqlConnector {
 
     @Nonnull
     @SuppressWarnings("SameParameterValue")
-    static SeriesTable createTable(String schemaName, String name, Integer start, Integer stop, Integer step) {
-        return new SeriesTable(INSTANCE, FIELDS, schemaName, name, start, stop, step);
+    static SeriesTable createTable(String schemaName, String name, List<Expression<?>> argumentExpressions) {
+        return new SeriesTable(INSTANCE, FIELDS, schemaName, name, argumentExpressions);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamGeneratorTableFunction.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamGeneratorTableFunction.java
@@ -26,11 +26,13 @@ import com.hazelcast.sql.impl.calcite.validate.HazelcastCallBinding;
 import com.hazelcast.sql.impl.calcite.validate.operand.OperandCheckerProgram;
 import com.hazelcast.sql.impl.calcite.validate.operand.TypedOperandChecker;
 import com.hazelcast.sql.impl.calcite.validate.operators.ReplaceUnknownOperandTypeInference;
+import com.hazelcast.sql.impl.expression.Expression;
 import org.apache.calcite.sql.SqlOperandCountRange;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.calcite.sql.type.SqlTypeName.INTEGER;
 
@@ -43,7 +45,7 @@ public final class StreamGeneratorTableFunction extends JetSpecificTableFunction
     public StreamGeneratorTableFunction() {
         super(
                 FUNCTION_NAME,
-                binding -> toTable(0).getRowType(binding.getTypeFactory()),
+                binding -> toTable0(emptyList()).getRowType(binding.getTypeFactory()),
                 new ReplaceUnknownOperandTypeInference(INTEGER),
                 StreamSqlConnector.INSTANCE
         );
@@ -73,14 +75,12 @@ public final class StreamGeneratorTableFunction extends JetSpecificTableFunction
     }
 
     @Override
-    public HazelcastTable toTable(List<Object> arguments) {
-        Integer rate = (Integer) arguments.get(0);
-
-        return toTable(rate);
+    public HazelcastTable toTable(List<Expression<?>> argumentExpressions) {
+        return toTable0(argumentExpressions);
     }
 
-    private static HazelcastTable toTable(Integer rate) {
-        StreamTable table = StreamSqlConnector.createTable(SCHEMA_NAME_STREAM, randomName(), rate);
+    private static HazelcastTable toTable0(List<Expression<?>> argumentExpressions) {
+        StreamTable table = StreamSqlConnector.createTable(SCHEMA_NAME_STREAM, randomName(), argumentExpressions);
         return new HazelcastTable(table, new HazelcastTableStatistic(Integer.MAX_VALUE));
     }
 

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/connector/generator/StreamSqlConnector.java
@@ -78,8 +78,8 @@ class StreamSqlConnector implements SqlConnector {
 
     @Nonnull
     @SuppressWarnings("SameParameterValue")
-    static StreamTable createTable(String schemaName, String name, Integer rate) {
-        return new StreamTable(INSTANCE, FIELDS, schemaName, name, rate);
+    static StreamTable createTable(String schemaName, String name, List<Expression<?>> argumentExpressions) {
+        return new StreamTable(INSTANCE, FIELDS, schemaName, name, argumentExpressions);
     }
 
     @Override

--- a/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/JetSpecificTableFunction.java
+++ b/hazelcast-jet-sql/src/main/java/com/hazelcast/jet/sql/impl/schema/JetSpecificTableFunction.java
@@ -19,6 +19,7 @@ package com.hazelcast.jet.sql.impl.schema;
 import com.hazelcast.jet.sql.impl.connector.SqlConnector;
 import com.hazelcast.sql.impl.calcite.schema.HazelcastTable;
 import com.hazelcast.sql.impl.calcite.validate.operators.common.HazelcastFunction;
+import com.hazelcast.sql.impl.expression.Expression;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
@@ -55,5 +56,5 @@ public abstract class JetSpecificTableFunction extends HazelcastFunction impleme
         return connector.isStream();
     }
 
-    public abstract HazelcastTable toTable(List<Object> arguments);
+    public abstract HazelcastTable toTable(List<Expression<?>> argumentExpressions);
 }


### PR DESCRIPTION
Refactored table functions, so the evaluation of arguments is performed during `DAG` creation -  it's an enabler for future work on dynamic parameters.