### PR TITLE
Replace usage of hasMessageEndingWith() with hasMessageContaining() in SQL tests

### DIFF
--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlAvroTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlAvroTest.java
@@ -240,7 +240,7 @@ public class SqlAvroTest extends SqlTestSupport {
         );
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + name).iterator().hasNext())
-                .hasMessageEndingWith("Cannot parse VARCHAR value to INTEGER");
+                .hasMessageContaining("Cannot parse VARCHAR value to INTEGER");
     }
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlCsvTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlCsvTest.java
@@ -235,7 +235,7 @@ public class SqlCsvTest extends SqlTestSupport {
         );
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + name).iterator().hasNext())
-                .hasMessageEndingWith("Cannot parse VARCHAR value to INTEGER");
+                .hasMessageContaining("Cannot parse VARCHAR value to INTEGER");
     }
 
     @Test

--- a/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlJsonTest.java
+++ b/hazelcast-jet-sql/src/test/java/com/hazelcast/jet/sql/impl/connector/file/SqlJsonTest.java
@@ -240,7 +240,7 @@ public class SqlJsonTest extends SqlTestSupport {
         );
 
         assertThatThrownBy(() -> sqlService.execute("SELECT * FROM " + name).iterator().hasNext())
-                .hasMessageEndingWith("Cannot parse VARCHAR value to INTEGER");
+                .hasMessageContaining("Cannot parse VARCHAR value to INTEGER");
     }
 
     @Test


### PR DESCRIPTION
There are cases when the cause of a failed job is _stringified_ before reported to the user ([here](https://github.com/hazelcast/hazelcast-jet/blob/2797c7ad3cecffa673e2d6f7ae276777885ad155/hazelcast-jet-core/src/main/java/com/hazelcast/jet/impl/JobCoordinationService.java#L654)).
Replaced usage of `hasMessageEndingWith()` with `hasMessageContaining()` to avoid false negatives.

Fixes #3048