### PR TITLE
Fix httpcore-nio dependency to 4.4.13

### DIFF
--- a/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
+++ b/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
@@ -35,7 +35,7 @@ Apache License, Version 2.0
   Apache HttpAsyncClient:4.1.2
   Apache HttpClient:4.5.13
   Apache HttpCore:4.4.13
-  Apache HttpCore NIO:4.4.5
+  Apache HttpCore NIO:4.4.13
   Apache Log4j API:2.13.3
   Lucene Common Analyzers:7.7.3
   Lucene Memory:7.7.3

--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -153,7 +153,7 @@ Apache License, Version 2.0
   Apache HttpAsyncClient:4.1.4
   Apache HttpClient:4.5.13
   Apache HttpCore:4.4.13
-  Apache HttpCore NIO:4.4.12
+  Apache HttpCore NIO:4.4.13
   Apache Kafka:2.2.2
   Apache Kafka:2.2.2
   Apache Kafka:2.2.2

--- a/pom.xml
+++ b/pom.xml
@@ -309,6 +309,11 @@
                 <version>4.5.13</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore-nio</artifactId>
+                <version>4.4.13</version>
+            </dependency>
+            <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-bom</artifactId>
                 <version>${netty.version}</version>


### PR DESCRIPTION
When compiled with maven 3.5.x, the enforcer plugin throws an error indicating that we are using the same library with different versions. This PR aims to fix the version of that library.

Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [ ] New public APIs have `@Nonnull/@Nullable` annotations
- [ ] New public APIs have `@since` tags in Javadoc
