### PR TITLE
Update Snakeyaml version to 1.26

### DIFF
--- a/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
+++ b/extensions/elasticsearch/elasticsearch-6/src/root/NOTICE
@@ -64,7 +64,7 @@ Apache License, Version 2.0
   lang-mustache:6.8.14
   parent-join:6.8.14
   rank-eval:6.8.14
-  SnakeYAML:1.17
+  SnakeYAML:1.26
 MIT License
   JOpt Simple:5.0.2
 Public Domain, per Creative Commons CC0

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <jline.version>3.16.0</jline.version>
         <classgraph.version>4.8.66</classgraph.version>
         <jackson.version>2.11.2</jackson.version>
+        <snakeyaml.version>1.26</snakeyaml.version>
         <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
         <affinity.version>3.2.3</affinity.version>
         <aws.sdk.version>1.11.976</aws.sdk.version>
@@ -252,6 +253,11 @@
                 <scope>import</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>


### PR DESCRIPTION
Forward port of https://github.com/hazelcast/hazelcast-jet/pull/2949

Checklist:
- [x] Labels and Milestone set
- [N/A] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)
- [N/A] New public APIs have `@Nonnull/@Nullable` annotations
- [N/A] New public APIs have `@since` tags in Javadoc
