### PR TITLE
Limit the number of parallel partition reads for map/cache.

### DIFF
--- a/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
+++ b/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/connector/ReadMapOrCacheP.java
@@ -99,8 +99,13 @@ import static java.util.stream.Collectors.toList;
  */
 public final class ReadMapOrCacheP<F extends CompletableFuture, B, R> extends AbstractProcessor {
 
-    private static final int MAX_FETCH_SIZE = 2048;
+    /**
+     * See <a href="https://github.com/hazelcast/hazelcast-jet/pull/3009#discussion_r606338266">discussion</a>
+     * for the numbers and how {@link #MAX_FETCH_SIZE} and
+     * {@code #MAX_PARALLEL_READ} affect the throughput.
+     */
     private static final int MAX_PARALLEL_READ = 5;
+    private static final int MAX_FETCH_SIZE = 2048;
 
     private final Reader<F, B, R> reader;
     private final int[] partitionIds;


### PR DESCRIPTION
Reading from all of the partitions in parallel can cause OOM on the
server-side. We limit the parallel reads to a constant value (5) and
decrease the max fetch size (2048).

Fixes #2926

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
