### PR TITLE
fix(sec): upgrade io.undertow:undertow-core to 2.3.0.Alpha2

### DIFF
--- a/examples/source-sink-builder/pom.xml
+++ b/examples/source-sink-builder/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
-            <version>2.0.13.Final</version>
+            <version>2.3.6.final</version>
         </dependency>
         <dependency>
             <groupId>org.jfree</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.undertow:undertow-core 2.0.13.Final
- [CVE-2021-3597](https://www.oscs1024.com/hd/CVE-2021-3597)


### What did I do？
Upgrade io.undertow:undertow-core from 2.0.13.Final to 2.3.0.Alpha2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS