### PR TITLE
Update to Hazelcast IMDG 4.2.6 [HZ-1438]

### DIFF
--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -130,7 +130,7 @@ Apache License, Version 2.0
   Apache Avro Mapred API:1.11.0
   Calcite Core:1.23.0
   Calcite Linq4j:1.23.0
-  Apache Calcite Avatica:1.16.0
+  Apache Calcite Avatica:1.22.0
   Apache Commons Compress:1.21
   Apache Commons Configuration:2.1.1
   Apache Commons Lang:3.7
@@ -159,6 +159,9 @@ Apache License, Version 2.0
   Apache HttpClient:4.5.13
   Apache HttpCore:4.4.13
   Apache HttpCore NIO:4.4.13
+  Apache HttpClient:5.1.3
+  Apache HttpComponents Core HTTP/1.1:5.1.3
+  Apache HttpComponents Core HTTP/2:5.1.3
   Apache Kafka:2.2.2
   Apache Kafka:2.2.2
   Apache Kafka:2.2.2

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <timestamp>${maven.build.timestamp}</timestamp>
 
         <!-- Main IMDG dependency -->
-        <hazelcast.version>4.2.4</hazelcast.version>
+        <hazelcast.version>4.2.6</hazelcast.version>
         <!-- Dependencies on IMDG modules: must be the same versions IMDG depends on! -->
         <hazelcast.aws.version>3.3</hazelcast.aws.version>
         <hazelcast.kubernetes.version>2.2.2</hazelcast.kubernetes.version>


### PR DESCRIPTION
This PR updates the underlying Hazelcast IMDG version to the new `4.2.6` one.