### PR TITLE
Decommission download machine - update links

### DIFF
--- a/site/docs/enterprise/management-center.md
+++ b/site/docs/enterprise/management-center.md
@@ -15,7 +15,7 @@ for more information.
 Download Jet Management Center and unzip it to a folder:
 
 ```bash
-wget https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-{jet-version}.tar.gz
+wget https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-{jet-version}.tar.gz
 tar zxvf hazelcast-jet-management-center-{jet-version}.tar.gz
 ```
 

--- a/site/website/pages/en/download.js
+++ b/site/website/pages/en/download.js
@@ -170,7 +170,7 @@ function Downloads(props) {
          </p>
 
          <p>
-          Download <a href={`https://download.hazelcast.com/management-center/hazelcast-management-center-${latest.mcVersion}.tar.gz`}>Hazelcast Management Center {latest.mcVersion}</a>
+          Download <a href={`https://repository.hazelcast.com/download/management-center/hazelcast-management-center-${latest.mcVersion}.tar.gz`}>Hazelcast Management Center {latest.mcVersion}</a>
            &nbsp;(compatible wit Hazelcast Jet {latest.version}).
          </p>
          <p>
@@ -212,8 +212,8 @@ function Downloads(props) {
                       </td>
                       <td>
                         <a
-                          href={current.mcVersion ? `https://download.hazelcast.com/management-center/hazelcast-management-center-${current.mcVersion}.tar.gz`
-                          : `https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-${current.version}.tar.gz`} target="_blank" rel="noreferrer noopener">
+                          href={current.mcVersion ? `https://repository.hazelcast.com/download/management-center/hazelcast-management-center-${current.mcVersion}.tar.gz`
+                          : `https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-${current.version}.tar.gz`} target="_blank" rel="noreferrer noopener">
                           Management Center
                         </a>
                       </td>

--- a/site/website/versioned_docs/version-4.0/enterprise/installation.md
+++ b/site/website/versioned_docs/version-4.0/enterprise/installation.md
@@ -10,7 +10,7 @@ Hazelcast Jet Enterprise requires a license key to run. You can get a
 
 ## Download Hazelcast Jet
 
-Once you have a license key, download Hazelcast Jet from [here](https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.0.tar.gz).
+Once you have a license key, download Hazelcast Jet from [here](https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.0.tar.gz).
 
 Hazelcast Jet requires a minimum of JDK 8, which can be acquired from
 [AdoptOpenJDK](https://adoptopenjdk.net/). Once you have the download,

--- a/site/website/versioned_docs/version-4.0/enterprise/management-center.md
+++ b/site/website/versioned_docs/version-4.0/enterprise/management-center.md
@@ -10,7 +10,7 @@ used to monitor a Jet cluster and manage the lifecycle of the jobs
 
 ## Download Management Center
 
-You can download Hazelcast Jet Management Center [here](https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-4.0.tar.gz).
+You can download Hazelcast Jet Management Center [here](https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-4.0.tar.gz).
 
 Once you have downloaded it, unzip it to a folder:
 

--- a/site/website/versioned_docs/version-4.1.1/enterprise/installation.md
+++ b/site/website/versioned_docs/version-4.1.1/enterprise/installation.md
@@ -10,14 +10,14 @@ Hazelcast Jet Enterprise requires a license key to run. You can get a
 
 ## Download Hazelcast Jet
 
-Once you have a license key, download Hazelcast Jet from [here](https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.1.1.tar.gz).
+Once you have a license key, download Hazelcast Jet from [here](https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.1.1.tar.gz).
 
 Hazelcast Jet requires a minimum of JDK 8, which can be acquired from
 [AdoptOpenJDK](https://adoptopenjdk.net/). Once you have the download,
 unzip it to a folder which we will refer from now on as `JET_HOME`.
 
 ```bash
-wget https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.1.1.tar.gz
+wget https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.1.1.tar.gz
 tar zxvf hazelcast-jet-enterprise-4.1.1.tar.gz
 cd hazelcast-jet-enterprise-4.1.1
 ```

--- a/site/website/versioned_docs/version-4.1.1/enterprise/management-center.md
+++ b/site/website/versioned_docs/version-4.1.1/enterprise/management-center.md
@@ -10,7 +10,7 @@ used to monitor a Jet cluster and manage the lifecycle of the jobs
 
 ## Download Management Center
 
-You can download Hazelcast Jet Management Center [here](https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-4.1.1.tar.gz).
+You can download Hazelcast Jet Management Center [here](https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-4.1.1.tar.gz).
 
 Once you have downloaded it, unzip it to a folder:
 

--- a/site/website/versioned_docs/version-4.2/enterprise/installation.md
+++ b/site/website/versioned_docs/version-4.2/enterprise/installation.md
@@ -17,7 +17,7 @@ Once you have a license key, download Hazelcast Jet and unzip it to a
 folder we will refer as `JET_HOME`.
 
 ```bash
-wget https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.2.tar.gz
+wget https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.2.tar.gz
 tar zxvf hazelcast-jet-enterprise-4.2.tar.gz
 cd hazelcast-jet-enterprise-4.2
 ```

--- a/site/website/versioned_docs/version-4.2/enterprise/management-center.md
+++ b/site/website/versioned_docs/version-4.2/enterprise/management-center.md
@@ -13,7 +13,7 @@ used to monitor a Jet cluster and manage the lifecycle of the jobs
 Download Jet Management Center and unzip it to a folder:
 
 ```bash
-wget https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-4.2.tar.gz
+wget https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-4.2.tar.gz
 tar zxvf hazelcast-jet-management-center-4.2.tar.gz
 ```
 

--- a/site/website/versioned_docs/version-4.3.1/enterprise/installation.md
+++ b/site/website/versioned_docs/version-4.3.1/enterprise/installation.md
@@ -17,7 +17,7 @@ Once you have a license key, download Hazelcast Jet and unzip it to a
 folder we will refer as `JET_HOME`.
 
 ```bash
-wget https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.3.1.tar.gz
+wget https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.3.1.tar.gz
 tar zxvf hazelcast-jet-enterprise-4.3.1.tar.gz
 cd hazelcast-jet-enterprise-4.3.1
 ```

--- a/site/website/versioned_docs/version-4.3.1/enterprise/management-center.md
+++ b/site/website/versioned_docs/version-4.3.1/enterprise/management-center.md
@@ -13,7 +13,7 @@ used to monitor a Jet cluster and manage the lifecycle of the jobs
 Download Jet Management Center and unzip it to a folder:
 
 ```bash
-wget https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-4.3.1.tar.gz
+wget https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-4.3.1.tar.gz
 tar zxvf hazelcast-jet-management-center-4.3.1.tar.gz
 ```
 

--- a/site/website/versioned_docs/version-4.4/enterprise/installation.md
+++ b/site/website/versioned_docs/version-4.4/enterprise/installation.md
@@ -17,7 +17,7 @@ Once you have a license key, download Hazelcast Jet and unzip it to a
 folder we will refer as `JET_HOME`.
 
 ```bash
-wget https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.4.tar.gz
+wget https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.4.tar.gz
 tar zxvf hazelcast-jet-enterprise-4.4.tar.gz
 cd hazelcast-jet-enterprise-4.4
 ```

--- a/site/website/versioned_docs/version-4.4/enterprise/management-center.md
+++ b/site/website/versioned_docs/version-4.4/enterprise/management-center.md
@@ -7,7 +7,7 @@ original_id: management-center
 
 Hazelcast Management Center can be used for monitoring the cluster.
 
-Download [Hazelcast Management Center](https://download.hazelcast.com/management-center/hazelcast-management-center-4.2021.02.tar.gz)
+Download [Hazelcast Management Center](https://repository.hazelcast.com/download/management-center/hazelcast-management-center-4.2021.02.tar.gz)
 (compatible wit Hazelcast Jet 4.4).
 
 See the reference Hazelcast Management Center [documentation](https://docs.hazelcast.com/management-center/4.2021.02/index.html).

--- a/site/website/versioned_docs/version-4.5.1/enterprise/installation.md
+++ b/site/website/versioned_docs/version-4.5.1/enterprise/installation.md
@@ -17,7 +17,7 @@ Once you have a license key, download Hazelcast Jet and unzip it to a
 folder we will refer as `JET_HOME`.
 
 ```bash
-wget https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.5.1.tar.gz
+wget https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.5.1.tar.gz
 tar zxvf hazelcast-jet-enterprise-4.5.1.tar.gz
 cd hazelcast-jet-enterprise-4.5.1
 ```

--- a/site/website/versioned_docs/version-4.5.1/enterprise/management-center.md
+++ b/site/website/versioned_docs/version-4.5.1/enterprise/management-center.md
@@ -17,7 +17,7 @@ for more information.
 Download Jet Management Center and unzip it to a folder:
 
 ```bash
-wget https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-4.5.1.tar.gz
+wget https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-4.5.1.tar.gz
 tar zxvf hazelcast-jet-management-center-4.5.1.tar.gz
 ```
 

--- a/site/website/versioned_docs/version-4.5/enterprise/installation.md
+++ b/site/website/versioned_docs/version-4.5/enterprise/installation.md
@@ -17,7 +17,7 @@ Once you have a license key, download Hazelcast Jet and unzip it to a
 folder we will refer as `JET_HOME`.
 
 ```bash
-wget https://download.hazelcast.com/jet-enterprise/hazelcast-jet-enterprise-4.5.tar.gz
+wget https://repository.hazelcast.com/download/jet-enterprise/hazelcast-jet-enterprise-4.5.tar.gz
 tar zxvf hazelcast-jet-enterprise-4.5.tar.gz
 cd hazelcast-jet-enterprise-4.5
 ```

--- a/site/website/versioned_docs/version-4.5/enterprise/management-center.md
+++ b/site/website/versioned_docs/version-4.5/enterprise/management-center.md
@@ -17,7 +17,7 @@ for more information.
 Download Jet Management Center and unzip it to a folder:
 
 ```bash
-wget https://download.hazelcast.com/hazelcast-jet-management-center/hazelcast-jet-management-center-4.5.tar.gz
+wget https://repository.hazelcast.com/download/jet-management-center/hazelcast-jet-management-center-4.5.tar.gz
 tar zxvf hazelcast-jet-management-center-4.5.tar.gz
 ```
 


### PR DESCRIPTION
Update links to do not link current download machine. See https://hazelcast.atlassian.net/browse/HZ-741 for more details.