### PR TITLE
fix(sec): upgrade org.springframework:spring-context to 5.3.19

### DIFF
--- a/examples/spring/pom.xml
+++ b/examples/spring/pom.xml
@@ -29,7 +29,7 @@
     </parent>
 
     <properties>
-        <spring.version>4.3.26.RELEASE</spring.version>
+        <spring.version>5.3.19</spring.version>
         <hsqldb.version>2.3.2</hsqldb.version>
         <dbh2.version>1.4.187</dbh2.version>
     </properties>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework:spring-context 4.3.26.RELEASE
- [CVE-2022-22968](https://www.oscs1024.com/hd/CVE-2022-22968)


### What did I do？
Upgrade org.springframework:spring-context from 4.3.26.RELEASE to 5.3.19 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS