### PR TITLE
Downgrade gRPC and upgrade Woodstox

### DIFF
--- a/extensions/grpc/src/main/resources/NOTICE
+++ b/extensions/grpc/src/main/resources/NOTICE
@@ -29,13 +29,13 @@ Apache License, Version 2.0
   Guava: Google Core Libraries for Java:30.1-jre
   Guava ListenableFuture only:9999.0-empty-to-avoid-conflict-with-guava
   J2ObjC Annotations:1.3
-  io.grpc:grpc-api:1.51.0
-  io.grpc:grpc-context:1.51.0
-  io.grpc:grpc-core:1.51.0
-  io.grpc:grpc-netty-shaded:1.51.0
-  io.grpc:grpc-protobuf:1.51.0
-  io.grpc:grpc-protobuf-lite:1.51.0
-  io.grpc:grpc-stub:1.51.0
+  io.grpc:grpc-api:1.48.2
+  io.grpc:grpc-context:1.48.2
+  io.grpc:grpc-core:1.48.2
+  io.grpc:grpc-netty-shaded:1.48.2
+  io.grpc:grpc-protobuf:1.48.2
+  io.grpc:grpc-protobuf-lite:1.48.2
+  io.grpc:grpc-stub:1.48.2
   perfmark:perfmark-api:0.25.0
 BSD 3-Clause License
   Protocol Buffers [Core]:3.19.6

--- a/extensions/hadoop-dist/files-azure/src/main/resources/NOTICE
+++ b/extensions/hadoop-dist/files-azure/src/main/resources/NOTICE
@@ -27,7 +27,7 @@ Apache License, Version 2.0
   Jackson-JAXRS: base:2.14.1
   Jackson-JAXRS: JSON:2.14.1
   Jackson module: Old JAXB Annotations (javax.xml.bind):2.14.1
-  Woodstox:5.3.0
+  Woodstox:6.4.0
   JCIP Annotations under Apache License:1.0-1
   FindBugs-jsr305:3.0.2
   Gson:2.10

--- a/extensions/hadoop-dist/files-gcs/src/main/resources/NOTICE
+++ b/extensions/hadoop-dist/files-gcs/src/main/resources/NOTICE
@@ -27,7 +27,7 @@ Apache License, Version 2.0
   Jackson-JAXRS: base:2.14.1
   Jackson-JAXRS: JSON:2.14.1
   Jackson module: Old JAXB Annotations (javax.xml.bind):2.14.1
-  Woodstox:5.3.0
+  Woodstox:6.4.0
   guava-retrying:2.0.0
   JCIP Annotations under Apache License:1.0-1
   Google Android Annotations Library:4.1.1.4
@@ -68,16 +68,16 @@ Apache License, Version 2.0
   Apache Commons Logging:1.2
   Apache Commons Net:3.6
   Commons Pool:1.6
-  io.grpc:grpc-alts:1.51.0
-  io.grpc:grpc-api:1.51.0
-  io.grpc:grpc-auth:1.51.0
-  io.grpc:grpc-context:1.51.0
-  io.grpc:grpc-core:1.51.0
-  io.grpc:grpc-grpclb:1.51.0
-  io.grpc:grpc-netty-shaded:1.51.0
-  io.grpc:grpc-protobuf:1.51.0
-  io.grpc:grpc-protobuf-lite:1.51.0
-  io.grpc:grpc-stub:1.51.0
+  io.grpc:grpc-alts:1.48.2
+  io.grpc:grpc-api:1.48.2
+  io.grpc:grpc-auth:1.48.2
+  io.grpc:grpc-context:1.48.2
+  io.grpc:grpc-core:1.48.2
+  io.grpc:grpc-grpclb:1.48.2
+  io.grpc:grpc-netty-shaded:1.48.2
+  io.grpc:grpc-protobuf:1.48.2
+  io.grpc:grpc-protobuf-lite:1.48.2
+  io.grpc:grpc-stub:1.48.2
   OpenCensus:0.24.0
   OpenCensus:0.24.0
   perfmark:perfmark-api:0.25.0

--- a/extensions/hadoop-dist/files-s3/src/main/resources/NOTICE
+++ b/extensions/hadoop-dist/files-s3/src/main/resources/NOTICE
@@ -28,7 +28,7 @@ Apache License, Version 2.0
   Jackson-JAXRS: base:2.14.1
   Jackson-JAXRS: JSON:2.14.1
   Jackson module: Old JAXB Annotations (javax.xml.bind):2.14.1
-  Woodstox:5.3.0
+  Woodstox:6.4.0
   JCIP Annotations under Apache License:1.0-1
   FindBugs-jsr305:3.0.2
   Gson:2.10

--- a/extensions/hadoop-dist/hadoop-all/src/main/resources/NOTICE
+++ b/extensions/hadoop-dist/hadoop-all/src/main/resources/NOTICE
@@ -27,7 +27,7 @@ Apache License, Version 2.0
   Jackson-JAXRS: base:2.14.1
   Jackson-JAXRS: JSON:2.14.1
   Jackson module: Old JAXB Annotations (javax.xml.bind):2.14.1
-  Woodstox:5.3.0
+  Woodstox:6.4.0
   JCIP Annotations under Apache License:1.0-1
   FindBugs-jsr305:3.0.2
   Gson:2.10

--- a/extensions/hadoop-dist/src/main/resources/NOTICE
+++ b/extensions/hadoop-dist/src/main/resources/NOTICE
@@ -27,7 +27,7 @@ Apache License, Version 2.0
   Jackson-JAXRS: base:2.14.1
   Jackson-JAXRS: JSON:2.14.1
   Jackson module: Old JAXB Annotations (javax.xml.bind):2.14.1
-  Woodstox:5.3.0
+  Woodstox:6.4.0
   JCIP Annotations under Apache License:1.0-1
   FindBugs-jsr305:3.0.2
   Gson:2.10

--- a/extensions/python/src/main/resources/NOTICE
+++ b/extensions/python/src/main/resources/NOTICE
@@ -29,13 +29,13 @@ Apache License, Version 2.0
   Guava: Google Core Libraries for Java:30.1-jre
   Guava ListenableFuture only:9999.0-empty-to-avoid-conflict-with-guava
   J2ObjC Annotations:1.3
-  io.grpc:grpc-api:1.51.0
-  io.grpc:grpc-context:1.51.0
-  io.grpc:grpc-core:1.51.0
-  io.grpc:grpc-netty-shaded:1.51.0
-  io.grpc:grpc-protobuf:1.51.0
-  io.grpc:grpc-protobuf-lite:1.51.0
-  io.grpc:grpc-stub:1.51.0
+  io.grpc:grpc-api:1.48.2
+  io.grpc:grpc-context:1.48.2
+  io.grpc:grpc-core:1.48.2
+  io.grpc:grpc-netty-shaded:1.48.2
+  io.grpc:grpc-protobuf:1.48.2
+  io.grpc:grpc-protobuf-lite:1.48.2
+  io.grpc:grpc-stub:1.48.2
   perfmark:perfmark-api:0.25.0
 BSD 3-Clause License
   Protocol Buffers [Core]:3.19.6

--- a/hazelcast-jet-distribution/src/root/NOTICE
+++ b/hazelcast-jet-distribution/src/root/NOTICE
@@ -42,7 +42,7 @@ Apache License, Version 2.0
   jackson-jr-annotation-support:2.14.1
   jackson-jr-objects:2.14.1
   Jackson module: Old JAXB Annotations (javax.xml.bind):2.14.1
-  Woodstox:5.3.0
+  Woodstox:6.4.0
   guava-retrying:2.0.0
   mysql-binlog-connector-java:0.20.1
   compiler:0.9.6
@@ -96,16 +96,16 @@ Apache License, Version 2.0
   Debezium Connector for PostgreSQL:1.2.5.Final
   Debezium Core:1.2.5.Final
   Debezium ANTLR DDL parsers:1.2.5.Final
-  io.grpc:grpc-alts:1.51.0
-  io.grpc:grpc-api:1.51.0
-  io.grpc:grpc-auth:1.51.0
-  io.grpc:grpc-context:1.51.0
-  io.grpc:grpc-core:1.51.0
-  io.grpc:grpc-grpclb:1.51.0
-  io.grpc:grpc-netty-shaded:1.51.0
-  io.grpc:grpc-protobuf:1.51.0
-  io.grpc:grpc-protobuf-lite:1.51.0
-  io.grpc:grpc-stub:1.51.0
+  io.grpc:grpc-alts:1.48.2
+  io.grpc:grpc-api:1.48.2
+  io.grpc:grpc-auth:1.48.2
+  io.grpc:grpc-context:1.48.2
+  io.grpc:grpc-core:1.48.2
+  io.grpc:grpc-grpclb:1.48.2
+  io.grpc:grpc-netty-shaded:1.48.2
+  io.grpc:grpc-protobuf:1.48.2
+  io.grpc:grpc-protobuf-lite:1.48.2
+  io.grpc:grpc-stub:1.48.2
   Netty/Buffer:4.1.72.Final
   Netty/Codec:4.1.72.Final
   Netty/Codec/HTTP:4.1.72.Final

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <scala.version>2.12</scala.version>
         <zookeeper.version>3.5.8</zookeeper.version>
         <kafka.version>2.2.2</kafka.version>
-        <grpc.version>1.34.0</grpc.version>
+        <grpc.version>1.48.2</grpc.version>
         <protobuf.version>3.13.0</protobuf.version>
         <picocli.version>3.9.0</picocli.version>
         <jline.version>3.16.0</jline.version>
@@ -133,6 +133,7 @@
         <aws.sdk.version>1.12.128</aws.sdk.version>
         <netty.version>4.1.72.Final</netty.version>
         <mysql.connector.version>8.0.25</mysql.connector.version>
+        <woodstox-version>6.4.0</woodstox-version>
 
         <!-- test dependencies -->
         <activemq.version>5.15.11</activemq.version>
@@ -223,6 +224,11 @@
                 <version>${jackson.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${woodstox-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Fixes gRPC Python requirement and Woodstox CVE

Fixes #3129


Checklist:
- [x] Labels and Milestone set
- [ ] Added a line in `hazelcast-jet-distribution/src/root/release_notes.txt` (for any non-trivial fix/enhancement/feature)